### PR TITLE
Add ignore file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ entire sem capabilities --json
 entire sem snapshot --repo . --format ndjson
 entire sem symbols --repo . --format ndjson
 entire sem edges --repo . --format ndjson
+entire sem snapshot --repo . --format ndjson --worktree --ignore-file .brainignore
 ```
 
 ## Status
@@ -140,7 +141,10 @@ symbol, and relation records. `symbols` and `edges` are filtered views over the
 same snapshot builder. By default, snapshots read the committed `HEAD` tree when
 git metadata is available, so dirty tracked edits and untracked files are excluded.
 Use `--worktree` to include live working-tree contents, and `--no-network` to make
-the provider's no-egress contract explicit to callers.
+the provider's no-egress contract explicit to callers. Worktree snapshots honor
+the repository root `.gitignore`. Pass repeatable `--ignore-file <path>` flags for
+additional gitignore-style exclusions, resolved relative to `--repo` unless the
+path is absolute.
 
 Run without installing through Entire:
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ entire sem snapshot --repo . --format ndjson
 entire sem symbols --repo . --format ndjson
 entire sem edges --repo . --format ndjson
 entire sem snapshot --repo . --format ndjson --worktree --ignore-file .brainignore
+entire sem snapshot --repo . --format ndjson --worktree --include-file .seminclude
 ```
 
 ## Status
@@ -144,7 +145,9 @@ Use `--worktree` to include live working-tree contents, and `--no-network` to ma
 the provider's no-egress contract explicit to callers. Worktree snapshots honor
 the repository root `.gitignore`. Pass repeatable `--ignore-file <path>` flags for
 additional gitignore-style exclusions, resolved relative to `--repo` unless the
-path is absolute.
+path is absolute. Pass repeatable `--include-file <path>` flags for gitignore-style
+inclusion rules that are applied after `.gitignore` and `--ignore-file`, allowing
+callers to reopen otherwise ignored paths.
 
 Run without installing through Entire:
 

--- a/docs/semantic_provider_requirements.md
+++ b/docs/semantic_provider_requirements.md
@@ -51,6 +51,7 @@ entire sem capabilities --json
 entire sem snapshot --repo . --format ndjson
 entire sem symbols --repo . --format ndjson
 entire sem edges --repo . --format ndjson
+entire sem snapshot --repo . --format ndjson --worktree --ignore-file .brainignore
 entire sem diff --base main --head HEAD --json
 ```
 
@@ -58,6 +59,12 @@ Whole-repo outputs should support newline-delimited JSON. Large repositories can
 produce hundreds of megabytes of semantic facts, so a single whole-repo JSON
 document should be treated as a debug/compatibility mode rather than the primary
 integration format.
+
+Worktree provider snapshots should honor the repository root `.gitignore` before
+walking or reading files. Callers may pass repeatable `--ignore-file <path>`
+flags for additional gitignore-style exclusions such as `.brainignore`; relative
+ignore-file paths resolve against `--repo`, and missing ignore files should fail
+closed with a clear error.
 
 ## Schema Contract
 

--- a/docs/semantic_provider_requirements.md
+++ b/docs/semantic_provider_requirements.md
@@ -52,6 +52,7 @@ entire sem snapshot --repo . --format ndjson
 entire sem symbols --repo . --format ndjson
 entire sem edges --repo . --format ndjson
 entire sem snapshot --repo . --format ndjson --worktree --ignore-file .brainignore
+entire sem snapshot --repo . --format ndjson --worktree --include-file .seminclude
 entire sem diff --base main --head HEAD --json
 ```
 
@@ -64,7 +65,10 @@ Worktree provider snapshots should honor the repository root `.gitignore` before
 walking or reading files. Callers may pass repeatable `--ignore-file <path>`
 flags for additional gitignore-style exclusions such as `.brainignore`; relative
 ignore-file paths resolve against `--repo`, and missing ignore files should fail
-closed with a clear error.
+closed with a clear error. Callers may also pass repeatable `--include-file
+<path>` flags containing gitignore-style inclusion rules. Include files are
+applied after `.gitignore` and `--ignore-file`, so they can reopen otherwise
+ignored paths.
 
 ## Schema Contract
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -92,9 +92,9 @@ Usage:
   entire sem doctor [--json]
   entire sem version [--json]
   entire sem capabilities --json
