### PR TITLE
Respect Go build constraints (//go:build, _GOOS/_GOARCH) in the snapshot

### DIFF
--- a/internal/sem/gobuild.go
+++ b/internal/sem/gobuild.go
@@ -1,0 +1,130 @@
+package sem
+
+import (
+	"go/build"
+	"go/build/constraint"
+	"path"
+	"strings"
+)
+
+// Go build-constraint evaluation. entire-sem parses with tree-sitter, which is
+// build-tag-blind: it would parse every .go file regardless of //go:build lines
+// or _GOOS/_GOARCH filename suffixes. The compiler (and brain-bench's go/types
+// oracle) compiles only the files in the default build for the host. Parsing the
+// excluded files poisons type inference — e.g. a package var declared with
+// conflicting types under mutually exclusive build tags (zerolog's `enc` is
+// json.Encoder under !binary_log and cbor.Encoder under binary_log) becomes
+// ambiguous and every call on it is dropped. Excluding non-matching files aligns
+// the heuristic with the compiler's view.
+
+var knownGOOS = map[string]bool{
+	"aix": true, "android": true, "darwin": true, "dragonfly": true,
+	"freebsd": true, "illumos": true, "ios": true, "js": true, "linux": true,
+	"netbsd": true, "openbsd": true, "plan9": true, "solaris": true,
+	"wasip1": true, "windows": true,
+}
+
+var knownGOARCH = map[string]bool{
+	"386": true, "amd64": true, "arm": true, "arm64": true, "loong64": true,
+	"mips": true, "mips64": true, "mips64le": true, "mipsle": true,
+	"ppc64": true, "ppc64le": true, "riscv64": true, "s390x": true, "wasm": true,
+}
+
+// unixGOOS mirrors the set Go treats as satisfying the "unix" build tag.
+var unixGOOS = map[string]bool{
+	"aix": true, "android": true, "darwin": true, "dragonfly": true,
+	"freebsd": true, "hurd": true, "illumos": true, "ios": true, "linux": true,
+	"netbsd": true, "openbsd": true, "solaris": true,
+}
+
+// goFileMatchesDefaultBuild reports whether a .go file is part of the default
+// build for the host (build.Default GOOS/GOARCH, no custom tags) — what the
+// compiler actually compiles. Non-matching files are excluded from the snapshot.
+func goFileMatchesDefaultBuild(filePath, content string) bool {
+	return goFilenameMatchesDefaultBuild(filePath) && goBuildCommentSatisfied(content)
+}
+
+// goFilenameMatchesDefaultBuild applies the implicit _GOOS / _GOARCH /
+// _GOOS_GOARCH filename constraints (go/build's name-based rule).
+func goFilenameMatchesDefaultBuild(filePath string) bool {
+	name := path.Base(filePath)
+	name = strings.TrimSuffix(name, ".go")
+	name = strings.TrimSuffix(name, "_test") // _test is not a platform suffix
+	parts := strings.Split(name, "_")
+	if len(parts) < 2 {
+		return true
+	}
+	last := parts[len(parts)-1]
+	// _GOOS_GOARCH: the final two segments are a known OS then a known arch.
+	if len(parts) >= 3 {
+		if os2 := parts[len(parts)-2]; knownGOOS[os2] && knownGOARCH[last] {
+			return os2 == build.Default.GOOS && last == build.Default.GOARCH
+		}
+	}
+	if knownGOOS[last] {
+		return last == build.Default.GOOS
+	}
+	if knownGOARCH[last] {
+		return last == build.Default.GOARCH
+	}
+	return true
+}
+
+// goBuildCommentSatisfied evaluates //go:build (preferred) or legacy // +build
+// constraints in the file header against the default build configuration.
+func goBuildCommentSatisfied(content string) bool {
+	var goBuildExpr constraint.Expr
+	var plusBuild []constraint.Expr
+	for _, line := range strings.Split(content, "\n") {
+		t := strings.TrimSpace(line)
+		if t == "" {
+			continue // blank lines are allowed in the header
+		}
+		if !strings.HasPrefix(t, "//") {
+			break // first line of code (e.g. the package clause) ends the header
+		}
+		if constraint.IsGoBuild(t) {
+			if e, err := constraint.Parse(t); err == nil {
+				goBuildExpr = e
+			}
+		} else if constraint.IsPlusBuild(t) {
+			if e, err := constraint.Parse(t); err == nil {
+				plusBuild = append(plusBuild, e)
+			}
+		}
+	}
+	// //go:build takes precedence; legacy // +build lines are ignored when present.
+	if goBuildExpr != nil {
+		return goBuildExpr.Eval(defaultBuildTagSatisfied)
+	}
+	for _, e := range plusBuild {
+		if !e.Eval(defaultBuildTagSatisfied) {
+			return false
+		}
+	}
+	return true
+}
+
+// defaultBuildTagSatisfied reports whether a build tag holds in the default build
+// for the host. Custom tags (binary_log, integration, …) are unsatisfied, which
+// is exactly what excludes the conflicting alternate-tag files.
+func defaultBuildTagSatisfied(tag string) bool {
+	switch tag {
+	case build.Default.GOOS, build.Default.GOARCH:
+		return true
+	case "unix":
+		return unixGOOS[build.Default.GOOS]
+	case "cgo":
+		return build.Default.CgoEnabled
+	case "gc":
+		return true
+	case "gccgo", "boringcrypto":
+		return false
+	}
+	for _, r := range build.Default.ReleaseTags { // go1.1 .. go1.N
+		if tag == r {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sem/gobuild_test.go
+++ b/internal/sem/gobuild_test.go
@@ -1,0 +1,56 @@
+package sem
+
+import (
+	"go/build"
+	"testing"
+)
+
+func TestGoFileMatchesDefaultBuild(t *testing.T) {
+	host := build.Default.GOOS
+	hostArch := build.Default.GOARCH
+	// Pick a definitely-different OS/arch for the negative cases.
+	otherOS := "linux"
+	if host == "linux" {
+		otherOS = "windows"
+	}
+	otherArch := "amd64"
+	if hostArch == "amd64" {
+		otherArch = "arm64"
+	}
+
+	cases := []struct {
+		name    string
+		path    string
+		content string
+		want    bool
+	}{
+		{"plain", "foo.go", "package foo", true},
+		{"host os suffix", "foo_" + host + ".go", "package foo", true},
+		{"other os suffix", "foo_" + otherOS + ".go", "package foo", false},
+		{"host arch suffix", "foo_" + hostArch + ".go", "package foo", true},
+		{"other arch suffix", "foo_" + otherArch + ".go", "package foo", false},
+		{"host os+arch", "foo_" + host + "_" + hostArch + ".go", "package foo", true},
+		{"other os+arch", "foo_" + otherOS + "_" + otherArch + ".go", "package foo", false},
+		{"test suffix is not a platform", "foo_test.go", "package foo", true},
+		{"non-platform suffix kept", "foo_helper.go", "package foo", true},
+		{"gobuild custom tag excluded", "foo.go", "//go:build binary_log\n\npackage foo", false},
+		{"gobuild negated custom tag included", "foo.go", "//go:build !binary_log\n\npackage foo", true},
+		{"gobuild host os included", "foo.go", "//go:build " + host + "\n\npackage foo", true},
+		{"gobuild other os excluded", "foo.go", "//go:build " + otherOS + "\n\npackage foo", false},
+		{"plusbuild custom tag excluded", "foo.go", "// +build binary_log\n\npackage foo", false},
+		{"gobuild wins over filename", "foo_" + otherOS + ".go", "//go:build " + host + "\n\npackage foo", false}, // filename still excludes
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := goFileMatchesDefaultBuild(c.path, c.content); got != c.want {
+				t.Fatalf("goFileMatchesDefaultBuild(%q) = %v, want %v", c.path, got, c.want)
+			}
+		})
+	}
+
+	// unix tag is satisfied on unix hosts, not on Windows/Plan9.
+	wantUnix := unixGOOS[host]
+	if got := goBuildCommentSatisfied("//go:build unix\n\npackage foo"); got != wantUnix {
+		t.Fatalf("unix tag on %s = %v, want %v", host, got, wantUnix)
+	}
+}

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -772,6 +772,12 @@ func StreamSnapshot(ctx context.Context, repo, providerVersion string, options P
 			continue
 		}
 		language := langSpec.language
+		// Skip Go files the default build excludes (build-tag / _GOOS_GOARCH), so
+		// the snapshot matches what the compiler compiles and alternate-tag files
+		// don't poison cross-file type inference.
+		if language == "Go" && !goFileMatchesDefaultBuild(path, content) {
+			continue
+		}
 		file := FileRecord{
 			RecordType: "file",
 			ID:         fileID(sc.key, path),


### PR DESCRIPTION
tree-sitter is build-tag-blind, so entire-sem parsed every `.go` file regardless of `//go:build` / `// +build` comments or `_GOOS`/`_GOARCH` filename suffixes. The compiler — and brain-bench's `go/types` oracle — compiles only the default-build files for the host, so parsing the rest **poisons cross-file type inference**: e.g. a package var declared with conflicting types under mutually exclusive build tags becomes ambiguous and every method call on it is dropped.

## Change
`internal/sem/gobuild.go`: `goFileMatchesDefaultBuild` applies the `_GOOS`/`_GOARCH`/`_GOOS_GOARCH` filename rules plus `//go:build` and legacy `// +build` evaluation (via stdlib `go/build/constraint`) against `build.Default` (host `GOOS`/`GOARCH`/`CgoEnabled`/`ReleaseTags`). Non-matching Go files are skipped in the snapshot's parse phase. Go-only; other languages untouched.

## Results (Go call-graph F1 vs the go/types oracle) — zero regressions, symbol F1 unchanged
| repo | before → after |
|---|---|
| jwt | 0.777 → **0.879** |
| xxhash | 0.946 → 0.983 |
| websocket | 0.903 → 0.920 |
| uuid | 0.917 → 0.928 |
| logrus / go-cmp / chi / zerolog | also up |

Host-independent unit test covers filename suffixes, `//go:build`, `// +build`, the `unix` tag, and precedence. (zerolog has a *second*, separate cause — a package var of an ambiguous imported type name — noted for a follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)