### PR TITLE
Add YAML workflow support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 `entire-sem` is an Entire CLI plugin for entity-level checkpoint context.
 
-Entire already knows a checkpoint touched `auth.py`. This plugin answers the next question:
-which functions, classes, types, or methods changed inside that file?
+Entire already knows a checkpoint touched `auth.py` or `.github/workflows/ci.yml`.
+This plugin answers the next question: which semantic entities changed inside that file?
 
 This plugin builds a binary named `entire-sem`, which is invoked through Entire as:
 
@@ -47,6 +47,7 @@ The plugin uses a tree-sitter-backed parser for:
 - Scala
 - SQL
 - Swift
+- YAML, including GitHub Actions workflow sections and jobs
 
 The parser is isolated behind `internal/sem`, so the command surface can stay stable
 while the semantic model gets richer.
@@ -207,8 +208,8 @@ auth.py
 
 When an agent changes a repo, you often need to decide if the checkpoint is safe
 to keep, revert, or continue from. File names are not enough. `entire-sem` shows
-the actual functions, classes, signatures, and renames that changed, so you can
-understand the checkpoint before reading the full diff.
+the actual code entities, workflow sections, signatures, and renames that changed,
+so you can understand the checkpoint before reading the full diff.
 
 ## Why This Exists
 
@@ -217,7 +218,8 @@ checkpoint context at the entity level instead of stopping at "this file changed
 `entire-sem` is a plugin-shaped implementation of that idea:
 
 - parse the before and after git trees with tree-sitter
-- extract named entities like functions, classes, methods, structs, traits, and types
+- extract named entities like functions, classes, methods, structs, traits, types,
+  YAML workflow sections, and GitHub Actions jobs
 - compare signatures and normalized bodies
 - build a heuristic dependent count from parsed references in the target tree
 - report added, removed, renamed, signature-changed, and body-changed entities

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -119,6 +119,73 @@ func TestAnalyzeGitRangeExpandedLanguageSignatureChange(t *testing.T) {
 	t.Fatalf("missing Java method signature change in %#v", result.Files)
 }
 
