### PR TITLE
Resolve method calls on package vars of package-qualified types

### DIFF
--- a/internal/sem/pkgvar_test.go
+++ b/internal/sem/pkgvar_test.go
@@ -1,0 +1,49 @@
+package sem
+
+import "testing"
+
+func TestCollectPackageVarTypes(t *testing.T) {
+	content := `package zerolog
+
+import "example.com/m/internal/json"
+
+var (
+	_   encoder = (*json.Encoder)(nil)
+	enc         = json.Encoder{}
+)
+
+var solo = &json.Encoder{}
+
+func useEnc() {
+	local := json.Encoder{} // inside a func body: must NOT be collected as a package var
+	_ = local
+}
+`
+	got := collectPackageVarTypes(content)
+	if qt, ok := got["enc"]; !ok || qt.alias != "json" || qt.typeName != "Encoder" {
+		t.Fatalf("enc: got %+v ok=%v", got["enc"], ok)
+	}
+	if qt, ok := got["solo"]; !ok || qt.alias != "json" || qt.typeName != "Encoder" {
+		t.Fatalf("solo: got %+v ok=%v", got["solo"], ok)
+	}
+	if _, ok := got["local"]; ok {
+		t.Fatalf("function-body var must not be collected as a package var")
+	}
+}
+
+func TestResolveQualifiedType(t *testing.T) {
+	jsonEnc := SymbolRecord{ID: "m:Go:internal/json/enc.go:type:Encoder", Name: "Encoder", Kind: "type", FilePath: "internal/json/enc.go"}
+	cborEnc := SymbolRecord{ID: "m:Go:internal/cbor/enc.go:type:Encoder", Name: "Encoder", Kind: "type", FilePath: "internal/cbor/enc.go"}
+	idx := map[string][]SymbolRecord{"Encoder": {jsonEnc, cborEnc}}
+
+	// json.Encoder must resolve to the Encoder in the json/ directory, not cbor's.
+	got, ok := resolveQualifiedType(pkgQualType{alias: "json", typeName: "Encoder"}, idx)
+	if !ok || got.ID != jsonEnc.ID {
+		t.Fatalf("expected json Encoder, got %+v ok=%v", got, ok)
+	}
+
+	// An alias matching no package directory resolves to nothing (not a wrong guess).
+	if _, ok := resolveQualifiedType(pkgQualType{alias: "msgpack", typeName: "Encoder"}, idx); ok {
+		t.Fatalf("unknown alias must not resolve")
+	}
+}

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -1849,6 +1849,34 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 	}
 	manifestImports := buildManifestImportResolver(files, readContent)
 
