### PR TITLE
Make relation generation scale to giant repos (5 bug fixes)

### DIFF
--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -119,6 +119,13 @@ func FileCochanges(ctx context.Context, repo string, maxCommits int) ([]FileCoch
 	// commit's output is either the marker alone (no files, e.g. a merge) or
 	// "<marker>\n<first file>" followed by NUL-separated paths.
 	const marker = "--entire-sem-commit--"
+	// maxFilesPerCommit bounds the O(n^2) co-change pair expansion for a single
+	// commit. A commit touching more files than this is a mass change (initial
+	// import, tree-wide rename/format, generated-file regeneration, large merge),
+	// whose pairs are co-change noise rather than signal — and enumerating them
+	// blows up memory: one 10k-file commit alone produces ~50M pair keys (multi-GB).
+	// Real feature/fix commits touch a handful of related files and stay well under.
+	const maxFilesPerCommit = 50
 	out, err := run(ctx, repo, "git", "log", "-z", "--name-only", "--pretty=format:"+marker, "-n", strconv.Itoa(maxCommits), "--")
 	if err != nil {
 		return nil, err
@@ -136,6 +143,10 @@ func FileCochanges(ctx context.Context, repo string, maxCommits int) ([]FileCoch
 			if len(uniq) == 0 || uniq[len(uniq)-1] != path {
 				uniq = append(uniq, path)
 			}
+		}
+		if len(uniq) > maxFilesPerCommit {
+			commitFiles = nil
+			return // mass-change commit: skip its O(n^2) noise pairs (the memory explosion source)
 		}
 		for i := 0; i < len(uniq); i++ {
 			for j := i + 1; j < len(uniq); j++ {

--- a/internal/sem/parser.go
+++ b/internal/sem/parser.go
@@ -3564,7 +3564,7 @@ func maskPostgresUnsupportedSyntax(content string) string {
 	for _, loc := range postgresVectorOperatorClassPattern.FindAllStringIndex(content, -1) {
 		maskBytesPreservingNewlines(masked, loc[0], loc[1])
 	}
-	lower := strings.ToLower(content)
+	lower := asciiLowerString(content)
 	offset := 0
 	for {
 		rel := strings.Index(lower[offset:], "create policy")
@@ -3626,7 +3626,7 @@ func maskBytesPreservingNewlines(src []byte, start, end int) {
 }
 
 func maskPostgresCheckConstraints(masked []byte, content string) {
-	lower := strings.ToLower(content)
+	lower := asciiLowerString(content)
 	offset := 0
 	for {
 		rel := strings.Index(lower[offset:], "check")
@@ -3683,8 +3683,31 @@ func maskPostgresCheckConstraints(masked []byte, content string) {
 	}
 }
 
+// asciiLowerString lowercases only ASCII A-Z, byte for byte, leaving every other
+// byte (including multi-byte UTF-8 sequences) untouched. Unlike strings.ToLower,
+// the result has exactly the same byte length as the input, so byte offsets from
+// a keyword search on the lowered copy stay valid when applied back to the
+// original content. SQL keywords are ASCII, so this finds the same matches —
+// strings.ToLower can grow the byte length (e.g. 'İ' -> "i̇"), which made these
+// offsets run past the end of content and panic on large SQL files.
+func asciiLowerString(s string) string {
+	var b []byte
+	for i := 0; i < len(s); i++ {
+		if c := s[i]; c >= 'A' && c <= 'Z' {
+			if b == nil {
+				b = []byte(s)
+			}
+			b[i] = c + ('a' - 'A')
+		}
+	}
+	if b == nil {
+		return s
+	}
+	return string(b)
+}
+
 func maskPostgresTableConstraints(masked []byte, content string) {
-	lower := strings.ToLower(content)
+	lower := asciiLowerString(content)
 	for _, keyword := range []string{"primary key", "foreign key", "unique", "constraint"} {
 		offset := 0
 		for {
@@ -3790,7 +3813,7 @@ func postgresFunctionEntities(src []byte) []Entity {
 
 func postgresPolicyEntities(src []byte) []Entity {
 	content := string(src)
-	lower := strings.ToLower(content)
+	lower := asciiLowerString(content)
 	var entities []Entity
 	offset := 0
 	for {
@@ -4513,7 +4536,7 @@ func sqlIdentifierContent(node *sitter.Node, src []byte) string {
 
 func sqlStatementEntity(node *sitter.Node, src []byte) (string, string, bool) {
 	content := strings.TrimSpace(node.Content(src))
-	lower := strings.ToLower(content)
+	lower := asciiLowerString(content)
 	if !strings.HasPrefix(lower, "create ") {
 		return "", "", false
 	}
@@ -4524,7 +4547,7 @@ func sqlStatementEntity(node *sitter.Node, src []byte) (string, string, bool) {
 }
 
 func matchSQLCreateFunctionName(content string) string {
-	lower := strings.ToLower(content)
+	lower := asciiLowerString(content)
 	idx := strings.Index(lower, "function")
 	if idx < 0 {
 		return ""
@@ -4544,7 +4567,7 @@ func matchSQLCreateFunctionName(content string) string {
 }
 
 func matchSQLCreatePolicyName(content string) string {
-	lower := strings.ToLower(content)
+	lower := asciiLowerString(content)
 	idx := strings.Index(lower, "create policy")
 	if idx < 0 {
 		return ""

--- a/internal/sem/parser.go
+++ b/internal/sem/parser.go
@@ -183,7 +183,23 @@ func (TreeSitterParser) ParseWithStatus(path, content string) ([]Entity, string,
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), treeSitterParseTimeout)
 	defer cancel()
-	root, err := sitter.ParseCtx(ctx, parseSrc, spec.grammar)
+	// Own the parser and tree explicitly and free their native (cgo) memory on
+	// return. sitter.ParseCtx leaves the C parser and tree to be reclaimed by Go
+	// finalizers, but the Go heap stays small while parsing, so GC — and thus those
+	// finalizers — runs only every couple of minutes. Re-parse-heavy passes on large
+	// repos then pile up thousands of tree-sitter trees off-heap (12+ GB RSS on
+	// microsoft/TypeScript) even though the live Go heap is well under 1 GB.
+	parser := sitter.NewParser()
+	defer parser.Close()
+	parser.SetLanguage(spec.grammar)
+	tree, err := parser.ParseCtx(ctx, nil, parseSrc)
+	if tree != nil {
+		defer tree.Close()
+	}
+	var root *sitter.Node
+	if tree != nil {
+		root = tree.RootNode()
+	}
 	if err != nil || root == nil || root.IsNull() {
 		detail := "tree-sitter parse failed"
 		code := "E_PARSE_ERROR"

--- a/internal/sem/parser_postgres_regression_test.go
+++ b/internal/sem/parser_postgres_regression_test.go
@@ -161,3 +161,38 @@ func TestPostgresDomainCastProcedureAndPlaceholders(t *testing.T) {
 		t.Fatalf("surrounding tables dropped: %#v", entities)
 	}
 }
+
+// Regression: a Unicode character that grows under strings.ToLower (e.g. 'İ' ->
+// "i̇", +1 byte) used to drift the keyword offsets in the Postgres SQL masking
+// past the end of the original content and panic with an index-out-of-range.
+// asciiLowerString keeps the byte length stable so offsets stay valid. Reproduces
+// the mono repo crash on GHTDB.DATA.PostgreSQL.sql.
+func TestPostgresUnicodeLowercaseDoesNotPanic(t *testing.T) {
+	src := "-- " + strings.Repeat("İ", 200) + "\n" +
+		"CREATE TABLE t (id int, CONSTRAINT pk PRIMARY KEY (id));\n" +
+		"CREATE POLICY İpol ON t USING (true);\n"
+	// Must not panic.
+	entities, _, _ := TreeSitterParser{}.ParseWithStatus("schema.sql", src)
+	if countEntity(entities, "table", "t") != 1 {
+		t.Errorf("table t missing after unicode-laden comment: %+v", entities)
+	}
+}
+
+func TestAsciiLowerStringPreservesByteLength(t *testing.T) {
+	cases := []string{
+		"PRIMARY KEY",
+		strings.Repeat("İ", 200),
+		"ß DROP TABLE Ω",
+		"plain ascii",
+		"",
+	}
+	for _, in := range cases {
+		out := asciiLowerString(in)
+		if len(out) != len(in) {
+			t.Errorf("length changed for %q: %d -> %d", in, len(in), len(out))
+		}
+	}
+	if asciiLowerString("CREATE Policy İ") != "create policy İ" {
+		t.Errorf("ASCII not lowercased / non-ASCII altered: %q", asciiLowerString("CREATE Policy İ"))
+	}
+}

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -813,6 +813,28 @@ func StreamSnapshot(ctx context.Context, repo, providerVersion string, options P
 			})
 			continue
 		}
+		// Skip minified/bundled files (e.g. site assets like main.js / *.min.js):
+		// their thousands of single-letter symbols in one file form a near-complete
+		// same-file call graph (the dominant relation-count + time blow-up on repos
+		// that vendor web assets), and they are not meaningful source to analyze.
+		if longestLineLen(content) > maxMinifiedLineLen {
+			languageSet[language] = struct{}{}
+			if err := emit(file); err != nil {
+				return err
+			}
+			files = append(files, file)
+			lc := completenessLangs[language]
+			lc.Files++
+			completenessLangs[language] = lc
+			failures = append(failures, PartialFailure{
+				Code:                 "E_MINIFIED",
+				Severity:             "warning",
+				FilePath:             path,
+				EffectOnCompleteness: "file record emitted but symbol parsing skipped",
+				Detail:               "file appears minified/bundled (very long lines); not analyzed as source",
+			})
+			continue
+		}
 		entities, language, parseStatus := parseWithProfile(parser, spec, langSpec, path, content)
 		if language == "" {
 			failures = append(failures, PartialFailure{

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -8486,6 +8486,13 @@ func (resolver manifestImportResolver) resolveRustImport(importingPath, spec str
 
 func (resolver manifestImportResolver) resolveRustModulePath(module string) (string, bool) {
 	module = strings.Trim(module, ":")
+	// No indexed modules (e.g. a Cargo workspace where crates live under
+	// <crate>/src/ rather than ./src/, so rustModuleKeysForPath matched nothing):
+	// resolution can never succeed, so skip the O(depth^2) alias-expansion walk
+	// that would otherwise run — and fail — for every import on large repos.
+	if len(resolver.rustModules) == 0 {
+		return "", false
+	}
 	seen := map[string]bool{}
 	for module != "" {
 		if path, ok := resolver.rustModules[module]; ok {

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -6488,8 +6488,15 @@ type manifestImportResolver struct {
 	phpTypeAmbiguous    map[string]bool
 	phpPSR4Prefixes     []phpPSR4Prefix
 	rustCrateName       string
+	rustCrateNames      map[string]bool
+	rustSrcRoots        []rustSrcRoot
 	rustModules         map[string]string
 	rustAliases         map[string]string
+}
+
+type rustSrcRoot struct {
+	dir   string
+	crate string
 }
 
 type manifestImportResolution struct {
@@ -6527,7 +6534,7 @@ type pythonPackageDirMapping struct {
 }
 
 func buildManifestImportResolver(files []FileRecord, readContent contentReader) manifestImportResolver {
-	resolver := manifestImportResolver{goPackages: map[string]string{}, jsPackageExports: map[string]string{}, jsPackageImports: map[string]string{}, jsImportMap: map[string]string{}, jsModuleFiles: map[string]string{}, pythonSourceRoots: []string{"src"}, pythonModules: map[string]string{}, pythonNamespaces: map[string]bool{}, jvmTypes: map[string]string{}, jvmTypeEvidence: map[string]string{}, csharpNamespaces: map[string]string{}, csharpEvidence: map[string]string{}, csharpAmbiguous: map[string]bool{}, phpTypes: map[string]string{}, phpTypeEvidence: map[string]string{}, phpTypeAmbiguous: map[string]bool{}, rustModules: map[string]string{}, rustAliases: map[string]string{}}
+	resolver := manifestImportResolver{goPackages: map[string]string{}, jsPackageExports: map[string]string{}, jsPackageImports: map[string]string{}, jsImportMap: map[string]string{}, jsModuleFiles: map[string]string{}, pythonSourceRoots: []string{"src"}, pythonModules: map[string]string{}, pythonNamespaces: map[string]bool{}, jvmTypes: map[string]string{}, jvmTypeEvidence: map[string]string{}, csharpNamespaces: map[string]string{}, csharpEvidence: map[string]string{}, csharpAmbiguous: map[string]bool{}, phpTypes: map[string]string{}, phpTypeEvidence: map[string]string{}, phpTypeAmbiguous: map[string]bool{}, rustModules: map[string]string{}, rustAliases: map[string]string{}, rustCrateNames: map[string]bool{}}
 	if content, ok := readContent("go.mod"); ok {
 		resolver.goModule = parseGoModulePath(content)
 	}
@@ -6594,6 +6601,7 @@ func buildManifestImportResolver(files []FileRecord, readContent contentReader) 
 	if content, ok := readContent("pom.xml"); ok {
 		resolver.jvmPackagePrefixes = append(resolver.jvmPackagePrefixes, parsePOMJVMPackagePrefixes(content)...)
 	}
+	var cargoPaths []string
 	var gradleArtifactName string
 	for _, path := range []string{"settings.gradle", "settings.gradle.kts"} {
 		if content, ok := readContent(path); ok {
@@ -6648,6 +6656,9 @@ func buildManifestImportResolver(files []FileRecord, readContent contentReader) 
 		}
 		if strings.EqualFold(filepath.Ext(file.Path), ".rs") {
 			rustPaths = append(rustPaths, filepath.ToSlash(file.Path))
+		}
+		if filepath.Base(file.Path) == "Cargo.toml" {
+			cargoPaths = append(cargoPaths, filepath.ToSlash(file.Path))
 		}
 	}
 	sort.Slice(goPaths, func(i, j int) bool {
@@ -6762,9 +6773,34 @@ func buildManifestImportResolver(files []FileRecord, readContent contentReader) 
 			}
 		}
 	}
+	// Build per-crate src roots from every Cargo.toml [package] (Cargo workspaces
+	// put crates under <crate>/src/, not ./src/). Longest dir first for nearest-match.
+	for _, cp := range cargoPaths {
+		content, ok := readContent(cp)
+		if !ok {
+			continue
+		}
+		name := normalizeRustCrateName(parseCargoPackageName(content))
+		if name == "" {
+			continue
+		}
+		dir := filepath.ToSlash(filepath.Dir(cp))
+		srcDir := "src"
+		if dir != "." && dir != "" {
+			srcDir = dir + "/src"
+		}
+		resolver.rustSrcRoots = append(resolver.rustSrcRoots, rustSrcRoot{dir: srcDir, crate: name})
+		resolver.rustCrateNames[name] = true
+	}
+	sort.Slice(resolver.rustSrcRoots, func(i, j int) bool {
+		return len(resolver.rustSrcRoots[i].dir) > len(resolver.rustSrcRoots[j].dir)
+	})
+	if resolver.rustCrateName != "" {
+		resolver.rustCrateNames[resolver.rustCrateName] = true
+	}
 	sort.Strings(rustPaths)
 	for _, path := range rustPaths {
-		for _, module := range rustModuleKeysForPath(path) {
+		for _, module := range resolver.rustModuleKeysForPath(path) {
 			if _, exists := resolver.rustModules[module]; !exists {
 				resolver.rustModules[module] = path
 			}
@@ -6775,7 +6811,7 @@ func buildManifestImportResolver(files []FileRecord, readContent contentReader) 
 		if !ok {
 			continue
 		}
-		for _, alias := range rustAliasesForFile(path, content) {
+		for _, alias := range resolver.rustAliasesForFile(path, content) {
 			if alias.From != "" && alias.To != "" {
 				resolver.rustAliases[alias.From] = alias.To
 			}
@@ -8460,18 +8496,42 @@ func (resolver manifestImportResolver) resolveRustImport(importingPath, spec str
 	if module == "" {
 		return manifestImportResolution{}, false
 	}
+	// Module keys are crate-qualified (e.g. "tokio::runtime::handle"), so import
+	// specs are resolved relative to the importing file's crate. crate::/self::/
+	// super:: are intra-crate; a bare path whose head is a known workspace crate is
+	// a cross-crate import; everything else (std, third-party deps) is external.
+	importCrate := resolver.crateForPath(importingPath)
 	evidenceKind := "rust_crate_import"
-	if strings.HasPrefix(module, "crate::") {
-		module = strings.TrimPrefix(module, "crate::")
-	} else if resolver.rustCrateName != "" && (module == resolver.rustCrateName || strings.HasPrefix(module, resolver.rustCrateName+"::")) {
-		module = strings.TrimPrefix(strings.TrimPrefix(module, resolver.rustCrateName), "::")
+	var qualified string
+	switch {
+	case module == "crate" || strings.HasPrefix(module, "crate::"):
+		qualified = rustJoinCrateRest(importCrate, strings.TrimPrefix(strings.TrimPrefix(module, "crate"), "::"))
+	case strings.HasPrefix(module, "self::"):
+		qualified = rustJoinCrateRest(resolver.rustCurrentModuleForPath(importingPath), strings.TrimPrefix(module, "self::"))
+	case strings.HasPrefix(module, "super::"):
+		current := resolver.rustCurrentModuleForPath(importingPath)
+		rest := module
+		for strings.HasPrefix(rest, "super::") {
+			rest = strings.TrimPrefix(rest, "super::")
+			if idx := strings.LastIndex(current, "::"); idx >= 0 {
+				current = current[:idx]
+			} else {
+				current = ""
+			}
+		}
+		qualified = rustJoinCrateRest(current, rest)
+	default:
+		head := module
+		if idx := strings.Index(module, "::"); idx >= 0 {
+			head = module[:idx]
+		}
+		if !resolver.rustCrateNames[head] {
+			return manifestImportResolution{}, false
+		}
+		qualified = module
 		evidenceKind = "cargo_package_import"
-	} else if strings.HasPrefix(module, "self::") {
-		module = strings.TrimPrefix(module, "self::")
-	} else {
-		return manifestImportResolution{}, false
 	}
-	path, ok := resolver.resolveRustModulePath(module)
+	path, ok := resolver.resolveRustModulePath(qualified)
 	if !ok || path == filepath.ToSlash(importingPath) {
 		return manifestImportResolution{}, false
 	}
@@ -8494,7 +8554,7 @@ func (resolver manifestImportResolver) resolveRustModulePath(module string) (str
 		return "", false
 	}
 	seen := map[string]bool{}
-	for module != "" {
+	for iters := 0; module != "" && iters < 256; iters++ {
 		if path, ok := resolver.rustModules[module]; ok {
 			return path, true
 		}
@@ -8549,23 +8609,62 @@ func normalizeRustImportSpec(spec string) string {
 	return strings.Trim(spec, ":")
 }
 
-func rustModuleKeysForPath(path string) []string {
-	path = filepath.ToSlash(path)
-	if !strings.HasPrefix(path, "src/") || !strings.HasSuffix(path, ".rs") {
-		return nil
-	}
-	rel := strings.TrimSuffix(strings.TrimPrefix(path, "src/"), ".rs")
+func rustModuleFromRel(rel string) string {
+	rel = strings.TrimSuffix(rel, ".rs")
 	if rel == "lib" || rel == "main" {
+		return ""
+	}
+	rel = strings.TrimSuffix(rel, "/mod")
+	return strings.ReplaceAll(rel, "/", "::")
+}
+
+func rustJoinCrateRest(base, rest string) string {
+	base, rest = strings.Trim(base, ":"), strings.Trim(rest, ":")
+	if base == "" {
+		return rest
+	}
+	if rest == "" {
+		return base
+	}
+	return base + "::" + rest
+}
+
+// rustModuleKeysForPath maps a .rs file to its crate-qualified module key
+// (e.g. tokio/src/runtime/handle.rs -> "tokio::runtime::handle") using the
+// per-crate src roots discovered from every Cargo.toml. Falls back to a bare
+// key for a root-level src/ when no crate metadata is available.
+func (resolver manifestImportResolver) rustModuleKeysForPath(path string) []string {
+	path = filepath.ToSlash(path)
+	if !strings.HasSuffix(path, ".rs") {
 		return nil
 	}
-	if strings.HasSuffix(rel, "/mod") {
-		rel = strings.TrimSuffix(rel, "/mod")
+	for _, sr := range resolver.rustSrcRoots {
+		if strings.HasPrefix(path, sr.dir+"/") {
+			mod := rustModuleFromRel(strings.TrimPrefix(path, sr.dir+"/"))
+			if mod == "" {
+				return []string{sr.crate}
+			}
+			return []string{sr.crate + "::" + mod}
+		}
 	}
-	module := strings.ReplaceAll(rel, "/", "::")
-	if module == "" {
-		return nil
+	if strings.HasPrefix(path, "src/") {
+		mod := rustModuleFromRel(strings.TrimPrefix(path, "src/"))
+		if mod == "" {
+			return nil
+		}
+		return []string{mod}
 	}
-	return []string{module}
+	return nil
+}
+
+func (resolver manifestImportResolver) crateForPath(path string) string {
+	path = filepath.ToSlash(path)
+	for _, sr := range resolver.rustSrcRoots {
+		if strings.HasPrefix(path, sr.dir+"/") {
+			return sr.crate
+		}
+	}
+	return resolver.rustCrateName
 }
 
 type rustAlias struct {
@@ -8573,20 +8672,21 @@ type rustAlias struct {
 	To   string
 }
 
-func rustAliasesForFile(path, content string) []rustAlias {
-	current := rustCurrentModuleForPath(path)
+func (resolver manifestImportResolver) rustAliasesForFile(path, content string) []rustAlias {
+	current := resolver.rustCurrentModuleForPath(path)
+	crate := resolver.crateForPath(path)
 	var aliases []rustAlias
-	aliases = append(aliases, rustPathModuleAliases(path, content, current)...)
-	aliases = append(aliases, rustPubUseAliases(content, current)...)
+	aliases = append(aliases, resolver.rustPathModuleAliases(path, content, current)...)
+	aliases = append(aliases, rustPubUseAliases(content, current, crate)...)
 	return aliases
 }
 
-func rustPathModuleAliases(path, content, current string) []rustAlias {
+func (resolver manifestImportResolver) rustPathModuleAliases(path, content, current string) []rustAlias {
 	re := regexp.MustCompile(`(?m)#\s*\[\s*path\s*=\s*"([^"]+)"\s*\]\s*(?:pub\s+)?mod\s+([A-Za-z_][A-Za-z0-9_]*)\s*;`)
 	var aliases []rustAlias
 	for _, match := range re.FindAllStringSubmatch(content, -1) {
 		targetPath := filepath.ToSlash(filepath.Join(filepath.Dir(path), match[1]))
-		keys := rustModuleKeysForPath(targetPath)
+		keys := resolver.rustModuleKeysForPath(targetPath)
 		if len(keys) == 0 {
 			continue
 		}
@@ -8596,11 +8696,11 @@ func rustPathModuleAliases(path, content, current string) []rustAlias {
 	return aliases
 }
 
-func rustPubUseAliases(content, current string) []rustAlias {
+func rustPubUseAliases(content, current, crate string) []rustAlias {
 	re := regexp.MustCompile(`(?m)^\s*pub\s+use\s+([^;]+);`)
 	var aliases []rustAlias
 	for _, match := range re.FindAllStringSubmatch(content, -1) {
-		source, exported, ok := parseRustPubUseAlias(match[1], current)
+		source, exported, ok := parseRustPubUseAlias(match[1], current, crate)
 		if ok {
 			aliases = append(aliases, rustAlias{From: exported, To: source})
 		}
@@ -8608,7 +8708,7 @@ func rustPubUseAliases(content, current string) []rustAlias {
 	return aliases
 }
 
-func parseRustPubUseAlias(expr, current string) (string, string, bool) {
+func parseRustPubUseAlias(expr, current, crate string) (string, string, bool) {
 	expr = strings.TrimSpace(expr)
 	if expr == "" || strings.Contains(expr, "*") || strings.Contains(expr, "{") || strings.Contains(expr, "}") {
 		return "", "", false
@@ -8619,7 +8719,7 @@ func parseRustPubUseAlias(expr, current string) (string, string, bool) {
 		expr = strings.TrimSpace(expr[:idx])
 	}
 	expr = normalizeRustImportSpec(expr)
-	target := rustNormalizeUsePath(expr, current)
+	target := rustNormalizeUsePath(expr, current, crate)
 	if target == "" {
 		return "", "", false
 	}
@@ -8631,11 +8731,11 @@ func parseRustPubUseAlias(expr, current string) (string, string, bool) {
 	return target, exported, true
 }
 
-func rustNormalizeUsePath(path, current string) string {
+func rustNormalizeUsePath(path, current, crate string) string {
 	path = strings.Trim(path, ": ")
 	switch {
 	case strings.HasPrefix(path, "crate::"):
-		return strings.TrimPrefix(path, "crate::")
+		return rustJoinModule(crate, strings.TrimPrefix(path, "crate::"))
 	case strings.HasPrefix(path, "self::"):
 		return rustJoinModule(current, strings.TrimPrefix(path, "self::"))
 	case strings.HasPrefix(path, "super::"):
@@ -8654,8 +8754,8 @@ func rustNormalizeUsePath(path, current string) string {
 	}
 }
 
-func rustCurrentModuleForPath(path string) string {
-	keys := rustModuleKeysForPath(path)
+func (resolver manifestImportResolver) rustCurrentModuleForPath(path string) string {
+	keys := resolver.rustModuleKeysForPath(path)
 	if len(keys) == 0 {
 		return ""
 	}

--- a/internal/sem/similarity.go
+++ b/internal/sem/similarity.go
@@ -23,6 +23,14 @@ const (
 	// is the dominant cost on large repos and yields only redundant clone-cluster
 	// noise, so such buckets are skipped. Genuine small clone groups are unaffected.
 	maxBucketMembers = 64
+	// maxSimilarityCandidates bounds the TOTAL candidate-pair set across all bands.
+	// The per-bucket cap bounds each near-dup cluster, but a repo with thousands of
+	// small near-identical clusters (e.g. microsoft/TypeScript's tests/cases corpus)
+	// can still accumulate enough pairs to exhaust memory. Past this many candidates
+	// the clone-hint signal is long since saturated, so further pairs are pure noise
+	// and memory pressure; stop collecting. Bucket iteration is sorted so the chosen
+	// subset is deterministic.
+	maxSimilarityCandidates = 2_000_000
 )
 
 var (
@@ -89,13 +97,22 @@ func similarityRelations(recordsByFile map[string][]SymbolRecord, readContent co
 	// LSH: group by per-band signature slices; symbols sharing a bucket in any
 	// band become candidate pairs.
 	candidates := map[[2]int]struct{}{}
-	for band := 0; band < lshBands; band++ {
+	capped := false
+	for band := 0; band < lshBands && !capped; band++ {
 		buckets := map[uint64][]int{}
 		for idx := range sigs {
 			key := bandKey(sigs[idx].signature, band)
 			buckets[key] = append(buckets[key], idx)
 		}
-		for _, group := range buckets {
+		// Iterate buckets in a deterministic order so that, if the global cap
+		// truncates the candidate set, the retained subset is reproducible.
+		keys := make([]uint64, 0, len(buckets))
+		for key := range buckets {
+			keys = append(keys, key)
+		}
+		sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+		for _, key := range keys {
+			group := buckets[key]
 			if len(group) > maxBucketMembers {
 				continue // mass-duplication bucket: skip its O(k^2) pairs (noise + the explosion source)
 			}
@@ -107,6 +124,10 @@ func similarityRelations(recordsByFile map[string][]SymbolRecord, readContent co
 					}
 					candidates[[2]int{a, b}] = struct{}{}
 				}
+			}
+			if len(candidates) >= maxSimilarityCandidates {
+				capped = true // total clone-hint budget reached: stop (bounds memory)
+				break
 			}
 		}
 	}

--- a/internal/sem/similarity.go
+++ b/internal/sem/similarity.go
@@ -17,6 +17,12 @@ const (
 	shingleSize      = 3
 	minShingles      = 8    // suppress boilerplate / tiny functions
 	similarThreshold = 0.82 // estimated Jaccard required to emit SIMILAR_TO
+	// maxBucketMembers bounds the all-pairs expansion within one LSH band bucket.
+	// A bucket larger than this means a body is mass-duplicated across the repo
+	// (generated getters, boilerplate, minified code); enumerating its O(k^2) pairs
+	// is the dominant cost on large repos and yields only redundant clone-cluster
+	// noise, so such buckets are skipped. Genuine small clone groups are unaffected.
+	maxBucketMembers = 64
 )
 
 var (
@@ -90,6 +96,9 @@ func similarityRelations(recordsByFile map[string][]SymbolRecord, readContent co
 			buckets[key] = append(buckets[key], idx)
 		}
 		for _, group := range buckets {
+			if len(group) > maxBucketMembers {
+				continue // mass-duplication bucket: skip its O(k^2) pairs (noise + the explosion source)
+			}
 			for i := 0; i < len(group); i++ {
 				for j := i + 1; j < len(group); j++ {
 					a, b := group[i], group[j]
@@ -137,6 +146,34 @@ func similarityRelations(recordsByFile map[string][]SymbolRecord, readContent co
 		})
 	}
 	return relations
+}
+
+// maxMinifiedLineLen: a line longer than this marks a file as minified/bundled.
+// Real source lines are short (rarely > a few hundred chars); minified assets pack
+// the whole program onto one line of tens of thousands of characters.
+const maxMinifiedLineLen = 5000
+
+// longestLineLen returns the length (in bytes) of the longest line, scanning once
+// and stopping early once the minified threshold is exceeded.
+func longestLineLen(content string) int {
+	longest, cur := 0, 0
+	for i := 0; i < len(content); i++ {
+		if content[i] == '\n' {
+			if cur > longest {
+				longest = cur
+			}
+			if longest > maxMinifiedLineLen {
+				return longest
+			}
+			cur = 0
+		} else {
+			cur++
+		}
+	}
+	if cur > longest {
+		longest = cur
+	}
+	return longest
 }
 
 func bodyShingles(block string) map[uint64]struct{} {


### PR DESCRIPTION
Measuring the large-repo tier (linux, TypeScript, mono, tokio, …) at the full profile surfaced several real bugs that either crashed the snapshot or blew up memory. This branch fixes them; all giants now index at the full profile within memory. Validated end-to-end against the brain-bench competitive-eval corpus.

## Fixes

- **`8f0a1fc` Bound two relation blow-ups** — SIMILAR_TO all-pairs within an LSH bucket (O(k²)) + minified/bundled files. Per-bucket cap + minified-file skip. (retrofit: 143 MB and climbing at 4 min → 8 s / 18 MB.)
- **`d3527c3` + `1cbd5ec` Rust workspace imports** — crates under `<crate>/src/` were never indexed; resolver walked futilely on an empty module index. Short-circuit + crate-aware resolution across Cargo workspaces. (tokio: 0 → 1499 resolved imports.)
- **`05c89f3` SQL Postgres-masking panic** — `strings.ToLower` changing byte length vs. content offsets → index-out-of-range on a 643 KB SQL file (mono). Length-preserving ASCII lowercase at the 7 offset-sensitive sites; regression-tested.
- **`b0a095c` SIMILAR_TO candidate cap** — global cap on total candidate pairs (deterministic) as a defensive bound alongside the per-bucket cap.
- **`096c073` tree-sitter off-heap leak** — parse trees were freed only by GC finalizers; with a small live heap GC runs rarely, piling up C parse trees off-heap (TypeScript: RSS 12 GB, Go heap <500 MB). Own the parser/tree and `Close()` per file.
- **`daf42dc` co-change O(n²) memory blowup** — `FileCochanges` enumerated O(n²) pairs per commit; mass-change commits (initial import, tree-wide renames, generated regens) minted tens of millions of pair-keys. Skip commits touching >50 files (their pairs are co-change noise). (TypeScript: OOM at 12+ GB → 1.24 GB.)

## Validation

`go test ./...` green. Full-profile snapshots complete for the giants — e.g. TypeScript (40,914 files, 243,435 symbols, 827,861 relations) at ~1.24 GB peak RSS; linux, dotnet/runtime, tensorflow, mysql-server, mono all index without OOM under the safemem harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect core indexing (parsing, relations, import resolution) on all repos; behavior is mostly additive caps and skips, but Rust import resolution semantics change for workspaces and some clone/co-change signal may be dropped on pathological inputs.
> 
> **Overview**
> Adds defensive bounds and correctness fixes so full-profile snapshots complete on very large repos (TypeScript, mono, tokio, etc.) without OOM or panics.
> 
> **Memory / blow-up guards:** `FileCochanges` skips commits with more than 50 unique files to avoid O(n²) pair keys on mass imports. SIMILAR_TO (MinHash/LSH) caps per-bucket members (64) and total candidate pairs (2M, deterministic bucket order). Minified/bundled files (any line >5000 bytes) still emit file records but skip symbol parsing with `E_MINIFIED`.
> 
> **Parser lifecycle:** Tree-sitter parsing now owns `Parser` and `Tree`, calling `Close()` per file so native memory is freed instead of piling up until GC finalizers run.
> 
> **Postgres SQL:** Keyword search uses length-preserving `asciiLowerString` instead of `strings.ToLower` at offset-sensitive masking sites, fixing index-out-of-range panics when Unicode expands under lowercasing (e.g. mono’s large SQL file). Regression tests added.
> 
> **Rust workspaces:** Import resolution discovers per-crate `src` roots from every `Cargo.toml`, indexes crate-qualified module keys, resolves `crate::`/`self::`/`super::` and cross-crate paths, and short-circuits alias expansion when the module index is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daf42dc4923c5f65de86d725fd91445f95e247bd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->