+func TestAnalyzeGitRangeIncludesGitHubWorkflowYAML(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Sem Test")
+	git(t, repo, "config", "user.email", "sem@example.com")
+
+	write(t, repo, ".github/workflows/ci.yml", `name: CI
+on:
+  push:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: go test ./...
+`)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	base := rev(t, repo, "HEAD")
+
+	write(t, repo, ".github/workflows/ci.yml", `name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: go test -race ./...
+`)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "update workflow")
+	head := rev(t, repo, "HEAD")
+
+	result, err := AnalyzeGitRange(context.Background(), repo, base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Files) != 1 {
+		t.Fatalf("files = %#v", result.Files)
+	}
+	file := result.Files[0]
+	if file.Path != ".github/workflows/ci.yml" {
+		t.Fatalf("path = %q", file.Path)
+	}
+	if file.Language != "YAML" {
+		t.Fatalf("language = %q", file.Language)
+	}
+
+	var sawJob bool
+	var sawTrigger bool
+	for _, change := range file.Changes {
+		if change.Type == "body_changed" && change.Kind == "job" && change.Name == "jobs.test" {
+			sawJob = true
+		}
+		if change.Type == "body_changed" && change.Kind == "section" && change.Name == "on" {
+			sawTrigger = true
+		}
+	}
+	if !sawJob || !sawTrigger {
+		t.Fatalf("workflow changes missing job=%v trigger=%v in %#v", sawJob, sawTrigger, file.Changes)
+	}
+}
+
 func TestAnalyzeCheckpointResolvesAssociatedCommit(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")

--- a/internal/sem/parser.go
+++ b/internal/sem/parser.go
@@ -33,6 +33,7 @@ import (
 	"github.com/smacker/go-tree-sitter/swift"
 	treesittertsx "github.com/smacker/go-tree-sitter/typescript/tsx"
 	treesitterts "github.com/smacker/go-tree-sitter/typescript/typescript"
+	treesitteryaml "github.com/smacker/go-tree-sitter/yaml"
 )
 
 type languageSpec struct {
@@ -81,6 +82,8 @@ var treeSitterLanguages = map[string]languageSpec{
 	".tfvars": {language: "HCL", grammar: hcl.GetLanguage()},
 	".ts":     {language: "TypeScript", grammar: treesitterts.GetLanguage()},
 	".tsx":    {language: "TypeScript", grammar: treesittertsx.GetLanguage()},
+	".yaml":   {language: "YAML", grammar: treesitteryaml.GetLanguage()},
+	".yml":    {language: "YAML", grammar: treesitteryaml.GetLanguage()},
 	".zsh":    {language: "Bash", grammar: bash.GetLanguage()},
 }
 
@@ -109,6 +112,13 @@ func (TreeSitterParser) ParseWithStatus(path, content string) ([]Entity, string,
 			detail = err.Error()
 		}
 		return nil, spec.language, ParseStatus{ParseError: true, Detail: detail}
+	}
+	if spec.language == "YAML" {
+		status := ParseStatus{}
+		if root.HasError() {
+			status = ParseStatus{ParseError: true, Detail: "tree-sitter syntax error nodes present"}
+		}
+		return yamlEntities(path, content), spec.language, status
 	}
 
 	var entities []Entity

--- a/internal/sem/parser_test.go
+++ b/internal/sem/parser_test.go
@@ -105,6 +105,29 @@ trait Run { fn run(&self); }
 `,
 			names: []string{"User", "validate", "Run", "Run.run"},
 		},
+		{
+			path:     ".github/workflows/ci.yml",
+			language: "YAML",
+			input: `name: CI
+on:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: go test ./...
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - run: ./scripts/deploy.sh
+`,
+			names: []string{"ci", "on", "permissions", "jobs.test", "jobs.deploy"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -120,6 +143,40 @@ trait Run { fn run(&self); }
 			if !seen[name] {
 				t.Fatalf("%s missing entity %q in %#v", tt.path, name, entities)
 			}
+		}
+	}
+}
+
+func TestTreeSitterParserSupportsYAMLWorkflowExtensions(t *testing.T) {
+	if !Supported(".github/workflows/ci.yml") {
+		t.Fatal(".yml workflow should be supported")
+	}
+	if !Supported(".github/workflows/deploy.yaml") {
+		t.Fatal(".yaml workflow should be supported")
+	}
+
+	entities, language := TreeSitterParser{}.Parse(".github/workflows/deploy.yaml", `name: Deploy
+on: workflow_dispatch
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo deploy
+`)
+	if language != "YAML" {
+		t.Fatalf("language = %q", language)
+	}
+	seen := map[string]string{}
+	for _, entity := range entities {
+		seen[entity.Name] = entity.Kind
+	}
+	for name, kind := range map[string]string{
+		"deploy":       "workflow",
+		"on":           "section",
+		"jobs.publish": "job",
+	} {
+		if seen[name] != kind {
+			t.Fatalf("%s kind = %q, want %q in %#v", name, seen[name], kind, entities)
 		}
 	}
 }

--- a/internal/sem/yaml.go
+++ b/internal/sem/yaml.go
@@ -1,0 +1,275 @@
+package sem
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+type yamlBlock struct {
+	Key       string
+	StartLine int
+	EndLine   int
+}
+
+func yamlEntities(path, content string) []Entity {
+	lines := strings.Split(content, "\n")
+	topLevel := yamlTopLevelBlocks(lines)
+	if len(topLevel) == 0 {
+		return nil
+	}
+
+	var entities []Entity
+	entities = append(entities, yamlEntity("workflow", yamlWorkflowEntityName(path), yamlWorkflowSignature(path, lines, topLevel), 1, len(lines), lines))
+	for _, block := range topLevel {
+		switch block.Key {
+		case "name":
+			continue
+		case "jobs":
+			entities = append(entities, yamlJobEntities(block, lines)...)
+		default:
+			entities = append(entities, yamlEntity("section", block.Key, "section "+block.Key, block.StartLine, block.EndLine, lines))
+		}
+	}
+
+	sort.Slice(entities, func(i, j int) bool {
+		if entities[i].StartLine == entities[j].StartLine {
+			return entities[i].Name < entities[j].Name
+		}
+		return entities[i].StartLine < entities[j].StartLine
+	})
+	return entities
+}
+
+func yamlTopLevelBlocks(lines []string) []yamlBlock {
+	var blocks []yamlBlock
+	for index, line := range lines {
+		if yamlIndent(line) != 0 || yamlIgnoreLine(line) {
+			continue
+		}
+		key, ok := yamlLineKey(line)
+		if !ok {
+			continue
+		}
+		if len(blocks) > 0 {
+			blocks[len(blocks)-1].EndLine = index
+		}
+		blocks = append(blocks, yamlBlock{Key: key, StartLine: index + 1, EndLine: len(lines)})
+	}
+	return blocks
+}
+
+func yamlJobEntities(jobs yamlBlock, lines []string) []Entity {
+	jobIndent := yamlDirectChildIndent(jobs, lines)
+	if jobIndent < 0 {
+		return nil
+	}
+
+	var blocks []yamlBlock
+	for index := jobs.StartLine; index < jobs.EndLine && index < len(lines); index++ {
+		line := lines[index]
+		if yamlIndent(line) != jobIndent || yamlIgnoreLine(line) {
+			continue
+		}
+		key, ok := yamlLineKey(line)
+		if !ok {
+			continue
+		}
+		if len(blocks) > 0 {
+			blocks[len(blocks)-1].EndLine = index
+		}
+		blocks = append(blocks, yamlBlock{Key: key, StartLine: index + 1, EndLine: jobs.EndLine})
+	}
+
+	entities := make([]Entity, 0, len(blocks))
+	for _, block := range blocks {
+		name := "jobs." + block.Key
+		entities = append(entities, yamlEntity("job", name, "job "+name, block.StartLine, block.EndLine, lines))
+	}
+	return entities
+}
+
+func yamlDirectChildIndent(parent yamlBlock, lines []string) int {
+	parentIndent := yamlIndent(lines[parent.StartLine-1])
+	childIndent := -1
+	for index := parent.StartLine; index < parent.EndLine && index < len(lines); index++ {
+		line := lines[index]
+		if yamlIgnoreLine(line) {
+			continue
+		}
+		indent := yamlIndent(line)
+		if indent <= parentIndent {
+			continue
+		}
+		if _, ok := yamlLineKey(line); !ok {
+			continue
+		}
+		if childIndent < 0 || indent < childIndent {
+			childIndent = indent
+		}
+	}
+	return childIndent
+}
+
+func yamlEntity(kind, name, signature string, startLine, endLine int, lines []string) Entity {
+	if startLine < 1 {
+		startLine = 1
+	}
+	if endLine < startLine {
+		endLine = startLine
+	}
+	if endLine > len(lines) {
+		endLine = len(lines)
+	}
+	block := strings.Join(lines[startLine-1:endLine], "\n")
+	return Entity{
+		Kind:        kind,
+		Name:        name,
+		Signature:   normalize(signature),
+		StartLine:   startLine,
+		EndLine:     endLine,
+		BodyHash:    hash(normalize(block)),
+		Fingerprint: hash(normalize(entityFingerprintSource(Entity{Name: name, Signature: signature}, block))),
+	}
+}
+
+func yamlWorkflowEntityName(path string) string {
+	base := filepath.Base(path)
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
+	if name == "" || name == "." {
+		return "workflow"
+	}
+	return name
+}
+
+func yamlWorkflowSignature(path string, lines []string, topLevel []yamlBlock) string {
+	name := yamlTopLevelScalar("name", lines, topLevel)
+	if name == "" {
+		name = yamlWorkflowEntityName(path)
+	}
+	return "workflow " + name
+}
+
+func yamlTopLevelScalar(key string, lines []string, blocks []yamlBlock) string {
+	for _, block := range blocks {
+		if block.Key != key || block.StartLine < 1 || block.StartLine > len(lines) {
+			continue
+		}
+		return yamlLineValue(lines[block.StartLine-1])
+	}
+	return ""
+}
+
+func yamlLineKey(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if yamlIgnoreTrimmedLine(trimmed) || strings.HasPrefix(trimmed, "- ") {
+		return "", false
+	}
+	colon := yamlKeyColonIndex(trimmed)
+	if colon <= 0 {
+		return "", false
+	}
+	key := strings.TrimSpace(trimmed[:colon])
+	if key == "" || strings.HasPrefix(key, "{") || strings.HasPrefix(key, "[") {
+		return "", false
+	}
+	return yamlUnquote(key), true
+}
+
+func yamlLineValue(line string) string {
+	trimmed := strings.TrimSpace(line)
+	colon := yamlKeyColonIndex(trimmed)
+	if colon < 0 || colon+1 >= len(trimmed) {
+		return ""
+	}
+	return yamlUnquote(strings.TrimSpace(yamlStripInlineComment(trimmed[colon+1:])))
+}
+
+func yamlKeyColonIndex(value string) int {
+	var quote rune
+	escaped := false
+	for index, char := range value {
+		if quote != 0 {
+			if quote == '"' && char == '\\' && !escaped {
+				escaped = true
+				continue
+			}
+			if char == quote && !escaped {
+				quote = 0
+			}
+			escaped = false
+			continue
+		}
+		switch char {
+		case '\'', '"':
+			quote = char
+		case ':':
+			return index
+		}
+	}
+	return -1
+}
+
+func yamlStripInlineComment(value string) string {
+	var quote rune
+	escaped := false
+	for index, char := range value {
+		if quote != 0 {
+			if quote == '"' && char == '\\' && !escaped {
+				escaped = true
+				continue
+			}
+			if char == quote && !escaped {
+				quote = 0
+			}
+			escaped = false
+			continue
+		}
+		switch char {
+		case '\'', '"':
+			quote = char
+		case '#':
+			if index == 0 || unicode.IsSpace(rune(value[index-1])) {
+				return strings.TrimSpace(value[:index])
+			}
+		}
+	}
+	return strings.TrimSpace(value)
+}
+
+func yamlUnquote(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) >= 2 {
+		first := value[0]
+		last := value[len(value)-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			return value[1 : len(value)-1]
+		}
+	}
+	return value
+}
+
+func yamlIndent(line string) int {
+	count := 0
+	for _, char := range line {
+		switch char {
+		case ' ':
+			count++
+		case '\t':
+			count += 2
+		default:
+			return count
+		}
+	}
+	return count
+}
+
+func yamlIgnoreLine(line string) bool {
+	return yamlIgnoreTrimmedLine(strings.TrimSpace(line))
+}
+
+func yamlIgnoreTrimmedLine(line string) bool {
+	return line == "" || strings.HasPrefix(line, "#") || line == "---" || line == "..."
+}


### PR DESCRIPTION
## Summary
- add .yml/.yaml parsing support using the existing go-tree-sitter YAML grammar
- extract YAML workflow, top-level section, and GitHub Actions jobs.<id> entities so Actions workflows are included in semantic output/brain input
- update README wording and supported language list for YAML
- add parser and git-range regression coverage for .github/workflows/ci.yml

## Verification
- go test ./...
- go run ./cmd/entire-sem capabilities --json shows .yaml/.yml and YAML

## Notes
This is the standalone entire-sem repo, not entire-adapter.