+	// Package-level vars of package-qualified types, keyed by directory. A Go
+	// package spans every file in a directory and a var is commonly declared in
+	// one file but called in another, so this must be built before the per-file
+	// loop. Used to resolve method calls on such vars to the right imported type.
+	pkgVarTypesByDir := map[string]map[string]pkgQualType{}
+	if needsReceiverCalls {
+		for _, file := range files {
+			if file.Language != "Go" {
+				continue
+			}
+			content, ok := readContent(file.Path)
+			if !ok {
+				continue
+			}
+			vars := collectPackageVarTypes(content)
+			if len(vars) == 0 {
+				continue
+			}
+			dir := filepath.ToSlash(filepath.Dir(file.Path))
+			if pkgVarTypesByDir[dir] == nil {
+				pkgVarTypesByDir[dir] = map[string]pkgQualType{}
+			}
+			for n, qt := range vars {
+				pkgVarTypesByDir[dir][n] = qt
+			}
+		}
+	}
+
 	for _, file := range files {
 		if shouldStop != nil && shouldStop() {
 			return
@@ -2181,7 +2209,7 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 				}
 			}
 			if spec.callResolution == "full" {
-				for _, r := range receiverCallRelations(from, block, methodsByContainer, symbolsByShortName, returnTypesBySymbolNameAndFile, importsByName, manifestImports.goModule) {
+				for _, r := range receiverCallRelations(from, block, methodsByContainer, symbolsByShortName, returnTypesBySymbolNameAndFile, importsByName, manifestImports.goModule, pkgVarTypesByDir[filepath.ToSlash(filepath.Dir(file.Path))]) {
 					emit(r)
 				}
 				for _, r := range importedReceiverCallRelations(from, block, importsByName, symbolsByShortName) {
@@ -2540,7 +2568,65 @@ func buildTypeRelation(repoKey string, anchor SymbolRecord, super, relation stri
 // type. These calls are otherwise dropped (a name preceded by '.'/'->' is not a
 // plain call), so this is purely additive. Type containers are skipped as
 // callers — calls live in methods/functions, not in the class declaration.
-func receiverCallRelations(from SymbolRecord, block string, methodsByContainer map[string]map[string]SymbolRecord, symbolsByShortName map[string][]SymbolRecord, returnTypesBySymbolNameAndFile map[string]map[string][]string, importsByName map[string][]string, goModule string) []RelationRecord {
+// pkgQualType is a package-qualified type reference (alias.TypeName), used to
+// resolve method calls on package-level vars whose bare type name is ambiguous
+// across packages (e.g. zerolog's `enc = json.Encoder{}` where both internal/json
+// and internal/cbor define an Encoder with the same methods).
+type pkgQualType struct {
+	alias    string
+	typeName string
+}
+
+// pkgQualVarRe matches a package-level composite-literal var assignment:
+//
+//	enc = json.Encoder{...}   /   var enc = &json.Encoder{...}
+var pkgQualVarRe = regexp.MustCompile(`^[ \t]*(?:var\s+)?([A-Za-z_]\w*)\s*=\s*&?([a-z]\w[\w]*)\.([A-Z]\w*)\s*\{`)
+
+// collectPackageVarTypes scans a Go file's package-level (brace-depth 0)
+// declarations for package-qualified composite literals and returns
+// name -> {alias, type}. Brace depth skips function bodies; the legacy
+// `var ( ... )` block uses parens, so its entries stay at depth 0.
+func collectPackageVarTypes(content string) map[string]pkgQualType {
+	stripped := stripCodeLiteralsAndComments(content)
+	out := map[string]pkgQualType{}
+	depth := 0
+	for _, line := range strings.Split(stripped, "\n") {
+		if depth == 0 {
+			if m := pkgQualVarRe.FindStringSubmatch(line); m != nil {
+				out[m[1]] = pkgQualType{alias: m[2], typeName: m[3]}
+			}
+		}
+		depth += strings.Count(line, "{") - strings.Count(line, "}")
+		if depth < 0 {
+			depth = 0
+		}
+	}
+	return out
+}
+
+// resolveQualifiedType picks the type-like symbol for a package-qualified
+// reference by the Go convention that a package's import alias equals its
+// directory basename (json.Encoder -> the Encoder in .../json/). Requires a
+// unique match so an ambiguous alias resolves to nothing rather than wrongly.
+func resolveQualifiedType(qt pkgQualType, symbolsByShortName map[string][]SymbolRecord) (SymbolRecord, bool) {
+	var match SymbolRecord
+	found := 0
+	for _, cand := range symbolsByShortName[qt.typeName] {
+		if !typeLikeKind(cand.Kind) {
+			continue
+		}
+		if filepath.Base(filepath.Dir(filepath.ToSlash(cand.FilePath))) == qt.alias {
+			match = cand
+			found++
+		}
+	}
+	if found == 1 {
+		return match, true
+	}
+	return SymbolRecord{}, false
+}
+
+func receiverCallRelations(from SymbolRecord, block string, methodsByContainer map[string]map[string]SymbolRecord, symbolsByShortName map[string][]SymbolRecord, returnTypesBySymbolNameAndFile map[string]map[string][]string, importsByName map[string][]string, goModule string, pkgVarTypes map[string]pkgQualType) []RelationRecord {
 	if typeLikeKind(from.Kind) {
 		return nil
 	}
@@ -2612,23 +2698,34 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 			confidence = 0.9
 			reason = "method call on this/self resolved to the enclosing type"
 		default:
-			typeName, ok := varTypes[call.Receiver]
-			if !ok {
+			if typeName, ok := varTypes[call.Receiver]; ok {
+				if _, ok := paramTypes[call.Receiver]; ok {
+					confidence = 0.83
+					reason = "method call resolved via typed parameter receiver"
+				}
+				if _, ok := factoryTypes[call.Receiver]; ok {
+					confidence = 0.77
+					reason = "method call resolved via assigned returned receiver type"
+				}
+				sym, ok := firstTypeLikeNamed(symbolsByShortName[typeName], typeName)
+				if !ok {
+					continue
+				}
+				targetID = sym.ID
+			} else if qt, ok := pkgVarTypes[call.Receiver]; ok {
+				// Package-level var of a package-qualified type (alias.Type). Resolve
+				// the specific imported type so an ambiguous bare name (Encoder in
+				// both json and cbor) maps to the right one.
+				sym, ok := resolveQualifiedType(qt, symbolsByShortName)
+				if !ok {
+					continue
+				}
+				targetID = sym.ID
+				confidence = 0.78
+				reason = "method call on package var resolved via qualified imported type"
+			} else {
 				continue
 			}
-			if _, ok := paramTypes[call.Receiver]; ok {
-				confidence = 0.83
-				reason = "method call resolved via typed parameter receiver"
-			}
-			if _, ok := factoryTypes[call.Receiver]; ok {
-				confidence = 0.77
-				reason = "method call resolved via assigned returned receiver type"
-			}
-			sym, ok := firstTypeLikeNamed(symbolsByShortName[typeName], typeName)
-			if !ok {
-				continue
-			}
-			targetID = sym.ID
 		}
 		method, ok := methodsByContainer[targetID][call.Method]
 		if !ok || method.ID == from.ID {


### PR DESCRIPTION
Method calls on a package-level var whose type is package-qualified (`enc = json.Encoder{}`) were dropped when the bare type name is ambiguous across packages. zerolog defines `Encoder` in both `internal/json` and `internal/cbor` with identical method names, so the unique-method-name fallback couldn't choose and every `enc.AppendX` call was lost.

## Change
Collect package-level composite-literal var declarations per directory (a Go package spans a dir; the var is often declared in one file, used in another), then resolve the qualified type by the Go convention that a package's import alias equals its directory basename (`json.Encoder` → the `Encoder` in `.../json/`). Requires a **unique** match, so an ambiguous alias resolves to nothing rather than wrongly — the conservative guard that keeps it regression-free.

## Result
zerolog call-graph F1 **0.516 → 0.646** (recall 0.36 → 0.49, precision 0.93 → **0.95**). **No other Go repo changes** in the full sweep. Unit tests cover collection (incl. grouped `var (...)` blocks and function-body exclusion) and the unique-match resolver.

Stacks on the build-constraint PR (which makes `enc`'s declaration itself unambiguous); the two together take zerolog 0.51 → 0.65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)