-  entire sem snapshot --repo . --format ndjson [--worktree] [--ignore-file path]
-  entire sem symbols --repo . --format ndjson [--worktree] [--ignore-file path]
-  entire sem edges --repo . --format ndjson [--worktree] [--ignore-file path]`)
+  entire sem snapshot --repo . --format ndjson [--worktree] [--ignore-file path] [--include-file path]
+  entire sem symbols --repo . --format ndjson [--worktree] [--ignore-file path] [--include-file path]
+  entire sem edges --repo . --format ndjson [--worktree] [--ignore-file path] [--include-file path]`)
 }
 
 func runDoctor(ctx context.Context, opts Options, args []string) error {
@@ -190,9 +190,10 @@ func runProviderRecords(ctx context.Context, opts Options, args []string, mode s
 		return err
 	}
 	snapshot, err := sem.BuildProviderSnapshotWithOptions(ctx, repo, opts.Version, sem.ProviderSnapshotOptions{
-		NoNetwork:   flags.NoNetwork,
-		Worktree:    flags.Worktree,
-		IgnoreFiles: flags.IgnoreFiles,
+		NoNetwork:    flags.NoNetwork,
+		Worktree:     flags.Worktree,
+		IgnoreFiles:  flags.IgnoreFiles,
+		IncludeFiles: flags.IncludeFiles,
 	})
 	if err != nil {
 		return err
@@ -215,11 +216,12 @@ type commonFlags struct {
 }
 
 type providerFlags struct {
-	Repo        string
-	Format      string
-	NoNetwork   bool
-	Worktree    bool
-	IgnoreFiles []string
+	Repo         string
+	Format       string
+	NoNetwork    bool
+	Worktree     bool
+	IgnoreFiles  []string
+	IncludeFiles []string
 }
 
 func parseProviderFlags(args []string) (providerFlags, []string, error) {
@@ -249,6 +251,12 @@ func parseProviderFlags(args []string) (providerFlags, []string, error) {
 				return flags, nil, errors.New("--ignore-file requires a value")
 			}
 			flags.IgnoreFiles = append(flags.IgnoreFiles, args[i])
+		case "--include-file":
+			i++
+			if i >= len(args) {
+				return flags, nil, errors.New("--include-file requires a value")
+			}
+			flags.IncludeFiles = append(flags.IncludeFiles, args[i])
 		default:
 			rest = append(rest, args[i])
 		}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -92,9 +92,9 @@ Usage:
   entire sem doctor [--json]
   entire sem version [--json]
   entire sem capabilities --json
-  entire sem snapshot --repo . --format ndjson
-  entire sem symbols --repo . --format ndjson
-  entire sem edges --repo . --format ndjson`)
+  entire sem snapshot --repo . --format ndjson [--worktree] [--ignore-file path]
+  entire sem symbols --repo . --format ndjson [--worktree] [--ignore-file path]
+  entire sem edges --repo . --format ndjson [--worktree] [--ignore-file path]`)
 }
 
 func runDoctor(ctx context.Context, opts Options, args []string) error {
@@ -190,8 +190,9 @@ func runProviderRecords(ctx context.Context, opts Options, args []string, mode s
 		return err
 	}
 	snapshot, err := sem.BuildProviderSnapshotWithOptions(ctx, repo, opts.Version, sem.ProviderSnapshotOptions{
-		NoNetwork: flags.NoNetwork,
-		Worktree:  flags.Worktree,
+		NoNetwork:   flags.NoNetwork,
+		Worktree:    flags.Worktree,
+		IgnoreFiles: flags.IgnoreFiles,
 	})
 	if err != nil {
 		return err
@@ -214,10 +215,11 @@ type commonFlags struct {
 }
 
 type providerFlags struct {
-	Repo      string
-	Format    string
-	NoNetwork bool
-	Worktree  bool
+	Repo        string
+	Format      string
+	NoNetwork   bool
+	Worktree    bool
+	IgnoreFiles []string
 }
 
 func parseProviderFlags(args []string) (providerFlags, []string, error) {
@@ -241,6 +243,12 @@ func parseProviderFlags(args []string) (providerFlags, []string, error) {
 			flags.NoNetwork = true
 		case "--worktree":
 			flags.Worktree = true
+		case "--ignore-file":
+			i++
+			if i >= len(args) {
+				return flags, nil, errors.New("--ignore-file requires a value")
+			}
+			flags.IgnoreFiles = append(flags.IgnoreFiles, args[i])
 		default:
 			rest = append(rest, args[i])
 		}

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -205,6 +205,33 @@ func TestSnapshotAcceptsWorktree(t *testing.T) {
 	}
 }
 
+func TestProviderCommandsAcceptIgnoreFile(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, ".brainignore", "ignored/\n")
+	write(t, repo, "ignored/ignored.py", "def ignored():\n    return True\n")
+	write(t, repo, "keep.py", "def keep():\n    return True\n")
+
+	for _, command := range []string{"snapshot", "symbols", "edges"} {
+		var out bytes.Buffer
+		err := Run(t.Context(), Options{Version: "0.1.0", Env: EntireEnv{RepoRoot: repo}, Stdout: &out}, []string{
+			command,
+			"--repo", repo,
+			"--format", "ndjson",
+			"--worktree",
+			"--ignore-file", ".brainignore",
+		})
+		if err != nil {
+			t.Fatalf("%s: %v", command, err)
+		}
+		if !strings.Contains(out.String(), `"schema_version":"1.0"`) {
+			t.Fatalf("%s output missing header:\n%s", command, out.String())
+		}
+		if strings.Contains(out.String(), "ignored.py") || strings.Contains(out.String(), "ignored") {
+			t.Fatalf("%s output included ignored path:\n%s", command, out.String())
+		}
+	}
+}
+
 func TestAnalyzeJSONCommand(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -232,6 +232,35 @@ func TestProviderCommandsAcceptIgnoreFile(t *testing.T) {
 	}
 }
 
+func TestProviderCommandsAcceptIncludeFile(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, ".gitignore", "ignored/\n")
+	write(t, repo, ".seminclude", "ignored/\n")
+	write(t, repo, "ignored/reopened.py", `def reopened():
+    return True
+`)
+
+	for _, command := range []string{"snapshot", "symbols", "edges"} {
+		var out bytes.Buffer
+		err := Run(t.Context(), Options{Version: "0.1.0", Env: EntireEnv{RepoRoot: repo}, Stdout: &out}, []string{
+			command,
+			"--repo", repo,
+			"--format", "ndjson",
+			"--worktree",
+			"--include-file", ".seminclude",
+		})
+		if err != nil {
+			t.Fatalf("%s: %v", command, err)
+		}
+		if !strings.Contains(out.String(), `"schema_version":"1.0"`) {
+			t.Fatalf("%s output missing header:\n%s", command, out.String())
+		}
+		if !strings.Contains(out.String(), "reopened") {
+			t.Fatalf("%s output did not include reopened file:\n%s", command, out.String())
+		}
+	}
+}
+
 func TestAnalyzeJSONCommand(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -223,7 +223,7 @@ func TestProviderCommandsAcceptIgnoreFile(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", command, err)
 		}
-		if !strings.Contains(out.String(), `"schema_version":"1.0"`) {
+		if !strings.Contains(out.String(), `"schema_version":"1.1"`) {
 			t.Fatalf("%s output missing header:\n%s", command, out.String())
 		}
 		if strings.Contains(out.String(), "ignored.py") || strings.Contains(out.String(), "ignored") {
@@ -252,7 +252,7 @@ func TestProviderCommandsAcceptIncludeFile(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", command, err)
 		}
-		if !strings.Contains(out.String(), `"schema_version":"1.0"`) {
+		if !strings.Contains(out.String(), `"schema_version":"1.1"`) {
 			t.Fatalf("%s output missing header:\n%s", command, out.String())
 		}
 		if !strings.Contains(out.String(), "reopened") {

--- a/internal/sem/ignore.go
+++ b/internal/sem/ignore.go
@@ -16,15 +16,25 @@ type ignoreMatcher struct {
 }
 
 type ignoreRule struct {
-	negated      bool
+	ignore       bool
+	includeFile  bool
 	directory    bool
 	basenameOnly bool
+	pattern      string
 	expression   *regexp.Regexp
 }
 
-func loadWorktreeIgnoreMatcher(repo string, ignoreFiles []string) (ignoreMatcher, error) {
+type ignoreMatchKind int
+
+const (
+	ignoreNoMatch ignoreMatchKind = iota
+	ignoreAncestorMatch
+	ignoreSelfMatch
+)
+
+func loadWorktreeIgnoreMatcher(repo string, ignoreFiles, includeFiles []string) (ignoreMatcher, error) {
 	var matcher ignoreMatcher
-	if err := matcher.loadOptional(filepath.Join(repo, ".gitignore")); err != nil {
+	if err := matcher.loadOptional(filepath.Join(repo, ".gitignore"), false); err != nil {
 		return ignoreMatcher{}, err
 	}
 	for _, ignoreFile := range ignoreFiles {
@@ -32,60 +42,79 @@ func loadWorktreeIgnoreMatcher(repo string, ignoreFiles []string) (ignoreMatcher
 		if !filepath.IsAbs(resolved) {
 			resolved = filepath.Join(repo, resolved)
 		}
-		if err := matcher.loadRequired(resolved); err != nil {
+		if err := matcher.loadRequired(resolved, false); err != nil {
+			return ignoreMatcher{}, err
+		}
+	}
+	for _, includeFile := range includeFiles {
+		resolved := includeFile
+		if !filepath.IsAbs(resolved) {
+			resolved = filepath.Join(repo, resolved)
+		}
+		if err := matcher.loadRequired(resolved, true); err != nil {
 			return ignoreMatcher{}, err
 		}
 	}
 	return matcher, nil
 }
 
-func (m *ignoreMatcher) loadOptional(file string) error {
+func (m *ignoreMatcher) loadOptional(file string, includeMode bool) error {
+	label := ignoreFileLabel(includeMode)
 	info, err := os.Stat(file)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("read ignore file %q: %w", file, err)
+		return fmt.Errorf("read %s %q: %w", label, file, err)
 	}
 	if !info.Mode().IsRegular() {
-		return fmt.Errorf("ignore file %q is not a regular file", file)
+		return fmt.Errorf("%s %q is not a regular file", label, file)
 	}
-	return m.loadFile(file)
+	return m.loadFile(file, includeMode)
 }
 
-func (m *ignoreMatcher) loadRequired(file string) error {
+func (m *ignoreMatcher) loadRequired(file string, includeMode bool) error {
+	label := ignoreFileLabel(includeMode)
 	info, err := os.Stat(file)
 	if errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("ignore file %q does not exist", file)
+		return fmt.Errorf("%s %q does not exist", label, file)
 	}
 	if err != nil {
-		return fmt.Errorf("read ignore file %q: %w", file, err)
+		return fmt.Errorf("read %s %q: %w", label, file, err)
 	}
 	if !info.Mode().IsRegular() {
-		return fmt.Errorf("ignore file %q is not a regular file", file)
+		return fmt.Errorf("%s %q is not a regular file", label, file)
 	}
-	return m.loadFile(file)
+	return m.loadFile(file, includeMode)
 }
 
-func (m *ignoreMatcher) loadFile(file string) error {
+func (m *ignoreMatcher) loadFile(file string, includeMode bool) error {
+	label := ignoreFileLabel(includeMode)
 	content, err := os.ReadFile(file)
 	if err != nil {
-		return fmt.Errorf("read ignore file %q: %w", file, err)
+		return fmt.Errorf("read %s %q: %w", label, file, err)
 	}
 	scanner := bufio.NewScanner(strings.NewReader(string(content)))
 	for scanner.Scan() {
-		rule, ok := parseIgnoreRule(scanner.Text())
+		rule, ok := parseIgnoreRule(scanner.Text(), includeMode)
 		if ok {
 			m.rules = append(m.rules, rule)
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("read ignore file %q: %w", file, err)
+		return fmt.Errorf("read %s %q: %w", label, file, err)
 	}
 	return nil
 }
 
-func parseIgnoreRule(line string) (ignoreRule, bool) {
+func ignoreFileLabel(includeMode bool) string {
+	if includeMode {
+		return "include file"
+	}
+	return "ignore file"
+}
+
+func parseIgnoreRule(line string, includeMode bool) (ignoreRule, bool) {
 	line = strings.TrimRight(line, "\r")
 	line = strings.TrimSpace(line)
 	if line == "" || strings.HasPrefix(line, "#") {
@@ -114,10 +143,16 @@ func parseIgnoreRule(line string) (ignoreRule, bool) {
 	}
 
 	basenameOnly := !anchored && !strings.Contains(line, "/")
+	ignore := !negated
+	if includeMode {
+		ignore = negated
+	}
 	return ignoreRule{
-		negated:      negated,
+		ignore:       ignore,
+		includeFile:  includeMode,
 		directory:    directory,
 		basenameOnly: basenameOnly,
+		pattern:      line,
 		expression:   regexp.MustCompile(globPatternExpression(line)),
 	}, true
 }
@@ -127,23 +162,50 @@ func (m ignoreMatcher) Ignored(rel string, isDir bool) bool {
 	if rel == "" {
 		return false
 	}
-	ignored := false
+	selfMatched := false
+	selfIgnored := false
+	ancestorMatched := false
+	ancestorIgnored := false
 	for _, rule := range m.rules {
-		if rule.matches(rel, isDir) {
-			ignored = !rule.negated
+		switch rule.matchKind(rel, isDir) {
+		case ignoreSelfMatch:
+			selfMatched = true
+			selfIgnored = rule.ignore
+		case ignoreAncestorMatch:
+			ancestorMatched = true
+			ancestorIgnored = rule.ignore
 		}
 	}
-	return ignored
-}
-
-func (r ignoreRule) matches(rel string, isDir bool) bool {
-	if r.basenameOnly {
-		return r.matchesBasename(rel, isDir)
+	if selfMatched {
+		return selfIgnored
 	}
-	return r.matchesPath(rel, isDir)
+	if ancestorMatched {
+		return ancestorIgnored
+	}
+	return false
 }
 
-func (r ignoreRule) matchesBasename(rel string, isDir bool) bool {
+func (m ignoreMatcher) MayIncludeDescendant(rel string) bool {
+	rel = cleanIgnorePath(rel)
+	if rel == "" {
+		return false
+	}
+	for _, rule := range m.rules {
+		if rule.includeFile && !rule.ignore && rule.mayMatchDescendant(rel) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r ignoreRule) matchKind(rel string, isDir bool) ignoreMatchKind {
+	if r.basenameOnly {
+		return r.matchBasename(rel, isDir)
+	}
+	return r.matchPath(rel, isDir)
+}
+
+func (r ignoreRule) matchBasename(rel string, isDir bool) ignoreMatchKind {
 	segments := strings.Split(rel, "/")
 	last := len(segments) - 1
 	if r.directory {
@@ -152,32 +214,49 @@ func (r ignoreRule) matchesBasename(rel string, isDir bool) bool {
 				continue
 			}
 			if r.expression.MatchString(segment) {
-				return true
+				if i == last {
+					return ignoreSelfMatch
+				}
+				return ignoreAncestorMatch
 			}
 		}
-		return false
+		return ignoreNoMatch
 	}
-	for _, segment := range segments {
+	for i, segment := range segments {
 		if r.expression.MatchString(segment) {
-			return true
+			if i == last {
+				return ignoreSelfMatch
+			}
+			return ignoreAncestorMatch
 		}
 	}
-	return false
+	return ignoreNoMatch
 }
 
-func (r ignoreRule) matchesPath(rel string, isDir bool) bool {
+func (r ignoreRule) matchPath(rel string, isDir bool) ignoreMatchKind {
 	if !r.directory && r.expression.MatchString(rel) {
-		return true
+		return ignoreSelfMatch
 	}
 	if r.directory && isDir && r.expression.MatchString(rel) {
-		return true
+		return ignoreSelfMatch
 	}
 	for _, ancestor := range ancestorPaths(rel) {
 		if r.expression.MatchString(ancestor) {
-			return true
+			return ignoreAncestorMatch
 		}
 	}
-	return false
+	return ignoreNoMatch
+}
+
+func (r ignoreRule) mayMatchDescendant(rel string) bool {
+	if r.basenameOnly {
+		return true
+	}
+	prefix := literalPatternPrefix(r.pattern)
+	if prefix == "" {
+		return true
+	}
+	return prefix == rel || strings.HasPrefix(prefix, rel+"/") || strings.HasPrefix(rel, prefix+"/")
 }
 
 func ancestorPaths(rel string) []string {
@@ -200,6 +279,14 @@ func cleanIgnorePath(value string) string {
 		return ""
 	}
 	return strings.TrimPrefix(cleaned, "/")
+}
+
+func literalPatternPrefix(pattern string) string {
+	index := strings.IndexAny(pattern, "*?[")
+	if index >= 0 {
+		pattern = pattern[:index]
+	}
+	return strings.Trim(strings.TrimRight(cleanIgnorePath(pattern), "/"), "/")
 }
 
 func globPatternExpression(pattern string) string {

--- a/internal/sem/ignore.go
+++ b/internal/sem/ignore.go
@@ -1,0 +1,233 @@
+package sem
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+type ignoreMatcher struct {
+	rules []ignoreRule
+}
+
+type ignoreRule struct {
+	negated      bool
+	directory    bool
+	basenameOnly bool
+	expression   *regexp.Regexp
+}
+
+func loadWorktreeIgnoreMatcher(repo string, ignoreFiles []string) (ignoreMatcher, error) {
+	var matcher ignoreMatcher
+	if err := matcher.loadOptional(filepath.Join(repo, ".gitignore")); err != nil {
+		return ignoreMatcher{}, err
+	}
+	for _, ignoreFile := range ignoreFiles {
+		resolved := ignoreFile
+		if !filepath.IsAbs(resolved) {
+			resolved = filepath.Join(repo, resolved)
+		}
+		if err := matcher.loadRequired(resolved); err != nil {
+			return ignoreMatcher{}, err
+		}
+	}
+	return matcher, nil
+}
+
+func (m *ignoreMatcher) loadOptional(file string) error {
+	info, err := os.Stat(file)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read ignore file %q: %w", file, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("ignore file %q is not a regular file", file)
+	}
+	return m.loadFile(file)
+}
+
+func (m *ignoreMatcher) loadRequired(file string) error {
+	info, err := os.Stat(file)
+	if errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("ignore file %q does not exist", file)
+	}
+	if err != nil {
+		return fmt.Errorf("read ignore file %q: %w", file, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("ignore file %q is not a regular file", file)
+	}
+	return m.loadFile(file)
+}
+
+func (m *ignoreMatcher) loadFile(file string) error {
+	content, err := os.ReadFile(file)
+	if err != nil {
+		return fmt.Errorf("read ignore file %q: %w", file, err)
+	}
+	scanner := bufio.NewScanner(strings.NewReader(string(content)))
+	for scanner.Scan() {
+		rule, ok := parseIgnoreRule(scanner.Text())
+		if ok {
+			m.rules = append(m.rules, rule)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("read ignore file %q: %w", file, err)
+	}
+	return nil
+}
+
+func parseIgnoreRule(line string) (ignoreRule, bool) {
+	line = strings.TrimRight(line, "\r")
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return ignoreRule{}, false
+	}
+	if strings.HasPrefix(line, `\#`) {
+		line = line[1:]
+	}
+	negated := false
+	if strings.HasPrefix(line, "!") {
+		negated = true
+		line = strings.TrimSpace(line[1:])
+		if line == "" {
+			return ignoreRule{}, false
+		}
+	}
+	line = filepath.ToSlash(line)
+	line = strings.TrimPrefix(line, "./")
+	anchored := strings.HasPrefix(line, "/")
+	line = strings.TrimLeft(line, "/")
+	directory := strings.HasSuffix(line, "/")
+	line = strings.TrimRight(line, "/")
+	line = cleanIgnorePath(line)
+	if line == "" {
+		return ignoreRule{}, false
+	}
+
+	basenameOnly := !anchored && !strings.Contains(line, "/")
+	return ignoreRule{
+		negated:      negated,
+		directory:    directory,
+		basenameOnly: basenameOnly,
+		expression:   regexp.MustCompile(globPatternExpression(line)),
+	}, true
+}
+
+func (m ignoreMatcher) Ignored(rel string, isDir bool) bool {
+	rel = cleanIgnorePath(rel)
+	if rel == "" {
+		return false
+	}
+	ignored := false
+	for _, rule := range m.rules {
+		if rule.matches(rel, isDir) {
+			ignored = !rule.negated
+		}
+	}
+	return ignored
+}
+
+func (r ignoreRule) matches(rel string, isDir bool) bool {
+	if r.basenameOnly {
+		return r.matchesBasename(rel, isDir)
+	}
+	return r.matchesPath(rel, isDir)
+}
+
+func (r ignoreRule) matchesBasename(rel string, isDir bool) bool {
+	segments := strings.Split(rel, "/")
+	last := len(segments) - 1
+	if r.directory {
+		for i, segment := range segments {
+			if i == last && !isDir {
+				continue
+			}
+			if r.expression.MatchString(segment) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, segment := range segments {
+		if r.expression.MatchString(segment) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r ignoreRule) matchesPath(rel string, isDir bool) bool {
+	if !r.directory && r.expression.MatchString(rel) {
+		return true
+	}
+	if r.directory && isDir && r.expression.MatchString(rel) {
+		return true
+	}
+	for _, ancestor := range ancestorPaths(rel) {
+		if r.expression.MatchString(ancestor) {
+			return true
+		}
+	}
+	return false
+}
+
+func ancestorPaths(rel string) []string {
+	parts := strings.Split(rel, "/")
+	if len(parts) <= 1 {
+		return nil
+	}
+	out := make([]string, 0, len(parts)-1)
+	for i := 1; i < len(parts); i++ {
+		out = append(out, strings.Join(parts[:i], "/"))
+	}
+	return out
+}
+
+func cleanIgnorePath(value string) string {
+	value = filepath.ToSlash(value)
+	value = strings.TrimPrefix(value, "./")
+	cleaned := path.Clean(value)
+	if cleaned == "." {
+		return ""
+	}
+	return strings.TrimPrefix(cleaned, "/")
+}
+
+func globPatternExpression(pattern string) string {
+	var out strings.Builder
+	out.WriteString("^")
+	for i := 0; i < len(pattern); {
+		switch pattern[i] {
+		case '*':
+			if i+1 < len(pattern) && pattern[i+1] == '*' {
+				if i+2 < len(pattern) && pattern[i+2] == '/' {
+					out.WriteString("(?:.*/)?")
+					i += 3
+					continue
+				}
+				out.WriteString(".*")
+				i += 2
+				continue
+			}
+			out.WriteString(`[^/]*`)
+			i++
+		case '?':
+			out.WriteString(`[^/]`)
+			i++
+		default:
+			out.WriteString(regexp.QuoteMeta(string(pattern[i])))
+			i++
+		}
+	}
+	out.WriteString("$")
+	return out.String()
+}

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -152,8 +152,9 @@ type ProviderSnapshot struct {
 }
 
 type ProviderSnapshotOptions struct {
-	NoNetwork bool
-	Worktree  bool
+	NoNetwork   bool
+	Worktree    bool
+	IgnoreFiles []string
 }
 
 func Capabilities() CapabilityReport {
@@ -214,7 +215,7 @@ func BuildProviderSnapshotWithOptions(ctx context.Context, repo, providerVersion
 	// explicit for callers that enforce no-egress provider execution.
 	_ = options.NoNetwork
 	useHead := !options.Worktree && commitErr == nil && treeErr == nil
-	paths, contentByFile, err := snapshotSource(ctx, absRepo, useHead)
+	paths, contentByFile, err := snapshotSource(ctx, absRepo, useHead, options.IgnoreFiles)
 	if err != nil {
 		return ProviderSnapshot{}, err
 	}
@@ -787,7 +788,7 @@ func externalParts(id string) (string, string) {
 	return kind, value
 }
 
-func snapshotSource(ctx context.Context, repo string, useHead bool) ([]string, map[string]string, error) {
+func snapshotSource(ctx context.Context, repo string, useHead bool, ignoreFiles []string) ([]string, map[string]string, error) {
 	if useHead {
 		paths, err := gitutil.ListFiles(ctx, repo, "HEAD")
 		if err != nil {
@@ -808,7 +809,11 @@ func snapshotSource(ctx context.Context, repo string, useHead bool) ([]string, m
 		}
 		return paths, contentByFile, nil
 	}
-	paths, err := workingTreeFiles(repo)
+	ignores, err := loadWorktreeIgnoreMatcher(repo, ignoreFiles)
+	if err != nil {
+		return nil, nil, err
+	}
+	paths, err := workingTreeFiles(repo, ignores)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -831,7 +836,7 @@ func snapshotSource(ctx context.Context, repo string, useHead bool) ([]string, m
 	return paths, contentByFile, nil
 }
 
-func workingTreeFiles(repo string) ([]string, error) {
+func workingTreeFiles(repo string, ignores ignoreMatcher) ([]string, error) {
 	var paths []string
 	err := filepath.WalkDir(repo, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil {
@@ -843,6 +848,15 @@ func workingTreeFiles(repo string) ([]string, error) {
 			case ".git", "node_modules", "vendor", ".next", "dist", "build":
 				return filepath.SkipDir
 			}
+			if path != repo {
+				rel, err := filepath.Rel(repo, path)
+				if err != nil {
+					return err
+				}
+				if ignores.Ignored(filepath.ToSlash(rel), true) {
+					return filepath.SkipDir
+				}
+			}
 			return nil
 		}
 		if entry.Type()&fs.ModeSymlink != 0 {
@@ -852,7 +866,11 @@ func workingTreeFiles(repo string) ([]string, error) {
 		if err != nil {
 			return err
 		}
-		paths = append(paths, filepath.ToSlash(rel))
+		rel = filepath.ToSlash(rel)
+		if ignores.Ignored(rel, false) {
+			return nil
+		}
+		paths = append(paths, rel)
 		return nil
 	})
 	sort.Strings(paths)

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -152,9 +152,10 @@ type ProviderSnapshot struct {
 }
 
 type ProviderSnapshotOptions struct {
-	NoNetwork   bool
-	Worktree    bool
-	IgnoreFiles []string
+	NoNetwork    bool
+	Worktree     bool
+	IgnoreFiles  []string
+	IncludeFiles []string
 }
 
 func Capabilities() CapabilityReport {
@@ -215,7 +216,7 @@ func BuildProviderSnapshotWithOptions(ctx context.Context, repo, providerVersion
 	// explicit for callers that enforce no-egress provider execution.
 	_ = options.NoNetwork
 	useHead := !options.Worktree && commitErr == nil && treeErr == nil
-	paths, contentByFile, err := snapshotSource(ctx, absRepo, useHead, options.IgnoreFiles)
+	paths, contentByFile, err := snapshotSource(ctx, absRepo, useHead, options.IgnoreFiles, options.IncludeFiles)
 	if err != nil {
 		return ProviderSnapshot{}, err
 	}
@@ -788,7 +789,7 @@ func externalParts(id string) (string, string) {
 	return kind, value
 }
 
-func snapshotSource(ctx context.Context, repo string, useHead bool, ignoreFiles []string) ([]string, map[string]string, error) {
+func snapshotSource(ctx context.Context, repo string, useHead bool, ignoreFiles, includeFiles []string) ([]string, map[string]string, error) {
 	if useHead {
 		paths, err := gitutil.ListFiles(ctx, repo, "HEAD")
 		if err != nil {
@@ -809,7 +810,7 @@ func snapshotSource(ctx context.Context, repo string, useHead bool, ignoreFiles 
 		}
 		return paths, contentByFile, nil
 	}
-	ignores, err := loadWorktreeIgnoreMatcher(repo, ignoreFiles)
+	ignores, err := loadWorktreeIgnoreMatcher(repo, ignoreFiles, includeFiles)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -853,7 +854,8 @@ func workingTreeFiles(repo string, ignores ignoreMatcher) ([]string, error) {
 				if err != nil {
 					return err
 				}
-				if ignores.Ignored(filepath.ToSlash(rel), true) {
+				rel = filepath.ToSlash(rel)
+				if ignores.Ignored(rel, true) && !ignores.MayIncludeDescendant(rel) {
 					return filepath.SkipDir
 				}
 			}

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -505,6 +505,143 @@ func TestBuildProviderSnapshotWorktreeIncludesDirtyFiles(t *testing.T) {
 	}
 }
 
+func TestBuildProviderSnapshotWorktreeHonorsRootGitignore(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, ".gitignore", "cache/\n")
+	writeFile(t, repo, "cache/ignored.py", "def ignored():\n    return True\n")
+	writeFile(t, repo, "src/keep.py", "def keep():\n    return True\n")
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{
+		Worktree: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !snapshotHasSymbol(snapshot, "keep") {
+		t.Fatalf("snapshot missing kept symbol: %#v", snapshot.Symbols)
+	}
+	assertSnapshotOmitsPathPrefix(t, snapshot, "cache/")
+	if snapshotHasSymbol(snapshot, "ignored") {
+		t.Fatalf("snapshot included ignored symbol: %#v", snapshot.Symbols)
+	}
+}
+
+func TestBuildProviderSnapshotWorktreeHonorsAdditionalIgnoreFile(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, ".brainignore", "generated/\n")
+	writeFile(t, repo, "generated/ignored.py", "def ignored():\n    return True\n")
+	writeFile(t, repo, "src/keep.py", "def keep():\n    return True\n")
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{
+		Worktree:    true,
+		IgnoreFiles: []string{".brainignore"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !snapshotHasSymbol(snapshot, "keep") {
+		t.Fatalf("snapshot missing kept symbol: %#v", snapshot.Symbols)
+	}
+	assertSnapshotOmitsPathPrefix(t, snapshot, "generated/")
+}
+
+func TestBuildProviderSnapshotWorktreeCombinesMultipleIgnoreFiles(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, ".brainignore", "cache/\n")
+	writeFile(t, repo, ".semignore", "# comments and blanks are ignored\n\n**/generated.py\nbenchmarks/agent-brain/results/\n")
+	writeFile(t, repo, "cache/cache.py", "def cache():\n    return True\n")
+	writeFile(t, repo, "src/generated.py", "def generated():\n    return True\n")
+	writeFile(t, repo, "benchmarks/agent-brain/results/result.py", "def result():\n    return True\n")
+	writeFile(t, repo, "src/keep.py", "def keep():\n    return True\n")
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{
+		Worktree:    true,
+		IgnoreFiles: []string{".brainignore", ".semignore"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !snapshotHasSymbol(snapshot, "keep") {
+		t.Fatalf("snapshot missing kept symbol: %#v", snapshot.Symbols)
+	}
+	for _, prefix := range []string{"cache/", "benchmarks/agent-brain/results/"} {
+		assertSnapshotOmitsPathPrefix(t, snapshot, prefix)
+	}
+	if snapshotHasPath(snapshot, "src/generated.py") {
+		t.Fatalf("snapshot included ignored recursive glob path: %#v", snapshot.Files)
+	}
+}
+
+func TestBuildProviderSnapshotIgnoredUnsupportedFilesDoNotProduceFailures(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, ".gitignore", "ignored/\n")
+	writeFile(t, repo, "ignored/Unsupported.dart", "class Ignored {}\n")
+	writeFile(t, repo, "Visible.dart", "class Visible {}\n")
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{
+		Worktree: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var sawVisibleFailure bool
+	for _, failure := range snapshot.Header.PartialFailures {
+		if failure.FilePath == "ignored/Unsupported.dart" {
+			t.Fatalf("ignored unsupported file produced a partial failure: %#v", snapshot.Header.PartialFailures)
+		}
+		if failure.FilePath == "Visible.dart" && failure.Code == "E_UNSUPPORTED_LANGUAGE" {
+			sawVisibleFailure = true
+		}
+	}
+	if !sawVisibleFailure {
+		t.Fatalf("visible unsupported file did not produce a partial failure: %#v", snapshot.Header.PartialFailures)
+	}
+}
+
+func TestBuildProviderSnapshotMissingIgnoreFileFailsClosed(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "auth.py", "def validate_token(token):\n    return bool(token)\n")
+
+	_, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{
+		Worktree:    true,
+		IgnoreFiles: []string{"does-not-exist"},
+	})
+	if err == nil {
+		t.Fatal("expected missing ignore file error")
+	}
+	if !strings.Contains(err.Error(), "ignore file") || !strings.Contains(err.Error(), "does-not-exist") {
+		t.Fatalf("missing ignore file error was not clear: %v", err)
+	}
+}
+
+func TestBuildProviderSnapshotHeadDoesNotReadLiveIgnoreFiles(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Sem Test")
+	git(t, repo, "config", "user.email", "sem@example.com")
+	writeFile(t, repo, "tracked.py", "def committed():\n    return True\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+
+	writeFile(t, repo, ".gitignore", "tracked.py\nignored/\n")
+	writeFile(t, repo, "ignored/worktree.py", "def worktree_only():\n    return True\n")
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !snapshotHasSymbol(snapshot, "committed") {
+		t.Fatalf("HEAD snapshot did not include committed tracked symbol: %#v", snapshot.Symbols)
+	}
+	if snapshotHasSymbol(snapshot, "worktree_only") {
+		t.Fatalf("HEAD snapshot included ignored untracked symbol: %#v", snapshot.Symbols)
+	}
+}
+
 func TestBuildProviderSnapshotWarnsWithoutGitHead(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, repo, "auth.py", "def validate_token(token):\n    return bool(token)\n")
@@ -618,6 +755,68 @@ func writeFile(t *testing.T, repo, path, content string) {
 	}
 	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func snapshotHasSymbol(snapshot ProviderSnapshot, qualifiedName string) bool {
+	for _, symbol := range snapshot.Symbols {
+		if symbol.QualifiedName == qualifiedName {
+			return true
+		}
+	}
+	return false
+}
+
+func snapshotHasPath(snapshot ProviderSnapshot, path string) bool {
+	for _, file := range snapshot.Files {
+		if file.Path == path {
+			return true
+		}
+	}
+	for _, symbol := range snapshot.Symbols {
+		if symbol.FilePath == path {
+			return true
+		}
+	}
+	for _, failure := range snapshot.Header.PartialFailures {
+		if failure.FilePath == path {
+			return true
+		}
+	}
+	for _, warning := range snapshot.Header.Warnings {
+		if warning.FilePath == path {
+			return true
+		}
+	}
+	return false
+}
+
+func assertSnapshotOmitsPathPrefix(t *testing.T, snapshot ProviderSnapshot, prefix string) {
+	t.Helper()
+	for _, file := range snapshot.Files {
+		if strings.HasPrefix(file.Path, prefix) {
+			t.Fatalf("snapshot included ignored file record: %#v", file)
+		}
+	}
+	for _, symbol := range snapshot.Symbols {
+		if strings.HasPrefix(symbol.FilePath, prefix) {
+			t.Fatalf("snapshot included ignored symbol record: %#v", symbol)
+		}
+	}
+	for _, failure := range snapshot.Header.PartialFailures {
+		if strings.HasPrefix(failure.FilePath, prefix) {
+			t.Fatalf("snapshot included ignored partial failure: %#v", failure)
+		}
+	}
+	for _, warning := range snapshot.Header.Warnings {
+		if strings.HasPrefix(warning.FilePath, prefix) {
+			t.Fatalf("snapshot included ignored warning: %#v", warning)
+		}
+	}
+	for _, relation := range snapshot.Relations {
+		if strings.Contains(relation.FromID, prefix) || strings.Contains(relation.ToID, prefix) {
+			t.Fatalf("snapshot included ignored relation: %#v", relation)
+		}
 	}
 }
 

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -575,6 +575,88 @@ func TestBuildProviderSnapshotWorktreeCombinesMultipleIgnoreFiles(t *testing.T) 
 	}
 }
 
+func TestBuildProviderSnapshotWorktreeIncludeFileReopensIgnoredDirectory(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, ".gitignore", "cache/\n")
+	writeFile(t, repo, ".seminclude", "cache/\n")
+	writeFile(t, repo, "cache/included.py", "def included():\n    return True\n")
+	writeFile(t, repo, "src/keep.py", "def keep():\n    return True\n")
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{
+		Worktree:     true,
+		IncludeFiles: []string{".seminclude"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !snapshotHasSymbol(snapshot, "included") {
+		t.Fatalf("snapshot did not include file from reopened directory: %#v", snapshot.Symbols)
+	}
+	if !snapshotHasSymbol(snapshot, "keep") {
+		t.Fatalf("snapshot missing kept symbol: %#v", snapshot.Symbols)
+	}
+}
+
+func TestBuildProviderSnapshotWorktreeIncludeFileWinsAfterIgnoreFile(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, ".brainignore", "generated/\n")
+	writeFile(t, repo, ".seminclude", "generated/\n")
+	writeFile(t, repo, "generated/included.py", "def included():\n    return True\n")
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{
+		Worktree:     true,
+		IgnoreFiles:  []string{".brainignore"},
+		IncludeFiles: []string{".seminclude"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !snapshotHasSymbol(snapshot, "included") {
+		t.Fatalf("snapshot did not include file from include-file override: %#v", snapshot.Symbols)
+	}
+}
+
+func TestBuildProviderSnapshotWorktreeIncludeDirectoryKeepsSpecificFileIgnore(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, ".gitignore", "cache/\ncache/skip.py\n")
+	writeFile(t, repo, ".seminclude", "cache/\n")
+	writeFile(t, repo, "cache/include.py", "def include_me():\n    return True\n")
+	writeFile(t, repo, "cache/skip.py", "def skip_me():\n    return True\n")
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{
+		Worktree:     true,
+		IncludeFiles: []string{".seminclude"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !snapshotHasSymbol(snapshot, "include_me") {
+		t.Fatalf("snapshot did not include file from reopened directory: %#v", snapshot.Symbols)
+	}
+	if snapshotHasPath(snapshot, "cache/skip.py") || snapshotHasSymbol(snapshot, "skip_me") {
+		t.Fatalf("snapshot included specifically ignored file: files=%#v symbols=%#v", snapshot.Files, snapshot.Symbols)
+	}
+}
+
+func TestBuildProviderSnapshotMissingIncludeFileFailsClosed(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "auth.py", "def validate_token(token):\n    return bool(token)\n")
+
+	_, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{
+		Worktree:     true,
+		IncludeFiles: []string{"does-not-exist"},
+	})
+	if err == nil {
+		t.Fatal("expected missing include file error")
+	}
+	if !strings.Contains(err.Error(), "include file") || !strings.Contains(err.Error(), "does-not-exist") {
+		t.Fatalf("missing include file error was not clear: %v", err)
+	}
+}
+
 func TestBuildProviderSnapshotIgnoredUnsupportedFilesDoNotProduceFailures(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, repo, ".gitignore", "ignored/\n")


### PR DESCRIPTION
This pull request adds support for custom ignore and include files to the semantic provider commands (`snapshot`, `symbols`, and `edges`). It allows callers to specify additional gitignore-style exclusion or inclusion rules using `--ignore-file` and `--include-file` flags, which are now honored when generating worktree-based snapshots. The implementation includes robust parsing and application of these rules, comprehensive documentation updates, and thorough tests to ensure correct behavior.

**Command-line interface and user experience:**

* Added `--ignore-file <path>` and `--include-file <path>` flags to the `snapshot`, `symbols`, and `edges` commands, allowing users to specify additional ignore or include files with gitignore-style patterns. These are now documented in both the CLI help and relevant markdown files. [[1]](diffhunk://#diff-aa84670cfbda5699ea29a1dad10df2df47f189c2748c57f6ea3efff057313658L95-R97) [[2]](diffhunk://#diff-aa84670cfbda5699ea29a1dad10df2df47f189c2748c57f6ea3efff057313658R223-R224) [[3]](diffhunk://#diff-aa84670cfbda5699ea29a1dad10df2df47f189c2748c57f6ea3efff057313658R248-R259) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R19-R20) [[5]](diffhunk://#diff-e68231479348698cb21818b6d8ef74656a2190fb4d0579205cc14d2d2d37b939R54-R55)

* Updated documentation (`README.md`, `docs/semantic_provider_requirements.md`) to explain how worktree snapshots honor `.gitignore` and how to use the new flags for custom exclusions and inclusions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L143-R150) [[2]](diffhunk://#diff-e68231479348698cb21818b6d8ef74656a2190fb4d0579205cc14d2d2d37b939R64-R72)

**Core logic and implementation:**

* Introduced the `ignoreMatcher` implementation in `internal/sem/ignore.go` to parse and apply ignore/include rules, including support for negation, directory patterns, and gitignore semantics.

* Modified the provider snapshot logic to load and apply these ignore/include rules when walking the working tree, ensuring that only the intended files are included in the snapshot. [[1]](diffhunk://#diff-7227b9ab64bf31f836a81acecc5ccccb0947dc77ff263e23c1ac049967094e12R157-R158) [[2]](diffhunk://#diff-7227b9ab64bf31f836a81acecc5ccccb0947dc77ff263e23c1ac049967094e12L217-R219) [[3]](diffhunk://#diff-7227b9ab64bf31f836a81acecc5ccccb0947dc77ff263e23c1ac049967094e12L790-R792) [[4]](diffhunk://#diff-7227b9ab64bf31f836a81acecc5ccccb0947dc77ff263e23c1ac049967094e12L811-R817) [[5]](diffhunk://#diff-7227b9ab64bf31f836a81acecc5ccccb0947dc77ff263e23c1ac049967094e12L834-R840) [[6]](diffhunk://#diff-7227b9ab64bf31f836a81acecc5ccccb0947dc77ff263e23c1ac049967094e12R852-R861) [[7]](diffhunk://#diff-7227b9ab64bf31f836a81acecc5ccccb0947dc77ff263e23c1ac049967094e12L855-R875)

**Testing:**

* Added tests to verify that the provider commands correctly honor custom ignore and include files, ensuring ignored files are excluded and included files can reopen otherwise ignored paths.