### PR TITLE
chore: LICENSE copyright → Entire Inc.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Suhaan Thayyil
+Copyright (c) 2026 Entire Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Per @ashtom: now that this repo is in the `entireio` org, the MIT license should be held by **Entire Inc.** rather than an individual (was `Suhaan Thayyil`). Matches `entireio/cli`'s LICENSE verbatim.