### PR TITLE
sem: fix C#/PHP call and definition extraction gaps found by the brain-bench C#/PHP batch

### DIFF
--- a/internal/sem/call_scanners.go
+++ b/internal/sem/call_scanners.go
@@ -1,0 +1,360 @@
+package sem
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	clojureCallHeadRe       = regexp.MustCompile(`\(\s*([A-Za-z0-9_.$!?*+\-<>=/]+)`)
+	sqlRoutineCallRe        = regexp.MustCompile(`(?i)\b((?:@?[A-Za-z_][A-Za-z0-9_]*@?|"[^"]+")(?:\s*\.\s*(?:@?[A-Za-z_][A-Za-z0-9_]*@?|"[^"]+"))*)\s*\(`)
+	objectiveCMessageSendRe = regexp.MustCompile(`\[\s*([A-Za-z_][A-Za-z0-9_]*)\s+([A-Za-z_][A-Za-z0-9_]*)`)
+	jsDottedCallRe          = regexp.MustCompile(`\b([A-Za-z_$][A-Za-z0-9_$]*(?:\s*\.\s*[A-Za-z_$][A-Za-z0-9_$]*)+)\s*\(`)
+	fsharpDottedCallRe      = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_']*(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_']*)+)\s*\(`)
+	fsharpDottedApplyRe     = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_']*(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_']*)+)\s+[A-Za-z_({\["'0-9]`)
+	juliaCallRe             = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_]*(?:!)?)\s*(?:\{[^{}\n;()]*\})?\s*\(`)
+	luaDottedCallRe         = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_]*(?:(?:\s*[.:]\s*)[A-Za-z_][A-Za-z0-9_]*)+)\s*\(`)
+	zigDottedCallRe         = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_]*(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_]*)+)\s*\(`)
+)
+
+func clojureCallIdentifiers(content string) map[string]struct{} {
+	stripped := stripCodeLiteralsAndComments(content)
+	out := map[string]struct{}{}
+	for _, match := range clojureCallHeadRe.FindAllStringSubmatch(stripped, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		name := clojureCallableName(match[1])
+		if name == "" || clojureCallNameIgnored(name) {
+			continue
+		}
+		out[name] = struct{}{}
+	}
+	return out
+}
+
+func clojureCallableName(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	if strings.Contains(name, "/") {
+		parts := strings.Split(name, "/")
+		name = parts[len(parts)-1]
+	}
+	return strings.Trim(name, ".")
+}
+
+func clojureCallNameIgnored(name string) bool {
+	switch name {
+	case ".", "..", "->", "->>", "as->", "case", "catch", "comment", "cond", "cond->", "cond->>", "def", "defmacro", "defmethod", "defmulti", "defn", "defn-", "defonce", "defprotocol", "defrecord", "deftype", "do", "doseq", "dotimes", "doto", "extend-protocol", "extend-type", "finally", "fn", "for", "if", "if-let", "if-not", "import", "let", "letfn", "loop", "new", "ns", "quote", "recur", "require", "set!", "throw", "try", "use", "var", "when", "when-let", "when-not", "while", "with-open":
+		return true
+	default:
+		return strings.HasPrefix(name, ":")
+	}
+}
+
+func sqlCallIdentifiers(content string) map[string]struct{} {
+	stripped := stripSQLComments(content)
+	out := map[string]struct{}{}
+	for _, match := range sqlRoutineCallRe.FindAllStringSubmatch(stripped, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		name := normalizeSQLDottedName(match[1])
+		if strings.Contains(name, ".") {
+			parts := strings.Split(name, ".")
+			name = parts[len(parts)-1]
+		}
+		name = strings.TrimSpace(name)
+		if name == "" || sqlCallNameIgnored(name) {
+			continue
+		}
+		out[name] = struct{}{}
+	}
+	return out
+}
+
+func sqlCallNameIgnored(name string) bool {
+	switch strings.ToLower(name) {
+	case "array", "cast", "coalesce", "count", "date_part", "exists", "extract", "function", "greatest", "if", "least", "lower", "max", "min", "nullif", "procedure", "sum", "upper", "values":
+		return true
+	default:
+		return false
+	}
+}
+
+func jsDottedCallIdentifiers(content string) map[string]struct{} {
+	return dottedCallIdentifiers(stripCodeLiteralsAndComments(content), jsDottedCallRe)
+}
+
+func jsCallableArgumentIdentifiers(content string) map[string]struct{} {
+	stripped := stripCodeLiteralsAndComments(content)
+	out := map[string]struct{}{}
+	for i := 0; i < len(stripped); i++ {
+		if stripped[i] != '(' || jsOpenParenStartsDeclarationOrControl(stripped, i) {
+			continue
+		}
+		close := findMatchingStaticDelimiter(stripped, i, '(', ')')
+		if close < 0 || jsParenFollowedByArrow(stripped, close) {
+			continue
+		}
+		for _, arg := range splitTopLevelStaticComma(stripped[i+1 : close]) {
+			arg = strings.TrimSpace(arg)
+			if !isSimpleIdentifier(arg) || jsCallableArgumentIgnored(arg) {
+				continue
+			}
+			out[arg] = struct{}{}
+		}
+		i = close
+	}
+	return out
+}
+
+func jsOpenParenStartsDeclarationOrControl(content string, open int) bool {
+	name, beforeName := identifierBefore(content, open)
+	switch name {
+	case "", "catch", "for", "function", "if", "switch", "while", "with":
+		return true
+	}
+	previous, _ := identifierBefore(content, beforeName)
+	return previous == "function"
+}
+
+func jsParenFollowedByArrow(content string, close int) bool {
+	for i := close + 1; i < len(content); i++ {
+		switch content[i] {
+		case ' ', '\t', '\r', '\n':
+			continue
+		case '=':
+			return i+1 < len(content) && content[i+1] == '>'
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+func identifierBefore(content string, pos int) (string, int) {
+	i := pos - 1
+	for i >= 0 && isASCIISpace(content[i]) {
+		i--
+	}
+	end := i + 1
+	for i >= 0 && isASCIIIdentifierByte(content[i]) {
+		i--
+	}
+	if end == i+1 {
+		return "", i + 1
+	}
+	return content[i+1 : end], i + 1
+}
+
+func isASCIISpace(ch byte) bool {
+	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r'
+}
+
+func jsCallableArgumentIgnored(name string) bool {
+	switch name {
+	case "false", "null", "this", "true", "undefined":
+		return true
+	default:
+		return false
+	}
+}
+
+func juliaCallIdentifiers(content string) map[string]struct{} {
+	stripped := maskJuliaLiteralsAndComments(content)
+	out := map[string]struct{}{}
+	for _, match := range juliaCallRe.FindAllStringSubmatchIndex(stripped, -1) {
+		if len(match) < 4 {
+			continue
+		}
+		name := stripped[match[2]:match[3]]
+		if juliaCallNameIgnored(stripped, match[2], name) {
+			continue
+		}
+		out[name] = struct{}{}
+	}
+	return out
+}
+
+func juliaCallNameIgnored(content string, start int, name string) bool {
+	for i := start - 1; i >= 0; i-- {
+		switch content[i] {
+		case ' ', '\t':
+			continue
+		case '.':
+			return true
+		default:
+			i = -1
+		}
+	}
+	switch strings.TrimSuffix(name, "!") {
+	case "begin", "catch", "do", "else", "elseif", "end", "finally", "for", "function", "if", "let", "macro", "quote", "return", "try", "while":
+		return true
+	default:
+		return false
+	}
+}
+
+func maskJuliaLiteralsAndComments(content string) string {
+	bytes := []byte(stripCodeLiteralsAndComments(content))
+	for i := 0; i < len(bytes); i++ {
+		if bytes[i] != '#' {
+			continue
+		}
+		if i+1 < len(bytes) && bytes[i+1] == '=' {
+			j := i + 2
+			for j+1 < len(bytes) && !(bytes[j] == '=' && bytes[j+1] == '#') {
+				j++
+			}
+			if j+1 < len(bytes) {
+				j += 2
+			}
+			maskBytes(bytes, i, j)
+			i = j - 1
+			continue
+		}
+		j := i + 1
+		for j < len(bytes) && bytes[j] != '\n' && bytes[j] != '\r' {
+			j++
+		}
+		maskBytes(bytes, i, j)
+		i = j
+	}
+	return string(bytes)
+}
+
+func fsharpDottedCallIdentifiers(content string) map[string]struct{} {
+	stripped := stripCodeLiteralsAndComments(content)
+	out := dottedCallIdentifiers(stripped, fsharpDottedCallRe)
+	for _, match := range fsharpDottedApplyRe.FindAllStringSubmatchIndex(stripped, -1) {
+		if len(match) < 4 {
+			continue
+		}
+		if fsharpDottedApplyIgnored(stripped, match[0]) {
+			continue
+		}
+		name := lastDottedCallSegment(stripped[match[2]:match[3]])
+		if name == "" {
+			continue
+		}
+		out[name] = struct{}{}
+	}
+	return out
+}
+
+func fsharpDottedApplyIgnored(content string, start int) bool {
+	previous, _ := identifierBefore(content, start)
+	switch previous {
+	case "inherit", "module", "namespace", "new", "open", "type":
+		return true
+	default:
+		return false
+	}
+}
+
+func luaDottedCallIdentifiers(content string) map[string]struct{} {
+	return dottedCallIdentifiers(maskLuaLiteralsAndComments(content), luaDottedCallRe)
+}
+
+func zigDottedCallIdentifiers(content string) map[string]struct{} {
+	return dottedCallIdentifiers(stripCodeLiteralsAndComments(content), zigDottedCallRe)
+}
+
+func dottedCallIdentifiers(content string, pattern *regexp.Regexp) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, match := range pattern.FindAllStringSubmatch(content, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		name := lastDottedCallSegment(match[1])
+		if name == "" {
+			continue
+		}
+		out[name] = struct{}{}
+	}
+	return out
+}
+
+func lastDottedCallSegment(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return ""
+	}
+	fields := strings.FieldsFunc(name, func(r rune) bool {
+		return r == '.' || r == ':'
+	})
+	if len(fields) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(fields[len(fields)-1])
+}
+
+func maskLuaLiteralsAndComments(content string) string {
+	bytes := []byte(content)
+	for i := 0; i < len(bytes); i++ {
+		switch bytes[i] {
+		case '"', '\'':
+			quote := bytes[i]
+			for j := i + 1; j < len(bytes); j++ {
+				if bytes[j] == '\n' || bytes[j] == '\r' {
+					i = j
+					break
+				}
+				if bytes[j] == '\\' {
+					j++
+					continue
+				}
+				if bytes[j] == quote {
+					maskBytes(bytes, i, j+1)
+					i = j
+					break
+				}
+			}
+		case '-':
+			if i+1 < len(bytes) && bytes[i+1] == '-' {
+				j := i + 2
+				for j < len(bytes) && bytes[j] != '\n' && bytes[j] != '\r' {
+					j++
+				}
+				maskBytes(bytes, i, j)
+				i = j
+			}
+		}
+	}
+	return string(bytes)
+}
+
+func objectiveCMessageReceiverCalls(content string) []receiverCall {
+	stripped := stripCodeLiteralsAndComments(content)
+	seen := map[string]bool{}
+	var out []receiverCall
+	for _, match := range objectiveCMessageSendRe.FindAllStringSubmatch(stripped, -1) {
+		if len(match) < 3 {
+			continue
+		}
+		receiver := strings.TrimSpace(match[1])
+		method := strings.TrimSpace(match[2])
+		if receiver == "" || method == "" || objectiveCMessageNameIgnored(method) {
+			continue
+		}
+		key := receiver + "." + method
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, receiverCall{Receiver: receiver, Method: method})
+	}
+	return out
+}
+
+func objectiveCMessageNameIgnored(name string) bool {
+	switch name {
+	case "alloc", "class", "copy", "init", "new", "superclass":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/sem/grammars/csharp/LICENSE
+++ b/internal/sem/grammars/csharp/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2023 Max Brunsfeld, Damien Guard, Amaan Qureshi, and contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/internal/sem/grammars/csharp/binding.go
+++ b/internal/sem/grammars/csharp/binding.go
@@ -1,0 +1,20 @@
+package csharp
+
+//#include "tree_sitter/parser.h"
+//TSLanguage *tree_sitter_c_sharp();
+import "C"
+
+import (
+	"unsafe"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// GetLanguage returns the vendored tree-sitter-c-sharp grammar
+// (v0.23.5, regenerated at ABI 14), replacing the C# 10-era grammar
+// bundled with go-tree-sitter so C# 12/13 syntax (collection
+// expressions, params collections, primary constructors) parses
+// without ERROR nodes.
+func GetLanguage() *sitter.Language {
+	return sitter.NewLanguage(unsafe.Pointer(C.tree_sitter_c_sharp()))
+}

--- a/internal/sem/grammars/csharp/scanner.c
+++ b/internal/sem/grammars/csharp/scanner.c
@@ -1,0 +1,421 @@
+#include "tree_sitter/alloc.h"
+#include "tree_sitter/array.h"
+#include "tree_sitter/parser.h"
+
+#include <wctype.h>
+
+enum TokenType {
+    OPT_SEMI,
+    INTERPOLATION_REGULAR_START,
+    INTERPOLATION_VERBATIM_START,
+    INTERPOLATION_RAW_START,
+    INTERPOLATION_START_QUOTE,
+    INTERPOLATION_END_QUOTE,
+    INTERPOLATION_OPEN_BRACE,
+    INTERPOLATION_CLOSE_BRACE,
+    INTERPOLATION_STRING_CONTENT,
+    RAW_STRING_START,
+    RAW_STRING_END,
+    RAW_STRING_CONTENT,
+};
+
+typedef enum {
+    REGULAR = 1 << 0,
+    VERBATIM = 1 << 1,
+    RAW = 1 << 2,
+} StringType;
+
+typedef struct {
+    uint8_t dollar_count;
+    uint8_t open_brace_count;
+    uint8_t quote_count;
+    StringType string_type;
+} Interpolation;
+
+static inline bool is_regular(Interpolation *interpolation) { return interpolation->string_type & REGULAR; }
+
+static inline bool is_verbatim(Interpolation *interpolation) { return interpolation->string_type & VERBATIM; }
+
+static inline bool is_raw(Interpolation *interpolation) { return interpolation->string_type & RAW; }
+
+typedef struct {
+    uint8_t quote_count;
+    Array(Interpolation) interpolation_stack;
+} Scanner;
+
+static inline void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
+
+static inline void skip(TSLexer *lexer) { lexer->advance(lexer, true); }
+
+void *tree_sitter_c_sharp_external_scanner_create() {
+    Scanner *scanner = ts_calloc(1, sizeof(Scanner));
+    array_init(&scanner->interpolation_stack);
+    return scanner;
+}
+
+void tree_sitter_c_sharp_external_scanner_destroy(void *payload) {
+    Scanner *scanner = (Scanner *)payload;
+    array_delete(&scanner->interpolation_stack);
+    ts_free(scanner);
+}
+
+unsigned tree_sitter_c_sharp_external_scanner_serialize(void *payload, char *buffer) {
+    Scanner *scanner = (Scanner *)payload;
+
+    if (scanner->interpolation_stack.size * 4 + 2 > TREE_SITTER_SERIALIZATION_BUFFER_SIZE) {
+        return 0;
+    }
+
+    unsigned size = 0;
+
+    buffer[size++] = (char)scanner->quote_count;
+    buffer[size++] = (char)scanner->interpolation_stack.size;
+
+    for (unsigned i = 0; i < scanner->interpolation_stack.size; i++) {
+        Interpolation interpolation = scanner->interpolation_stack.contents[i];
+        buffer[size++] = (char)interpolation.dollar_count;
+        buffer[size++] = (char)interpolation.open_brace_count;
+        buffer[size++] = (char)interpolation.quote_count;
+        buffer[size++] = (char)interpolation.string_type;
+    }
+
+    return size;
+}
+
+void tree_sitter_c_sharp_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {
+    Scanner *scanner = (Scanner *)payload;
+
+    scanner->quote_count = 0;
+    array_clear(&scanner->interpolation_stack);
+    unsigned size = 0;
+
+    if (length > 0) {
+        scanner->quote_count = (unsigned char)buffer[size++];
+        scanner->interpolation_stack.size = (unsigned char)buffer[size++];
+        array_reserve(&scanner->interpolation_stack, scanner->interpolation_stack.size);
+
+        for (unsigned i = 0; i < scanner->interpolation_stack.size; i++) {
+            Interpolation interpolation = {0};
+            interpolation.dollar_count = buffer[size++];
+            interpolation.open_brace_count = buffer[size++];
+            interpolation.quote_count = buffer[size++];
+            interpolation.string_type = (unsigned char)buffer[size++];
+            scanner->interpolation_stack.contents[i] = interpolation;
+        }
+    }
+
+    assert(size == length);
+}
+
+bool tree_sitter_c_sharp_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
+    Scanner *scanner = (Scanner *)payload;
+
+    uint8_t brace_advanced = 0;
+    uint8_t quote_count = 0;
+    bool did_advance = false;
+
+    // error recovery, gives better trees this way
+    if (valid_symbols[OPT_SEMI] && valid_symbols[INTERPOLATION_REGULAR_START]) {
+        return false;
+    }
+
+    if (valid_symbols[OPT_SEMI]) {
+        lexer->result_symbol = OPT_SEMI;
+        if (lexer->lookahead == ';') {
+            advance(lexer);
+        }
+        return true;
+    }
+
+    if (valid_symbols[RAW_STRING_START]) {
+        while (iswspace(lexer->lookahead)) {
+            skip(lexer);
+        }
+
+        if (lexer->lookahead == '"') {
+            while (lexer->lookahead == '"') {
+                advance(lexer);
+                quote_count++;
+            }
+
+            if (quote_count >= 3) {
+                lexer->result_symbol = RAW_STRING_START;
+                scanner->quote_count = quote_count;
+                return true;
+            }
+        }
+    }
+
+    if (valid_symbols[RAW_STRING_END] && lexer->lookahead == '"') {
+        while (lexer->lookahead == '"') {
+            advance(lexer);
+            quote_count++;
+        }
+
+        if (quote_count == scanner->quote_count) {
+            lexer->result_symbol = RAW_STRING_END;
+            scanner->quote_count = 0;
+            return true;
+        }
+
+        did_advance = quote_count > 0;
+    }
+
+    if (valid_symbols[RAW_STRING_CONTENT]) {
+        while (lexer->lookahead) {
+            if (lexer->lookahead == '"') {
+                lexer->mark_end(lexer);
+                quote_count = 0;
+
+                while (lexer->lookahead == '"') {
+                    advance(lexer);
+                    quote_count++;
+                }
+
+                if (quote_count == scanner->quote_count) {
+                    lexer->result_symbol = RAW_STRING_CONTENT;
+                    return true;
+                }
+            }
+            advance(lexer);
+            did_advance = true;
+        }
+        lexer->mark_end(lexer);
+        lexer->result_symbol = RAW_STRING_CONTENT;
+        return true;
+    }
+
+    if (valid_symbols[INTERPOLATION_REGULAR_START] || valid_symbols[INTERPOLATION_VERBATIM_START] ||
+        valid_symbols[INTERPOLATION_RAW_START]) {
+        while (iswspace(lexer->lookahead)) {
+            skip(lexer);
+        }
+
+        uint8_t dollar_advanced = 0;
+
+        bool is_verbatim = false;
+
+        if (lexer->lookahead == '@') {
+            is_verbatim = true;
+            advance(lexer);
+        }
+
+        while (lexer->lookahead == '$' && quote_count == 0) {
+            advance(lexer);
+            dollar_advanced++;
+        }
+
+        if (dollar_advanced > 0 && (lexer->lookahead == '"' || lexer->lookahead == '@')) {
+            lexer->result_symbol = INTERPOLATION_REGULAR_START;
+            Interpolation interpolation = {
+                .dollar_count = dollar_advanced,
+                .open_brace_count = 0,
+                .quote_count = 0,
+                .string_type = 0,
+            };
+
+            if (is_verbatim || lexer->lookahead == '@') {
+                if (lexer->lookahead == '@') {
+                    advance(lexer);
+                    is_verbatim = true;
+                }
+                lexer->result_symbol = INTERPOLATION_VERBATIM_START;
+                interpolation.string_type = VERBATIM;
+            }
+
+            lexer->mark_end(lexer);
+            advance(lexer);
+
+            if (lexer->lookahead == '"' && !is_verbatim) {
+                advance(lexer);
+                if (lexer->lookahead == '"') {
+                    lexer->result_symbol = INTERPOLATION_RAW_START;
+                    interpolation.string_type |= RAW;
+                    array_push(&scanner->interpolation_stack, interpolation);
+                }
+                // If we find 1 or 3 quotes, we push an interpolation.
+                // If there's only two quotes, that's just an empty string
+            } else {
+                interpolation.string_type |= REGULAR;
+                array_push(&scanner->interpolation_stack, interpolation);
+            }
+
+            return true;
+        }
+    }
+
+    if (valid_symbols[INTERPOLATION_START_QUOTE] && scanner->interpolation_stack.size > 0) {
+        Interpolation *current_interpolation = array_back(&scanner->interpolation_stack);
+
+        if (is_verbatim(current_interpolation) || is_regular(current_interpolation)) {
+            if (lexer->lookahead == '"') {
+                advance(lexer);
+                current_interpolation->quote_count++;
+            }
+        } else {
+            while (lexer->lookahead == '"') {
+                advance(lexer);
+                current_interpolation->quote_count++;
+            }
+        }
+
+        lexer->result_symbol = INTERPOLATION_START_QUOTE;
+        return current_interpolation->quote_count > 0;
+    }
+
+    if (valid_symbols[INTERPOLATION_END_QUOTE] && scanner->interpolation_stack.size > 0) {
+        Interpolation *current_interpolation = array_back(&scanner->interpolation_stack);
+
+        while (lexer->lookahead == '"') {
+            advance(lexer);
+            quote_count++;
+        }
+
+        if (quote_count == current_interpolation->quote_count) {
+            lexer->result_symbol = INTERPOLATION_END_QUOTE;
+            array_pop(&scanner->interpolation_stack);
+            return true;
+        }
+
+        did_advance = quote_count > 0;
+    }
+
+    if (valid_symbols[INTERPOLATION_OPEN_BRACE] && scanner->interpolation_stack.size > 0) {
+        Interpolation *current_interpolation = array_back(&scanner->interpolation_stack);
+
+        while (lexer->lookahead == '{' && brace_advanced < current_interpolation->dollar_count) {
+            advance(lexer);
+            brace_advanced++;
+        }
+
+        if (brace_advanced > 0 && brace_advanced == current_interpolation->dollar_count &&
+            (brace_advanced == 0 || lexer->lookahead != '{')) {
+            current_interpolation->open_brace_count = brace_advanced;
+            lexer->result_symbol = INTERPOLATION_OPEN_BRACE;
+            return true;
+        }
+    }
+
+    if (valid_symbols[INTERPOLATION_CLOSE_BRACE] && scanner->interpolation_stack.size > 0) {
+        uint8_t brace_advanced = 0;
+        Interpolation *current_interpolation = array_back(&scanner->interpolation_stack);
+
+        while (iswspace(lexer->lookahead)) {
+            advance(lexer);
+        }
+
+        while (lexer->lookahead == '}') {
+            advance(lexer);
+            brace_advanced++;
+
+            if (brace_advanced == current_interpolation->open_brace_count) {
+                current_interpolation->open_brace_count = 0;
+                lexer->result_symbol = INTERPOLATION_CLOSE_BRACE;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    if (valid_symbols[INTERPOLATION_STRING_CONTENT] && scanner->interpolation_stack.size > 0) {
+        lexer->result_symbol = INTERPOLATION_STRING_CONTENT;
+        Interpolation *current_interpolation = array_back(&scanner->interpolation_stack);
+
+        while (lexer->lookahead) {
+            // top-down approach, first see if it's raw
+            if (is_raw(current_interpolation)) {
+                if (lexer->lookahead == '"') {
+                    lexer->mark_end(lexer);
+                    advance(lexer);
+                    if (lexer->lookahead == '"') {
+                        advance(lexer);
+                        uint8_t quote_advanced = 2;
+                        while (lexer->lookahead == '"') {
+                            quote_advanced++;
+                            advance(lexer);
+                        }
+                        if (quote_advanced == current_interpolation->quote_count) {
+                            return did_advance;
+                        }
+                    }
+                }
+
+                if (lexer->lookahead == '{') {
+                    lexer->mark_end(lexer);
+
+                    while (lexer->lookahead == '{' && brace_advanced < current_interpolation->open_brace_count) {
+                        advance(lexer);
+                        brace_advanced++;
+                    }
+
+                    if (brace_advanced == current_interpolation->open_brace_count &&
+                        (brace_advanced == 0 || lexer->lookahead != '{')) {
+                        return did_advance;
+                    }
+                }
+            }
+
+            // then verbatim, since it could be verbatim + raw, but run the raw branch first
+            else if (is_verbatim(current_interpolation)) {
+                if (lexer->lookahead == '"') {
+                    lexer->mark_end(lexer);
+                    advance(lexer);
+                    if (lexer->lookahead == '"') {
+                        advance(lexer);
+                        continue;
+                    }
+                    return did_advance;
+                }
+
+                if (lexer->lookahead == '{') {
+                    lexer->mark_end(lexer);
+
+                    while (lexer->lookahead == '{' && brace_advanced < current_interpolation->open_brace_count) {
+                        advance(lexer);
+                        brace_advanced++;
+                    }
+
+                    if (brace_advanced == current_interpolation->open_brace_count &&
+                        (brace_advanced == 0 || lexer->lookahead != '{')) {
+                        return did_advance;
+                    }
+                }
+            }
+
+            // finally regular
+            else if (is_regular(current_interpolation)) {
+                if (lexer->lookahead == '\\' || lexer->lookahead == '\n' || lexer->lookahead == '"') {
+                    lexer->mark_end(lexer);
+                    return did_advance;
+                }
+
+                if (lexer->lookahead == '{') {
+                    lexer->mark_end(lexer);
+
+                    while (lexer->lookahead == '{' && brace_advanced < current_interpolation->open_brace_count) {
+                        advance(lexer);
+                        brace_advanced++;
+                    }
+
+                    if (brace_advanced == current_interpolation->open_brace_count &&
+                        (brace_advanced == 0 || lexer->lookahead != '{')) { // if we're in a brace we're not allowed to
+                                                                            // collect more than the open_brace_count
+                        return did_advance;
+                    }
+                }
+            }
+
+            if (lexer->lookahead != '{') {
+                brace_advanced = 0;
+            }
+            advance(lexer);
+            did_advance = true;
+        }
+
+        lexer->mark_end(lexer);
+        return did_advance;
+    }
+
+    return false;
+}

--- a/internal/sem/grammars/csharp/tree_sitter/alloc.h
+++ b/internal/sem/grammars/csharp/tree_sitter/alloc.h
@@ -1,0 +1,54 @@
+#ifndef TREE_SITTER_ALLOC_H_
+#define TREE_SITTER_ALLOC_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// Allow clients to override allocation functions
+#ifdef TREE_SITTER_REUSE_ALLOCATOR
+
+extern void *(*ts_current_malloc)(size_t size);
+extern void *(*ts_current_calloc)(size_t count, size_t size);
+extern void *(*ts_current_realloc)(void *ptr, size_t size);
+extern void (*ts_current_free)(void *ptr);
+
+#ifndef ts_malloc
+#define ts_malloc  ts_current_malloc
+#endif
+#ifndef ts_calloc
+#define ts_calloc  ts_current_calloc
+#endif
+#ifndef ts_realloc
+#define ts_realloc ts_current_realloc
+#endif
+#ifndef ts_free
+#define ts_free    ts_current_free
+#endif
+
+#else
+
+#ifndef ts_malloc
+#define ts_malloc  malloc
+#endif
+#ifndef ts_calloc
+#define ts_calloc  calloc
+#endif
+#ifndef ts_realloc
+#define ts_realloc realloc
+#endif
+#ifndef ts_free
+#define ts_free    free
+#endif
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_ALLOC_H_

--- a/internal/sem/grammars/csharp/tree_sitter/array.h
+++ b/internal/sem/grammars/csharp/tree_sitter/array.h
@@ -1,0 +1,291 @@
+#ifndef TREE_SITTER_ARRAY_H_
+#define TREE_SITTER_ARRAY_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "./alloc.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4101)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
+
+#define Array(T)       \
+  struct {             \
+    T *contents;       \
+    uint32_t size;     \
+    uint32_t capacity; \
+  }
+
+/// Initialize an array.
+#define array_init(self) \
+  ((self)->size = 0, (self)->capacity = 0, (self)->contents = NULL)
+
+/// Create an empty array.
+#define array_new() \
+  { NULL, 0, 0 }
+
+/// Get a pointer to the element at a given `index` in the array.
+#define array_get(self, _index) \
+  (assert((uint32_t)(_index) < (self)->size), &(self)->contents[_index])
+
+/// Get a pointer to the first element in the array.
+#define array_front(self) array_get(self, 0)
+
+/// Get a pointer to the last element in the array.
+#define array_back(self) array_get(self, (self)->size - 1)
+
+/// Clear the array, setting its size to zero. Note that this does not free any
+/// memory allocated for the array's contents.
+#define array_clear(self) ((self)->size = 0)
+
+/// Reserve `new_capacity` elements of space in the array. If `new_capacity` is
+/// less than the array's current capacity, this function has no effect.
+#define array_reserve(self, new_capacity) \
+  _array__reserve((Array *)(self), array_elem_size(self), new_capacity)
+
+/// Free any memory allocated for this array. Note that this does not free any
+/// memory allocated for the array's contents.
+#define array_delete(self) _array__delete((Array *)(self))
+
+/// Push a new `element` onto the end of the array.
+#define array_push(self, element)                            \
+  (_array__grow((Array *)(self), 1, array_elem_size(self)), \
+   (self)->contents[(self)->size++] = (element))
+
+/// Increase the array's size by `count` elements.
+/// New elements are zero-initialized.
+#define array_grow_by(self, count) \
+  do { \
+    if ((count) == 0) break; \
+    _array__grow((Array *)(self), count, array_elem_size(self)); \
+    memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
+    (self)->size += (count); \
+  } while (0)
+
+/// Append all elements from one array to the end of another.
+#define array_push_all(self, other)                                       \
+  array_extend((self), (other)->size, (other)->contents)
+
+/// Append `count` elements to the end of the array, reading their values from the
+/// `contents` pointer.
+#define array_extend(self, count, contents)                    \
+  _array__splice(                                               \
+    (Array *)(self), array_elem_size(self), (self)->size, \
+    0, count,  contents                                        \
+  )
+
+/// Remove `old_count` elements from the array starting at the given `index`. At
+/// the same index, insert `new_count` new elements, reading their values from the
+/// `new_contents` pointer.
+#define array_splice(self, _index, old_count, new_count, new_contents)  \
+  _array__splice(                                                       \
+    (Array *)(self), array_elem_size(self), _index,                \
+    old_count, new_count, new_contents                                 \
+  )
+
+/// Insert one `element` into the array at the given `index`.
+#define array_insert(self, _index, element) \
+  _array__splice((Array *)(self), array_elem_size(self), _index, 0, 1, &(element))
+
+/// Remove one element from the array at the given `index`.
+#define array_erase(self, _index) \
+  _array__erase((Array *)(self), array_elem_size(self), _index)
+
+/// Pop the last element off the array, returning the element by value.
+#define array_pop(self) ((self)->contents[--(self)->size])
+
+/// Assign the contents of one array to another, reallocating if necessary.
+#define array_assign(self, other) \
+  _array__assign((Array *)(self), (const Array *)(other), array_elem_size(self))
+
+/// Swap one array with another
+#define array_swap(self, other) \
+  _array__swap((Array *)(self), (Array *)(other))
+
+/// Get the size of the array contents
+#define array_elem_size(self) (sizeof *(self)->contents)
+
+/// Search a sorted array for a given `needle` value, using the given `compare`
+/// callback to determine the order.
+///
+/// If an existing element is found to be equal to `needle`, then the `index`
+/// out-parameter is set to the existing value's index, and the `exists`
+/// out-parameter is set to true. Otherwise, `index` is set to an index where
+/// `needle` should be inserted in order to preserve the sorting, and `exists`
+/// is set to false.
+#define array_search_sorted_with(self, compare, needle, _index, _exists) \
+  _array__search_sorted(self, 0, compare, , needle, _index, _exists)
+
+/// Search a sorted array for a given `needle` value, using integer comparisons
+/// of a given struct field (specified with a leading dot) to determine the order.
+///
+/// See also `array_search_sorted_with`.
+#define array_search_sorted_by(self, field, needle, _index, _exists) \
+  _array__search_sorted(self, 0, _compare_int, field, needle, _index, _exists)
+
+/// Insert a given `value` into a sorted array, using the given `compare`
+/// callback to determine the order.
+#define array_insert_sorted_with(self, compare, value) \
+  do { \
+    unsigned _index, _exists; \
+    array_search_sorted_with(self, compare, &(value), &_index, &_exists); \
+    if (!_exists) array_insert(self, _index, value); \
+  } while (0)
+
+/// Insert a given `value` into a sorted array, using integer comparisons of
+/// a given struct field (specified with a leading dot) to determine the order.
+///
+/// See also `array_search_sorted_by`.
+#define array_insert_sorted_by(self, field, value) \
+  do { \
+    unsigned _index, _exists; \
+    array_search_sorted_by(self, field, (value) field, &_index, &_exists); \
+    if (!_exists) array_insert(self, _index, value); \
+  } while (0)
+
+// Private
+
+typedef Array(void) Array;
+
+/// This is not what you're looking for, see `array_delete`.
+static inline void _array__delete(Array *self) {
+  if (self->contents) {
+    ts_free(self->contents);
+    self->contents = NULL;
+    self->size = 0;
+    self->capacity = 0;
+  }
+}
+
+/// This is not what you're looking for, see `array_erase`.
+static inline void _array__erase(Array *self, size_t element_size,
+                                uint32_t index) {
+  assert(index < self->size);
+  char *contents = (char *)self->contents;
+  memmove(contents + index * element_size, contents + (index + 1) * element_size,
+          (self->size - index - 1) * element_size);
+  self->size--;
+}
+
+/// This is not what you're looking for, see `array_reserve`.
+static inline void _array__reserve(Array *self, size_t element_size, uint32_t new_capacity) {
+  if (new_capacity > self->capacity) {
+    if (self->contents) {
+      self->contents = ts_realloc(self->contents, new_capacity * element_size);
+    } else {
+      self->contents = ts_malloc(new_capacity * element_size);
+    }
+    self->capacity = new_capacity;
+  }
+}
+
+/// This is not what you're looking for, see `array_assign`.
+static inline void _array__assign(Array *self, const Array *other, size_t element_size) {
+  _array__reserve(self, element_size, other->size);
+  self->size = other->size;
+  memcpy(self->contents, other->contents, self->size * element_size);
+}
+
+/// This is not what you're looking for, see `array_swap`.
+static inline void _array__swap(Array *self, Array *other) {
+  Array swap = *other;
+  *other = *self;
+  *self = swap;
+}
+
+/// This is not what you're looking for, see `array_push` or `array_grow_by`.
+static inline void _array__grow(Array *self, uint32_t count, size_t element_size) {
+  uint32_t new_size = self->size + count;
+  if (new_size > self->capacity) {
+    uint32_t new_capacity = self->capacity * 2;
+    if (new_capacity < 8) new_capacity = 8;
+    if (new_capacity < new_size) new_capacity = new_size;
+    _array__reserve(self, element_size, new_capacity);
+  }
+}
+
+/// This is not what you're looking for, see `array_splice`.
+static inline void _array__splice(Array *self, size_t element_size,
+                                 uint32_t index, uint32_t old_count,
+                                 uint32_t new_count, const void *elements) {
+  uint32_t new_size = self->size + new_count - old_count;
+  uint32_t old_end = index + old_count;
+  uint32_t new_end = index + new_count;
+  assert(old_end <= self->size);
+
+  _array__reserve(self, element_size, new_size);
+
+  char *contents = (char *)self->contents;
+  if (self->size > old_end) {
+    memmove(
+      contents + new_end * element_size,
+      contents + old_end * element_size,
+      (self->size - old_end) * element_size
+    );
+  }
+  if (new_count > 0) {
+    if (elements) {
+      memcpy(
+        (contents + index * element_size),
+        elements,
+        new_count * element_size
+      );
+    } else {
+      memset(
+        (contents + index * element_size),
+        0,
+        new_count * element_size
+      );
+    }
+  }
+  self->size += new_count - old_count;
+}
+
+/// A binary search routine, based on Rust's `std::slice::binary_search_by`.
+/// This is not what you're looking for, see `array_search_sorted_with` or `array_search_sorted_by`.
+#define _array__search_sorted(self, start, compare, suffix, needle, _index, _exists) \
+  do { \
+    *(_index) = start; \
+    *(_exists) = false; \
+    uint32_t size = (self)->size - *(_index); \
+    if (size == 0) break; \
+    int comparison; \
+    while (size > 1) { \
+      uint32_t half_size = size / 2; \
+      uint32_t mid_index = *(_index) + half_size; \
+      comparison = compare(&((self)->contents[mid_index] suffix), (needle)); \
+      if (comparison <= 0) *(_index) = mid_index; \
+      size -= half_size; \
+    } \
+    comparison = compare(&((self)->contents[*(_index)] suffix), (needle)); \
+    if (comparison == 0) *(_exists) = true; \
+    else if (comparison < 0) *(_index) += 1; \
+  } while (0)
+
+/// Helper macro for the `_sorted_by` routines below. This takes the left (existing)
+/// parameter by reference in order to work with the generic sorting function above.
+#define _compare_int(a, b) ((int)*(a) - (int)(b))
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#elif defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_ARRAY_H_

--- a/internal/sem/grammars/csharp/tree_sitter/parser.h
+++ b/internal/sem/grammars/csharp/tree_sitter/parser.h
@@ -1,0 +1,266 @@
+#ifndef TREE_SITTER_PARSER_H_
+#define TREE_SITTER_PARSER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define ts_builtin_sym_error ((TSSymbol)-1)
+#define ts_builtin_sym_end 0
+#define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
+
+#ifndef TREE_SITTER_API_H_
+typedef uint16_t TSStateId;
+typedef uint16_t TSSymbol;
+typedef uint16_t TSFieldId;
+typedef struct TSLanguage TSLanguage;
+#endif
+
+typedef struct {
+  TSFieldId field_id;
+  uint8_t child_index;
+  bool inherited;
+} TSFieldMapEntry;
+
+typedef struct {
+  uint16_t index;
+  uint16_t length;
+} TSFieldMapSlice;
+
+typedef struct {
+  bool visible;
+  bool named;
+  bool supertype;
+} TSSymbolMetadata;
+
+typedef struct TSLexer TSLexer;
+
+struct TSLexer {
+  int32_t lookahead;
+  TSSymbol result_symbol;
+  void (*advance)(TSLexer *, bool);
+  void (*mark_end)(TSLexer *);
+  uint32_t (*get_column)(TSLexer *);
+  bool (*is_at_included_range_start)(const TSLexer *);
+  bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
+};
+
+typedef enum {
+  TSParseActionTypeShift,
+  TSParseActionTypeReduce,
+  TSParseActionTypeAccept,
+  TSParseActionTypeRecover,
+} TSParseActionType;
+
+typedef union {
+  struct {
+    uint8_t type;
+    TSStateId state;
+    bool extra;
+    bool repetition;
+  } shift;
+  struct {
+    uint8_t type;
+    uint8_t child_count;
+    TSSymbol symbol;
+    int16_t dynamic_precedence;
+    uint16_t production_id;
+  } reduce;
+  uint8_t type;
+} TSParseAction;
+
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+} TSLexMode;
+
+typedef union {
+  TSParseAction action;
+  struct {
+    uint8_t count;
+    bool reusable;
+  } entry;
+} TSParseActionEntry;
+
+typedef struct {
+  int32_t start;
+  int32_t end;
+} TSCharacterRange;
+
+struct TSLanguage {
+  uint32_t version;
+  uint32_t symbol_count;
+  uint32_t alias_count;
+  uint32_t token_count;
+  uint32_t external_token_count;
+  uint32_t state_count;
+  uint32_t large_state_count;
+  uint32_t production_id_count;
+  uint32_t field_count;
+  uint16_t max_alias_sequence_length;
+  const uint16_t *parse_table;
+  const uint16_t *small_parse_table;
+  const uint32_t *small_parse_table_map;
+  const TSParseActionEntry *parse_actions;
+  const char * const *symbol_names;
+  const char * const *field_names;
+  const TSFieldMapSlice *field_map_slices;
+  const TSFieldMapEntry *field_map_entries;
+  const TSSymbolMetadata *symbol_metadata;
+  const TSSymbol *public_symbol_map;
+  const uint16_t *alias_map;
+  const TSSymbol *alias_sequences;
+  const TSLexMode *lex_modes;
+  bool (*lex_fn)(TSLexer *, TSStateId);
+  bool (*keyword_lex_fn)(TSLexer *, TSStateId);
+  TSSymbol keyword_capture_token;
+  struct {
+    const bool *states;
+    const TSSymbol *symbol_map;
+    void *(*create)(void);
+    void (*destroy)(void *);
+    bool (*scan)(void *, TSLexer *, const bool *symbol_whitelist);
+    unsigned (*serialize)(void *, char *);
+    void (*deserialize)(void *, const char *, unsigned);
+  } external_scanner;
+  const TSStateId *primary_state_ids;
+};
+
+static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+  uint32_t index = 0;
+  uint32_t size = len - index;
+  while (size > 1) {
+    uint32_t half_size = size / 2;
+    uint32_t mid_index = index + half_size;
+    TSCharacterRange *range = &ranges[mid_index];
+    if (lookahead >= range->start && lookahead <= range->end) {
+      return true;
+    } else if (lookahead > range->end) {
+      index = mid_index;
+    }
+    size -= half_size;
+  }
+  TSCharacterRange *range = &ranges[index];
+  return (lookahead >= range->start && lookahead <= range->end);
+}
+
+/*
+ *  Lexer Macros
+ */
+
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
+#define START_LEXER()           \
+  bool result = false;          \
+  bool skip = false;            \
+  UNUSED                        \
+  bool eof = false;             \
+  int32_t lookahead;            \
+  goto start;                   \
+  next_state:                   \
+  lexer->advance(lexer, skip);  \
+  start:                        \
+  skip = false;                 \
+  lookahead = lexer->lookahead;
+
+#define ADVANCE(state_value) \
+  {                          \
+    state = state_value;     \
+    goto next_state;         \
+  }
+
+#define ADVANCE_MAP(...)                                              \
+  {                                                                   \
+    static const uint16_t map[] = { __VA_ARGS__ };                    \
+    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
+      if (map[i] == lookahead) {                                      \
+        state = map[i + 1];                                           \
+        goto next_state;                                              \
+      }                                                               \
+    }                                                                 \
+  }
+
+#define SKIP(state_value) \
+  {                       \
+    skip = true;          \
+    state = state_value;  \
+    goto next_state;      \
+  }
+
+#define ACCEPT_TOKEN(symbol_value)     \
+  result = true;                       \
+  lexer->result_symbol = symbol_value; \
+  lexer->mark_end(lexer);
+
+#define END_STATE() return result;
+
+/*
+ *  Parse Table Macros
+ */
+
+#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
+
+#define STATE(id) id
+
+#define ACTIONS(id) id
+
+#define SHIFT(state_value)            \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = (state_value)          \
+    }                                 \
+  }}
+
+#define SHIFT_REPEAT(state_value)     \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = (state_value),         \
+      .repetition = true              \
+    }                                 \
+  }}
+
+#define SHIFT_EXTRA()                 \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .extra = true                   \
+    }                                 \
+  }}
+
+#define REDUCE(symbol_name, children, precedence, prod_id) \
+  {{                                                       \
+    .reduce = {                                            \
+      .type = TSParseActionTypeReduce,                     \
+      .symbol = symbol_name,                               \
+      .child_count = children,                             \
+      .dynamic_precedence = precedence,                    \
+      .production_id = prod_id                             \
+    },                                                     \
+  }}
+
+#define RECOVER()                    \
+  {{                                 \
+    .type = TSParseActionTypeRecover \
+  }}
+
+#define ACCEPT_INPUT()              \
+  {{                                \
+    .type = TSParseActionTypeAccept \
+  }}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_PARSER_H_

--- a/internal/sem/ignore.go
+++ b/internal/sem/ignore.go
@@ -37,13 +37,28 @@ func loadWorktreeIgnoreMatcher(repo string, ignoreFiles, includeFiles []string) 
 	if err := matcher.loadOptional(filepath.Join(repo, ".gitignore"), false); err != nil {
 		return ignoreMatcher{}, err
 	}
+	if err := matcher.loadExplicit(repo, ignoreFiles, includeFiles); err != nil {
+		return ignoreMatcher{}, err
+	}
+	return matcher, nil
+}
+
+func loadExplicitIgnoreMatcher(repo string, ignoreFiles, includeFiles []string) (ignoreMatcher, error) {
+	var matcher ignoreMatcher
+	if err := matcher.loadExplicit(repo, ignoreFiles, includeFiles); err != nil {
+		return ignoreMatcher{}, err
+	}
+	return matcher, nil
+}
+
+func (m *ignoreMatcher) loadExplicit(repo string, ignoreFiles, includeFiles []string) error {
 	for _, ignoreFile := range ignoreFiles {
 		resolved := ignoreFile
 		if !filepath.IsAbs(resolved) {
 			resolved = filepath.Join(repo, resolved)
 		}
-		if err := matcher.loadRequired(resolved, false); err != nil {
-			return ignoreMatcher{}, err
+		if err := m.loadRequired(resolved, false); err != nil {
+			return err
 		}
 	}
 	for _, includeFile := range includeFiles {
@@ -51,11 +66,11 @@ func loadWorktreeIgnoreMatcher(repo string, ignoreFiles, includeFiles []string) 
 		if !filepath.IsAbs(resolved) {
 			resolved = filepath.Join(repo, resolved)
 		}
-		if err := matcher.loadRequired(resolved, true); err != nil {
-			return ignoreMatcher{}, err
+		if err := m.loadRequired(resolved, true); err != nil {
+			return err
 		}
 	}
-	return matcher, nil
+	return nil
 }
 
 func (m *ignoreMatcher) loadOptional(file string, includeMode bool) error {

--- a/internal/sem/kotlin.go
+++ b/internal/sem/kotlin.go
@@ -315,6 +315,55 @@ func kotlinPropertyTypes(content string, returnTypesBySymbolNameAndFile map[stri
 	return out
 }
 
+// kotlinFieldInitializerTypes infers types for parser-confirmed class fields
+// whose declaration has no explicit type in the emitted signature, e.g.
+// `val koin = Koin()`. Because the input symbols are already fields, not local
+// property declarations, this can accept unmodified `val`/`var` lines without
+// reading method locals as class properties.
+func kotlinFieldInitializerTypes(content string, fields []SymbolRecord) map[string]string {
+	lines := strings.Split(stripKotlinCodeText(content), "\n")
+	out := map[string]string{}
+	conflicted := map[string]bool{}
+	record := func(name, typeName string) {
+		if name == "" || typeName == "" {
+			return
+		}
+		if existing, ok := out[name]; ok && existing != typeName {
+			conflicted[name] = true
+			return
+		}
+		out[name] = typeName
+	}
+	for _, field := range fields {
+		if field.Kind != "field" || field.Language != "Kotlin" {
+			continue
+		}
+		start := maxInt(1, field.StartLine)
+		end := maxInt(start, field.EndLine)
+		if start > len(lines) {
+			continue
+		}
+		if end > len(lines) {
+			end = len(lines)
+		}
+		block := strings.Join(lines[start-1:end], "\n")
+		pattern := regexp.MustCompile(`\b(?:val|var)\s+` + regexp.QuoteMeta(field.Name) + `\s*(?::\s*([A-Za-z_][\w.]*(?:<[^>\n]+>)?\??))?\s*=\s*([A-Z]\w*)\s*\(`)
+		match := pattern.FindStringSubmatch(block)
+		if match == nil {
+			continue
+		}
+		if typeName := kotlinTypeName(strings.TrimSuffix(stripGenerics(match[1]), "?")); typeName != "" {
+			record(field.Name, typeName)
+			continue
+		}
+		record(field.Name, match[2])
+	}
+	for name := range conflicted {
+		delete(out, name)
+	}
+	return out
+}
+
 // kotlinUniqueReturnType returns the single declared return type of the named
 // callable when every declaration in the workspace agrees on exactly one type
 // name (`fun newQueue(): TaskQueue` -> TaskQueue). Ambiguity (overloads with

--- a/internal/sem/kotlin_test.go
+++ b/internal/sem/kotlin_test.go
@@ -352,6 +352,41 @@ class Other {
 	}
 }
 
+func TestKotlinFieldInitializerTypes(t *testing.T) {
+	content := `class Koin {
+  val scopeRegistry = ScopeRegistry(this)
+  val instanceRegistry = InstanceRegistry(this)
+
+  fun loadModules() {
+    val local = LocalOnly()
+  }
+}
+
+class KoinApplication {
+  val koin = Koin()
+}
+`
+	fields := []SymbolRecord{
+		{Kind: "field", Language: "Kotlin", Name: "scopeRegistry", StartLine: 2, EndLine: 2},
+		{Kind: "field", Language: "Kotlin", Name: "instanceRegistry", StartLine: 3, EndLine: 3},
+		{Kind: "field", Language: "Kotlin", Name: "koin", StartLine: 11, EndLine: 11},
+	}
+	types := kotlinFieldInitializerTypes(content, fields)
+	want := map[string]string{
+		"scopeRegistry":    "ScopeRegistry",
+		"instanceRegistry": "InstanceRegistry",
+		"koin":             "Koin",
+	}
+	for name, typeName := range want {
+		if types[name] != typeName {
+			t.Fatalf("field %s: got %q, want %q (all: %v)", name, types[name], typeName, types)
+		}
+	}
+	if _, ok := types["local"]; ok {
+		t.Fatalf("local initializer should not be typed from field-only scan: %v", types)
+	}
+}
+
 // kotlinLocalVarTypes reads declared-type local declarations, dropping names
 // declared with two different types.
 func TestKotlinLocalVarTypes(t *testing.T) {

--- a/internal/sem/ocaml.go
+++ b/internal/sem/ocaml.go
@@ -25,8 +25,9 @@ import (
 // e.g. "Ordered_set_lang.Unexpanded"), or a bare application `name args` when
 // Path is empty.
 type ocamlCallSite struct {
-	Path string
-	Name string
+	Path      string
+	Name      string
+	Reference bool
 }
 
 var (
@@ -35,6 +36,7 @@ var (
 	// or module reference, not a value, and is deliberately not matched.
 	ocamlQualifiedRe = regexp.MustCompile(`([A-Z][A-Za-z0-9_']*(?:\.[A-Z][A-Za-z0-9_']*)*)\.([a-z_][A-Za-z0-9_']*)`)
 	ocamlIdentRe     = regexp.MustCompile(`[A-Za-z_][A-Za-z0-9_']*`)
+	ocamlOpenRe      = regexp.MustCompile(`(?m)^[ \t]*open!?[ \t]+([A-Z][A-Za-z0-9_']*(?:\.[A-Z][A-Za-z0-9_']*)*)\b`)
 )
 
 // ocamlKeyword reports OCaml reserved words. Identifiers in the scan are never
@@ -237,10 +239,10 @@ func ocamlPipelineApplied(s string, start int) bool {
 // ocamlCallSites scans an OCaml block for application expressions,
 // deduplicated and in deterministic order. Qualified applications
 // (`Mod.Sub.fn args`) are matched anywhere in expression position; bare
-// applications are only reported for names in `localNames` (the enclosing
-// file's own let bindings) and never from a binding head (`let f x y = ...`
-// binds f, x, and y — it applies nothing).
-func ocamlCallSites(block string, localNames map[string]bool) []ocamlCallSite {
+// applications are only reported for names in `callableNames` (visible let
+// bindings plus names exported by opened modules) and never from a binding head
+// (`let f x y = ...` binds f, x, and y — it applies nothing).
+func ocamlCallSites(block string, callableNames, referenceNames map[string]bool) []ocamlCallSite {
 	stripped := stripOCamlCodeText(block)
 	seen := map[ocamlCallSite]bool{}
 	qualifiedAt := map[int]bool{} // offsets covered by qualified paths
@@ -259,9 +261,14 @@ func ocamlCallSites(block string, localNames map[string]bool) []ocamlCallSite {
 		}
 		seen[ocamlCallSite{Path: stripped[m[2]:m[3]], Name: stripped[m[4]:m[5]]}] = true
 	}
-	if len(localNames) > 0 {
-		for _, site := range ocamlBareCallSites(stripped, localNames, qualifiedAt) {
+	if len(callableNames) > 0 {
+		for _, site := range ocamlBareCallSites(stripped, callableNames, qualifiedAt) {
 			seen[site] = true
+		}
+		if len(referenceNames) > 0 {
+			for _, site := range ocamlCallableReferenceSites(stripped, referenceNames, qualifiedAt) {
+				seen[site] = true
+			}
 		}
 	}
 	sites := make([]ocamlCallSite, 0, len(seen))
@@ -281,9 +288,9 @@ func ocamlCallSites(block string, localNames map[string]bool) []ocamlCallSite {
 // tracking whether the scan is inside a binding head — between `let`/`and`/
 // `fun`/`function`/`method`/`external`/`val` and the `=` or `->` that starts
 // the body — where every identifier is a binder or parameter, not a call.
-// Outside a head, a lowercase identifier that names a known same-file binding
+// Outside a head, a lowercase identifier that names a known callable binding
 // and stands in application position is reported as a bare call site.
-func ocamlBareCallSites(stripped string, localNames map[string]bool, qualifiedAt map[int]bool) []ocamlCallSite {
+func ocamlBareCallSites(stripped string, callableNames map[string]bool, qualifiedAt map[int]bool) []ocamlCallSite {
 	var sites []ocamlCallSite
 	inHead := false
 	prevEnd := 0
@@ -308,7 +315,7 @@ func ocamlBareCallSites(stripped string, localNames map[string]bool, qualifiedAt
 		if qualifiedAt[start] {
 			continue // part of a Mod.name path handled by the qualified pass
 		}
-		if !localNames[word] {
+		if !callableNames[word] {
 			continue
 		}
 		if start > 0 {
@@ -326,6 +333,81 @@ func ocamlBareCallSites(stripped string, localNames map[string]bool, qualifiedAt
 		sites = append(sites, ocamlCallSite{Name: word})
 	}
 	return sites
+}
+
+// ocamlCallableReferenceSites reports known callable values used as expression
+// arguments rather than application heads, e.g.
+// `make_int_padding_precision ... convert_int iconv`. Those higher-order
+// references are semantic outbound dependencies even though OCaml does not write
+// them as `convert_int(...)`.
+func ocamlCallableReferenceSites(stripped string, callableNames map[string]bool, qualifiedAt map[int]bool) []ocamlCallSite {
+	var sites []ocamlCallSite
+	inHead := false
+	prevEnd := 0
+	for _, m := range ocamlIdentRe.FindAllStringIndex(stripped, -1) {
+		start, end := m[0], m[1]
+		gap := stripped[prevEnd:start]
+		prevEnd = end
+		if inHead && (strings.Contains(gap, "=") || strings.Contains(gap, "->")) {
+			inHead = false
+		}
+		word := stripped[start:end]
+		if ocamlKeyword(word) {
+			switch word {
+			case "let", "and", "fun", "function", "method", "external", "val":
+				inHead = true
+			}
+			continue
+		}
+		if inHead || !callableNames[word] || qualifiedAt[start] {
+			continue
+		}
+		if start > 0 {
+			switch stripped[start-1] {
+			case '.', '~', '?', '`', '#', '\'', '%', ':':
+				continue
+			}
+		}
+		// Plain head applications are handled by ocamlBareCallSites. This pass is
+		// for callable values that occur as arguments to another expression.
+		if ocamlHeadPosition(stripped, start) && ocamlArgumentFollows(stripped, end) {
+			continue
+		}
+		if !ocamlReferenceArgumentPosition(stripped, start, end) {
+			continue
+		}
+		sites = append(sites, ocamlCallSite{Name: word, Reference: true})
+	}
+	return sites
+}
+
+func ocamlReferenceArgumentPosition(s string, start, end int) bool {
+	prev := start - 1
+	for prev >= 0 && (s[prev] == ' ' || s[prev] == '\t' || s[prev] == '\n' || s[prev] == '\r') {
+		prev--
+	}
+	if prev < 0 {
+		return false
+	}
+	prevIsExpr := s[prev] == ')' || s[prev] == ']' || s[prev] == '}' || isOCamlIdentByte(s[prev]) || (s[prev] >= '0' && s[prev] <= '9')
+	if !prevIsExpr {
+		return false
+	}
+	next := end
+	for next < len(s) && (s[next] == ' ' || s[next] == '\t' || s[next] == '\n' || s[next] == '\r') {
+		next++
+	}
+	if next >= len(s) {
+		return true
+	}
+	switch s[next] {
+	case ';', ')', ']', '}', ',', '|':
+		return true
+	}
+	if s[next] == '-' && next+1 < len(s) && s[next+1] == '>' {
+		return false
+	}
+	return ocamlArgumentFollows(s, end)
 }
 
 // ocamlFileDefinesModule reports whether an OCaml source file defines module
@@ -357,25 +439,176 @@ func ocamlCallableKind(kind string) bool {
 	return kind == "function" || kind == "method"
 }
 
-// ocamlCallRelations resolves the application sites in an OCaml symbol's
-// block. Bare applications resolve within the same file only, to `let`
-// bindings the caller can actually see unqualified; qualified applications
-// resolve to callables defined in a file that defines the root module of the
-// qualifier. When both `mod.ml` and `mod.mli` match, the implementation wins:
-// the `.mli` is an interface restating the same value. Recursive calls to the
-// enclosing symbol itself are skipped.
-func ocamlCallRelations(from SymbolRecord, block string, sameFile []SymbolRecord, symbolsByShortName map[string][]SymbolRecord) []RelationRecord {
-	localNames := map[string]bool{}
+func ocamlOpenModules(content string) []string {
+	stripped := stripOCamlCodeText(content)
+	seen := map[string]bool{}
+	var modules []string
+	for _, m := range ocamlOpenRe.FindAllStringSubmatch(stripped, -1) {
+		if len(m) < 2 || seen[m[1]] {
+			continue
+		}
+		seen[m[1]] = true
+		modules = append(modules, m[1])
+	}
+	return modules
+}
+
+func ocamlVisibleSameFileCallables(from SymbolRecord, sameFile []SymbolRecord) []SymbolRecord {
+	var visible []SymbolRecord
 	for _, s := range sameFile {
-		if s.Kind == "function" && s.ID != from.ID {
-			localNames[s.Name] = true
+		if s.ID == from.ID || !ocamlCallableKind(s.Kind) {
+			continue
+		}
+		// OCaml top-level values are sequential, while `let rec ... and ...`
+		// siblings are contained in the parsed recursive block. A later binding
+		// outside the caller's block is not in scope and commonly has short
+		// parameter-like names (`k`, `f`) that would otherwise false-match.
+		if s.StartLine > from.EndLine {
+			continue
+		}
+		visible = append(visible, s)
+	}
+	return visible
+}
+
+func ocamlOpenedCallableNames(openedModules []string, symbolsByShortName map[string][]SymbolRecord) map[string]bool {
+	names := map[string]bool{}
+	if len(openedModules) == 0 {
+		return names
+	}
+	for name, symbols := range symbolsByShortName {
+		for _, s := range symbols {
+			if s.Language != "OCaml" || !ocamlCallableKind(s.Kind) {
+				continue
+			}
+			if ocamlAnyOpenedModuleDefinesFile(s.FilePath, openedModules, symbolsByShortName) {
+				names[name] = true
+				break
+			}
 		}
 	}
+	return names
+}
+
+func ocamlOpenedCallableReferenceNames(openedModules []string, symbolsByShortName map[string][]SymbolRecord) map[string]bool {
+	names := map[string]bool{}
+	if len(openedModules) == 0 {
+		return names
+	}
+	for name, symbols := range symbolsByShortName {
+		for _, s := range symbols {
+			if s.Language != "OCaml" || !ocamlCallableReferenceTarget(s) {
+				continue
+			}
+			if ocamlAnyOpenedModuleDefinesFile(s.FilePath, openedModules, symbolsByShortName) {
+				names[name] = true
+				break
+			}
+		}
+	}
+	return names
+}
+
+func ocamlCallableReferenceTarget(symbol SymbolRecord) bool {
+	if !ocamlCallableKind(symbol.Kind) {
+		return false
+	}
+	signature := strings.TrimSpace(symbol.Signature)
+	if signature == "" {
+		return true
+	}
+	if strings.Contains(signature, " = fun ") || strings.Contains(signature, " -> ") {
+		return true
+	}
+	for _, prefix := range []string{"let rec ", "let ", "and "} {
+		if !strings.HasPrefix(signature, prefix) {
+			continue
+		}
+		rest := strings.TrimSpace(strings.TrimPrefix(signature, prefix))
+		if !strings.HasPrefix(rest, symbol.Name) {
+			continue
+		}
+		after := strings.TrimSpace(rest[len(symbol.Name):])
+		if after == "" || strings.HasPrefix(after, "=") {
+			return false
+		}
+		if strings.HasPrefix(after, ":") {
+			return strings.Contains(after, "->") || strings.Contains(after, "= fun")
+		}
+		return true
+	}
+	return false
+}
+
+func ocamlAnyOpenedModuleDefinesFile(path string, openedModules []string, symbolsByShortName map[string][]SymbolRecord) bool {
+	for _, modulePath := range openedModules {
+		root, _, _ := strings.Cut(modulePath, ".")
+		if ocamlFileDefinesModule(path, root, symbolsByShortName) {
+			return true
+		}
+	}
+	return false
+}
+
+func ocamlResolveOpenedTargets(name string, from SymbolRecord, openedModules []string, symbolsByShortName map[string][]SymbolRecord) []resolvedCallTarget {
+	for i := len(openedModules) - 1; i >= 0; i-- {
+		root, _, _ := strings.Cut(openedModules[i], ".")
+		var targets []resolvedCallTarget
+		for _, to := range symbolsByShortName[name] {
+			if to.ID == from.ID || to.Language != "OCaml" || !ocamlCallableKind(to.Kind) {
+				continue
+			}
+			if !localReachable(from, to) || !ocamlFileDefinesModule(to.FilePath, root, symbolsByShortName) {
+				continue
+			}
+			targets = append(targets, resolvedCallTarget{
+				SymbolRecord: to,
+				Confidence:   0.84,
+				Reason:       "bare application resolved through open module",
+				Resolution:   "import_resolved",
+				Scope:        "module",
+			})
+		}
+		targets = ocamlPreferImplementationTargets(targets)
+		if len(targets) > 0 {
+			return targets
+		}
+	}
+	return nil
+}
+
+// ocamlCallRelations resolves the application sites in an OCaml symbol's block.
+// Bare applications resolve first to visible same-file `let` bindings, then
+// through top-level opened modules; qualified applications resolve to callables
+// defined in a file that defines the root module of the qualifier. When both
+// `mod.ml` and `mod.mli` match, the implementation wins: the `.mli` is an
+// interface restating the same value. Recursive calls to the enclosing symbol
+// itself are skipped.
+func ocamlCallRelations(from SymbolRecord, block string, sameFile []SymbolRecord, symbolsByShortName map[string][]SymbolRecord, openedModules []string, openedCallableNames, openedReferenceNames map[string]bool) []RelationRecord {
+	localNames := map[string]bool{}
+	referenceNames := map[string]bool{}
+	visibleSameFile := ocamlVisibleSameFileCallables(from, sameFile)
+	for _, s := range visibleSameFile {
+		localNames[s.Name] = true
+		if ocamlCallableReferenceTarget(s) {
+			referenceNames[s.Name] = true
+		}
+	}
+	callableNames := map[string]bool{}
+	for name := range localNames {
+		callableNames[name] = true
+	}
+	for name := range openedCallableNames {
+		callableNames[name] = true
+	}
+	for name := range openedReferenceNames {
+		referenceNames[name] = true
+	}
 	var relations []RelationRecord
-	for _, site := range ocamlCallSites(block, localNames) {
+	for _, site := range ocamlCallSites(block, callableNames, referenceNames) {
 		var targets []resolvedCallTarget
 		if site.Path == "" {
-			for _, to := range sameFile {
+			for _, to := range visibleSameFile {
 				if to.ID == from.ID || to.Kind != "function" || to.Name != site.Name {
 					continue
 				}
@@ -386,6 +619,9 @@ func ocamlCallRelations(from SymbolRecord, block string, sameFile []SymbolRecord
 					Resolution:   "exact",
 					Scope:        "file",
 				})
+			}
+			if len(targets) == 0 {
+				targets = ocamlResolveOpenedTargets(site.Name, from, openedModules, symbolsByShortName)
 			}
 		} else {
 			root, _, _ := strings.Cut(site.Path, ".")
@@ -411,13 +647,17 @@ func ocamlCallRelations(from SymbolRecord, block string, sameFile []SymbolRecord
 			detail = site.Path + "." + site.Name
 		}
 		for _, to := range targets {
+			reason := to.Reason
+			if site.Reference {
+				reason = "callable value reference resolved to OCaml symbol"
+			}
 			relations = append(relations, RelationRecord{
 				RecordType:    "relation",
 				FromID:        from.ID,
 				ToID:          to.ID,
 				Type:          "CALLS",
 				Confidence:    to.Confidence,
-				Reason:        to.Reason,
+				Reason:        reason,
 				RelationScope: to.Scope,
 				Resolution:    to.Resolution,
 				TargetKind:    "symbol",

--- a/internal/sem/ocaml_test.go
+++ b/internal/sem/ocaml_test.go
@@ -58,7 +58,7 @@ func TestOCamlCallSites(t *testing.T) {
   set |> helper;
   Ordered_set_lang.eval set ~standard ~eq:String.equal ~parse:(fun ~loc:_ s -> s)
 `
-	sites := ocamlCallSites(block, locals)
+	sites := ocamlCallSites(block, locals, nil)
 	got := map[ocamlCallSite]bool{}
 	for _, site := range sites {
 		got[site] = true
@@ -186,6 +186,76 @@ val eval : t -> standard:string list -> eq:(string -> string -> bool) -> parse:(
 		// literal must not fabricate extra edges into ordered_set_lang.
 		if e.from == "src/ocaml_flags_db.ml:ocaml_flags_env" && strings.Contains(e.to, "ordered_set_lang") {
 			t.Fatalf("masked text fabricated OCaml CALLS edge %v", e)
+		}
+	}
+}
+
+func TestOCamlOpenModuleAndCallableReferenceExtraction(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "stdlib/camlinternalFormatBasics.ml", `let rec concat_fmt fmt rest =
+  if fmt = rest then fmt else concat_fmt rest fmt
+`)
+	writeFile(t, repo, "stdlib/camlinternalFormat.ml", `open CamlinternalFormatBasics
+
+let convert_int iconv n = iconv + n
+let convert_int32 iconv n = iconv + n
+let convert_int64 iconv n = iconv + n
+
+let make_int_padding_precision _k _acc _rest _pad _prec trans iconv =
+  trans iconv 1
+
+let rec make_printf fmt =
+  make_int_padding_precision () () fmt () () convert_int 0;
+  make_int_padding_precision () () fmt () () convert_int32 0;
+  make_int_padding_precision () () fmt () () convert_int64 0;
+  concat_fmt fmt fmt
+`)
+	writeFile(t, repo, "stdlib/format.ml", `open CamlinternalFormatBasics
+open CamlinternalFormat
+
+let printf fmt =
+  make_printf fmt
+
+let eprintf fmt =
+  make_printf fmt
+`)
+	writeFile(t, repo, "stdlib/printf.ml", `open CamlinternalFormat
+
+let kbprintf fmt =
+  make_printf fmt
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	type edge struct{ from, to string }
+	calls := map[edge]bool{}
+	for _, r := range snapshot.Relations {
+		if r.Type != "CALLS" {
+			continue
+		}
+		from, fromOK := symbolsByID[r.FromID]
+		to, toOK := symbolsByID[r.ToID]
+		if !fromOK || !toOK || from.Language != "OCaml" || to.Language != "OCaml" {
+			continue
+		}
+		calls[edge{from.FilePath + ":" + from.Name, to.FilePath + ":" + to.Name}] = true
+	}
+	for _, want := range []edge{
+		{"stdlib/format.ml:printf", "stdlib/camlinternalFormat.ml:make_printf"},
+		{"stdlib/format.ml:eprintf", "stdlib/camlinternalFormat.ml:make_printf"},
+		{"stdlib/printf.ml:kbprintf", "stdlib/camlinternalFormat.ml:make_printf"},
+		{"stdlib/camlinternalFormat.ml:make_printf", "stdlib/camlinternalFormatBasics.ml:concat_fmt"},
+		{"stdlib/camlinternalFormat.ml:make_printf", "stdlib/camlinternalFormat.ml:convert_int"},
+		{"stdlib/camlinternalFormat.ml:make_printf", "stdlib/camlinternalFormat.ml:convert_int32"},
+		{"stdlib/camlinternalFormat.ml:make_printf", "stdlib/camlinternalFormat.ml:convert_int64"},
+	} {
+		if !calls[want] {
+			t.Fatalf("missing OCaml open/callable-reference CALLS edge %v in %v", want, calls)
 		}
 	}
 }

--- a/internal/sem/parser.go
+++ b/internal/sem/parser.go
@@ -302,6 +302,18 @@ func (TreeSitterParser) ParseWithStatus(path, content string) ([]Entity, string,
 		entities = append(entities, postgresFunctionEntities(regexSrc)...)
 		entities = append(entities, postgresPolicyEntities(regexSrc)...)
 	}
+	if spec.language == "Lua" {
+		// tree-sitter-lua can recover from large annotated files with incomplete
+		// top-level function coverage. Supplement it with the canonical Lua
+		// declaration forms so exported table functions stay discoverable.
+		entities = appendMissingEntities(entities, luaFunctionEntities(content)...)
+	}
+	if spec.language == "Objective-C" {
+		// Large Objective-C implementation files with blocks/macros can leave
+		// recoverable method definitions out of the tree-sitter walk. Supplement
+		// only brace-backed implementation methods; header prototypes end in ';'.
+		entities = appendMissingEntities(entities, objectiveCMethodEntities(content)...)
+	}
 	sort.Slice(entities, func(i, j int) bool {
 		if entities[i].StartLine == entities[j].StartLine {
 			return entities[i].Name < entities[j].Name
@@ -1129,18 +1141,18 @@ func maskSwiftOptionalBindingShorthand(text string) (string, bool) {
 }
 
 var (
-	cSharpPointerDerefCastPattern           = regexp.MustCompile(`\*+\(\s*[A-Za-z_@][\w<>,.\s]*?\*+\s*\)`)
-	cSharpDictionaryIndexInitializerPattern = regexp.MustCompile(`\{\s*\[[^\]\n]+\]\s*=\s*[^{}\n]+\}`)
-	swiftTypedThrowsPattern                         = regexp.MustCompile(`throws\([A-Za-z_][A-Za-z0-9_.<>]*\)`)
-	swiftOptionalBindingShorthandPattern            = regexp.MustCompile(`\bif\s+let\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{`)
-	swiftEmptyAttributeCallPattern                  = regexp.MustCompile(`@[A-Za-z_][A-Za-z0-9_]*\(\)`)
-	swiftPropertyWrapperPrefixPattern               = regexp.MustCompile(`^(\s*)@[A-Za-z_][A-Za-z0-9_]*(?:\([^)]*\))?\s+(?:var|let)\s+`)
-	swiftLeadingOperatorContinuationLinePattern     = regexp.MustCompile(`^\s*(?:<|>|<=|>=|==|!=|&&|\|\|)\s+`)
-	swiftComputedStringPropertyStartPattern         = regexp.MustCompile(`^((?:(?:private|fileprivate|internal|public)\s+)?)var\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(String|\[String\])\s*\{$`)
-	cControlIteratorMacroPattern                    = regexp.MustCompile(`^(?:(?:TAILQ|STAILQ|LIST|SLIST|RB|SPLAY)_(?:FOREACH|FOREACH_SAFE|FOREACH_REVERSE|FOREACH_REVERSE_SAFE)|(?:foreach|foreach_ptr|foreach_node|foreach_oid|foreach_int|foreach_xid|foreach_delete_current|forboth|for_both_cell|forthree|for_fourth_cell|for_each_from|dlist_foreach(?:_modify)?|dclist_foreach(?:_modify)?|slist_foreach(?:_modify)?|hash_seq_search|SGITITERATE))\s*\(`)
-	cGenerateMacroPattern                           = regexp.MustCompile(`^(?:TAILQ|STAILQ|LIST|SLIST|RB|SPLAY)_(?:HEAD|ENTRY|PROTOTYPE|PROTOTYPE_STATIC|GENERATE|GENERATE_STATIC)\s*\(`)
-	cEnumMacroPattern                               = regexp.MustCompile(`^[A-Z][A-Z0-9_]*_KEYS\s*\(`)
-	cFileScopeStatementMacroPattern                 = regexp.MustCompile(`^(?:PG_MODULE_MAGIC(?:_EXT)?|PG_FUNCTION_INFO_V1|PGDLLEXPORT|PG_KEYWORD|PG_FUNCTION_ARGS|PG_USED_FOR_ASSERTS_ONLY|DECLARE_[A-Z][A-Z0-9_]*|MAKE_SYSCACHE)\s*\(`)
+	cSharpPointerDerefCastPattern               = regexp.MustCompile(`\*+\(\s*[A-Za-z_@][\w<>,.\s]*?\*+\s*\)`)
+	cSharpDictionaryIndexInitializerPattern     = regexp.MustCompile(`\{\s*\[[^\]\n]+\]\s*=\s*[^{}\n]+\}`)
+	swiftTypedThrowsPattern                     = regexp.MustCompile(`throws\([A-Za-z_][A-Za-z0-9_.<>]*\)`)
+	swiftOptionalBindingShorthandPattern        = regexp.MustCompile(`\bif\s+let\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{`)
+	swiftEmptyAttributeCallPattern              = regexp.MustCompile(`@[A-Za-z_][A-Za-z0-9_]*\(\)`)
+	swiftPropertyWrapperPrefixPattern           = regexp.MustCompile(`^(\s*)@[A-Za-z_][A-Za-z0-9_]*(?:\([^)]*\))?\s+(?:var|let)\s+`)
+	swiftLeadingOperatorContinuationLinePattern = regexp.MustCompile(`^\s*(?:<|>|<=|>=|==|!=|&&|\|\|)\s+`)
+	swiftComputedStringPropertyStartPattern     = regexp.MustCompile(`^((?:(?:private|fileprivate|internal|public)\s+)?)var\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(String|\[String\])\s*\{$`)
+	cControlIteratorMacroPattern                = regexp.MustCompile(`^(?:(?:TAILQ|STAILQ|LIST|SLIST|RB|SPLAY)_(?:FOREACH|FOREACH_SAFE|FOREACH_REVERSE|FOREACH_REVERSE_SAFE)|(?:foreach|foreach_ptr|foreach_node|foreach_oid|foreach_int|foreach_xid|foreach_delete_current|forboth|for_both_cell|forthree|for_fourth_cell|for_each_from|dlist_foreach(?:_modify)?|dclist_foreach(?:_modify)?|slist_foreach(?:_modify)?|hash_seq_search|SGITITERATE))\s*\(`)
+	cGenerateMacroPattern                       = regexp.MustCompile(`^(?:TAILQ|STAILQ|LIST|SLIST|RB|SPLAY)_(?:HEAD|ENTRY|PROTOTYPE|PROTOTYPE_STATIC|GENERATE|GENERATE_STATIC)\s*\(`)
+	cEnumMacroPattern                           = regexp.MustCompile(`^[A-Z][A-Z0-9_]*_KEYS\s*\(`)
+	cFileScopeStatementMacroPattern             = regexp.MustCompile(`^(?:PG_MODULE_MAGIC(?:_EXT)?|PG_FUNCTION_INFO_V1|PGDLLEXPORT|PG_KEYWORD|PG_FUNCTION_ARGS|PG_USED_FOR_ASSERTS_ONLY|DECLARE_[A-Z][A-Z0-9_]*|MAKE_SYSCACHE)\s*\(`)
 	// PostgreSQL system-catalog header macros: the `CATALOG(name,oid,...) BKI_...`
 	// struct opener (the `{` follows on the next line) and BKI_* field/struct
 	// annotations. BEGIN/END_CATALOG_STRUCT markers are handled as bare lines.
@@ -3216,6 +3228,23 @@ var cFamilyNonFunctionNames = map[string]bool{
 	"while":   true,
 }
 
+func cFamilyTypedefAliasName(node *sitter.Node, src []byte) string {
+	text := strings.TrimSpace(stripCodeLiteralsAndComments(node.Content(src)))
+	if !strings.HasPrefix(text, "typedef ") {
+		return ""
+	}
+	text = strings.TrimSuffix(strings.TrimSpace(text), ";")
+	match := cFamilyTypedefNameRe.FindStringSubmatch(text)
+	if match == nil {
+		return ""
+	}
+	name := match[1]
+	if cFamilyNonFunctionNames[name] {
+		return ""
+	}
+	return name
+}
+
 func fastCFamilyEntities(path, content, language string) []Entity {
 	_ = path
 	_ = language
@@ -4500,6 +4529,12 @@ func entityFromNode(node *sitter.Node, src []byte, language, scope string) (Enti
 			// *_type_defn child; the generic name descent would instead latch onto
 			// a leading attribute ([<CustomEquality>] type SemVerInfo -> "CustomEquality").
 			name = fsharpTypeName(node, src)
+		} else if (language == "C" || language == "C++") && node.Type() == "type_definition" {
+			if alias := cFamilyTypedefAliasName(node, src); alias != "" {
+				name = alias
+			} else {
+				name = nodeName(node, src)
+			}
 		} else {
 			name = nodeName(node, src)
 		}
@@ -6208,6 +6243,9 @@ func functionLikeValue(node *sitter.Node) bool {
 
 var jsExportedVariablePattern = regexp.MustCompile(`(?m)^\s*export\s+(?:const|let|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=`)
 var jsAssignmentMethodPattern = regexp.MustCompile(`(?m)^\s*((?:[A-Za-z_$][A-Za-z0-9_$]*\s*\.\s*)+[A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*(?:async\s+)?function(?:\s+[A-Za-z_$][A-Za-z0-9_$]*)?\s*\(`)
+var luaFunctionLinePattern = regexp.MustCompile(`(?m)^[ \t]*(?:local[ \t]+)?function[ \t]+([A-Za-z_][A-Za-z0-9_]*(?:(?:[.:])[A-Za-z_][A-Za-z0-9_]*)*)[ \t]*\(`)
+var luaBlockTokenPattern = regexp.MustCompile(`\b(function|if|for|while|repeat|do|end|until)\b`)
+var objectiveCMethodNamePattern = regexp.MustCompile(`^\s*([A-Za-z_][A-Za-z0-9_]*)`)
 
 func javascriptExportedVariableEntities(content string) []Entity {
 	matches := jsExportedVariablePattern.FindAllStringSubmatchIndex(content, -1)
@@ -6285,6 +6323,201 @@ func javascriptAssignmentMethodEntities(content string) []Entity {
 		})
 	}
 	return entities
+}
+
+func luaFunctionEntities(content string) []Entity {
+	matches := luaFunctionLinePattern.FindAllStringSubmatchIndex(content, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	lines := strings.Split(content, "\n")
+	entities := make([]Entity, 0, len(matches))
+	for _, match := range matches {
+		if len(match) < 4 {
+			continue
+		}
+		name := strings.ReplaceAll(strings.TrimSpace(content[match[2]:match[3]]), ":", ".")
+		if name == "" {
+			continue
+		}
+		lineStart := strings.LastIndexByte(content[:match[0]], '\n') + 1
+		lineEndRel := strings.IndexByte(content[match[0]:], '\n')
+		lineEnd := len(content)
+		if lineEndRel >= 0 {
+			lineEnd = match[0] + lineEndRel
+		}
+		signature := strings.TrimSpace(content[lineStart:lineEnd])
+		startLine := countLinesBefore(content, match[0]) + 1
+		endLine := luaFunctionEndLine(lines, startLine)
+		block := luaBlock(lines, startLine, endLine)
+		entities = append(entities, Entity{
+			Kind:        "function",
+			Name:        name,
+			Signature:   signature,
+			StartLine:   startLine,
+			EndLine:     endLine,
+			BodyHash:    hash(normalize(block)),
+			Fingerprint: hash(normalize(entityFingerprintSource(Entity{Name: name, Signature: signature}, block))),
+		})
+	}
+	return entities
+}
+
+func luaBlock(lines []string, startLine, endLine int) string {
+	if startLine < 1 {
+		startLine = 1
+	}
+	if endLine < startLine {
+		endLine = startLine
+	}
+	if endLine > len(lines) {
+		endLine = len(lines)
+	}
+	if startLine > len(lines) || endLine < startLine {
+		return ""
+	}
+	return strings.Join(lines[startLine-1:endLine], "\n")
+}
+
+func luaFunctionEndLine(lines []string, startLine int) int {
+	depth := 0
+	for i := startLine - 1; i < len(lines); i++ {
+		code := stripLuaLineForBlockScan(lines[i])
+		previous := ""
+		for _, match := range luaBlockTokenPattern.FindAllStringSubmatch(code, -1) {
+			if len(match) < 2 {
+				continue
+			}
+			token := match[1]
+			switch token {
+			case "function", "if", "for", "while", "repeat":
+				depth++
+			case "do":
+				if previous != "for" && previous != "while" {
+					depth++
+				}
+			case "end", "until":
+				depth--
+				if depth <= 0 {
+					return i + 1
+				}
+			}
+			previous = token
+		}
+	}
+	return len(lines)
+}
+
+func stripLuaLineForBlockScan(line string) string {
+	bytes := []byte(line)
+	quote := byte(0)
+	for i := 0; i < len(bytes); i++ {
+		if quote != 0 {
+			if bytes[i] == '\\' {
+				i++
+				continue
+			}
+			if bytes[i] == quote {
+				quote = 0
+			}
+			bytes[i] = ' '
+			continue
+		}
+		switch bytes[i] {
+		case '"', '\'':
+			quote = bytes[i]
+			bytes[i] = ' '
+		case '-':
+			if i+1 < len(bytes) && bytes[i+1] == '-' {
+				for j := i; j < len(bytes); j++ {
+					bytes[j] = ' '
+				}
+				return string(bytes)
+			}
+		}
+	}
+	return string(bytes)
+}
+
+func objectiveCMethodEntities(content string) []Entity {
+	lines := strings.SplitAfter(content, "\n")
+	offsets := make([]int, len(lines))
+	offset := 0
+	for i, line := range lines {
+		offsets[i] = offset
+		offset += len(line)
+	}
+
+	var entities []Entity
+	for i := 0; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if !strings.HasPrefix(trimmed, "- (") && !strings.HasPrefix(trimmed, "+ (") {
+			continue
+		}
+		startLine := i + 1
+		startByte := offsets[i] + strings.Index(lines[i], strings.TrimLeft(lines[i], " \t"))
+		headerParts := []string{strings.TrimSpace(strings.TrimRight(lines[i], "\r\n"))}
+		openByte := -1
+		prototype := false
+		for j := i; j < len(lines) && j < i+40; j++ {
+			if j > i {
+				headerParts = append(headerParts, strings.TrimSpace(strings.TrimRight(lines[j], "\r\n")))
+			}
+			line := lines[j]
+			brace := strings.IndexByte(line, '{')
+			semi := strings.IndexByte(line, ';')
+			if semi >= 0 && (brace < 0 || semi < brace) {
+				prototype = true
+				break
+			}
+			if brace >= 0 {
+				openByte = offsets[j] + brace
+				break
+			}
+		}
+		if prototype || openByte < 0 {
+			continue
+		}
+		header := strings.Join(headerParts, " ")
+		name := objectiveCMethodHeaderName(header)
+		if name == "" {
+			continue
+		}
+		endLine := startLine
+		closeByte := matchingDelimiterOffset(content, openByte, '{', '}')
+		if closeByte >= 0 {
+			endLine = countLinesBefore(content, closeByte) + 1
+		}
+		signature := strings.TrimSpace(strings.TrimSuffix(header[:strings.Index(header, "{")+1], "{"))
+		blockEnd := minInt(len(content), openByte+1)
+		if closeByte >= 0 {
+			blockEnd = closeByte + 1
+		}
+		block := content[startByte:blockEnd]
+		entities = append(entities, Entity{
+			Kind:        "method",
+			Name:        name,
+			Signature:   signature,
+			StartLine:   startLine,
+			EndLine:     endLine,
+			BodyHash:    hash(normalize(block)),
+			Fingerprint: hash(normalize(entityFingerprintSource(Entity{Name: name, Signature: signature}, block))),
+		})
+	}
+	return entities
+}
+
+func objectiveCMethodHeaderName(header string) string {
+	closeReturnType := strings.IndexByte(header, ')')
+	if closeReturnType < 0 || closeReturnType+1 >= len(header) {
+		return ""
+	}
+	rest := header[closeReturnType+1:]
+	match := objectiveCMethodNamePattern.FindStringSubmatch(rest)
+	if len(match) < 2 {
+		return ""
+	}
+	return match[1]
 }
 
 func appendMissingEntities(entities []Entity, candidates ...Entity) []Entity {

--- a/internal/sem/parser.go
+++ b/internal/sem/parser.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	clojure "github.com/entireio/entire-sem/internal/sem/grammars/clojure"
+	csharp "github.com/entireio/entire-sem/internal/sem/grammars/csharp"
 	dart "github.com/entireio/entire-sem/internal/sem/grammars/dart"
 	erlang "github.com/entireio/entire-sem/internal/sem/grammars/erlang"
 	fsharp "github.com/entireio/entire-sem/internal/sem/grammars/fsharp"
@@ -27,7 +28,6 @@ import (
 	"github.com/smacker/go-tree-sitter/bash"
 	"github.com/smacker/go-tree-sitter/c"
 	"github.com/smacker/go-tree-sitter/cpp"
-	"github.com/smacker/go-tree-sitter/csharp"
 	"github.com/smacker/go-tree-sitter/cue"
 	"github.com/smacker/go-tree-sitter/elixir"
 	"github.com/smacker/go-tree-sitter/golang"
@@ -799,24 +799,27 @@ func maskCSharpUnsupportedSyntax(content string) string {
 		switch {
 		case strings.HasPrefix(trimmed, "#"):
 			lines[i] = maskLineText(text) + newline
-		case cSharpPrimaryConstructorClassLinePattern.MatchString(text):
-			lines[i] = cSharpMaskPrimaryConstructorClass(text) + newline
 		default:
-			text = replacePatternSameLength(text, cSharpNullCoalescingCollectionExpressionPattern, "??= null")
-			text = replacePatternSameLength(text, cSharpAssignmentCollectionExpressionPattern, "= null")
+			// The vendored C# 13 grammar parses collection expressions,
+			// primary constructors, and params collections natively. Two
+			// constructs still degrade to ERROR nodes: prefix dereference
+			// of a pointer cast (`*(T*)&x`, unsafe hot paths) and
+			// dictionary index initializers with non-literal keys
+			// (`{ [key] = value }`).
+			text = maskPointerDerefCasts(text)
 			lines[i] = replacePatternSameLength(text, cSharpDictionaryIndexInitializerPattern, "{}") + newline
 		}
 	}
 	return strings.Join(lines, "")
 }
 
-func cSharpMaskPrimaryConstructorClass(text string) string {
-	matches := cSharpPrimaryConstructorClassLinePattern.FindStringSubmatch(text)
-	if len(matches) < 2 {
-		return text
-	}
-	replacement := "class " + matches[1] + " {}"
-	return paddedReplacement(leadingWhitespace(text), replacement, len(text))
+// maskPointerDerefCasts rewrites `*(T*)expr` into ` (T )expr` (same byte
+// length) because tree-sitter-c-sharp cannot disambiguate a prefix pointer
+// dereference applied directly to a pointer-cast expression.
+func maskPointerDerefCasts(text string) string {
+	return cSharpPointerDerefCastPattern.ReplaceAllStringFunc(text, func(m string) string {
+		return strings.ReplaceAll(m, "*", " ")
+	})
 }
 
 var ocamlValSignaturePattern = regexp.MustCompile(`^(\s*)val\s+(\([^)\n]*\)|[A-Za-z_][\w']*)\b`)
@@ -1126,10 +1129,8 @@ func maskSwiftOptionalBindingShorthand(text string) (string, bool) {
 }
 
 var (
-	cSharpPrimaryConstructorClassLinePattern        = regexp.MustCompile(`^\s*(?:(?:public|internal|private|protected|sealed|abstract|partial|static)\s+)*class\s+([A-Za-z_][A-Za-z0-9_]*)\s*\([^;\n]*\)\s*(?::\s*[^{};\n]+)?\s*;\s*$`)
-	cSharpDictionaryIndexInitializerPattern         = regexp.MustCompile(`\{\s*\[[^\]\n]+\]\s*=\s*[^{}\n]+\}`)
-	cSharpAssignmentCollectionExpressionPattern     = regexp.MustCompile(`=\s*\[\]`)
-	cSharpNullCoalescingCollectionExpressionPattern = regexp.MustCompile(`\?\?=\s*\[\]`)
+	cSharpPointerDerefCastPattern           = regexp.MustCompile(`\*+\(\s*[A-Za-z_@][\w<>,.\s]*?\*+\s*\)`)
+	cSharpDictionaryIndexInitializerPattern = regexp.MustCompile(`\{\s*\[[^\]\n]+\]\s*=\s*[^{}\n]+\}`)
 	swiftTypedThrowsPattern                         = regexp.MustCompile(`throws\([A-Za-z_][A-Za-z0-9_.<>]*\)`)
 	swiftOptionalBindingShorthandPattern            = regexp.MustCompile(`\bif\s+let\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{`)
 	swiftEmptyAttributeCallPattern                  = regexp.MustCompile(`@[A-Za-z_][A-Za-z0-9_]*\(\)`)

--- a/internal/sem/parser.go
+++ b/internal/sem/parser.go
@@ -819,6 +819,7 @@ func maskCSharpUnsupportedSyntax(content string) string {
 			// dictionary index initializers with non-literal keys
 			// (`{ [key] = value }`).
 			text = maskPointerDerefCasts(text)
+			text = maskBareAsyncArguments(text)
 			lines[i] = replacePatternSameLength(text, cSharpDictionaryIndexInitializerPattern, "{}") + newline
 		}
 	}
@@ -856,6 +857,21 @@ var ocamlValStartKeywords = map[string]struct{}{
 // ocamlContinuesValSignature reports whether a line continues the multi-line
 // type of the preceding `val` (i.e. it is non-blank, not a comment, and does
 // not begin a new top-level signature item).
+// maskBareAsyncArguments rewrites a bare `async` identifier in argument
+// position (`F(request, async, this)`) into `true ` (same byte length).
+// tree-sitter-c-sharp reads argument-position `async` as the start of an
+// async lambda and the resulting ERROR can swallow the enclosing class
+// declaration (dotnet/runtime HttpConnectionPool.cs lost its class symbol
+// and every member's qualification). Lambda forms (`async x => ...`,
+// `async () => ...`) never match: the token must be followed directly by
+// `,` or `)`. Applied twice because adjacent matches share delimiters.
+func maskBareAsyncArguments(text string) string {
+	for i := 0; i < 2; i++ {
+		text = cSharpBareAsyncArgumentPattern.ReplaceAllString(text, "${1}true $2")
+	}
+	return text
+}
+
 func ocamlContinuesValSignature(line string) bool {
 	t := strings.TrimSpace(line)
 	if t == "" || strings.HasPrefix(t, "(*") {
@@ -1142,6 +1158,7 @@ func maskSwiftOptionalBindingShorthand(text string) (string, bool) {
 
 var (
 	cSharpPointerDerefCastPattern               = regexp.MustCompile(`\*+\(\s*[A-Za-z_@][\w<>,.\s]*?\*+\s*\)`)
+	cSharpBareAsyncArgumentPattern              = regexp.MustCompile(`([(,]\s*)async(\s*[,)])`)
 	cSharpDictionaryIndexInitializerPattern     = regexp.MustCompile(`\{\s*\[[^\]\n]+\]\s*=\s*[^{}\n]+\}`)
 	swiftTypedThrowsPattern                     = regexp.MustCompile(`throws\([A-Za-z_][A-Za-z0-9_.<>]*\)`)
 	swiftOptionalBindingShorthandPattern        = regexp.MustCompile(`\bif\s+let\s+([A-Za-z_][A-Za-z0-9_]*)\s*\{`)

--- a/internal/sem/parser_test.go
+++ b/internal/sem/parser_test.go
@@ -3162,3 +3162,42 @@ void jv_free(jv x) {
 		t.Errorf("return type jv_kind extracted as a function name")
 	}
 }
+
+func TestTreeSitterParserCAnonymousTypedefStructUsesAliasName(t *testing.T) {
+	// codebase-memory-mcp: anonymous typedef structs in cbm.h were named after
+	// the first field type/name (`CBMArena`, `name`, ...), not the trailing
+	// typedef alias (`CBMExtractCtx`, `CBMDefinition`, ...).
+	entities, language, status := TreeSitterParser{}.ParseWithStatus("cbm.h", `typedef struct {
+    const char *name;
+    const char *qualified_name;
+} CBMDefinition;
+
+typedef struct {
+    CBMArena *arena;
+    CBMDefinition *defs;
+    int count;
+} CBMExtractCtx;
+`)
+	if language != "C" {
+		t.Fatalf("language = %q", language)
+	}
+	if status.ParseError {
+		t.Fatalf("unexpected parse status: %#v", status)
+	}
+	seen := map[string]string{}
+	for _, entity := range entities {
+		if entity.Kind == "type" {
+			seen[entity.Name] = entity.Kind
+		}
+	}
+	for _, name := range []string{"CBMDefinition", "CBMExtractCtx"} {
+		if seen[name] != "type" {
+			t.Fatalf("typedef alias %q not extracted as a type; seen: %#v; entities: %#v", name, seen, entities)
+		}
+	}
+	for _, wrong := range []string{"name", "CBMArena"} {
+		if seen[wrong] == "type" {
+			t.Fatalf("anonymous typedef struct named after body token %q; seen: %#v; entities: %#v", wrong, seen, entities)
+		}
+	}
+}

--- a/internal/sem/parser_test.go
+++ b/internal/sem/parser_test.go
@@ -1031,6 +1031,128 @@ func TestTreeSitterParserYAMLMasksQuotedMappingKeys(t *testing.T) {
 	}
 }
 
+func TestTreeSitterParserCSharp13SyntaxParses(t *testing.T) {
+	// The vendored tree-sitter-c-sharp grammar must parse C# 12/13 syntax
+	// that the old bundled grammar degraded to ERROR nodes: params
+	// collections, collection expressions, primary constructors, and the
+	// `field` keyword. Regression: dotnet/runtime Task.cs lost its
+	// top-level `class Task` symbol and every member after the first
+	// `params ReadOnlySpan<Task>` overload.
+	entities, language, status := TreeSitterParser{}.ParseWithStatus("Scheduler.cs", `namespace Runtime.Tasks;
+
+public partial class Scheduler(string name) : SchedulerBase(name)
+{
+    private int[] _pending = [];
+
+    public string Label { get; set => field = value; }
+
+    public static void WaitAll(params Task[] tasks) { }
+
+    public static void WaitAll(params ReadOnlySpan<Task> tasks) { }
+
+    public static Task WhenAll(IEnumerable<Task> tasks) { return null; }
+}
+`)
+	if language != "C#" {
+		t.Fatalf("language = %q", language)
+	}
+	if status.ParseError {
+		t.Fatalf("C# 13 syntax must parse cleanly, got: %#v", status)
+	}
+	seen := map[string]string{}
+	for _, entity := range entities {
+		seen[entity.Name] = entity.Kind
+	}
+	for name, kind := range map[string]string{
+		"Scheduler":         "class",
+		"Scheduler.WaitAll": "method",
+		"Scheduler.WhenAll": "method",
+	} {
+		if seen[name] != kind {
+			t.Fatalf("%s kind = %q, want %q in %#v", name, seen[name], kind, seen)
+		}
+	}
+}
+
+func TestTreeSitterParserCSharpPointerDerefCastMasked(t *testing.T) {
+	// Prefix dereference of a pointer cast (`*(T*)&x`) is the one unsafe
+	// construct the C# 13 grammar still rejects; the masker blanks the
+	// `*`s so the rest of the method parses.
+	entities, language, status := TreeSitterParser{}.ParseWithStatus("Cache.cs", `public class Cache
+{
+    public unsafe Task<TResult> Fetch<TResult>(TResult result)
+    {
+        Task<bool> task = *(bool*)&result ? TaskCache.s_trueTask : TaskCache.s_falseTask;
+        return *(Task<TResult>*)&task;
+    }
+
+    public void After() { }
+}
+`)
+	if language != "C#" {
+		t.Fatalf("language = %q", language)
+	}
+	if status.ParseError {
+		t.Fatalf("pointer-deref cast must be masked into parseable form, got: %#v", status)
+	}
+	seen := map[string]string{}
+	for _, entity := range entities {
+		seen[entity.Name] = entity.Kind
+	}
+	for name, kind := range map[string]string{
+		"Cache":       "class",
+		"Cache.Fetch": "method",
+		"Cache.After": "method",
+	} {
+		if seen[name] != kind {
+			t.Fatalf("%s kind = %q, want %q in %#v", name, seen[name], kind, seen)
+		}
+	}
+}
+
+func TestTreeSitterParserCSharpErrorNodeDoesNotSuppressSiblings(t *testing.T) {
+	// Even when a member fails to parse, the enclosing class, its other
+	// members, and later top-level declarations must still be extracted.
+	entities, language, status := TreeSitterParser{}.ParseWithStatus("Salvage.cs", `namespace Demo.Space
+{
+    public partial class Container
+    {
+        public void Before() { }
+
+        public static void Broken(some !!! unparseable @@@ garbage here ###) { }
+
+        public void After() { }
+    }
+
+    public class Later
+    {
+        public void Fine() { }
+    }
+}
+`)
+	if language != "C#" {
+		t.Fatalf("language = %q", language)
+	}
+	if !status.ParseError {
+		t.Fatalf("expected ParseError for garbage member, got: %#v", status)
+	}
+	seen := map[string]string{}
+	for _, entity := range entities {
+		seen[entity.Name] = entity.Kind
+	}
+	for name, kind := range map[string]string{
+		"Container":        "class",
+		"Container.Before": "method",
+		"Container.After":  "method",
+		"Later":            "class",
+		"Later.Fine":       "method",
+	} {
+		if seen[name] != kind {
+			t.Fatalf("ERROR node suppressed %s (kind = %q, want %q) in %#v", name, seen[name], kind, seen)
+		}
+	}
+}
+
 func TestTreeSitterParserCSharpMasksPreprocessorAndPrimaryConstructors(t *testing.T) {
 	entities, language, status := TreeSitterParser{}.ParseWithStatus("WrappedReaderTests.cs", "\ufeff"+`#if !NET5_0_OR_GREATER
 namespace System.Diagnostics.CodeAnalysis

--- a/internal/sem/parser_test.go
+++ b/internal/sem/parser_test.go
@@ -3118,3 +3118,47 @@ pub fn check(value: u8) -> bool {
 		t.Fatalf("plain function missing: %#v", entities)
 	}
 }
+
+func TestTreeSitterParserCTypedefReturnTypeDoesNotSwallowFunctionName(t *testing.T) {
+	// jqlang/jq: `jv_kind jv_get_kind(jv x)` was extracted as a function
+	// named "jv_kind" — the pre-order name fallback latched onto the
+	// typedef'd return type instead of the declarator. Only void/primitive
+	// returns produced correct names.
+	entities, language, status := TreeSitterParser{}.ParseWithStatus("jv.c", `typedef enum { JV_KIND_INVALID } jv_kind;
+typedef struct { int x; } jv;
+
+jv_kind jv_get_kind(jv x) {
+  return JV_KIND_INVALID;
+}
+
+jv jv_true(void) {
+  jv v;
+  return v;
+}
+
+jv* jv_alloc(void) {
+  return 0;
+}
+
+void jv_free(jv x) {
+}
+`)
+	if language != "C" {
+		t.Fatalf("language = %q", language)
+	}
+	if status.ParseError {
+		t.Fatalf("unexpected parse status: %#v", status)
+	}
+	seen := map[string]string{}
+	for _, entity := range entities {
+		seen[entity.Name] = entity.Kind
+	}
+	for _, name := range []string{"jv_get_kind", "jv_true", "jv_alloc", "jv_free"} {
+		if seen[name] != "function" {
+			t.Errorf("function %q not extracted (got kind %q); seen: %#v", name, seen[name], seen)
+		}
+	}
+	if seen["jv_kind"] == "function" {
+		t.Errorf("return type jv_kind extracted as a function name")
+	}
+}

--- a/internal/sem/parser_test.go
+++ b/internal/sem/parser_test.go
@@ -3201,3 +3201,44 @@ typedef struct {
 		}
 	}
 }
+
+func TestTreeSitterParserCSharpBareAsyncArgumentMasked(t *testing.T) {
+	// dotnet/runtime passes `async` (a bool parameter) as a plain argument:
+	// `AuthenticationHelper.SendWithRequestAuthAsync(request, async, ...)`.
+	// tree-sitter-c-sharp reads argument-position `async` as an async-lambda
+	// head; the ERROR swallowed HttpConnectionPool's class declaration and
+	// left every member unqualified. The masker rewrites the token to a
+	// same-length literal so the file parses.
+	entities, language, status := TreeSitterParser{}.ParseWithStatus("Pool.cs", `internal sealed class HttpConnectionPool
+{
+    public string SendAsync(string request, bool async)
+    {
+        return Helper.F(request, async, this);
+    }
+
+    public string SendWithProxyAuthAsync(string request, bool async)
+    {
+        return G(async);
+    }
+}
+`)
+	if language != "C#" {
+		t.Fatalf("language = %q", language)
+	}
+	if status.ParseError {
+		t.Fatalf("bare async argument must be masked into parseable form, got: %#v", status)
+	}
+	seen := map[string]string{}
+	for _, entity := range entities {
+		seen[entity.Name] = entity.Kind
+	}
+	for name, kind := range map[string]string{
+		"HttpConnectionPool":                        "class",
+		"HttpConnectionPool.SendAsync":              "method",
+		"HttpConnectionPool.SendWithProxyAuthAsync": "method",
+	} {
+		if seen[name] != kind {
+			t.Fatalf("%s kind = %q, want %q in %#v", name, seen[name], kind, seen)
+		}
+	}
+}

--- a/internal/sem/perl.go
+++ b/internal/sem/perl.go
@@ -1,0 +1,43 @@
+package sem
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	perlReceiverChainRe   = regexp.MustCompile(`(?:\$?[A-Za-z_]\w*|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)[ \t]*(?:->[ \t]*[A-Za-z_]\w*[ \t]*(?:\([^()\n]*\))?[ \t]*)+`)
+	perlReceiverSegmentRe = regexp.MustCompile(`->[ \t]*([A-Za-z_]\w*)`)
+)
+
+// perlReceiverCalls extracts terminal `$obj->method` call sites. Perl commonly
+// omits parentheses for method calls (`$self->stash`, `$base->protocol`), so the
+// generic receiver scanner only sees a subset of real call sites.
+func perlReceiverCalls(block string) []receiverCall {
+	stripped := stripCodeLiteralsAndComments(block)
+	var out []receiverCall
+	seen := map[string]bool{}
+	for _, loc := range perlReceiverChainRe.FindAllStringIndex(stripped, -1) {
+		chain := stripped[loc[0]:loc[1]]
+		segments := perlReceiverSegmentRe.FindAllStringSubmatch(chain, -1)
+		if len(segments) == 0 {
+			continue
+		}
+		method := segments[len(segments)-1][1]
+		if method == "" || method == "new" {
+			continue
+		}
+		receiver := strings.TrimSpace(strings.SplitN(chain, "->", 2)[0])
+		receiver = strings.TrimPrefix(receiver, "$")
+		if receiver == "" {
+			continue
+		}
+		key := receiver + "." + method
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, receiverCall{Receiver: receiver, Method: method})
+	}
+	return out
+}

--- a/internal/sem/php.go
+++ b/internal/sem/php.go
@@ -52,6 +52,8 @@ var (
 	phpVarDocPropRe = regexp.MustCompile(`@var\s+\\?((?:[A-Za-z_]\w*\\)*)([A-Z]\w*)\s*\*/\s*(?:(?:public|protected|private|static|readonly)\s+)+\$([A-Za-z_]\w*)`)
 	// $this->prop = $param assignments inside the constructor body.
 	phpCtorPropAssignRe = regexp.MustCompile(`\$this\s*->\s*([A-Za-z_]\w*)\s*=\s*\$([A-Za-z_]\w*)`)
+	// $this->fooFactory->create(...)->bar(...) generated-factory chains.
+	phpPropertyFactoryChainStartRe = regexp.MustCompile(`\$this\s*->\s*([A-Za-z_]\w*)\s*->\s*([A-Za-z_]\w*)\s*\(`)
 	// Constructor header (params follow at the returned match's end).
 	phpCtorHeaderRe = regexp.MustCompile(`\bfunction\s+__construct\s*\(`)
 	// One constructor parameter: optional promotion visibility, optional
@@ -71,6 +73,13 @@ type phpStaticCall struct {
 	Class  string
 	Method string
 	Detail string
+}
+
+type phpPropertyFactoryChainCall struct {
+	Property      string
+	FactoryMethod string
+	Method        string
+	Detail        string
 }
 
 // stripPHPCodeText extends the generic literal/comment stripper with the PHP
@@ -207,6 +216,46 @@ func phpChainedConstructorCalls(block string) []typedMethodCall {
 		}
 		seen[key] = true
 		out = append(out, typedMethodCall{TypeName: typeName, Method: method, Detail: "new " + typeName + "()->" + method})
+	}
+	return out
+}
+
+func phpPropertyFactoryChainCalls(block string) []phpPropertyFactoryChainCall {
+	stripped := stripPHPCodeText(block)
+	var out []phpPropertyFactoryChainCall
+	seen := map[string]bool{}
+	for _, m := range phpPropertyFactoryChainStartRe.FindAllStringSubmatchIndex(stripped, -1) {
+		prop := stripped[m[2]:m[3]]
+		factory := stripped[m[4]:m[5]]
+		open := m[1] - 1
+		close := matchingParen(stripped, open)
+		if close < 0 {
+			continue
+		}
+		i := skipPHPSpace(stripped, close+1)
+		if !strings.HasPrefix(stripped[i:], "->") {
+			continue
+		}
+		i = skipPHPSpace(stripped, i+2)
+		j := i
+		for j < len(stripped) && isPHPWordByte(stripped[j]) {
+			j++
+		}
+		method := stripped[i:j]
+		if method == "" || skipPHPSpace(stripped, j) >= len(stripped) || stripped[skipPHPSpace(stripped, j)] != '(' {
+			continue
+		}
+		key := prop + "." + factory + "." + method
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, phpPropertyFactoryChainCall{
+			Property:      prop,
+			FactoryMethod: factory,
+			Method:        method,
+			Detail:        "this->" + prop + "->" + factory + "()->" + method,
+		})
 	}
 	return out
 }

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -3424,13 +3424,13 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 					confidence = 0.75
 					reason = "method call resolved via property-chain-typed local receiver"
 				}
-				sym, ok := firstTypeLikeNamedPreferFile(symbolsByShortName[typeName], typeName, from.FilePath)
+				sym, ok := typeLikeNamedWithMethod(symbolsByShortName[typeName], typeName, from.FilePath, call.Method, methodsByContainer, superContainerByID)
 				if !ok {
 					continue
 				}
 				targetID = sym.ID
 				receiverTypeKind = sym.Kind
-			} else if cls, ok := firstTypeLikeNamedPreferFile(symbolsByShortName[call.Receiver], call.Receiver, from.FilePath); ok {
+			} else if cls, ok := typeLikeNamedWithMethod(symbolsByShortName[call.Receiver], call.Receiver, from.FilePath, call.Method, methodsByContainer, superContainerByID); ok {
 				// ClassName.method(): the receiver is itself a type name, not a
 				// variable, so this is a static (class-qualified) call and the
 				// target is that class's own method.
@@ -7225,6 +7225,35 @@ func firstTypeLikeNamed(records []SymbolRecord, name string) (SymbolRecord, bool
 // Same-file preference matters when a repo vendors a mirror copy of its sources
 // (e.g. a Deno build alongside src/): without it a class-qualified call could
 // bind to the twin in the wrong file.
+// typeLikeNamedWithMethod resolves a type name to the declaration that
+// actually defines the called method. C# partial classes declare the same
+// type in several files, and the lexically-first declaration may not hold
+// the method (roslyn's Contract.InterpolatedStringHandlers.cs sorts before
+// Contract.cs, which defines ThrowIfFalse); probing only the first
+// candidate dropped every such static call. Preference order: a same-file
+// declaration defining the method, any declaration defining it (directly
+// or up its supertype chain), then the plain prefer-file lookup.
+func typeLikeNamedWithMethod(records []SymbolRecord, name, file, method string, methodsByContainer map[string]map[string]SymbolRecord, superContainerByID map[string]string) (SymbolRecord, bool) {
+	var withMethod []SymbolRecord
+	for _, symbol := range records {
+		if symbol.Name != name || !typeLikeKind(symbol.Kind) {
+			continue
+		}
+		if _, _, ok := lookupMethodUpChain(symbol.ID, method, methodsByContainer, superContainerByID); ok {
+			withMethod = append(withMethod, symbol)
+		}
+	}
+	if len(withMethod) > 0 {
+		for _, symbol := range withMethod {
+			if symbol.FilePath == file {
+				return symbol, true
+			}
+		}
+		return withMethod[0], true
+	}
+	return firstTypeLikeNamedPreferFile(records, name, file)
+}
+
 func firstTypeLikeNamedPreferFile(records []SymbolRecord, name, file string) (SymbolRecord, bool) {
 	for _, symbol := range records {
 		if symbol.Name == name && symbol.FilePath == file && typeLikeKind(symbol.Kind) {

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -574,7 +574,7 @@ func supportsCallExtraction(spec languageSpec) bool {
 		return false
 	}
 	switch spec.language {
-	case "Bash", "C", "C++", "C#", "Dart", "Elixir", "Erlang", "Go", "Groovy", "Haskell", "Java", "JavaScript", "Kotlin", "Lua", "OCaml", "PHP", "Python", "Ruby", "Rust", "Scala", "Swift", "TypeScript", "Zsh":
+	case "Bash", "C", "C++", "C#", "Clojure", "ClojureScript", "Dart", "Elixir", "Erlang", "F#", "Go", "Groovy", "Haskell", "Java", "JavaScript", "Kotlin", "Lua", "Objective-C", "OCaml", "Perl", "PHP", "Python", "Ruby", "Rust", "Scala", "SQL", "Swift", "TypeScript", "Zig", "Zsh":
 		return true
 	default:
 		return false
@@ -1465,7 +1465,7 @@ func localReachable(from, to SymbolRecord) bool {
 // receiver and is handled by receiverCallRelations instead.
 func implicitReceiverLanguage(lang string) bool {
 	switch lang {
-	case "Java", "C#", "C++", "Dart", "Groovy", "Kotlin", "Scala", "Ruby", "Swift":
+	case "Java", "C#", "C++", "Dart", "Elixir", "Groovy", "Kotlin", "Scala", "Ruby", "Swift":
 		return true
 	}
 	return false
@@ -1509,7 +1509,7 @@ func resolveCallTargets(name string, from SymbolRecord, candidates, sameFile []S
 		})
 	}
 	if len(local) == 1 {
-		return local
+		return appendSQLDerivedDuplicateTargets(local, from, candidates)
 	}
 	if len(local) > 1 {
 		// Ambiguous bare name with multiple same-file definitions: emit the
@@ -1539,6 +1539,9 @@ func resolveCallTargets(name string, from SymbolRecord, candidates, sameFile []S
 				Scope:        "module",
 			})
 		}
+	}
+	if len(imported) == 0 {
+		imported = jsExportedImportFallbackTargets(name, from, candidates, importsByName[name], allowMethodTargets)
 	}
 	if len(imported) > 0 {
 		return imported
@@ -1658,6 +1661,121 @@ func resolveCallTargets(name string, from SymbolRecord, candidates, sameFile []S
 		}
 	}
 	return nil
+}
+
+func jsExportedImportFallbackTargets(name string, from SymbolRecord, candidates []SymbolRecord, modules []string, allowMethodTargets bool) []resolvedCallTarget {
+	if len(modules) == 0 || (from.Language != "JavaScript" && from.Language != "TypeScript") {
+		return nil
+	}
+	var exported []SymbolRecord
+	var imported []SymbolRecord
+	for _, to := range candidates {
+		if to.ID == from.ID || to.Kind == "field" || (to.Kind == "method" && !nameCallMayTargetMethod(from.Language) && !allowMethodTargets) || !localReachable(from, to) {
+			continue
+		}
+		if importedNameMatchesFile(modules, from.FilePath, to.FilePath) {
+			imported = append(imported, to)
+		}
+		if jsExportedSymbol(name, to) {
+			exported = append(exported, to)
+		}
+	}
+	if len(exported) != 1 {
+		exported = preferExportedSymbols(name, imported)
+		if len(exported) != 1 {
+			return nil
+		}
+	}
+	return []resolvedCallTarget{{
+		SymbolRecord: exported[0],
+		Confidence:   0.64,
+		Reason:       "JS/TS imported name matched unique exported workspace symbol",
+		Resolution:   "import_resolved",
+		Scope:        "module",
+	}}
+}
+
+func preferExportedSymbols(name string, candidates []SymbolRecord) []SymbolRecord {
+	var exported []SymbolRecord
+	for _, candidate := range candidates {
+		if jsExportedSymbol(name, candidate) {
+			exported = append(exported, candidate)
+		}
+	}
+	if len(exported) == 1 {
+		return exported
+	}
+	if len(candidates) == 1 {
+		return candidates
+	}
+	return nil
+}
+
+func jsExportedSymbol(name string, symbol SymbolRecord) bool {
+	signature := strings.TrimSpace(symbol.Signature)
+	for _, prefix := range []string{
+		"export function " + name,
+		"export async function " + name,
+		"export const " + name,
+		"export let " + name,
+		"export var " + name,
+		"export class " + name,
+	} {
+		if strings.HasPrefix(signature, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func appendSQLDerivedDuplicateTargets(targets []resolvedCallTarget, from SymbolRecord, candidates []SymbolRecord) []resolvedCallTarget {
+	if from.Language != "SQL" || len(targets) == 0 {
+		return targets
+	}
+	seen := map[string]bool{}
+	for _, target := range targets {
+		seen[target.ID] = true
+	}
+	var extras []resolvedCallTarget
+	for _, target := range targets {
+		if !sqlDerivedScriptPath(target.FilePath) {
+			continue
+		}
+		for _, candidate := range candidates {
+			if candidate.ID == from.ID || seen[candidate.ID] || candidate.QualifiedName != target.QualifiedName || candidate.Kind != target.Kind || sqlDerivedScriptPath(candidate.FilePath) || !localReachable(from, candidate) {
+				continue
+			}
+			seen[candidate.ID] = true
+			extras = append(extras, resolvedCallTarget{
+				SymbolRecord: candidate,
+				Confidence:   0.54,
+				Reason:       "SQL migration-script call also linked to canonical same-qualified routine",
+				Resolution:   "name_only",
+				Scope:        "workspace",
+			})
+		}
+	}
+	if len(extras) == 0 {
+		return targets
+	}
+	out := append([]resolvedCallTarget(nil), targets...)
+	out = append(out, extras...)
+	return out
+}
+
+func sqlDerivedScriptPath(path string) bool {
+	path = strings.ToLower(filepath.ToSlash(path))
+	base := filepath.Base(path)
+	if strings.Contains(base, "--") {
+		return true
+	}
+	for _, part := range strings.Split(path, "/") {
+		switch part {
+		case "migration", "migrations", "update", "updates", "upgrade", "upgrades", "downgrade", "downgrades":
+			return true
+		}
+	}
+	return false
 }
 
 func cFamilyOverloadResolutionEnabled(language string) bool {
@@ -2025,6 +2143,7 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 	// global index. Single-inheritance only (first EXTENDS edge), which matches
 	// class semantics in every language that reaches here.
 	superContainerByID := map[string]string{}
+	implementersByContainer := map[string][]string{}
 	if needsReceiverCalls {
 		for _, file := range files {
 			for _, symbol := range recordsByFile[file.Path] {
@@ -2032,17 +2151,19 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 					continue
 				}
 				for _, edge := range supertypesFromSignature(symbol.Language, symbol.Signature) {
-					if edge.Relation != "EXTENDS" {
-						continue
-					}
 					sup, ok := firstTypeLikeNamed(symbolsByFile[symbol.FilePath], edge.Super)
 					if !ok || sup.ID == symbol.ID {
 						sup, ok = firstTypeLikeNamed(symbolsByShortName[edge.Super], edge.Super)
 					}
-					if ok && sup.ID != symbol.ID {
-						superContainerByID[symbol.ID] = sup.ID
+					if !ok || sup.ID == symbol.ID {
+						continue
 					}
-					break
+					implementersByContainer[sup.ID] = append(implementersByContainer[sup.ID], symbol.ID)
+					if edge.Relation == "EXTENDS" {
+						if _, exists := superContainerByID[symbol.ID]; !exists {
+							superContainerByID[symbol.ID] = sup.ID
+						}
+					}
 				}
 			}
 		}
@@ -2275,6 +2396,14 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 			// and imported bare names can resolve.
 			hsImports = haskellImports(content)
 		}
+		var ocamlOpenedModules []string
+		var ocamlOpenedCallables map[string]bool
+		var ocamlOpenedReferences map[string]bool
+		if file.Language == "OCaml" && fileNeedsCallScan {
+			ocamlOpenedModules = ocamlOpenModules(content)
+			ocamlOpenedCallables = ocamlOpenedCallableNames(ocamlOpenedModules, symbolsByShortName)
+			ocamlOpenedReferences = ocamlOpenedCallableReferenceNames(ocamlOpenedModules, symbolsByShortName)
+		}
 		var kotlinPropTypes map[string]string
 		if file.Language == "Kotlin" && spec.callResolution == "full" {
 			// Kotlin property types live at the class level too (primary
@@ -2282,6 +2411,21 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 			// and factory initializers): collect them once per file so
 			// property-receiver calls (`taskQueue.execute(...)`) can resolve.
 			kotlinPropTypes = kotlinPropertyTypes(content, returnTypesBySymbolNameAndFile)
+			for name, typeName := range kotlinFieldInitializerTypes(content, recordsByFile[file.Path]) {
+				if existing, ok := kotlinPropTypes[name]; !ok || existing == typeName {
+					kotlinPropTypes[name] = typeName
+				} else {
+					delete(kotlinPropTypes, name)
+				}
+			}
+		}
+		var typeScriptPropTypes map[string]string
+		if file.Language == "TypeScript" && spec.callResolution == "full" {
+			// TypeScript class-property receivers are commonly typed by Angular
+			// DI initializers (`private router = inject(Router)`) or field
+			// annotations outside the method body. Collect those once per file
+			// and let receiverCallRelations apply the usual shadowing rules.
+			typeScriptPropTypes = typeScriptPropertyTypes(content, recordsByFile[file.Path])
 		}
 		var swiftTypes swiftFileTypes
 		if file.Language == "Swift" && spec.callResolution == "full" {
@@ -2316,7 +2460,7 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 				// only type mentions, and a nested module's block spans its
 				// members' bodies, so both are skipped rather than misread.
 				if from.Kind != "module" && ocamlCallScanFile(file.Path) {
-					for _, r := range ocamlCallRelations(from, block, currentFileSymbols, symbolsByShortName) {
+					for _, r := range ocamlCallRelations(from, block, currentFileSymbols, symbolsByShortName, ocamlOpenedModules, ocamlOpenedCallables, ocamlOpenedReferences) {
 						emit(r)
 					}
 				}
@@ -2353,6 +2497,14 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 					callBlock = maskGroovyLiteralsAndComments(block)
 				}
 				callNames := callLikeIdentifiers(callBlock, file.Language)
+				if file.Language == "Julia" {
+					callNames = juliaCallIdentifiers(callBlock)
+				}
+				if file.Language == "Rust" {
+					for name := range rustTurbofishCallIdentifiers(callBlock) {
+						callNames[name] = struct{}{}
+					}
+				}
 				if file.Language == "Ruby" {
 					// Ruby method names may end in `!`/`?` and are commonly called
 					// without parentheses; the generic scanner misses both.
@@ -2376,10 +2528,59 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 						callNames[name] = struct{}{}
 					}
 				}
+				if file.Language == "JavaScript" || file.Language == "TypeScript" {
+					// JS/TS often routes calls through generated namespace imports
+					// (`performance.mark(...)`, `Parser.parseSourceFile(...)`), and
+					// callback helpers can be passed as bare identifiers (`noop`).
+					for name := range jsDottedCallIdentifiers(callBlock) {
+						callNames[name] = struct{}{}
+					}
+					for name := range jsCallableArgumentIdentifiers(callBlock) {
+						callNames[name] = struct{}{}
+					}
+				}
+				if file.Language == "F#" {
+					// F# module-qualified calls (`UpdateProcess.SmartInstall(...)`,
+					// `LoadingScripts.ScriptGeneration.constructScriptsFromData(...)`)
+					// hide the target behind a dotted path.
+					for name := range fsharpDottedCallIdentifiers(callBlock) {
+						callNames[name] = struct{}{}
+					}
+				}
+				if file.Language == "Lua" {
+					// Lua table/module calls (`vim.split(...)`, `M.joinpath(...)`)
+					// are dotted or colon-qualified; the generic scanner drops the
+					// final segment because it follows a selector.
+					for name := range luaDottedCallIdentifiers(callBlock) {
+						callNames[name] = struct{}{}
+					}
+				}
+				if file.Language == "Zig" {
+					// Zig code frequently calls imported analyzer helpers through
+					// module aliases (`analysis.resolveVarDeclAlias(...)`).
+					for name := range zigDottedCallIdentifiers(callBlock) {
+						callNames[name] = struct{}{}
+					}
+				}
 				if shellCallLanguage(file.Language) {
 					// Shell functions are invoked as bare commands with no
 					// parentheses; the generic scanner sees no call sites at all.
 					for name := range shellCommandCallIdentifiers(callBlock) {
+						callNames[name] = struct{}{}
+					}
+				}
+				if file.Language == "Clojure" || file.Language == "ClojureScript" {
+					// Clojure calls are list heads, usually `(name ...)` or
+					// `(alias/name ...)`, not `name(...)`.
+					for name := range clojureCallIdentifiers(callBlock) {
+						callNames[name] = struct{}{}
+					}
+				}
+				if file.Language == "SQL" {
+					// PostgreSQL function/procedure bodies call routines as
+					// `name(...)` or `schema.name(...)`. The generic scanner
+					// drops schema-qualified calls because of the preceding dot.
+					for name := range sqlCallIdentifiers(callBlock) {
 						callNames[name] = struct{}{}
 					}
 				}
@@ -2641,7 +2842,7 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 				}
 			}
 			if spec.callResolution == "full" {
-				for _, r := range receiverCallRelations(from, block, methodsByContainer, superContainerByID, symbolsByShortName, returnTypesBySymbolNameAndFile, returnTypesBySymbolNameAndDir, importsByName, manifestImports.goModule, pkgVarTypesByDir[filepath.ToSlash(filepath.Dir(file.Path))], phpPropTypes, kotlinPropTypes, fieldsByContainer, swiftTypes) {
+				for _, r := range receiverCallRelations(from, block, methodsByContainer, superContainerByID, implementersByContainer, symbolsByShortName, returnTypesBySymbolNameAndFile, returnTypesBySymbolNameAndDir, importsByName, manifestImports.goModule, pkgVarTypesByDir[filepath.ToSlash(filepath.Dir(file.Path))], phpPropTypes, kotlinPropTypes, typeScriptPropTypes, fieldsByContainer, swiftTypes) {
 					emit(r)
 				}
 				for _, r := range importedReceiverCallRelations(from, block, importsByName, symbolsByShortName) {
@@ -2687,6 +2888,47 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 					Language: file.Language,
 				}
 				topLevelNames := callLikeIdentifiers(topLevel, file.Language)
+				if file.Language == "Julia" {
+					topLevelNames = juliaCallIdentifiers(topLevel)
+				}
+				if file.Language == "Rust" {
+					for name := range rustTurbofishCallIdentifiers(topLevel) {
+						topLevelNames[name] = struct{}{}
+					}
+				}
+				if file.Language == "JavaScript" || file.Language == "TypeScript" {
+					for name := range jsDottedCallIdentifiers(topLevel) {
+						topLevelNames[name] = struct{}{}
+					}
+					for name := range jsCallableArgumentIdentifiers(topLevel) {
+						topLevelNames[name] = struct{}{}
+					}
+				}
+				if file.Language == "F#" {
+					for name := range fsharpDottedCallIdentifiers(topLevel) {
+						topLevelNames[name] = struct{}{}
+					}
+				}
+				if file.Language == "Lua" {
+					for name := range luaDottedCallIdentifiers(topLevel) {
+						topLevelNames[name] = struct{}{}
+					}
+				}
+				if file.Language == "Zig" {
+					for name := range zigDottedCallIdentifiers(topLevel) {
+						topLevelNames[name] = struct{}{}
+					}
+				}
+				if file.Language == "Clojure" || file.Language == "ClojureScript" {
+					for name := range clojureCallIdentifiers(topLevel) {
+						topLevelNames[name] = struct{}{}
+					}
+				}
+				if file.Language == "SQL" {
+					for name := range sqlCallIdentifiers(topLevel) {
+						topLevelNames[name] = struct{}{}
+					}
+				}
 				if file.Language == "Ruby" {
 					for name := range rubySuffixedCallIdentifiers(topLevel) {
 						topLevelNames[name] = struct{}{}
@@ -3044,6 +3286,38 @@ func lookupMethodUpChain(start, name string, methodsByContainer map[string]map[s
 	return SymbolRecord{}, false, false
 }
 
+func uniqueImplementedMethod(start, name string, methodsByContainer map[string]map[string]SymbolRecord, superContainerByID map[string]string, implementersByContainer map[string][]string) (SymbolRecord, bool) {
+	seenContainers := map[string]bool{}
+	seenMethods := map[string]bool{}
+	var out SymbolRecord
+	var walk func(string, int) bool
+	walk = func(container string, depth int) bool {
+		if container == "" || depth > 16 || seenContainers[container] {
+			return true
+		}
+		seenContainers[container] = true
+		for _, impl := range implementersByContainer[container] {
+			if method, _, ok := lookupMethodUpChain(impl, name, methodsByContainer, superContainerByID); ok {
+				if !seenMethods[method.ID] {
+					if out.ID != "" {
+						return false
+					}
+					out = method
+					seenMethods[method.ID] = true
+				}
+			}
+			if !walk(impl, depth+1) {
+				return false
+			}
+		}
+		return true
+	}
+	if !walk(start, 0) || out.ID == "" {
+		return SymbolRecord{}, false
+	}
+	return out, true
+}
+
 // resolveContainerAcrossFiles resolves a member's container name to a
 // type-like symbol when per-file linking left the member orphaned. Preference
 // order keeps it conservative: a unique same-file type (per-file linking can
@@ -3135,7 +3409,7 @@ func resolveQualifiedType(qt pkgQualType, symbolsByShortName map[string][]Symbol
 	return SymbolRecord{}, false
 }
 
-func receiverCallRelations(from SymbolRecord, block string, methodsByContainer map[string]map[string]SymbolRecord, superContainerByID map[string]string, symbolsByShortName map[string][]SymbolRecord, returnTypesBySymbolNameAndFile, returnTypesBySymbolNameAndDir map[string]map[string][]string, importsByName map[string][]string, goModule string, pkgVarTypes map[string]pkgQualType, phpPropTypes, kotlinPropTypes map[string]string, fieldsByContainer map[string]map[string]SymbolRecord, swiftTypes swiftFileTypes) []RelationRecord {
+func receiverCallRelations(from SymbolRecord, block string, methodsByContainer map[string]map[string]SymbolRecord, superContainerByID map[string]string, implementersByContainer map[string][]string, symbolsByShortName map[string][]SymbolRecord, returnTypesBySymbolNameAndFile, returnTypesBySymbolNameAndDir map[string]map[string][]string, importsByName map[string][]string, goModule string, pkgVarTypes map[string]pkgQualType, phpPropTypes, kotlinPropTypes, typeScriptPropTypes map[string]string, fieldsByContainer map[string]map[string]SymbolRecord, swiftTypes swiftFileTypes) []RelationRecord {
 	if typeLikeKind(from.Kind) {
 		return nil
 	}
@@ -3206,8 +3480,18 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 		// nested call arguments.
 		javaChains = javaConstructorChainCalls(block)
 	}
+	if from.Language == "Objective-C" {
+		// Objective-C message sends use bracket syntax (`[self setState:...]`),
+		// not `receiver.method(...)`, so the generic receiver scanner never sees
+		// intra-class selector calls.
+		objcCalls := objectiveCMessageReceiverCalls(block)
+		calls = mergeReceiverCalls(calls, objcCalls)
+		allReceiverCalls = mergeReceiverCalls(allReceiverCalls, objcCalls)
+	}
 	var phpStatics []phpStaticCall
 	var phpPropCalls []receiverCall
+	var phpFactoryChains []phpPropertyFactoryChainCall
+	var rustPathCalls []rustPathCall
 	if from.Language == "PHP" {
 		// PHP static calls use `::` (never matched by receiverCallRe) and
 		// constructor chains are spelled `(new Klass(...))->m(` rather than
@@ -3215,7 +3499,19 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 		// property types the caller collected from this file.
 		phpStatics = phpStaticCalls(block)
 		phpPropCalls = phpPropertyReceiverCalls(block)
+		phpFactoryChains = phpPropertyFactoryChainCalls(block)
 		chainedCalls = append(chainedCalls, phpChainedConstructorCalls(block)...)
+	}
+	if from.Language == "Rust" {
+		// Rust module calls (`strings::index_of(...)`) are not receiver calls:
+		// the left side is a `use`-bound module alias, not a value. Resolve them
+		// through Rust import bindings and Cargo/module alias resolution.
+		rustPathCalls = rustModulePathCalls(block)
+	}
+	if from.Language == "Perl" {
+		// Perl method calls commonly omit parentheses (`$self->stash`,
+		// `$base->protocol`), which the generic receiver scanner never sees.
+		calls = mergeReceiverCalls(calls, perlReceiverCalls(block))
 	}
 	var csChainCalls []csharpChainCall
 	if from.Language == "C#" {
@@ -3225,7 +3521,7 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 		// class-level member types can resolve it hop by hop.
 		csChainCalls = csharpMemberChainCalls(block)
 	}
-	if len(calls) == 0 && len(allReceiverCalls) == 0 && len(chainedCalls) == 0 && len(returnedCalls) == 0 && len(chainedReturnCalls) == 0 && len(deepChainedReturnCalls) == 0 && len(returnedChainCalls) == 0 && len(returnedDeepChainCalls) == 0 && len(rubyBareCalls) == 0 && len(phpStatics) == 0 && len(phpPropCalls) == 0 && len(csChainCalls) == 0 && len(kotlinChains) == 0 && len(javaChains) == 0 && len(swiftChains) == 0 {
+	if len(calls) == 0 && len(allReceiverCalls) == 0 && len(chainedCalls) == 0 && len(returnedCalls) == 0 && len(chainedReturnCalls) == 0 && len(deepChainedReturnCalls) == 0 && len(returnedChainCalls) == 0 && len(returnedDeepChainCalls) == 0 && len(rubyBareCalls) == 0 && len(phpStatics) == 0 && len(phpPropCalls) == 0 && len(phpFactoryChains) == 0 && len(rustPathCalls) == 0 && len(csChainCalls) == 0 && len(kotlinChains) == 0 && len(javaChains) == 0 && len(swiftChains) == 0 {
 		return nil
 	}
 	varTypes := parameterVarTypes(from.Signature)
@@ -3268,6 +3564,27 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 		// against `fun status(..., handler: suspend (ApplicationCall,
 		// HttpStatusCode) -> Unit)`) or by an explicit annotation.
 		for name, typeName := range kotlinLambdaParamVarTypes(block, from, symbolsByShortName) {
+			if _, exists := localTypes[name]; !exists {
+				localTypes[name] = typeName
+			}
+		}
+	}
+	if from.Language == "TypeScript" {
+		// Declared-type and Angular-DI locals (`const router: Router = ...`,
+		// `const ref = inject(ViewContainerRef)`), which the generic
+		// constructor-assignment scan cannot type.
+		for name, typeName := range typeScriptLocalVarTypes(block) {
+			if _, exists := localTypes[name]; !exists {
+				localTypes[name] = typeName
+			}
+		}
+	}
+	if from.Language == "Rust" {
+		// Locals assigned from associated constructors (`let id =
+		// task::Id::next()`) carry their receiver type in the path, not a
+		// declaration annotation or constructor call shape the generic scanner
+		// understands.
+		for name, typeName := range rustAssociatedPathVarTypes(block) {
 			if _, exists := localTypes[name]; !exists {
 				localTypes[name] = typeName
 			}
@@ -3331,6 +3648,17 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 			}
 		}
 	}
+	if from.Language == "Rust" {
+		// Rust locals often come from a typed receiver method, e.g.
+		// `let c = ctx.c();` where `ctx: GenerateChunkCtx` and `c()` returns
+		// `&mut LinkerContext`. Type the local through the receiver method's
+		// declared return type before resolving `c.method(...)`.
+		for name, typeName := range rustReceiverFactoryVarTypes(block, varTypes, methodsByContainer, superContainerByID, symbolsByShortName, returnTypesBySymbolNameAndFile, from.FilePath) {
+			if _, exists := factoryTypes[name]; !exists {
+				factoryTypes[name] = typeName
+			}
+		}
+	}
 	for name, typeName := range factoryTypes {
 		if _, exists := varTypes[name]; !exists {
 			varTypes[name] = typeName
@@ -3364,6 +3692,15 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 					varTypes[call.Receiver] = typeName
 					kotlinPropReceivers[call.Receiver] = true
 				}
+			}
+		}
+	}
+	typeScriptPropReceivers := map[string]bool{}
+	if from.Language == "TypeScript" {
+		for name, typeName := range typeScriptPropTypes {
+			if _, exists := varTypes[name]; !exists {
+				varTypes[name] = typeName
+				typeScriptPropReceivers[name] = true
 			}
 		}
 	}
@@ -3465,7 +3802,7 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 					confidence = 0.77
 					reason = "method call resolved via assigned returned receiver type"
 				}
-				if kotlinPropReceivers[call.Receiver] || swiftPropReceivers[call.Receiver] {
+				if kotlinPropReceivers[call.Receiver] || swiftPropReceivers[call.Receiver] || typeScriptPropReceivers[call.Receiver] {
 					confidence = 0.8
 					reason = "method call resolved via typed property receiver"
 				}
@@ -3545,6 +3882,14 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 				resolution = "name_only"
 			}
 		}
+		if !ok && from.Language == "TypeScript" && targetID != "" {
+			if impl, implOK := uniqueImplementedMethod(targetID, call.Method, methodsByContainer, superContainerByID, implementersByContainer); implOK {
+				method, ok = impl, true
+				confidence = minFloat(confidence, 0.72)
+				reason = "interface-typed receiver call resolved to the unique TypeScript implementation"
+				resolution = "type_inferred"
+			}
+		}
 		if !ok || method.ID == from.ID {
 			continue
 		}
@@ -3581,10 +3926,10 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 		methodResolved[call.Receiver+"."+call.Method] = true
 	}
 	// Globally-unique method-name fallback: when receiver-type resolution did not
-	// resolve a receiver.method() call and exactly one method with this short name
-	// exists in the workspace, resolve to it. This is conflict-free — a unique
-	// method name means type-based and name-based resolution agree — and it is the
-	// same "unique name" heuristic the comparison baseline (CBM) uses.
+	// resolve a Go receiver.method() call and exactly one method with this short
+	// name exists in the workspace, resolve to it. This is conflict-free for Go
+	// once package selectors and external receiver variables have been excluded:
+	// a unique method name means type-based and name-based resolution agree.
 	for _, call := range calls {
 		if call.Receiver == "this" || call.Receiver == "self" {
 			continue
@@ -3592,10 +3937,6 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 		if methodResolved[call.Receiver+"."+call.Method] {
 			continue
 		}
-		// Restrict to Go (the only language this tier is validated on) and skip
-		// imported-package selectors like json.Marshal(): there the receiver is a
-		// package, not a variable, and the call is external — without this guard
-		// the fallback would emit a spurious local edge to any same-named method.
 		if from.Language != "Go" {
 			continue
 		}
@@ -3639,6 +3980,73 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 			}},
 			WarningCodes: []string{},
 		})
+	}
+	for _, call := range calls {
+		if from.Language != "Zig" || call.Receiver == "this" || call.Receiver == "self" {
+			continue
+		}
+		if methodResolved[call.Receiver+"."+call.Method] {
+			continue
+		}
+		m, ok := uniqueMethodByShortName(symbolsByShortName[call.Method])
+		if !ok || m.ID == from.ID || m.FilePath != from.FilePath {
+			continue
+		}
+		methodResolved[call.Receiver+"."+call.Method] = true
+		relations = append(relations, RelationRecord{
+			RecordType:    "relation",
+			FromID:        from.ID,
+			ToID:          m.ID,
+			Type:          "CALLS",
+			Confidence:    0.62,
+			Reason:        "Zig namespace-style receiver call matched same-file unique callable",
+			RelationScope: "file",
+			Resolution:    "name_only",
+			TargetKind:    "symbol",
+			Evidence: []Evidence{{
+				Kind:      "call_site",
+				FilePath:  from.FilePath,
+				StartLine: from.StartLine,
+				EndLine:   from.EndLine,
+				Detail:    call.Receiver + "." + call.Method,
+			}},
+			WarningCodes: []string{},
+		})
+	}
+	if from.Language == "Perl" {
+		for _, call := range calls {
+			if methodResolved[call.Receiver+"."+call.Method] {
+				continue
+			}
+			target, ok := uniqueCallableByShortName(symbolsByShortName[call.Method], from.Language)
+			if !ok || target.ID == from.ID {
+				continue
+			}
+			methodResolved[call.Receiver+"."+call.Method] = true
+			scope := "file"
+			if target.FilePath != from.FilePath {
+				scope = "module"
+			}
+			relations = append(relations, RelationRecord{
+				RecordType:    "relation",
+				FromID:        from.ID,
+				ToID:          target.ID,
+				Type:          "CALLS",
+				Confidence:    0.68,
+				Reason:        "Perl receiver call matched globally unique subroutine name",
+				RelationScope: scope,
+				Resolution:    "name_only",
+				TargetKind:    "symbol",
+				Evidence: []Evidence{{
+					Kind:      "call_site",
+					FilePath:  from.FilePath,
+					StartLine: from.StartLine,
+					EndLine:   from.EndLine,
+					Detail:    call.Receiver + "." + call.Method,
+				}},
+				WarningCodes: []string{},
+			})
+		}
 	}
 	// Kotlin extension functions (`fun Closeable.closeQuietly()`) are top-level
 	// functions, not members of the receiver's type, so the container lookups
@@ -3876,6 +4284,46 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 			})
 		}
 	}
+	if from.Language == "Swift" {
+		swiftChainTails := swiftReceiverCallTailsInLongerChains(block)
+		for _, chain := range swiftChains {
+			swiftChainTails[chain.Property+"."+chain.Method] = true
+		}
+		for _, call := range calls {
+			key := call.Receiver + "." + call.Method
+			if methodResolved[key] || swiftChainTails[key] {
+				continue
+			}
+			target, ok := swiftReceiverMethodByArgumentLabels(call, symbolsByShortName[call.Method])
+			if !ok || target.ID == from.ID {
+				continue
+			}
+			methodResolved[key] = true
+			scope := "file"
+			if target.FilePath != from.FilePath {
+				scope = "module"
+			}
+			relations = append(relations, RelationRecord{
+				RecordType:    "relation",
+				FromID:        from.ID,
+				ToID:          target.ID,
+				Type:          "CALLS",
+				Confidence:    0.66,
+				Reason:        "Swift receiver call matched unique argument-label signature",
+				RelationScope: scope,
+				Resolution:    "signature",
+				TargetKind:    "symbol",
+				Evidence: []Evidence{{
+					Kind:      "call_site",
+					FilePath:  from.FilePath,
+					StartLine: from.StartLine,
+					EndLine:   from.EndLine,
+					Detail:    call.Receiver + "." + call.Method,
+				}},
+				WarningCodes: []string{},
+			})
+		}
+	}
 	// Java fluent constructor chains (`new Retrofit.Builder().baseUrl(...)
 	// .build()`): every chained method resolves against the constructed type
 	// when the whole chain is defined on it (fluent builders return `this`);
@@ -4078,6 +4526,57 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 			WarningCodes: []string{},
 		})
 	}
+	// Generated factory convention: a property typed `CustomerFactory` exposes
+	// `create()`, whose returned object is the generated product type
+	// (`Customer`). Resolve the terminal chain call on that product.
+	for _, call := range phpFactoryChains {
+		factoryType, ok := phpPropTypes[call.Property]
+		if !ok || call.FactoryMethod != "create" || !strings.HasSuffix(factoryType, "Factory") {
+			continue
+		}
+		typeName := strings.TrimSuffix(factoryType, "Factory")
+		if typeName == "" {
+			continue
+		}
+		sym, ok := firstTypeLikeNamedPreferFile(symbolsByShortName[typeName], typeName, from.FilePath)
+		if !ok {
+			continue
+		}
+		method, inherited, ok := lookupMethodUpChain(sym.ID, call.Method, methodsByContainer, superContainerByID)
+		if !ok || method.ID == from.ID {
+			continue
+		}
+		confidence := 0.72
+		reason := "PHP factory property chain resolved via generated Factory::create product type"
+		if inherited {
+			confidence = 0.7
+			reason += " (inherited from a base type)"
+		}
+		scope := "file"
+		if method.FilePath != from.FilePath {
+			scope = "module"
+		}
+		relations = append(relations, RelationRecord{
+			RecordType:    "relation",
+			FromID:        from.ID,
+			ToID:          method.ID,
+			Type:          "CALLS",
+			Confidence:    confidence,
+			Reason:        reason,
+			RelationScope: scope,
+			Resolution:    "type_inferred",
+			TargetKind:    "symbol",
+			Evidence: []Evidence{{
+				Kind:      "call_site",
+				FilePath:  from.FilePath,
+				StartLine: from.StartLine,
+				EndLine:   from.EndLine,
+				Detail:    call.Detail,
+			}},
+			WarningCodes: []string{},
+		})
+	}
+	relations = append(relations, rustModulePathCallRelations(from, rustPathCalls, importsByName, symbolsByShortName)...)
 	// C# one-hop member chains `A.B.Method(...)`: A is a typed member of the
 	// enclosing class (or a typed parameter/local), B a typed property on A's
 	// type — declared in that type's own file — and Method resolves up B's
@@ -4261,6 +4760,36 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 			// package (one package spans a directory), so fall back to the
 			// package-level return types when this file declares no such factory.
 			returnTypes = returnTypesBySymbolNameAndDir[call.Factory][filepath.ToSlash(filepath.Dir(from.FilePath))]
+		}
+		if len(returnTypes) == 0 && from.Language == "Rust" {
+			method, ok := uniqueMethodByShortName(symbolsByShortName[call.Method])
+			if !ok || method.ID == from.ID || method.Language != "Rust" {
+				continue
+			}
+			scope := "file"
+			if method.FilePath != from.FilePath {
+				scope = "module"
+			}
+			relations = append(relations, RelationRecord{
+				RecordType:    "relation",
+				FromID:        from.ID,
+				ToID:          method.ID,
+				Type:          "CALLS",
+				Confidence:    0.66,
+				Reason:        "Rust returned receiver call matched globally unique method name",
+				RelationScope: scope,
+				Resolution:    "name_only",
+				TargetKind:    "symbol",
+				Evidence: []Evidence{{
+					Kind:      "call_site",
+					FilePath:  from.FilePath,
+					StartLine: from.StartLine,
+					EndLine:   from.EndLine,
+					Detail:    call.Detail,
+				}},
+				WarningCodes: []string{},
+			})
+			continue
 		}
 		for _, typeName := range returnTypes {
 			sym, ok := firstTypeLikeNamed(symbolsByShortName[typeName], typeName)
@@ -4527,6 +5056,22 @@ func uniqueMethodByShortName(candidates []SymbolRecord) (SymbolRecord, bool) {
 	}
 	if len(methods) == 1 {
 		return methods[0], true
+	}
+	return SymbolRecord{}, false
+}
+
+func uniqueCallableByShortName(candidates []SymbolRecord, language string) (SymbolRecord, bool) {
+	var callables []SymbolRecord
+	for _, c := range candidates {
+		if language != "" && c.Language != language {
+			continue
+		}
+		if c.Kind == "function" || c.Kind == "method" {
+			callables = append(callables, c)
+		}
+	}
+	if len(callables) == 1 {
+		return callables[0], true
 	}
 	return SymbolRecord{}, false
 }
@@ -7458,11 +8003,16 @@ func externalParts(id string) (string, string) {
 // so the snapshot never holds all source content in memory.
 func openSource(ctx context.Context, repo string, useHead bool, ignoreFiles, includeFiles []string) ([]string, contentReader, prefixReader, func() error, error) {
 	if useHead {
+		ignores, err := loadExplicitIgnoreMatcher(repo, ignoreFiles, includeFiles)
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
 		paths, err := gitutil.ListFiles(ctx, repo, "HEAD")
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}
 		paths = filterVendoredPaths(paths, headIgnoreMatcher(ctx, repo))
+		paths = filterIgnoredPaths(paths, ignores)
 		batch, err := gitutil.NewBatchFileReader(ctx, repo, "HEAD")
 		if err != nil {
 			return nil, nil, nil, nil, err
@@ -7688,6 +8238,18 @@ func filterVendoredPaths(paths []string, ignores ignoreMatcher) []string {
 	return filtered
 }
 
+func filterIgnoredPaths(paths []string, ignores ignoreMatcher) []string {
+	filtered := paths[:0]
+	for _, rel := range paths {
+		rel = filepath.ToSlash(rel)
+		if ignores.Ignored(rel, false) {
+			continue
+		}
+		filtered = append(filtered, rel)
+	}
+	return filtered
+}
+
 // headIgnoreMatcher parses the repository's root .gitignore as of HEAD so the
 // vendored-directory heuristic can honor negation rules (see
 // ReincludesDescendant) when listing files from the HEAD tree, matching the
@@ -7778,22 +8340,7 @@ func resolveLocalImport(importingPath, spec string, knownFiles map[string]bool) 
 	case ".c", ".h", ".cc", ".cpp", ".cxx", ".hh", ".hpp", ".hxx":
 		return resolveCFamilyLocalInclude(importingPath, spec, knownFiles)
 	case ".js", ".jsx", ".ts", ".tsx":
-		if !strings.HasPrefix(spec, "./") && !strings.HasPrefix(spec, "../") {
-			return "", false
-		}
-		base := filepath.ToSlash(filepath.Join(filepath.Dir(importingPath), spec))
-		exts := []string{".ts", ".tsx", ".js", ".jsx"}
-		var candidates []string
-		if filepath.Ext(base) != "" {
-			candidates = append(candidates, base)
-		}
-		for _, ext := range exts {
-			candidates = append(candidates, base+ext)
-		}
-		for _, ext := range exts {
-			candidates = append(candidates, filepath.ToSlash(filepath.Join(base, "index"+ext)))
-		}
-		for _, candidate := range candidates {
+		for _, candidate := range jsLocalImportCandidates(importingPath, spec) {
 			if knownFiles[candidate] {
 				return candidate, true
 			}
@@ -7823,6 +8370,45 @@ func resolveLocalImport(importingPath, spec string, knownFiles map[string]bool) 
 	default:
 		return "", false
 	}
+}
+
+func resolveReadableLocalImport(importingPath, spec string, readContent contentReader) (string, bool) {
+	switch strings.ToLower(filepath.Ext(importingPath)) {
+	case ".js", ".jsx", ".ts", ".tsx":
+		for _, candidate := range jsLocalImportCandidates(importingPath, spec) {
+			if _, ok := readContent(candidate); ok {
+				return candidate, true
+			}
+		}
+	}
+	return "", false
+}
+
+func jsLocalImportCandidates(importingPath, spec string) []string {
+	if !strings.HasPrefix(spec, "./") && !strings.HasPrefix(spec, "../") {
+		return nil
+	}
+	base := filepath.ToSlash(filepath.Join(filepath.Dir(importingPath), spec))
+	exts := []string{".ts", ".tsx", ".js", ".jsx"}
+	var candidates []string
+	if ext := strings.ToLower(filepath.Ext(base)); ext != "" {
+		candidates = append(candidates, base)
+		stem := strings.TrimSuffix(base, filepath.Ext(base))
+		switch ext {
+		case ".js":
+			candidates = append(candidates, stem+".ts", stem+".tsx")
+		case ".jsx":
+			candidates = append(candidates, stem+".tsx")
+		}
+		return candidates
+	}
+	for _, ext := range exts {
+		candidates = append(candidates, base+ext)
+	}
+	for _, ext := range exts {
+		candidates = append(candidates, filepath.ToSlash(filepath.Join(base, "index"+ext)))
+	}
+	return candidates
 }
 
 func resolveCFamilyLocalInclude(importingPath, spec string, knownFiles map[string]bool) (string, bool) {
@@ -8070,6 +8656,8 @@ func buildManifestImportResolver(files []FileRecord, readContent contentReader) 
 			cargoPaths = append(cargoPaths, filepath.ToSlash(file.Path))
 		}
 	}
+	cargoPaths = append(cargoPaths, inferCargoManifestsFromRustPaths(rustPaths, readContent)...)
+	cargoPaths = uniqueStrings(cargoPaths)
 	sort.Slice(goPaths, func(i, j int) bool {
 		leftTest := strings.HasSuffix(goPaths[i], "_test.go")
 		rightTest := strings.HasSuffix(goPaths[j], "_test.go")
@@ -8193,11 +8781,7 @@ func buildManifestImportResolver(files []FileRecord, readContent contentReader) 
 		if name == "" {
 			continue
 		}
-		dir := filepath.ToSlash(filepath.Dir(cp))
-		srcDir := "src"
-		if dir != "." && dir != "" {
-			srcDir = dir + "/src"
-		}
+		srcDir := cargoRustSourceRootDir(cp, content)
 		resolver.rustSrcRoots = append(resolver.rustSrcRoots, rustSrcRoot{dir: srcDir, crate: name})
 		resolver.rustCrateNames[name] = true
 	}
@@ -8207,6 +8791,14 @@ func buildManifestImportResolver(files []FileRecord, readContent contentReader) 
 	if resolver.rustCrateName != "" {
 		resolver.rustCrateNames[resolver.rustCrateName] = true
 	}
+	for _, sr := range resolver.rustSrcRoots {
+		for _, rootFile := range []string{sr.dir + "/lib.rs", sr.dir + "/main.rs", sr.dir + "/mod.rs"} {
+			if _, ok := readContent(rootFile); ok {
+				rustPaths = append(rustPaths, rootFile)
+			}
+		}
+	}
+	rustPaths = uniqueStrings(rustPaths)
 	sort.Strings(rustPaths)
 	for _, path := range rustPaths {
 		for _, module := range resolver.rustModuleKeysForPath(path) {
@@ -8903,9 +9495,79 @@ func parseCargoPackageName(content string) string {
 	return ""
 }
 
+func parseCargoLibPath(content string) string {
+	inLib := false
+	scanner := bufio.NewScanner(strings.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimSpace(stripTOMLComment(scanner.Text()))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			inLib = line == "[lib]"
+			continue
+		}
+		if inLib && strings.HasPrefix(strings.ToLower(line), "path") {
+			if path, ok := parseSimpleConfigKeyValue(line, "path"); ok {
+				return filepath.ToSlash(path)
+			}
+		}
+	}
+	return ""
+}
+
+func cargoRustSourceRootDir(cargoPath, content string) string {
+	dir := filepath.ToSlash(filepath.Dir(cargoPath))
+	if libPath := parseCargoLibPath(content); libPath != "" {
+		root := filepath.ToSlash(filepath.Dir(filepath.Join(dir, libPath)))
+		if root == "." {
+			return ""
+		}
+		return root
+	}
+	if dir == "." || dir == "" {
+		return "src"
+	}
+	return dir + "/src"
+}
+
+func inferCargoManifestsFromRustPaths(rustPaths []string, readContent contentReader) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, path := range rustPaths {
+		dir := filepath.ToSlash(filepath.Dir(path))
+		for {
+			candidate := "Cargo.toml"
+			if dir != "." && dir != "" {
+				candidate = dir + "/Cargo.toml"
+			}
+			if !seen[candidate] {
+				if _, ok := readContent(candidate); ok {
+					seen[candidate] = true
+					out = append(out, candidate)
+				}
+			}
+			if dir == "." || dir == "" {
+				break
+			}
+			parent := filepath.ToSlash(filepath.Dir(dir))
+			if parent == dir {
+				break
+			}
+			dir = parent
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
 func parseSimpleConfigValue(line string) (string, bool) {
+	return parseSimpleConfigKeyValue(line, "name")
+}
+
+func parseSimpleConfigKeyValue(line, key string) (string, bool) {
 	parts := strings.SplitN(line, "=", 2)
-	if len(parts) != 2 || strings.ToLower(strings.TrimSpace(parts[0])) != "name" {
+	if len(parts) != 2 || strings.ToLower(strings.TrimSpace(parts[0])) != strings.ToLower(key) {
 		return "", false
 	}
 	value := strings.TrimSpace(parts[1])
@@ -10465,8 +11127,12 @@ func importedNamesFor(path, content string) map[string][]string {
 		return importedGoNames(content)
 	case ".js", ".jsx", ".ts", ".tsx":
 		return importedJavaScriptNames(content)
+	case ".kt", ".kts":
+		return importedKotlinNames(content)
 	case ".py":
 		return importedPythonNames(content)
+	case ".rs":
+		return importedRustNames(content)
 	default:
 		return map[string][]string{}
 	}
@@ -10581,47 +11247,138 @@ func importedJavaScriptNames(content string) map[string][]string {
 	return imports
 }
 
+func importedKotlinNames(content string) map[string][]string {
+	imports := map[string][]string{}
+	importRe := regexp.MustCompile(`(?m)^\s*import\s+([A-Za-z_][A-Za-z0-9_.]*(?:\.\*)?)(?:\s+as\s+([A-Za-z_][A-Za-z0-9_]*))?`)
+	for _, match := range importRe.FindAllStringSubmatch(content, -1) {
+		module := strings.TrimSpace(match[1])
+		if module == "" || strings.HasSuffix(module, ".*") {
+			continue
+		}
+		local := strings.TrimSpace(match[2])
+		if local == "" {
+			parts := strings.Split(module, ".")
+			local = parts[len(parts)-1]
+		}
+		if local != "" {
+			imports[local] = append(imports[local], module)
+		}
+	}
+	return imports
+}
+
 func resolvedImportedNameModules(importingPath string, imports map[string][]string, manifestImports manifestImportResolver, knownFiles map[string]bool, readContent contentReader) map[string][]string {
 	if len(imports) == 0 {
 		return imports
 	}
+	readCached := cachingContentReader(readContent)
+	reexportCache := map[string][]string{}
 	resolved := make(map[string][]string, len(imports))
 	for name, modules := range imports {
 		resolved[name] = append(resolved[name], modules...)
 		for _, module := range modules {
-			var targetPath string
-			switch {
-			case isRelativeImportSpec(importingPath, module):
-				if path, ok := resolveLocalImport(importingPath, module, knownFiles); ok {
-					targetPath = path
-				}
-			default:
-				if resolution, ok := manifestImports.resolve(importingPath, module); ok {
-					targetPath = resolution.Path
-				}
-			}
+			targetPath, _ := resolveImportSpecPath(importingPath, module, manifestImports, knownFiles, readCached)
 			if targetPath == "" {
 				continue
 			}
 			resolved[name] = append(resolved[name], targetPath)
-			if content, ok := readContent(targetPath); ok {
-				for _, reexport := range javascriptReexportModulesForName(content, name) {
-					if path, ok := resolveLocalImport(targetPath, reexport, knownFiles); ok {
-						resolved[name] = append(resolved[name], path)
-					} else if resolution, ok := manifestImports.resolve(targetPath, reexport); ok {
-						resolved[name] = append(resolved[name], resolution.Path)
-					}
-				}
-			}
+			resolved[name] = append(resolved[name], resolvedJavaScriptReexportTargets(targetPath, name, manifestImports, knownFiles, readCached, map[string]bool{}, reexportCache, 0)...)
 		}
 		resolved[name] = uniqueStrings(resolved[name])
 	}
 	return resolved
 }
 
-var jsNamedReexportPattern = regexp.MustCompile(`(?ms)^\s*export\s+(?:type\s+)?\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]`)
+func cachingContentReader(readContent contentReader) contentReader {
+	type cached struct {
+		content string
+		ok      bool
+	}
+	cache := map[string]cached{}
+	return func(path string) (string, bool) {
+		if hit, ok := cache[path]; ok {
+			return hit.content, hit.ok
+		}
+		content, ok := readContent(path)
+		cache[path] = cached{content: content, ok: ok}
+		return content, ok
+	}
+}
 
-func javascriptReexportModulesForName(content, name string) []string {
+func resolveImportSpecPath(importingPath, module string, manifestImports manifestImportResolver, knownFiles map[string]bool, readContent contentReader) (string, bool) {
+	switch {
+	case isRelativeImportSpec(importingPath, module):
+		if path, ok := resolveLocalImport(importingPath, module, knownFiles); ok {
+			return path, true
+		}
+		return resolveReadableLocalImport(importingPath, module, readContent)
+	default:
+		if resolution, ok := manifestImports.resolve(importingPath, module); ok {
+			return resolution.Path, true
+		}
+	}
+	return "", false
+}
+
+func resolvedJavaScriptReexportTargets(path, name string, manifestImports manifestImportResolver, knownFiles map[string]bool, readContent contentReader, seen map[string]bool, cache map[string][]string, depth int) []string {
+	if path == "" || depth > 8 || seen[path] {
+		return nil
+	}
+	cacheKey := path + "\x00" + name
+	if cached, ok := cache[cacheKey]; ok {
+		return cached
+	}
+	seen[path] = true
+	content, ok := readContent(path)
+	if !ok {
+		return nil
+	}
+	var out []string
+	for _, reexport := range javascriptNamedReexportModulesForName(content, name) {
+		targetPath, ok := resolveImportSpecPath(path, reexport, manifestImports, knownFiles, readContent)
+		if !ok || targetPath == "" {
+			continue
+		}
+		out = append(out, targetPath)
+		out = append(out, resolvedJavaScriptReexportTargets(targetPath, name, manifestImports, knownFiles, readContent, seen, cache, depth+1)...)
+	}
+	out = append(out, resolvedJavaScriptStarReexportClosure(path, manifestImports, knownFiles, readContent, map[string]bool{}, cache, 0)...)
+	out = uniqueStrings(out)
+	cache[cacheKey] = out
+	return out
+}
+
+func resolvedJavaScriptStarReexportClosure(path string, manifestImports manifestImportResolver, knownFiles map[string]bool, readContent contentReader, seen map[string]bool, cache map[string][]string, depth int) []string {
+	if path == "" || depth > 8 || seen[path] {
+		return nil
+	}
+	cacheKey := "\x00star\x00" + path
+	if cached, ok := cache[cacheKey]; ok {
+		return cached
+	}
+	seen[path] = true
+	content, ok := readContent(path)
+	if !ok {
+		return nil
+	}
+	var out []string
+	for _, reexport := range javascriptStarReexportModules(content) {
+		targetPath, ok := resolveImportSpecPath(path, reexport, manifestImports, knownFiles, readContent)
+		if !ok || targetPath == "" {
+			continue
+		}
+		out = append(out, targetPath)
+		out = append(out, resolvedJavaScriptStarReexportClosure(targetPath, manifestImports, knownFiles, readContent, seen, cache, depth+1)...)
+	}
+	out = uniqueStrings(out)
+	cache[cacheKey] = out
+	return out
+}
+
+var jsNamedReexportPattern = regexp.MustCompile(`(?ms)^\s*export\s+(?:type\s+)?\{([^}]+)\}\s+from\s+['"]([^'"]+)['"]`)
+var jsStarReexportPattern = regexp.MustCompile(`(?m)^\s*export\s+(?:type\s+)?\*\s+from\s+['"]([^'"]+)['"]`)
+
+func javascriptNamedReexportModulesForName(content, name string) []string {
 	var modules []string
 	for _, match := range jsNamedReexportPattern.FindAllStringSubmatch(content, -1) {
 		if len(match) != 3 {
@@ -10633,6 +11390,16 @@ func javascriptReexportModulesForName(content, name string) []string {
 				modules = append(modules, match[2])
 				break
 			}
+		}
+	}
+	return uniqueStrings(modules)
+}
+
+func javascriptStarReexportModules(content string) []string {
+	var modules []string
+	for _, match := range jsStarReexportPattern.FindAllStringSubmatch(content, -1) {
+		if len(match) == 2 {
+			modules = append(modules, match[1])
 		}
 	}
 	return uniqueStrings(modules)
@@ -10827,7 +11594,23 @@ func importModuleMatchesFile(module, importingPath, targetPath string) bool {
 		return false
 	}
 	targetPath = filepath.ToSlash(targetPath)
+	if strings.Contains(module, ".") && !strings.Contains(module, "/") {
+		dottedPath := strings.ReplaceAll(module, ".", "/")
+		target := strings.TrimSuffix(targetPath, filepath.Ext(targetPath))
+		if target == dottedPath || strings.HasSuffix(target, "/"+dottedPath) {
+			return true
+		}
+		if parent := filepath.ToSlash(filepath.Dir(dottedPath)); parent != "." && parent != "" {
+			targetDir := filepath.ToSlash(filepath.Dir(targetPath))
+			if targetDir == parent || strings.HasSuffix(targetDir, "/"+parent) {
+				return true
+			}
+		}
+	}
 	if strings.HasPrefix(module, ".") {
+		if dottedRelativeModuleStemMatchesFile(module, targetPath) {
+			return true
+		}
 		base := filepath.ToSlash(filepath.Join(filepath.Dir(importingPath), module))
 		target := strings.TrimSuffix(targetPath, filepath.Ext(targetPath))
 		return target == base || (strings.HasSuffix(target, "/index") && strings.TrimSuffix(target, "/index") == base)
@@ -10849,6 +11632,30 @@ func importModuleMatchesFile(module, importingPath, targetPath string) bool {
 	module = strings.TrimSuffix(filepath.ToSlash(module), filepath.Ext(module))
 	target := strings.TrimSuffix(targetPath, filepath.Ext(targetPath))
 	return strings.HasSuffix(target, module) || strings.HasSuffix(target, "/"+module) || target == module
+}
+
+func dottedRelativeModuleStemMatchesFile(module, targetPath string) bool {
+	stem := jsModuleSpecifierStem(module)
+	if !strings.Contains(stem, ".") {
+		return false
+	}
+	parts := strings.Split(stem, ".")
+	if len(parts) < 2 {
+		return false
+	}
+	exportedModule := strings.TrimSpace(parts[len(parts)-1])
+	targetBase := strings.TrimSuffix(filepath.Base(targetPath), filepath.Ext(targetPath))
+	return exportedModule != "" && targetBase == exportedModule
+}
+
+func jsModuleSpecifierStem(module string) string {
+	base := filepath.Base(filepath.ToSlash(module))
+	for _, suffix := range []string{".d.ts", ".d.tsx", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"} {
+		if strings.HasSuffix(base, suffix) {
+			return strings.TrimSuffix(base, suffix)
+		}
+	}
+	return strings.TrimSuffix(base, filepath.Ext(base))
 }
 
 // rustCodegenMacroStart matches the opening of a Rust code-generation macro

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -1616,6 +1616,32 @@ func resolveCallTargets(name string, from SymbolRecord, candidates, sameFile []S
 			Scope:        "workspace",
 		}}
 	}
+	if from.Language == "PHP" && len(remaining) > 1 {
+		// PHP repos commonly re-declare bare functions (WordPress ships
+		// apply_filters in plugin.php plus compat/noop stubs), and PHP has
+		// no import statements for functions to disambiguate through.
+		// Ambiguity must not mean silence: emit candidate edges to the
+		// same-name declarations, largest declaration first (the canonical
+		// implementation dwarfs its stubs), capped to keep noise bounded.
+		ranked := append([]SymbolRecord(nil), remaining...)
+		sort.SliceStable(ranked, func(i, j int) bool {
+			return ranked[i].EndLine-ranked[i].StartLine > ranked[j].EndLine-ranked[j].StartLine
+		})
+		if len(ranked) > 4 {
+			ranked = ranked[:4]
+		}
+		out := make([]resolvedCallTarget, 0, len(ranked))
+		for _, cand := range ranked {
+			out = append(out, resolvedCallTarget{
+				SymbolRecord: cand,
+				Confidence:   0.55,
+				Reason:       fmt.Sprintf("ambiguous bare call: candidate among %d same-name declarations", len(remaining)),
+				Resolution:   "name_only",
+				Scope:        "workspace",
+			})
+		}
+		return out
+	}
 	if cFamilyOverloadResolutionEnabled(from.Language) {
 		if overloads, ok := sameFileOverloadSet(remaining); ok {
 			out := make([]resolvedCallTarget, 0, len(overloads))
@@ -1964,6 +1990,29 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 						returnTypesBySymbolNameAndDir[symbol.Name][dir] = append(returnTypesBySymbolNameAndDir[symbol.Name][dir], typeName)
 					}
 				}
+			}
+		}
+	}
+	// PHP declares return types in docblocks far more often than in native
+	// hints (WordPress uses docblocks exclusively), and the signature pass
+	// above cannot see them. Harvest '@return Type' from the docblock
+	// directly above each PHP function/method so factory-return and
+	// chained-call receiver inference work (rest_get_server()->dispatch()
+	// must resolve through '@return WP_REST_Server').
+	if needsReceiverCalls {
+		for _, file := range files {
+			if file.Language != "PHP" {
+				continue
+			}
+			content, ok := readContent(file.Path)
+			if !ok {
+				continue
+			}
+			for name, typeName := range phpDocblockReturnTypes(content) {
+				if returnTypesBySymbolNameAndFile[name] == nil {
+					returnTypesBySymbolNameAndFile[name] = map[string][]string{}
+				}
+				returnTypesBySymbolNameAndFile[name][file.Path] = append(returnTypesBySymbolNameAndFile[name][file.Path], typeName)
 			}
 		}
 	}
@@ -3459,6 +3508,16 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 				targetID = sym.ID
 				confidence = 0.8
 				reason = "method call resolved via typed property receiver"
+			} else if from.ContainerID != "" && strings.EqualFold(call.Receiver, enclosingTypeShortName(from)) {
+				// An untyped receiver named after the enclosing type resolves
+				// to it: laravel/framework's Container.getClosure returns a
+				// closure whose $container parameter is (by convention) the
+				// container itself, so $container->resolve(...) is a call on
+				// the enclosing class. The method-existence check below keeps
+				// this honest — no edge unless the type defines the method.
+				targetID = from.ContainerID
+				confidence = 0.62
+				reason = "method call receiver named after the enclosing type"
 			} else {
 				continue
 			}
@@ -7225,6 +7284,19 @@ func firstTypeLikeNamed(records []SymbolRecord, name string) (SymbolRecord, bool
 // Same-file preference matters when a repo vendors a mirror copy of its sources
 // (e.g. a Deno build alongside src/): without it a class-qualified call could
 // bind to the twin in the wrong file.
+// enclosingTypeShortName extracts the short name of a symbol's enclosing
+// type from its container ID (".../class:Outer.Inner" -> "Inner").
+func enclosingTypeShortName(from SymbolRecord) string {
+	id := from.ContainerID
+	if idx := strings.LastIndex(id, ":"); idx >= 0 {
+		id = id[idx+1:]
+	}
+	if idx := strings.LastIndex(id, "."); idx >= 0 {
+		id = id[idx+1:]
+	}
+	return id
+}
+
 // typeLikeNamedWithMethod resolves a type name to the declaration that
 // actually defines the called method. C# partial classes declare the same
 // type in several files, and the lexically-first declaration may not hold

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -375,6 +375,53 @@ function createApplication() {
 	}
 }
 
+func TestTypeScriptReceiverCallsWithTypeArgumentsResolve(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "src/injector.ts", `class Controller {}
+
+class Injector {
+  public async loadInstance<T>() {
+    const callback = async () => {
+      await this.resolveProperties<T>();
+      await this.instantiateClass<T>();
+    };
+    await this.resolveConstructorParams<T>(callback);
+  }
+
+  public async loadController() {
+    await this.loadInstance<Controller>();
+  }
+
+  public async loadProvider<T>() {
+    await this.loadInstance<T>();
+  }
+
+  private async resolveConstructorParams<T>(callback: () => Promise<void>) {
+    await callback();
+  }
+
+  private async resolveProperties<T>() {}
+
+  private async instantiateClass<T>() {}
+}
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range [][2]string{
+		{"Injector.loadController", "Injector.loadInstance"},
+		{"Injector.loadProvider", "Injector.loadInstance"},
+		{"Injector.loadInstance", "Injector.resolveConstructorParams"},
+		{"Injector.loadInstance", "Injector.resolveProperties"},
+		{"Injector.loadInstance", "Injector.instantiateClass"},
+	} {
+		if !hasRelationByLastSegment(snapshot.Relations, "CALLS", want[0], want[1]) {
+			t.Fatalf("missing TypeScript generic receiver call %s -> %s in %#v", want[0], want[1], snapshot.Relations)
+		}
+	}
+}
+
 func TestTypeScriptManifestImportsResolveThroughExtendedTSConfig(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, repo, "package.json", `{"name":"@acme/app"}`)
@@ -6589,6 +6636,89 @@ extension LenientParser {
 	}
 }
 
+func TestBuildProviderSnapshotResolvesSwiftExistentialDelegateAndLabelCalls(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "Source/Core/Request.swift", `class Request {
+  public private(set) weak var delegate: (any RequestDelegate)?
+  var isCancelled: Bool { false }
+
+  func retryOrFinish(error: AFError?) {
+    guard !isCancelled, let error, let delegate else { finish(); return }
+    delegate.retryResult(for: self, dueTo: error) { retryResult in
+      switch retryResult {
+      case .doNotRetry:
+        self.finish()
+      case let .doNotRetryWithError(retryError):
+        self.finish(error: retryError.asAFError(orFailWith: "Received retryError was not already AFError"))
+      case .retry, .retryWithDelay:
+        delegate.retryRequest(self, withDelay: retryResult.delay)
+      }
+    }
+  }
+
+  func finish(error: AFError? = nil) {}
+}
+
+protocol RequestDelegate: AnyObject {
+  func retryResult(for request: Request, dueTo error: AFError, completion: @escaping (RetryResult) -> Void)
+  func retryRequest(_ request: Request, withDelay timeDelay: Double?)
+}
+`)
+	writeFile(t, repo, "Source/Core/Session.swift", `class Session: RequestDelegate {
+  func retryResult(for request: Request, dueTo error: AFError, completion: @escaping (RetryResult) -> Void) {}
+  func retryRequest(_ request: Request, withDelay timeDelay: Double?) {}
+}
+`)
+	writeFile(t, repo, "Source/Core/AFError.swift", `struct AFError {}
+
+extension Error {
+  func asAFError(orFailWith message: @autoclosure () -> String) -> AFError {
+    return AFError()
+  }
+
+  func asAFError(or defaultAFError: @autoclosure () -> AFError) -> AFError {
+    return defaultAFError()
+  }
+}
+`)
+	writeFile(t, repo, "Source/Features/RequestInterceptor.swift", `enum RetryResult {
+  case doNotRetry
+  case doNotRetryWithError(any Error)
+  case retry
+  case retryWithDelay
+
+  var delay: Double? { nil }
+}
+`)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, edge := range [][2]string{
+		{"Request.retryOrFinish", "Request.finish"},
+		{"Request.retryOrFinish", "Session.retryResult"},
+		{"Request.retryOrFinish", "Session.retryRequest"},
+	} {
+		if !hasRelationByLastSegment(snapshot.Relations, "CALLS", edge[0], edge[1]) {
+			t.Fatalf("Swift call %s -> %s not resolved: %#v", edge[0], edge[1], snapshot.Relations)
+		}
+	}
+	foundAsAFError := false
+	for _, relation := range snapshot.Relations {
+		if relation.Type == "CALLS" &&
+			lastSegment(relation.FromID) == "Request.retryOrFinish" &&
+			strings.Contains(relation.ToID, ":method:Error.asAFError") {
+			foundAsAFError = true
+			break
+		}
+	}
+	if !foundAsAFError {
+		t.Fatalf("Swift call Request.retryOrFinish -> Error.asAFError not resolved: %#v", snapshot.Relations)
+	}
+}
+
 func TestBuildProviderSnapshotResolvesJavaSamePackageStaticOverload(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, repo, "src/main/java/org/acme/LauncherDiscoveryRequest.java", `package org.acme;
@@ -9375,6 +9505,42 @@ func hasRelationByLastSegmentWithResolution(relations []RelationRecord, relation
 	return false
 }
 
+func hasRelationBySymbolName(snapshot ProviderSnapshot, relationType, from, to string) bool {
+	symbolsByID := map[string]SymbolRecord{}
+	for _, symbol := range snapshot.Symbols {
+		symbolsByID[symbol.ID] = symbol
+	}
+	for _, relation := range snapshot.Relations {
+		if relation.Type != relationType {
+			continue
+		}
+		fromSymbol, fromOK := symbolsByID[relation.FromID]
+		toSymbol, toOK := symbolsByID[relation.ToID]
+		if fromOK && toOK && fromSymbol.Name == from && toSymbol.Name == to {
+			return true
+		}
+	}
+	return false
+}
+
+func hasRelationBySymbolNameAndFile(snapshot ProviderSnapshot, relationType, from, fromFile, to, toFile string) bool {
+	symbolsByID := map[string]SymbolRecord{}
+	for _, symbol := range snapshot.Symbols {
+		symbolsByID[symbol.ID] = symbol
+	}
+	for _, relation := range snapshot.Relations {
+		if relation.Type != relationType {
+			continue
+		}
+		fromSymbol, fromOK := symbolsByID[relation.FromID]
+		toSymbol, toOK := symbolsByID[relation.ToID]
+		if fromOK && toOK && fromSymbol.Name == from && fromSymbol.FilePath == fromFile && toSymbol.Name == to && toSymbol.FilePath == toFile {
+			return true
+		}
+	}
+	return false
+}
+
 func hasRelationToExternalRoute(relations []RelationRecord, relationType, from, route string) bool {
 	for _, relation := range relations {
 		if relation.Type == relationType && lastSegment(relation.FromID) == from && relation.ToID == externalID("route", route) {
@@ -9950,6 +10116,94 @@ class Greeter {
 	} {
 		if !hasRelationByLastSegment(snapshot.Relations, want.relationType, want.from, want.to) {
 			t.Fatalf("missing Kotlin %s %s -> %s in %#v", want.relationType, want.from, want.to, snapshot.Relations)
+		}
+	}
+}
+
+func TestKotlinClassPropertyInitializersAndImportedTopLevelCallsResolve(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "src/org/koin/core/module/Module.kt", `package org.koin.core.module
+
+class Module
+
+fun flatten(modules: List<Module>): Set<Module> = modules.toSet()
+`)
+	writeFile(t, repo, "src/org/koin/core/registry/InstanceRegistry.kt", `package org.koin.core.registry
+
+import org.koin.core.module.Module
+
+class InstanceRegistry {
+  fun loadModules(modules: Set<Module>, allowOverride: Boolean) {}
+}
+`)
+	writeFile(t, repo, "src/org/koin/core/registry/ScopeRegistry.kt", `package org.koin.core.registry
+
+import org.koin.core.module.Module
+
+class ScopeRegistry {
+  fun loadScopes(modules: Set<Module>) {}
+}
+`)
+	writeFile(t, repo, "src/org/koin/core/Koin.kt", `package org.koin.core
+
+import org.koin.core.module.Module
+import org.koin.core.module.flatten
+import org.koin.core.registry.InstanceRegistry
+import org.koin.core.registry.ScopeRegistry
+
+class Koin {
+  val instanceRegistry = InstanceRegistry()
+  val scopeRegistry = ScopeRegistry()
+
+  fun loadModules(modules: List<Module>, allowOverride: Boolean = true, createEagerInstances: Boolean = false) {
+    val flattedModules = flatten(modules)
+    instanceRegistry.loadModules(flattedModules, allowOverride)
+    scopeRegistry.loadScopes(flattedModules)
+    if (createEagerInstances) {
+      createEagerInstances()
+    }
+  }
+
+  fun createEagerInstances() {}
+}
+`)
+	writeFile(t, repo, "src/org/koin/core/KoinApplication.kt", `package org.koin.core
+
+import org.koin.core.module.Module
+
+class KoinApplication {
+  val koin = Koin()
+
+  private fun loadModules(modules: List<Module>) {
+    koin.loadModules(modules, allowOverride = true, createEagerInstances = false)
+  }
+}
+`)
+	writeFile(t, repo, "src/other/Other.kt", `package other
+
+import org.koin.core.module.Module
+
+fun flatten(modules: List<Module>): Set<Module> = emptySet()
+`)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []struct {
+		from     string
+		fromFile string
+		to       string
+		toFile   string
+	}{
+		{"loadModules", "src/org/koin/core/KoinApplication.kt", "loadModules", "src/org/koin/core/Koin.kt"},
+		{"loadModules", "src/org/koin/core/Koin.kt", "flatten", "src/org/koin/core/module/Module.kt"},
+		{"loadModules", "src/org/koin/core/Koin.kt", "loadModules", "src/org/koin/core/registry/InstanceRegistry.kt"},
+		{"loadModules", "src/org/koin/core/Koin.kt", "loadScopes", "src/org/koin/core/registry/ScopeRegistry.kt"},
+		{"loadModules", "src/org/koin/core/Koin.kt", "createEagerInstances", "src/org/koin/core/Koin.kt"},
+	} {
+		if !hasRelationBySymbolNameAndFile(snapshot, "CALLS", want.from, want.fromFile, want.to, want.toFile) {
+			t.Fatalf("missing Kotlin CALLS %s:%s -> %s:%s in %#v", want.fromFile, want.from, want.toFile, want.to, relationsOfType(snapshot.Relations, "CALLS"))
 		}
 	}
 }
@@ -10614,6 +10868,34 @@ func TestBuildProviderSnapshotWorktreeIncludeDirectoryKeepsSpecificFileIgnore(t 
 	}
 	if snapshotHasPath(snapshot, "cache/skip.py") || snapshotHasSymbol(snapshot, "skip_me") {
 		t.Fatalf("snapshot included specifically ignored file: files=%#v symbols=%#v", snapshot.Files, snapshot.Symbols)
+	}
+}
+
+func TestBuildProviderSnapshotHeadHonorsIgnoreAndIncludeFiles(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Sem Test")
+	git(t, repo, "config", "user.email", "sem@example.com")
+	writeFile(t, repo, ".semignore", "*\n")
+	writeFile(t, repo, ".seminclude", "src/keep.py\n")
+	writeFile(t, repo, "src/keep.py", "def keep_me():\n    return True\n")
+	writeFile(t, repo, "src/drop.py", "def drop_me():\n    return False\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{
+		IgnoreFiles:  []string{".semignore"},
+		IncludeFiles: []string{".seminclude"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !snapshotHasSymbol(snapshot, "keep_me") {
+		t.Fatalf("snapshot did not include explicitly included HEAD file: %#v", snapshot.Symbols)
+	}
+	if snapshotHasPath(snapshot, "src/drop.py") || snapshotHasSymbol(snapshot, "drop_me") {
+		t.Fatalf("snapshot included ignored HEAD file: files=%#v symbols=%#v", snapshot.Files, snapshot.Symbols)
 	}
 }
 
@@ -11364,6 +11646,51 @@ end
 	}
 }
 
+func TestJuliaBangCallsAndHashCommentsResolve(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "src/hpack.jl", `function _decode_integer(block, index, bits)
+    return index, bits
+end
+
+function _decode_literal!(decoder, block, index)
+    return decoder, block, index
+end
+
+function set_max_dynamic_table_size!(decoder, size)
+    return size
+end
+
+function decode_header_block(decoder, block)
+    index, bits = _decode_integer(block, 1, 7)
+    header = _decode_literal!(decoder, block, index)
+    # Keep this comment ending with a selector-looking dot.
+    set_max_dynamic_table_size!(decoder, bits)
+    return header
+end
+`)
+	writeFile(t, repo, "src/http2_server.jl", `function _h2_server_refuse_stream!(decoder, block)
+    # Keep the shared decoder state consistent with the peer's encoder.
+    decode_header_block(decoder, block)
+    return nothing
+end
+`)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range [][2]string{
+		{"decode_header_block", "_decode_integer"},
+		{"decode_header_block", "_decode_literal!"},
+		{"decode_header_block", "set_max_dynamic_table_size!"},
+		{"_h2_server_refuse_stream!", "decode_header_block"},
+	} {
+		if !hasRelationByLastSegment(snapshot.Relations, "CALLS", want[0], want[1]) {
+			t.Fatalf("missing Julia CALLS %s->%s: %#v", want[0], want[1], relationsOfType(snapshot.Relations, "CALLS"))
+		}
+	}
+}
+
 func TestClojureSemanticExtraction(t *testing.T) {
 	// Clojure was promoted from inventory to the semantic tier (vendored
 	// grammar). tree-sitter-clojure only produces generic list_lit nodes, so
@@ -11546,6 +11873,69 @@ run();
 		t.Fatalf("Perl sub inside package block not extracted: %#v", kinds)
 	}
 }
+
+func TestPerlReceiverCallsWithoutParentheses(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "lib/Mojolicious/Controller.pm", `package Mojolicious::Controller;
+
+sub stash { return {} }
+
+sub url_for {
+  my ($self, $target) = (shift, shift // '');
+  my $req  = $self->req;
+  my $base = $self->base;
+
+  if (defined(my $prefix = $self->stash->{path})) {
+    my $real = $req->url->path->to_route;
+  }
+
+  return $base->protocol eq 'https';
+}
+`)
+	writeFile(t, repo, "lib/Mojo/Path.pm", `package Mojo::Path;
+
+sub to_route {
+  return '/';
+}
+`)
+	writeFile(t, repo, "lib/Mojo/URL.pm", `package Mojo::URL;
+
+sub protocol {
+  return 'http';
+}
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	calls := map[string]RelationRecord{}
+	for _, r := range snapshot.Relations {
+		if r.Type == "CALLS" {
+			calls[lastSegment(r.FromID)+"->"+lastSegment(r.ToID)] = r
+		}
+	}
+	for _, want := range []string{
+		"url_for->stash",
+		"url_for->to_route",
+		"url_for->protocol",
+	} {
+		r, ok := calls[want]
+		if !ok {
+			t.Fatalf("missing Perl receiver call %s in %#v", want, calls)
+		}
+		if got := r.Reason; got != "Perl receiver call matched globally unique subroutine name" {
+			t.Fatalf("%s reason = %q", want, got)
+		}
+		if symbolsByID[r.ToID].Language != "Perl" {
+			t.Fatalf("%s resolved to non-Perl target: %#v", want, symbolsByID[r.ToID])
+		}
+	}
+}
+
 func TestHaskellSemanticExtraction(t *testing.T) {
 	// Haskell was promoted from inventory to the semantic tier (vendored
 	// grammar); it must now extract top-level function bindings (one symbol
@@ -11850,6 +12240,75 @@ module Nested =
 	}
 }
 
+func TestFSharpQualifiedCallExtraction(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "src/Paket.Core/Installation/InstallProcess.fs", `module Paket.InstallProcess
+
+let InstallIntoProjects(options, forceTouch, dependenciesFile, lockFile, projectsAndReferences, updatedGroups, touchedPackages) =
+    ignore (options, forceTouch, dependenciesFile, lockFile, projectsAndReferences, updatedGroups, touchedPackages)
+`)
+	writeFile(t, repo, "src/Paket.Core/Installation/GarbageCollection.fs", `module Paket.GarbageCollection
+
+let CleanUp(dependenciesFile, lockFile) =
+    ignore (dependenciesFile, lockFile)
+`)
+	writeFile(t, repo, "src/Paket.Core/Installation/ScriptGeneration.fs", `module Paket.LoadingScripts
+
+module ScriptGeneration =
+    let constructScriptsFromData depCache groups frameworks scriptTypes =
+        ignore (depCache, groups, frameworks, scriptTypes)
+`)
+	writeFile(t, repo, "src/Paket.Core/Installation/UpdateProcess.fs", `module Paket.UpdateProcess
+
+let SelectiveUpdate(dependenciesFile, alternativeProjectRoot, updateMode, semVerUpdateMode, force) =
+    ignore (dependenciesFile, alternativeProjectRoot, updateMode, semVerUpdateMode, force)
+
+let SmartInstall(dependenciesFile, updateMode, options) =
+    SelectiveUpdate(dependenciesFile, None, updateMode, None, false)
+    InstallProcess.InstallIntoProjects(options, false, dependenciesFile, lockFile, [], [], None)
+    GarbageCollection.CleanUp(dependenciesFile, lockFile)
+    LoadingScripts.ScriptGeneration.constructScriptsFromData depCache [] [] []
+`)
+	writeFile(t, repo, "src/Paket.Core/PublicAPI.fs", `module Paket.PublicAPI
+
+type Dependencies() =
+    member private this.Install(options) =
+        UpdateProcess.SmartInstall("deps", "Install", options)
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	type edge struct{ from, to string }
+	calls := map[edge]bool{}
+	for _, r := range snapshot.Relations {
+		if r.Type != "CALLS" {
+			continue
+		}
+		from, fromOK := symbolsByID[r.FromID]
+		to, toOK := symbolsByID[r.ToID]
+		if !fromOK || !toOK || from.Language != "F#" || to.Language != "F#" {
+			continue
+		}
+		calls[edge{from.FilePath + ":" + from.Name, to.FilePath + ":" + to.Name}] = true
+	}
+	for _, want := range []edge{
+		{"src/Paket.Core/PublicAPI.fs:Install", "src/Paket.Core/Installation/UpdateProcess.fs:SmartInstall"},
+		{"src/Paket.Core/Installation/UpdateProcess.fs:SmartInstall", "src/Paket.Core/Installation/UpdateProcess.fs:SelectiveUpdate"},
+		{"src/Paket.Core/Installation/UpdateProcess.fs:SmartInstall", "src/Paket.Core/Installation/InstallProcess.fs:InstallIntoProjects"},
+		{"src/Paket.Core/Installation/UpdateProcess.fs:SmartInstall", "src/Paket.Core/Installation/GarbageCollection.fs:CleanUp"},
+		{"src/Paket.Core/Installation/UpdateProcess.fs:SmartInstall", "src/Paket.Core/Installation/ScriptGeneration.fs:constructScriptsFromData"},
+	} {
+		if !calls[want] {
+			t.Fatalf("missing F# qualified CALLS edge %v in %v", want, calls)
+		}
+	}
+}
+
 func TestSwiftProtocolDeclarationsEmitted(t *testing.T) {
 	// tree-sitter-swift emits protocol_declaration; an Objective-C-only gate
 	// on that node type silently dropped every Swift protocol (regression
@@ -11915,6 +12374,298 @@ pub fn boot() -> u32 {
 	}
 	if !found {
 		t.Fatalf("Rust Type::method path call did not resolve to the method")
+	}
+}
+
+func TestRustReceiverFactoryAssignmentTypesLocal(t *testing.T) {
+	// Bun's bundler code often types a local through a receiver method
+	// (`let c = ctx.c();`) before dispatching on that local. The receiver
+	// method's declared return type should type the local for the next call.
+	repo := t.TempDir()
+	writeFile(t, repo, "src/lib.rs", `pub struct LinkerContext;
+pub struct GenerateChunkCtx;
+
+impl GenerateChunkCtx {
+    pub fn c(&self) -> &mut LinkerContext {
+        todo!()
+    }
+}
+
+impl LinkerContext {
+    pub fn break_output_into_pieces(&self) {}
+}
+
+pub fn post_process(ctx: GenerateChunkCtx) {
+    let c = ctx.c();
+    c.break_output_into_pieces();
+}
+
+pub fn post_process_typed(ctx: GenerateChunkCtx) {
+    let c: &mut LinkerContext = ctx.c();
+    c.break_output_into_pieces();
+}
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := map[string]bool{}
+	for _, r := range snapshot.Relations {
+		if r.Type == "CALLS" && strings.Contains(r.ToID, "LinkerContext.break_output_into_pieces") {
+			if strings.Contains(r.FromID, "post_process_typed") {
+				found["post_process_typed"] = true
+			} else if strings.Contains(r.FromID, "post_process") {
+				found["post_process"] = true
+			}
+		}
+	}
+	for _, name := range []string{"post_process", "post_process_typed"} {
+		if !found[name] {
+			t.Fatalf("missing Rust receiver-factory CALLS edge from %s to break_output_into_pieces; found=%v", name, found)
+		}
+	}
+}
+
+func TestRustTokioStyleBlockingSpawnEdges(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "Cargo.toml", `[package]
+name = "tokio-shape"
+version = "0.1.0"
+`)
+	writeFile(t, repo, "src/lib.rs", `pub mod runtime;
+pub mod task;
+pub mod util;
+`)
+	writeFile(t, repo, "src/runtime/mod.rs", `pub mod blocking;
+pub mod task;
+
+pub struct Handle {
+    pub inner: scheduler::Handle,
+}
+
+pub mod scheduler {
+    pub enum Handle {}
+}
+`)
+	writeFile(t, repo, "src/runtime/blocking/mod.rs", `pub mod pool;
+`)
+	writeFile(t, repo, "src/runtime/blocking/pool.rs", `use crate::runtime::task::Id;
+use crate::util::trace::blocking_task;
+
+pub struct Spawner;
+pub struct JoinHandle;
+pub struct BlockingTask<F>(F);
+
+impl<F> BlockingTask<F> {
+    pub fn new(func: F) -> Self {
+        BlockingTask(func)
+    }
+}
+
+impl Spawner {
+    pub fn spawn_blocking_inner<F>(&self, func: F) -> JoinHandle {
+        let id = Id::next();
+        let _fut = blocking_task::<F, BlockingTask<F>>(BlockingTask::new(func), id.as_u64());
+        JoinHandle
+    }
+}
+`)
+	writeFile(t, repo, "src/runtime/task.rs", `pub struct Id(u64);
+
+impl Id {
+    pub fn next() -> Id {
+        Id(1)
+    }
+
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+`)
+	writeFile(t, repo, "src/task/mod.rs", `pub mod builder;
+`)
+	writeFile(t, repo, "src/task/builder.rs", `use crate::runtime::Handle;
+
+pub struct Builder;
+
+impl Builder {
+    pub fn spawn_blocking_on(&self, handle: &Handle) {
+        handle.inner.blocking_spawner().spawn_blocking_inner(|| {});
+    }
+}
+`)
+	writeFile(t, repo, "src/util/mod.rs", `pub mod trace;
+`)
+	writeFile(t, repo, "src/util/trace.rs", `pub fn blocking_task<Fn, Fut>(task: Fut, id: u64) -> Fut {
+    task
+}
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := map[string]RelationRecord{}
+	for _, r := range snapshot.Relations {
+		if r.Type == "CALLS" {
+			calls[lastSegment(r.FromID)+"->"+lastSegment(r.ToID)] = r
+		}
+	}
+	for _, want := range []string{
+		"Builder.spawn_blocking_on->Spawner.spawn_blocking_inner",
+		"Spawner.spawn_blocking_inner->blocking_task",
+		"Spawner.spawn_blocking_inner->Id.as_u64",
+	} {
+		if _, ok := calls[want]; !ok {
+			t.Fatalf("missing Rust Tokio-style CALLS edge %s in %#v", want, calls)
+		}
+	}
+	if got := calls["Builder.spawn_blocking_on->Spawner.spawn_blocking_inner"].Reason; got != "Rust returned receiver call matched globally unique method name" {
+		t.Fatalf("spawn_blocking_inner resolved for the wrong reason %q", got)
+	}
+}
+
+func TestRustUseBoundModulePathCallResolvesThroughAlias(t *testing.T) {
+	// `use crate::strings; strings::index_of(...)` should resolve through the
+	// public alias `pub use crate::string::immutable as strings`, not fall back
+	// to a bare unique-name guess.
+	repo := t.TempDir()
+	writeFile(t, repo, "Cargo.toml", `[package]
+name = "acme-core"
+version = "0.1.0"
+`)
+	writeFile(t, repo, "src/lib.rs", `pub mod string;
+pub use crate::string::immutable as strings;
+
+use crate::strings;
+
+pub fn caller() {
+    strings::index_of();
+}
+`)
+	writeFile(t, repo, "src/string/mod.rs", `pub mod immutable;
+`)
+	writeFile(t, repo, "src/string/immutable.rs", `pub fn index_of() {}
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, r := range snapshot.Relations {
+		if r.Type == "CALLS" && strings.Contains(r.FromID, "caller") && strings.Contains(r.ToID, "index_of") && strings.Contains(r.ToID, "src/string/immutable.rs") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("Rust use-bound module path call did not resolve through alias")
+	}
+}
+
+func TestRustNestedCrateLibPathAliasResolves(t *testing.T) {
+	// Bun's `bun_core` crate lives under `src/bun_core` and declares
+	// `[lib] path = "lib.rs"`, so the crate root is not `src/bun_core/src`.
+	// The manifest resolver must still index `pub use ... as strings`.
+	repo := t.TempDir()
+	writeFile(t, repo, "Cargo.toml", `[workspace]
+members = ["src/bun_core", "src/bundler"]
+`)
+	writeFile(t, repo, "src/bun_core/Cargo.toml", `[package]
+name = "bun_core"
+version = "0.1.0"
+
+[lib]
+path = "lib.rs"
+`)
+	writeFile(t, repo, "src/bun_core/lib.rs", `pub mod string;
+pub use crate::string::immutable as strings;
+`)
+	writeFile(t, repo, "src/bun_core/string/mod.rs", `pub mod immutable;
+`)
+	writeFile(t, repo, "src/bun_core/string/immutable.rs", `pub fn index_of() {}
+`)
+	writeFile(t, repo, "src/bundler/Cargo.toml", `[package]
+name = "bundler"
+version = "0.1.0"
+`)
+	writeFile(t, repo, "src/bundler/src/lib.rs", `use bun_core::strings;
+
+pub fn caller() {
+    strings::index_of();
+}
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, r := range snapshot.Relations {
+		if r.Type == "CALLS" && strings.Contains(r.FromID, "caller") && strings.Contains(r.ToID, "src/bun_core/string/immutable.rs:function:index_of") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("Rust nested crate [lib] path alias call did not resolve")
+	}
+}
+
+func TestElixirBareSameModuleCallsResolveToMethods(t *testing.T) {
+	// Elixir functions inside a module are emitted as method symbols. Bare
+	// same-module calls (`terminate_children(...)`, `monitor_children(...)`)
+	// must therefore be allowed to resolve to methods.
+	repo := t.TempDir()
+	writeFile(t, repo, "lib/dynamic_supervisor.ex", `defmodule DynamicSupervisor do
+  def handle_call({:terminate_child, pid}, _from, %{children: children} = state) do
+    :ok = terminate_children(%{pid => :child}, state)
+    {:reply, :ok, state}
+  end
+
+  def terminate(_, %{children: children} = state) do
+    :ok = terminate_children(children, state)
+  end
+
+  defp terminate_children(children, state) do
+    pids = monitor_children(children)
+    wait_children(pids, state)
+    report_error(:shutdown_error, state)
+    :ok
+  end
+
+  defp monitor_children(children), do: children
+  defp wait_children(pids, state), do: {pids, state}
+  defp report_error(error, state), do: {error, state}
+end
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	type edge struct{ from, to string }
+	calls := map[edge]bool{}
+	for _, r := range snapshot.Relations {
+		if r.Type != "CALLS" {
+			continue
+		}
+		from, fromOK := symbolsByID[r.FromID]
+		to, toOK := symbolsByID[r.ToID]
+		if !fromOK || !toOK || from.Language != "Elixir" || to.Language != "Elixir" {
+			continue
+		}
+		calls[edge{from.Name, to.Name}] = true
+	}
+	for _, want := range []edge{
+		{"handle_call", "terminate_children"},
+		{"terminate", "terminate_children"},
+		{"terminate_children", "monitor_children"},
+		{"terminate_children", "wait_children"},
+		{"terminate_children", "report_error"},
+	} {
+		if !calls[want] {
+			t.Fatalf("missing Elixir CALLS edge %v in %v", want, calls)
+		}
 	}
 }
 
@@ -12197,6 +12948,350 @@ class WP_REST_Server
 	}
 	if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "rest_do_request", "WP_REST_Server.dispatch") {
 		t.Errorf("missing CALLS rest_do_request->WP_REST_Server.dispatch via docblock @return receiver type: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}
+
+func TestPHPGeneratedFactoryCreateChainResolvesProductMethod(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "src/Session.php", `<?php
+
+class Session
+{
+    /**
+     * @var CustomerFactory
+     */
+    protected $_customerFactory;
+
+    public function setCustomerDataAsLoggedIn($customer)
+    {
+        $customerModel = $this->_customerFactory->create()->updateData($customer);
+        return $customerModel;
+    }
+}
+`)
+	writeFile(t, repo, "src/Customer.php", `<?php
+
+class Customer
+{
+    public function updateData($customer)
+    {
+        return $this;
+    }
+}
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "Session.setCustomerDataAsLoggedIn", "Customer.updateData") {
+		t.Errorf("missing generated-factory chain CALLS edge: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}
+
+func TestObjectiveCMessageSendCallsResolveToMethods(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "Indicator.m", `@interface Indicator
+- (void)setEnabled;
+- (void)setCurrentState:(int)state;
+- (void)cancelActivationDelayTimer;
+@end
+
+@implementation Indicator
+- (void)setEnabled {
+    [self setCurrentState:1];
+}
+
+- (void)setCurrentState:(int)state {
+    [self cancelActivationDelayTimer];
+}
+
+- (void)cancelActivationDelayTimer {}
+@end
+`)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasRelationBySymbolName(snapshot, "CALLS", "setEnabled", "setCurrentState") {
+		t.Errorf("missing Objective-C message CALLS setEnabled->setCurrentState: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+	if !hasRelationBySymbolName(snapshot, "CALLS", "setCurrentState", "cancelActivationDelayTimer") {
+		t.Errorf("missing Objective-C message CALLS setCurrentState->cancelActivationDelayTimer: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}
+
+func TestObjectiveCMethodFallbackExtractsColonSelectors(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "AFURLSessionManager.m", `@implementation AFURLSessionManager
+- (void)invalidateSessionCancelingTasks:(BOOL)cancelPendingTasks resetSession:(BOOL)resetSession {
+    if (cancelPendingTasks) {
+        [self.session invalidateAndCancel];
+    } else {
+        [self.session finishTasksAndInvalidate];
+    }
+    if (resetSession) {
+        self.session = nil;
+    }
+}
+@end
+`)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !snapshotHasSymbol(snapshot, "invalidateSessionCancelingTasks") {
+		t.Fatalf("missing Objective-C colon selector method: %#v", snapshot.Symbols)
+	}
+}
+
+func TestClojureListHeadCallsResolve(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "core.clj", `(ns app.core
+  (:require [app.urls :as urls]))
+
+(defn dashcard-url [id] id)
+(defn make-title-if-needed [] "title")
+(defn render-pulse-card []
+  (make-title-if-needed)
+  (urls/dashcard-url 1))
+(defn caller []
+  (render-pulse-card))
+`)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasRelationBySymbolName(snapshot, "CALLS", "caller", "render-pulse-card") {
+		t.Errorf("missing Clojure CALLS caller->render-pulse-card: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+	if !hasRelationBySymbolName(snapshot, "CALLS", "render-pulse-card", "make-title-if-needed") {
+		t.Errorf("missing Clojure CALLS render-pulse-card->make-title-if-needed: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+	if !hasRelationBySymbolName(snapshot, "CALLS", "render-pulse-card", "dashcard-url") {
+		t.Errorf("missing Clojure namespaced CALLS render-pulse-card->dashcard-url: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}
+
+func TestLuaTableFunctionDefinitionsAndDottedCallsResolve(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "vim.lua", `_G.vim = _G.vim or {}
+local M = {}
+
+function vim.gsplit(s, sep)
+  return s
+end
+
+function vim.split(s, sep)
+  return vim.gsplit(s, sep)
+end
+
+function M.joinpath(...)
+  return table.concat({ ... }, "/")
+end
+
+function M.normalize(path)
+  return M.joinpath(path, "child")
+end
+`)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"vim.gsplit", "vim.split", "M.joinpath", "M.normalize"} {
+		if !snapshotHasSymbol(snapshot, want) {
+			t.Fatalf("missing Lua table function %s: %#v", want, snapshot.Symbols)
+		}
+	}
+	if !hasRelationBySymbolName(snapshot, "CALLS", "split", "gsplit") {
+		t.Errorf("missing Lua dotted CALLS split->gsplit: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+	if !hasRelationBySymbolName(snapshot, "CALLS", "normalize", "joinpath") {
+		t.Errorf("missing Lua module CALLS normalize->joinpath: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}
+
+func TestTypeScriptNamespaceImportsAndCallbackReferencesResolve(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "src/compiler/core.ts", `export function noop() {}
+`)
+	writeFile(t, repo, "src/compiler/performance.ts", `export function mark(name: string) {}
+export function measure(name: string, start: string, end: string) {}
+`)
+	writeFile(t, repo, "src/compiler/generated/ts.ts", `export { noop } from "../core";
+export { createSourceFile } from "../parser";
+`)
+	writeFile(t, repo, "src/compiler/generated/ts.performance.ts", `export * from "../performance";
+`)
+	writeFile(t, repo, "src/compiler/parser.ts", `import { noop } from "./generated/ts.js";
+import * as performance from "./generated/ts.performance.js";
+
+export function createSourceFile() {
+    performance.mark("beforeParse");
+    Parser.parseSourceFile(noop);
+    performance.measure("Parse", "beforeParse", "afterParse");
+}
+
+namespace Parser {
+    export function parseSourceFile(done: () => void) {
+        done();
+    }
+
+    function createSourceFile() {
+        return undefined;
+    }
+}
+`)
+	writeFile(t, repo, "src/compiler/program.ts", `import { createSourceFile } from "./generated/ts.js";
+
+export function createGetSourceFile() {
+    return createSourceFile();
+}
+`)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{
+		Worktree: true,
+		IncludeFiles: []string{
+			"src/compiler/core.ts",
+			"src/compiler/parser.ts",
+			"src/compiler/performance.ts",
+			"src/compiler/program.ts",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasRelationBySymbolNameAndFile(snapshot, "CALLS", "createGetSourceFile", "src/compiler/program.ts", "createSourceFile", "src/compiler/parser.ts") {
+		t.Errorf("missing TypeScript generated namespace import CALLS createGetSourceFile->createSourceFile: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+	for _, want := range []struct {
+		name string
+		file string
+	}{
+		{name: "parseSourceFile", file: "src/compiler/parser.ts"},
+		{name: "mark", file: "src/compiler/performance.ts"},
+		{name: "measure", file: "src/compiler/performance.ts"},
+		{name: "noop", file: "src/compiler/core.ts"},
+	} {
+		if !hasRelationBySymbolNameAndFile(snapshot, "CALLS", "createSourceFile", "src/compiler/parser.ts", want.name, want.file) {
+			t.Errorf("missing TypeScript createSourceFile->%s CALLS: %#v", want.name, relationsOfType(snapshot.Relations, "CALLS"))
+		}
+	}
+}
+
+func TestSQLRoutineCallsResolve(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "policy.sql", `CREATE FUNCTION compress_chunk() RETURNS void LANGUAGE SQL AS $$
+SELECT 1;
+$$;
+
+CREATE FUNCTION policy_compression_execute() RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  PERFORM _timescaledb_internal.compress_chunk();
+  PERFORM @extschema@.compress_chunk();
+END
+$$;
+
+CREATE FUNCTION policy_compression() RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  CALL policy_compression_execute();
+END
+$$;
+`)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasRelationBySymbolName(snapshot, "CALLS", "policy_compression_execute", "compress_chunk") {
+		t.Errorf("missing SQL schema-qualified CALLS policy_compression_execute->compress_chunk: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+	if !hasRelationBySymbolName(snapshot, "CALLS", "policy_compression", "policy_compression_execute") {
+		t.Errorf("missing SQL CALLS policy_compression->policy_compression_execute: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}
+
+func TestSQLMigrationScriptCallsAlsoLinkCanonicalRoutine(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "sql/policy_internal.sql", `CREATE PROCEDURE _timescaledb_functions.policy_compression_execute(job_id INTEGER)
+AS $$
+BEGIN
+  PERFORM @extschema@.compress_chunk();
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE PROCEDURE _timescaledb_functions.policy_compression(job_id INTEGER)
+AS $$
+BEGIN
+  CALL _timescaledb_functions.policy_compression_execute(job_id);
+END
+$$ LANGUAGE PLPGSQL;
+`)
+	writeFile(t, repo, "db/migrations/V2__policy_compression.sql", `CREATE PROCEDURE _timescaledb_functions.policy_compression_execute(job_id INTEGER)
+AS $$
+BEGIN
+  PERFORM @extschema@.compress_chunk();
+END
+$$ LANGUAGE PLPGSQL;
+
+CREATE PROCEDURE _timescaledb_functions.policy_compression(job_id INTEGER)
+AS $$
+BEGIN
+  CALL _timescaledb_functions.policy_compression_execute(job_id);
+END
+$$ LANGUAGE PLPGSQL;
+`)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasRelationBySymbolNameAndFile(snapshot, "CALLS", "policy_compression", "db/migrations/V2__policy_compression.sql", "policy_compression_execute", "db/migrations/V2__policy_compression.sql") {
+		t.Errorf("missing SQL migration local CALLS policy_compression->policy_compression_execute: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+	if !hasRelationBySymbolNameAndFile(snapshot, "CALLS", "policy_compression", "db/migrations/V2__policy_compression.sql", "policy_compression_execute", "sql/policy_internal.sql") {
+		t.Errorf("missing SQL migration canonical CALLS policy_compression->canonical policy_compression_execute: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}
+
+func TestZigBareAndReceiverCallsResolve(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "analysis.zig", `const analysis = struct {};
+
+const Type = struct {
+    pub fn lookupSymbol(self: *Type) void {
+        _ = self;
+    }
+};
+
+fn resolveTypeOfNode() void {}
+
+fn resolveVarDeclAlias(t: Type) void {
+    analysis.resolveTypeOfNode();
+    t.lookupSymbol();
+}
+
+fn definitionToken() void {
+    analysis.resolveVarDeclAlias(Type{});
+}
+`)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasRelationBySymbolName(snapshot, "CALLS", "definitionToken", "resolveVarDeclAlias") {
+		t.Errorf("missing Zig CALLS definitionToken->resolveVarDeclAlias: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+	if !hasRelationBySymbolName(snapshot, "CALLS", "resolveVarDeclAlias", "resolveTypeOfNode") {
+		t.Errorf("missing Zig CALLS resolveVarDeclAlias->resolveTypeOfNode: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+	if !hasRelationBySymbolName(snapshot, "CALLS", "resolveVarDeclAlias", "lookupSymbol") {
+		t.Errorf("missing Zig receiver CALLS resolveVarDeclAlias->lookupSymbol: %#v", relationsOfType(snapshot.Relations, "CALLS"))
 	}
 }
 

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -11181,6 +11181,46 @@ abstract mixin class BaseClient implements Client {
 	// globally ambiguous (dart-lang/http has a second Request in ok_http).
 	writeFile(t, repo, "other_pkg/lib/src/bindings.dart", `class Request {
   Request();
+func TestCSharpNullableAndOutVarReceiversResolveCrossFile(t *testing.T) {
+	// dotnet/runtime HttpConnectionPoolManager.SendAsyncCore: a local
+	// declared with a nullable annotation ('HttpConnectionPool? pool;'),
+	// assigned via 'out pool' / 'pool = new HttpConnectionPool(...)', then
+	// invoked ('pool.SendAsync(...)') must resolve to the method declared
+	// in another file, and the constructor call must emit CONSTRUCTS.
+	repo := t.TempDir()
+	writeFile(t, repo, "Net/HttpConnectionPool.cs", `namespace System.Net.Http
+{
+    internal sealed class HttpConnectionPool
+    {
+        public HttpConnectionPool(object owner) { }
+
+        public string SendAsync(string request, bool async) { return request; }
+    }
+}
+`)
+	writeFile(t, repo, "Net/HttpConnectionPoolManager.cs", `namespace System.Net.Http
+{
+    internal sealed class HttpConnectionPoolManager
+    {
+        public string SendAsyncCore(string request, bool async)
+        {
+            HttpConnectionPool? pool;
+            while (!_pools.TryGetValue(request, out pool))
+            {
+                pool = new HttpConnectionPool(this);
+            }
+            return pool.SendAsync(request, async);
+        }
+
+        public string SendViaOutDeclaration(string request)
+        {
+            if (_pools.TryGetValue(request, out HttpConnectionPool? cached))
+            {
+                return cached.SendAsync(request, false);
+            }
+            return request;
+        }
+    }
 }
 `)
 
@@ -11188,6 +11228,7 @@ abstract mixin class BaseClient implements Client {
 	if err != nil {
 		t.Fatal(err)
 	}
+<<<<<<< HEAD
 
 	edges := map[string]RelationRecord{}
 	for _, r := range snapshot.Relations {
@@ -11915,5 +11956,15 @@ pub fn boot() -> u32 {
 	}
 	if !found {
 		t.Fatalf("Rust Type::method path call did not resolve to the method")
+=======
+	if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "HttpConnectionPoolManager.SendAsyncCore", "HttpConnectionPool.SendAsync") {
+		t.Errorf("missing CALLS SendAsyncCore->HttpConnectionPool.SendAsync (nullable local + new assignment)")
+	}
+	if !hasRelationByLastSegment(snapshot.Relations, "CONSTRUCTS", "HttpConnectionPoolManager.SendAsyncCore", "HttpConnectionPool") {
+		t.Errorf("missing CONSTRUCTS SendAsyncCore->HttpConnectionPool")
+	}
+	if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "HttpConnectionPoolManager.SendViaOutDeclaration", "HttpConnectionPool.SendAsync") {
+		t.Errorf("missing CALLS SendViaOutDeclaration->HttpConnectionPool.SendAsync (out Type? declaration)")
+>>>>>>> 051bc95 (sem(csharp): infer receiver types from out-declarations and nullable locals)
 	}
 }

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -11968,3 +11968,73 @@ pub fn boot() -> u32 {
 >>>>>>> 051bc95 (sem(csharp): infer receiver types from out-declarations and nullable locals)
 	}
 }
+
+func TestCSharpStaticCallResolvesAcrossPartialClassFiles(t *testing.T) {
+	// roslyn declares 'internal static partial class Contract' in both
+	// Contract.cs (which holds ThrowIfFalse) and
+	// Contract.InterpolatedStringHandlers.cs (which does not, and sorts
+	// lexically first). A static type-qualified call
+	// 'Contract.ThrowIfFalse(...)' must resolve to the partial
+	// declaration that actually defines the method instead of being
+	// dropped after probing only the first candidate.
+	repo := t.TempDir()
+	writeFile(t, repo, "Contracts/Contract.InterpolatedStringHandlers.cs", `namespace Roslyn.Utilities
+{
+    internal static partial class Contract
+    {
+        public readonly struct ThrowIfFalseInterpolatedStringHandler
+        {
+            public string GetFormattedText() { return ""; }
+        }
+    }
+}
+`)
+	writeFile(t, repo, "Contracts/Contract.cs", `namespace Roslyn.Utilities
+{
+    internal static partial class Contract
+    {
+        public static void ThrowIfFalse(bool condition) { }
+
+        public static void ThrowIfFalse(bool condition, string message) { }
+    }
+}
+`)
+	writeFile(t, repo, "Workspace/Workspace_Editor.cs", `namespace Microsoft.CodeAnalysis
+{
+    public partial class Workspace
+    {
+        private void UpdateCurrentContextMapping_NoLock(bool isCurrentContext)
+        {
+            Contract.ThrowIfFalse(isCurrentContext);
+        }
+    }
+}
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, relation := range snapshot.Relations {
+		if relation.Type == "CALLS" &&
+			strings.Contains(relation.FromID, "Workspace.UpdateCurrentContextMapping_NoLock") &&
+			strings.Contains(relation.ToID, "Contracts/Contract.cs") &&
+			strings.Contains(relation.ToID, "Contract.ThrowIfFalse") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("missing static type-qualified CALLS to the partial class that defines ThrowIfFalse: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}
+
+func relationsOfType(relations []RelationRecord, relationType string) []RelationRecord {
+	var out []RelationRecord
+	for _, relation := range relations {
+		if relation.Type == relationType {
+			out = append(out, relation)
+		}
+	}
+	return out
+}

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12199,3 +12199,43 @@ class WP_REST_Server
 		t.Errorf("missing CALLS rest_do_request->WP_REST_Server.dispatch via docblock @return receiver type: %#v", relationsOfType(snapshot.Relations, "CALLS"))
 	}
 }
+
+func TestGoSelfModuleImportResolvesCrossPackageCall(t *testing.T) {
+	// entire-sem's own snapshot missed cli->sem edges: a package imported
+	// via the repo's own module path ("github.com/acme/tool/internal/sem")
+	// fell through to an external fallback because the module prefix was
+	// never mapped back to the in-repo package directory.
+	repo := t.TempDir()
+	writeFile(t, repo, "go.mod", `module github.com/acme/tool
+
+go 1.24
+`)
+	writeFile(t, repo, "internal/sem/analyze.go", `package sem
+
+func analyzeNothing() {}
+`)
+	writeFile(t, repo, "internal/sem/provider.go", `package sem
+
+func StreamSnapshot(repo string) error {
+	return nil
+}
+`)
+	writeFile(t, repo, "internal/cli/root.go", `package cli
+
+import (
+	"github.com/acme/tool/internal/sem"
+)
+
+func runProviderRecords(repo string) error {
+	return sem.StreamSnapshot(repo)
+}
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "runProviderRecords", "StreamSnapshot") {
+		t.Errorf("missing CALLS runProviderRecords->StreamSnapshot via self-module import: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -11181,46 +11181,6 @@ abstract mixin class BaseClient implements Client {
 	// globally ambiguous (dart-lang/http has a second Request in ok_http).
 	writeFile(t, repo, "other_pkg/lib/src/bindings.dart", `class Request {
   Request();
-func TestCSharpNullableAndOutVarReceiversResolveCrossFile(t *testing.T) {
-	// dotnet/runtime HttpConnectionPoolManager.SendAsyncCore: a local
-	// declared with a nullable annotation ('HttpConnectionPool? pool;'),
-	// assigned via 'out pool' / 'pool = new HttpConnectionPool(...)', then
-	// invoked ('pool.SendAsync(...)') must resolve to the method declared
-	// in another file, and the constructor call must emit CONSTRUCTS.
-	repo := t.TempDir()
-	writeFile(t, repo, "Net/HttpConnectionPool.cs", `namespace System.Net.Http
-{
-    internal sealed class HttpConnectionPool
-    {
-        public HttpConnectionPool(object owner) { }
-
-        public string SendAsync(string request, bool async) { return request; }
-    }
-}
-`)
-	writeFile(t, repo, "Net/HttpConnectionPoolManager.cs", `namespace System.Net.Http
-{
-    internal sealed class HttpConnectionPoolManager
-    {
-        public string SendAsyncCore(string request, bool async)
-        {
-            HttpConnectionPool? pool;
-            while (!_pools.TryGetValue(request, out pool))
-            {
-                pool = new HttpConnectionPool(this);
-            }
-            return pool.SendAsync(request, async);
-        }
-
-        public string SendViaOutDeclaration(string request)
-        {
-            if (_pools.TryGetValue(request, out HttpConnectionPool? cached))
-            {
-                return cached.SendAsync(request, false);
-            }
-            return request;
-        }
-    }
 }
 `)
 
@@ -11228,7 +11188,6 @@ func TestCSharpNullableAndOutVarReceiversResolveCrossFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-<<<<<<< HEAD
 
 	edges := map[string]RelationRecord{}
 	for _, r := range snapshot.Relations {
@@ -11956,7 +11915,56 @@ pub fn boot() -> u32 {
 	}
 	if !found {
 		t.Fatalf("Rust Type::method path call did not resolve to the method")
-=======
+	}
+}
+
+func TestCSharpNullableAndOutVarReceiversResolveCrossFile(t *testing.T) {
+	// dotnet/runtime HttpConnectionPoolManager.SendAsyncCore: a local
+	// declared with a nullable annotation ('HttpConnectionPool? pool;'),
+	// assigned via 'out pool' / 'pool = new HttpConnectionPool(...)', then
+	// invoked ('pool.SendAsync(...)') must resolve to the method declared
+	// in another file, and the constructor call must emit CONSTRUCTS.
+	repo := t.TempDir()
+	writeFile(t, repo, "Net/HttpConnectionPool.cs", `namespace System.Net.Http
+{
+    internal sealed class HttpConnectionPool
+    {
+        public HttpConnectionPool(object owner) { }
+
+        public string SendAsync(string request, bool async) { return request; }
+    }
+}
+`)
+	writeFile(t, repo, "Net/HttpConnectionPoolManager.cs", `namespace System.Net.Http
+{
+    internal sealed class HttpConnectionPoolManager
+    {
+        public string SendAsyncCore(string request, bool async)
+        {
+            HttpConnectionPool? pool;
+            while (!_pools.TryGetValue(request, out pool))
+            {
+                pool = new HttpConnectionPool(this);
+            }
+            return pool.SendAsync(request, async);
+        }
+
+        public string SendViaOutDeclaration(string request)
+        {
+            if (_pools.TryGetValue(request, out HttpConnectionPool? cached))
+            {
+                return cached.SendAsync(request, false);
+            }
+            return request;
+        }
+    }
+}
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "HttpConnectionPoolManager.SendAsyncCore", "HttpConnectionPool.SendAsync") {
 		t.Errorf("missing CALLS SendAsyncCore->HttpConnectionPool.SendAsync (nullable local + new assignment)")
 	}
@@ -11965,7 +11973,6 @@ pub fn boot() -> u32 {
 	}
 	if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "HttpConnectionPoolManager.SendViaOutDeclaration", "HttpConnectionPool.SendAsync") {
 		t.Errorf("missing CALLS SendViaOutDeclaration->HttpConnectionPool.SendAsync (out Type? declaration)")
->>>>>>> 051bc95 (sem(csharp): infer receiver types from out-declarations and nullable locals)
 	}
 }
 
@@ -12037,4 +12044,158 @@ func relationsOfType(relations []RelationRecord, relationType string) []Relation
 		}
 	}
 	return out
+}
+
+func TestPHPClosureBodyCallsResolveToEnclosingClassViaReceiverName(t *testing.T) {
+	// laravel/framework Container.getClosure returns a closure whose body
+	// calls $container->build(...) and $container->resolve(...). The calls
+	// must be attributed to the enclosing named method, and the untyped
+	// $container receiver (named after the enclosing class) must resolve
+	// to the Container class's own methods.
+	repo := t.TempDir()
+	writeFile(t, repo, "src/Container.php", `<?php
+
+namespace Illuminate\Container;
+
+class Container
+{
+    protected function getClosure($abstract, $concrete)
+    {
+        return function ($container, $parameters = []) use ($abstract, $concrete) {
+            if ($abstract == $concrete) {
+                return $container->build($concrete);
+            }
+
+            return $container->resolve(
+                $concrete, $parameters, raiseEvents: false
+            );
+        };
+    }
+
+    public function build($concrete)
+    {
+        return $concrete;
+    }
+
+    public function resolve($abstract, $parameters = [], $raiseEvents = true)
+    {
+        return $abstract;
+    }
+}
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "Container.getClosure", "Container.resolve") {
+		t.Errorf("missing CALLS Container.getClosure->Container.resolve (closure body, receiver named after enclosing class)")
+	}
+	if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "Container.getClosure", "Container.build") {
+		t.Errorf("missing CALLS Container.getClosure->Container.build (closure body, receiver named after enclosing class)")
+	}
+}
+
+func TestPHPAmbiguousBareCallEmitsCandidateEdges(t *testing.T) {
+	// WordPress declares apply_filters() three times (plugin.php canonical,
+	// a compat copy, and a wp-admin noop stub). The globally-unique gate
+	// dropped the call entirely; ambiguity must not mean silence — emit
+	// candidate edges to the same-name declarations instead.
+	repo := t.TempDir()
+	writeFile(t, repo, "src/wp-includes/plugin.php", `<?php
+
+function apply_filters( $hook_name, $value ) {
+    global $wp_filter;
+    if ( ! isset( $wp_filter[ $hook_name ] ) ) {
+        return $value;
+    }
+    return $wp_filter[ $hook_name ]->apply_filters( $value, func_get_args() );
+}
+`)
+	writeFile(t, repo, "src/wp-admin/includes/noop.php", `<?php
+
+function apply_filters( $hook_name, $value ) {
+    return $value;
+}
+`)
+	writeFile(t, repo, "src/wp-includes/rest-api/class-wp-rest-server.php", `<?php
+
+class WP_REST_Server
+{
+    public function dispatch( $request ) {
+        $result = apply_filters( 'rest_pre_dispatch', null, $this, $request );
+        return $result;
+    }
+}
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var toPlugin, toNoop bool
+	for _, relation := range snapshot.Relations {
+		if relation.Type != "CALLS" || !strings.Contains(relation.FromID, "WP_REST_Server.dispatch") {
+			continue
+		}
+		if strings.Contains(relation.ToID, "wp-includes/plugin.php") && strings.Contains(relation.ToID, "apply_filters") {
+			toPlugin = true
+		}
+		if strings.Contains(relation.ToID, "noop.php") && strings.Contains(relation.ToID, "apply_filters") {
+			toNoop = true
+		}
+	}
+	if !toPlugin {
+		t.Errorf("missing candidate CALLS edge to the canonical apply_filters in plugin.php: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+	if !toNoop {
+		t.Errorf("missing candidate CALLS edge to the noop.php apply_filters (ambiguous calls emit all candidates): %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}
+
+func TestPHPChainedCallResolvesViaDocblockReturnType(t *testing.T) {
+	// WordPress rest_do_request() calls rest_get_server()->dispatch($request).
+	// rest_get_server() has no native return hint, only a docblock
+	// '@return WP_REST_Server'; the chained call must resolve to
+	// WP_REST_Server::dispatch via that inferred receiver type.
+	repo := t.TempDir()
+	writeFile(t, repo, "src/wp-includes/rest-api.php", `<?php
+
+/**
+ * Do a REST request.
+ *
+ * @param WP_REST_Request $request Request.
+ * @return WP_REST_Response The response.
+ */
+function rest_do_request( $request ) {
+    return rest_get_server()->dispatch( $request );
+}
+
+/**
+ * Retrieves the current REST server instance.
+ *
+ * @return WP_REST_Server REST server instance.
+ */
+function rest_get_server() {
+    global $wp_rest_server;
+    return $wp_rest_server;
+}
+`)
+	writeFile(t, repo, "src/wp-includes/rest-api/class-wp-rest-server.php", `<?php
+
+class WP_REST_Server
+{
+    public function dispatch( $request ) {
+        return $request;
+    }
+}
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "rest_do_request", "WP_REST_Server.dispatch") {
+		t.Errorf("missing CALLS rest_do_request->WP_REST_Server.dispatch via docblock @return receiver type: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
 }

--- a/internal/sem/rust.go
+++ b/internal/sem/rust.go
@@ -1,0 +1,292 @@
+package sem
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	rustReceiverFactoryAssignRe = regexp.MustCompile(`\b(?:let\s+(?:mut\s+)?)?([A-Za-z_]\w*)\s*(?::[^=\n]+)?=\s*([A-Za-z_]\w*)\s*\.\s*([A-Za-z_]\w*)\s*\(`)
+	rustAssociatedPathAssignRe  = regexp.MustCompile(`\b(?:let\s+(?:mut\s+)?)?([a-z_]\w*)\s*(?::[^=\n]+)?=\s*(?:(?:[A-Za-z_]\w*)::)*([A-Z]\w*)::[A-Za-z_]\w*(?:\s*::\s*<[^>\n]*>)?\s*\(`)
+	rustTurbofishCallRe         = regexp.MustCompile(`\b([a-z_]\w*)\s*::\s*<[^()\n]+>\s*\(`)
+)
+
+func rustReceiverFactoryVarTypes(block string, varTypes map[string]string, methodsByContainer map[string]map[string]SymbolRecord, superContainerByID map[string]string, symbolsByShortName map[string][]SymbolRecord, returnTypesBySymbolNameAndFile map[string]map[string][]string, filePath string) map[string]string {
+	stripped := stripCodeLiteralsAndComments(block)
+	out := map[string]string{}
+	conflicted := map[string]bool{}
+	for _, m := range rustReceiverFactoryAssignRe.FindAllStringSubmatch(stripped, -1) {
+		if len(m) != 4 {
+			continue
+		}
+		name, receiver, factory := m[1], m[2], m[3]
+		receiverType := varTypes[receiver]
+		if name == "" || receiverType == "" || factory == "" {
+			continue
+		}
+		typeSym, ok := firstTypeLikeNamedPreferFile(symbolsByShortName[receiverType], receiverType, filePath)
+		if !ok {
+			continue
+		}
+		method, _, ok := lookupMethodUpChain(typeSym.ID, factory, methodsByContainer, superContainerByID)
+		if !ok {
+			continue
+		}
+		types := returnTypesBySymbolNameAndFile[method.Name][method.FilePath]
+		if len(types) == 0 {
+			continue
+		}
+		typeName := types[0]
+		if existing, ok := out[name]; ok && existing != typeName {
+			conflicted[name] = true
+			continue
+		}
+		out[name] = typeName
+	}
+	for name := range conflicted {
+		delete(out, name)
+	}
+	return out
+}
+
+func rustAssociatedPathVarTypes(block string) map[string]string {
+	stripped := stripCodeLiteralsAndComments(block)
+	out := map[string]string{}
+	conflicted := map[string]bool{}
+	for _, m := range rustAssociatedPathAssignRe.FindAllStringSubmatch(stripped, -1) {
+		if len(m) != 3 {
+			continue
+		}
+		name, typeName := m[1], m[2]
+		if existing, ok := out[name]; ok && existing != typeName {
+			conflicted[name] = true
+			continue
+		}
+		out[name] = typeName
+	}
+	for name := range conflicted {
+		delete(out, name)
+	}
+	return out
+}
+
+func rustTurbofishCallIdentifiers(block string) map[string]struct{} {
+	stripped := stripCodeLiteralsAndComments(block)
+	out := map[string]struct{}{}
+	for _, m := range rustTurbofishCallRe.FindAllStringSubmatch(stripped, -1) {
+		if len(m) == 2 {
+			out[m[1]] = struct{}{}
+		}
+	}
+	return out
+}
+
+func rustModulePathCalls(block string) []rustPathCall {
+	stripped := stripCodeLiteralsAndComments(block)
+	var out []rustPathCall
+	seen := map[string]bool{}
+	re := regexp.MustCompile(`\b([a-z_]\w*)\s*::\s*([A-Za-z_]\w*)\s*\(`)
+	for _, m := range re.FindAllStringSubmatch(stripped, -1) {
+		if len(m) != 3 {
+			continue
+		}
+		key := m[1] + "::" + m[2]
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, rustPathCall{Module: m[1], Function: m[2], Detail: key})
+	}
+	return out
+}
+
+type rustPathCall struct {
+	Module   string
+	Function string
+	Detail   string
+}
+
+func rustModulePathCallRelations(from SymbolRecord, calls []rustPathCall, importsByName map[string][]string, symbolsByShortName map[string][]SymbolRecord) []RelationRecord {
+	if from.Language != "Rust" || len(calls) == 0 {
+		return nil
+	}
+	var relations []RelationRecord
+	seen := map[string]bool{}
+	for _, call := range calls {
+		if len(importsByName[call.Module]) == 0 {
+			continue
+		}
+		for _, to := range symbolsByShortName[call.Function] {
+			if to.ID == from.ID || to.Kind == "field" || to.Name != call.Function || to.Language != "Rust" || !localReachable(from, to) {
+				continue
+			}
+			if !importedNameMatchesFile(importsByName[call.Module], from.FilePath, to.FilePath) {
+				continue
+			}
+			key := to.ID + "|" + call.Detail
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			scope := "file"
+			if to.FilePath != from.FilePath {
+				scope = "module"
+			}
+			relations = append(relations, RelationRecord{
+				RecordType:    "relation",
+				FromID:        from.ID,
+				ToID:          to.ID,
+				Type:          "CALLS",
+				Confidence:    0.84,
+				Reason:        "Rust module path call resolved through use binding",
+				RelationScope: scope,
+				Resolution:    "import_resolved",
+				TargetKind:    "symbol",
+				Evidence: []Evidence{{
+					Kind:      "call_site",
+					FilePath:  from.FilePath,
+					StartLine: from.StartLine,
+					EndLine:   from.EndLine,
+					Detail:    call.Detail,
+				}},
+				WarningCodes: []string{},
+			})
+		}
+	}
+	return relations
+}
+
+type rustImportBinding struct {
+	Local  string
+	Module string
+}
+
+func importedRustNames(content string) map[string][]string {
+	imports := map[string][]string{}
+	add := func(local, module string) {
+		local = strings.TrimSpace(local)
+		module = strings.TrimSpace(module)
+		if local == "" || module == "" || local == "_" || local == "*" {
+			return
+		}
+		imports[local] = append(imports[local], module)
+	}
+
+	stripped := stripCodeLiteralsAndComments(content)
+	var stmt strings.Builder
+	collecting := false
+	for _, line := range strings.Split(stripped, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !collecting && !strings.HasPrefix(trimmed, "use ") && !strings.HasPrefix(trimmed, "pub use ") && !strings.HasPrefix(trimmed, "pub(crate) use ") && !strings.HasPrefix(trimmed, "pub(super) use ") && !strings.HasPrefix(trimmed, "pub(self) use ") {
+			continue
+		}
+		if stmt.Len() > 0 {
+			stmt.WriteByte(' ')
+		}
+		stmt.WriteString(trimmed)
+		collecting = true
+		if !strings.Contains(trimmed, ";") {
+			continue
+		}
+		text := stmt.String()
+		stmt.Reset()
+		collecting = false
+		if idx := strings.Index(text, ";"); idx >= 0 {
+			text = text[:idx]
+		}
+		expr := strings.TrimSpace(text)
+		if strings.HasPrefix(expr, "pub(crate) use ") {
+			expr = strings.TrimSpace(strings.TrimPrefix(expr, "pub(crate) use "))
+		} else if strings.HasPrefix(expr, "pub(super) use ") {
+			expr = strings.TrimSpace(strings.TrimPrefix(expr, "pub(super) use "))
+		} else if strings.HasPrefix(expr, "pub(self) use ") {
+			expr = strings.TrimSpace(strings.TrimPrefix(expr, "pub(self) use "))
+		} else if strings.HasPrefix(expr, "pub use ") {
+			expr = strings.TrimSpace(strings.TrimPrefix(expr, "pub use "))
+		} else if strings.HasPrefix(expr, "use ") {
+			expr = strings.TrimSpace(strings.TrimPrefix(expr, "use "))
+		}
+		for _, binding := range rustUseImportBindings(expr) {
+			add(binding.Local, binding.Module)
+		}
+	}
+	for name, modules := range imports {
+		imports[name] = uniqueStrings(modules)
+	}
+	return imports
+}
+
+func rustUseImportBindings(expr string) []rustImportBinding {
+	expr = strings.TrimSpace(expr)
+	if expr == "" || strings.Contains(expr, "*") {
+		return nil
+	}
+	if open := rustTopLevelByte(expr, '{'); open >= 0 {
+		close := matchDelimiter([]byte(expr), open)
+		if close < 0 {
+			return nil
+		}
+		prefix := strings.TrimSuffix(strings.TrimSpace(expr[:open]), "::")
+		var out []rustImportBinding
+		for _, item := range splitTopLevelCommas(expr[open+1 : close]) {
+			item = strings.TrimSpace(item)
+			if item == "" {
+				continue
+			}
+			out = append(out, rustUseImportBindings(rustJoinModule(prefix, item))...)
+		}
+		return out
+	}
+	local, module := rustUseTerminalBinding(expr)
+	if local == "" || module == "" {
+		return nil
+	}
+	return []rustImportBinding{{Local: local, Module: module}}
+}
+
+func rustUseTerminalBinding(expr string) (local, module string) {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return "", ""
+	}
+	alias := ""
+	if idx := strings.LastIndex(expr, " as "); idx >= 0 {
+		alias = strings.TrimSpace(expr[idx+4:])
+		expr = strings.TrimSpace(expr[:idx])
+	}
+	expr = strings.Trim(expr, ": ")
+	if expr == "" {
+		return "", ""
+	}
+	parts := strings.Split(expr, "::")
+	if len(parts) > 0 && parts[len(parts)-1] == "self" {
+		parts = parts[:len(parts)-1]
+		expr = strings.Join(parts, "::")
+	}
+	if expr == "" {
+		return alias, expr
+	}
+	if alias != "" {
+		return alias, expr
+	}
+	parts = strings.Split(expr, "::")
+	return parts[len(parts)-1], expr
+}
+
+func rustTopLevelByte(s string, want byte) int {
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '{':
+			if want == '{' && depth == 0 {
+				return i
+			}
+			depth++
+		case '}':
+			if depth > 0 {
+				depth--
+			}
+		}
+	}
+	return -1
+}

--- a/internal/sem/swift.go
+++ b/internal/sem/swift.go
@@ -52,7 +52,7 @@ var (
 	swiftCaseLetBindingRe = regexp.MustCompile(`\bcase\s+(?:let|var)\s+\.([A-Za-z_]\w*)\s*\(\s*([A-Za-z_]\w*)\s*\)`)
 	// Modifier-prefixed class-body stored properties with explicit types
 	// (`internal private(set) var _buffer: ByteBuffer?`).
-	swiftPropTypedRe = regexp.MustCompile(`(?m)^[ \t]*` + swiftModifierPattern + `+(?:let|var)\s+([A-Za-z_]\w*)\s*:\s*([A-Za-z_][\w.]*)`)
+	swiftPropTypedRe = regexp.MustCompile(`(?m)^[ \t]*` + swiftModifierPattern + `+(?:let|var)\s+([A-Za-z_]\w*)\s*:\s*((?:\(\s*)?(?:any\s+|some\s+)?[A-Za-z_][\w.]*(?:\s*\))?[?!]?)`)
 	// Modifier-prefixed stored property with a constructor initializer instead
 	// of a type annotation: `private var buffers = CircularBuffer<ByteBuffer>()`.
 	swiftPropInitRe = regexp.MustCompile(`(?m)^[ \t]*` + swiftModifierPattern + `+(?:let|var)\s+([A-Za-z_]\w*)\s*=\s*([A-Z]\w*)\s*[<(]`)
@@ -75,6 +75,7 @@ var (
 	// accepts Vapor-style multi-line chains (`request\n  .fileio\n
 	// .streamFile(...)`).
 	swiftChainedReceiverCallRe = regexp.MustCompile(`(?:^|[^\w.$)\]!?])([a-z_]\w*)[!?]?\s*\.\s*([a-z_]\w*)[!?]?\s*\.\s*([A-Za-z_]\w*)\s*[({]`)
+	swiftLongChainTailRe       = regexp.MustCompile(`\b(?:[A-Za-z_]\w*[!?]?\s*\.\s*)+([a-z_]\w*)[!?]?\s*\.\s*([A-Za-z_]\w*)\s*[({]`)
 	// Local bound from a property chain: `let contentRange = request.headers.range`,
 	// `if let firstRange = contentRange.ranges.first`. The hops are lowercase
 	// property names; validation of what follows the chain happens in
@@ -260,6 +261,17 @@ func swiftChainedReceiverCalls(block string) []swiftChainedCall {
 	return out
 }
 
+func swiftReceiverCallTailsInLongerChains(block string) map[string]bool {
+	stripped := stripSwiftCodeText(block)
+	out := map[string]bool{}
+	for _, m := range swiftLongChainTailRe.FindAllStringSubmatch(stripped, -1) {
+		if len(m) == 3 {
+			out[m[1]+"."+m[2]] = true
+		}
+	}
+	return out
+}
+
 // swiftTypeRefText reports whether text is a plain (possibly dotted) type
 // reference: word characters and dots only. Signature-derived type text can
 // carry arrays, tuples, or generics, which the chain typing never guesses at.
@@ -283,6 +295,10 @@ func swiftTypeRefText(text string) bool {
 // reference (arrays, dictionaries, tuples, function types).
 func swiftDeclaredTypeName(raw string) string {
 	raw = strings.TrimSuffix(strings.TrimSuffix(strings.TrimSpace(stripGenerics(raw)), "?"), "!")
+	if strings.HasPrefix(raw, "(") && strings.HasSuffix(raw, ")") {
+		raw = strings.TrimSpace(raw[1 : len(raw)-1])
+	}
+	raw = strings.TrimPrefix(strings.TrimPrefix(raw, "any "), "some ")
 	if !swiftTypeRefText(raw) {
 		return ""
 	}
@@ -392,6 +408,78 @@ func swiftUniqueQualifiedMethod(typeRef, name string, symbolsByShortName map[str
 		return SymbolRecord{}, false
 	}
 	return match, true
+}
+
+func swiftReceiverMethodByArgumentLabels(call receiverCall, candidates []SymbolRecord) (SymbolRecord, bool) {
+	labels := swiftCallArgumentLabels(call.Args)
+	if len(labels) == 0 {
+		return SymbolRecord{}, false
+	}
+	var matches []SymbolRecord
+	for _, cand := range candidates {
+		if cand.Kind != "method" || cand.Language != "Swift" {
+			continue
+		}
+		if labelSetIntersects(labels, swiftSignatureArgumentLabels(cand.Signature, call.Method)) {
+			matches = append(matches, cand)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], true
+	}
+	return SymbolRecord{}, false
+}
+
+func swiftCallArgumentLabels(args string) map[string]bool {
+	labels := map[string]bool{}
+	for _, arg := range splitTopLevelCommas(args) {
+		arg = strings.TrimSpace(arg)
+		m := regexp.MustCompile(`^([A-Za-z_]\w*)\s*:`).FindStringSubmatch(arg)
+		if len(m) == 2 {
+			labels[m[1]] = true
+		}
+	}
+	return labels
+}
+
+func swiftSignatureArgumentLabels(signature, name string) map[string]bool {
+	labels := map[string]bool{}
+	loc := regexp.MustCompile(`\bfunc\s+` + regexp.QuoteMeta(name) + `\s*(?:<[^<>]*>)?\s*\(`).FindStringIndex(signature)
+	if loc == nil {
+		return labels
+	}
+	open := loc[1] - 1
+	close := matchingParen(signature, open)
+	if close < 0 {
+		return labels
+	}
+	for _, param := range splitTopLevelCommas(signature[open+1 : close]) {
+		param = strings.TrimSpace(param)
+		if param == "" {
+			continue
+		}
+		param = regexp.MustCompile(`^@\w+(?:\([^)]*\))?\s+`).ReplaceAllString(param, "")
+		if strings.HasPrefix(param, "_ ") {
+			continue
+		}
+		if m := regexp.MustCompile(`^([A-Za-z_]\w*)\s+(?:[A-Za-z_]\w*)\s*:`).FindStringSubmatch(param); len(m) == 2 {
+			labels[m[1]] = true
+			continue
+		}
+		if m := regexp.MustCompile(`^([A-Za-z_]\w*)\s*:`).FindStringSubmatch(param); len(m) == 2 {
+			labels[m[1]] = true
+		}
+	}
+	return labels
+}
+
+func labelSetIntersects(left, right map[string]bool) bool {
+	for label := range left {
+		if right[label] {
+			return true
+		}
+	}
+	return false
 }
 
 // swiftChainBoundLocalTypes infers local -> type for locals bound from

--- a/internal/sem/types.go
+++ b/internal/sem/types.go
@@ -2381,7 +2381,7 @@ type receiverCall struct {
 	Args     string
 }
 
-var receiverCallRe = regexp.MustCompile(`([A-Za-z_$][\w$]*)\s*(?:->|\.)\s*([A-Za-z_]\w*)\s*\(`)
+var receiverCallRe = regexp.MustCompile(`([A-Za-z_$][\w$]*)\s*(?:->|\.)\s*([A-Za-z_]\w*)\s*(?:<[^>\n;{}()]*>)?\(`)
 
 // receiverCalls extracts distinct receiver.method() call sites from a code
 // block (literals and comments stripped). Leading `$` is dropped so PHP

--- a/internal/sem/types.go
+++ b/internal/sem/types.go
@@ -2666,6 +2666,13 @@ var (
 	newAssignRe           = regexp.MustCompile(`([A-Za-z_$][\w$]*)\s*:?=\s*new\s+([A-Za-z_]\w*)`)
 	ctorAssignRe          = regexp.MustCompile(`([A-Za-z_$][\w$]*)\s*:?=\s*&?([A-Z][A-Za-z0-9_]*)\s*[({]`)
 	factoryReturnAssignRe = regexp.MustCompile(`([A-Za-z_$][\w$]*)\s*(?::[^=\n]+)?\s*(?::=|=)\s*(?:await\s+)?([A-Za-z_$][\w$]*)\s*\(`)
+	// C#-style declarations that carry the variable's type at a use site:
+	// `out HttpConnectionPool? pool` (argument-position out-declaration) and
+	// `HttpConnectionPool? pool;` / `= ...` (nullable-annotated local).
+	// Both require a capitalized type followed by the variable name, so
+	// name-first languages (Go `out Type`) cannot match.
+	outParamDeclRe      = regexp.MustCompile(`\bout\s+([A-Z][A-Za-z0-9_]*)(?:<[^;()<>]*>)?\s*\??\s+([A-Za-z_]\w*)\b`)
+	nullableLocalDeclRe = regexp.MustCompile(`\b([A-Z][A-Za-z0-9_]*)(?:<[^;()<>]*>)?\?\s+([A-Za-z_]\w*)\s*[;=]`)
 )
 
 // localVarTypes infers a best-effort variable -> type-name map from constructor
@@ -2682,6 +2689,14 @@ func localVarTypes(block string) map[string]string {
 		name := strings.TrimPrefix(m[1], "$")
 		if _, exists := out[name]; !exists {
 			out[name] = m[2]
+		}
+	}
+	for _, re := range []*regexp.Regexp{outParamDeclRe, nullableLocalDeclRe} {
+		for _, m := range re.FindAllStringSubmatch(stripped, -1) {
+			name := m[2]
+			if _, exists := out[name]; !exists {
+				out[name] = m[1]
+			}
 		}
 	}
 	return out
@@ -2720,7 +2735,11 @@ func parameterVarTypes(signature string) map[string]string {
 	// `&'a`) before the type, so `bytes: &mut Bytes` registers bytes -> Bytes.
 	// Harmless for the other colon-style languages (they have no such prefix).
 	colonParamRe := regexp.MustCompile(`^\s*\$?([A-Za-z_][A-Za-z0-9_]*)\??\s*:\s*(?:&\s*)*(?:'[A-Za-z_]\w*\s+)?(?:mut\s+)?\??([A-Z][A-Za-z0-9_]*)\b`)
-	typeFirstParamRe := regexp.MustCompile(`^\s*(?:final\s+)?(?:[*&]\s*)?([A-Z][A-Za-z0-9_]*)\s+\$?([A-Za-z_][A-Za-z0-9_]*)\b`)
+	// Leading modifiers cover Java (`final`) and C# parameter modifiers
+	// (`out`/`ref`/`in`/`params`/`this`/`scoped`/`readonly`); a trailing
+	// `?` on the type is C#'s nullable annotation (`out HttpConnectionPool?
+	// pool` must register pool -> HttpConnectionPool, not out -> ...).
+	typeFirstParamRe := regexp.MustCompile(`^\s*(?:(?:final|out|ref|in|params|this|scoped|readonly)\s+)*(?:[*&]\s*)?([A-Z][A-Za-z0-9_]*)\s*\??\s+\$?([A-Za-z_][A-Za-z0-9_]*)\b`)
 	nameFirstParamRe := regexp.MustCompile(`^\s*\$?([A-Za-z_][A-Za-z0-9_]*)\s+(?:[*&]\s*)?([A-Z][A-Za-z0-9_]*)\b`)
 	for _, param := range params {
 		param = strings.TrimSpace(strings.SplitN(param, "=", 2)[0])

--- a/internal/sem/types.go
+++ b/internal/sem/types.go
@@ -1920,6 +1920,8 @@ func splitSignatureTypes(language, signature string) (string, string) {
 		// prefix-scan below would misread `function name(` signatures.
 		if strings.HasPrefix(after, ":") {
 			after = strings.TrimSpace(strings.TrimPrefix(after, ":"))
+			// PHP nullable return hint (`: ?Foo`).
+			after = strings.TrimPrefix(after, "?")
 		} else {
 			after = ""
 		}
@@ -2454,13 +2456,13 @@ type typedMethodDeepChainCall struct {
 var (
 	newCtorMethodDeepChainCallRe = regexp.MustCompile(`\bnew\s+([A-Z][A-Za-z0-9_]*)\s*\([^)]*\)\s*\.\s*([A-Za-z_]\w*)\s*\([^)]*\)\s*\.\s*([A-Za-z_]\w*)\s*\([^)]*\)\s*\.\s*([A-Za-z_]\w*)\s*\(`)
 	ctorMethodDeepChainCallRe    = regexp.MustCompile(`\b([A-Z][A-Za-z0-9_]*)\s*\([^)]*\)\s*\.\s*([A-Za-z_]\w*)\s*\([^)]*\)\s*\.\s*([A-Za-z_]\w*)\s*\([^)]*\)\s*\.\s*([A-Za-z_]\w*)\s*\(`)
-	returnedMethodDeepChainRe    = regexp.MustCompile(`\b([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*\.\s*([A-Za-z_]\w*)\s*\([^)]*\)\s*\.\s*([A-Za-z_]\w*)\s*\([^)]*\)\s*\.\s*([A-Za-z_]\w*)\s*\(`)
-	newCtorMethodChainCallRe     = regexp.MustCompile(`\bnew\s+([A-Z][A-Za-z0-9_]*)\s*\([^)]*\)\s*\.\s*([A-Za-z_]\w*)\s*\([^)]*\)\s*\.\s*([A-Za-z_]\w*)\s*\(`)
-	ctorMethodChainCallRe        = regexp.MustCompile(`\b([A-Z][A-Za-z0-9_]*)\s*\([^)]*\)\s*\.\s*([A-Za-z_]\w*)\s*\([^)]*\)\s*\.\s*([A-Za-z_]\w*)\s*\(`)
-	returnedMethodChainCallRe    = regexp.MustCompile(`\b([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*\.\s*([A-Za-z_]\w*)\s*\([^)]*\)\s*\.\s*([A-Za-z_]\w*)\s*\(`)
-	newCtorMethodCallRe          = regexp.MustCompile(`\bnew\s+([A-Z][A-Za-z0-9_]*)\s*\([^)]*\)\s*\.\s*([A-Za-z_]\w*)\s*\(`)
-	ctorMethodCallRe             = regexp.MustCompile(`\b([A-Z][A-Za-z0-9_]*)\s*\([^)]*\)\s*\.\s*([A-Za-z_]\w*)\s*\(`)
-	returnedMethodCallRe         = regexp.MustCompile(`\b([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*\.\s*([A-Za-z_]\w*)\s*\(`)
+	returnedMethodDeepChainRe    = regexp.MustCompile(`\b([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*(?:->|\.)\s*([A-Za-z_]\w*)\s*\([^)]*\)\s*(?:->|\.)\s*([A-Za-z_]\w*)\s*\([^)]*\)\s*(?:->|\.)\s*([A-Za-z_]\w*)\s*\(`)
+	newCtorMethodChainCallRe     = regexp.MustCompile(`\bnew\s+([A-Z][A-Za-z0-9_]*)\s*\([^)]*\)\s*(?:->|\.)\s*([A-Za-z_]\w*)\s*\([^)]*\)\s*(?:->|\.)\s*([A-Za-z_]\w*)\s*\(`)
+	ctorMethodChainCallRe        = regexp.MustCompile(`\b([A-Z][A-Za-z0-9_]*)\s*\([^)]*\)\s*(?:->|\.)\s*([A-Za-z_]\w*)\s*\([^)]*\)\s*(?:->|\.)\s*([A-Za-z_]\w*)\s*\(`)
+	returnedMethodChainCallRe    = regexp.MustCompile(`\b([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*(?:->|\.)\s*([A-Za-z_]\w*)\s*\([^)]*\)\s*(?:->|\.)\s*([A-Za-z_]\w*)\s*\(`)
+	newCtorMethodCallRe          = regexp.MustCompile(`\bnew\s+([A-Z][A-Za-z0-9_]*)\s*\([^)]*\)\s*(?:->|\.)\s*([A-Za-z_]\w*)\s*\(`)
+	ctorMethodCallRe             = regexp.MustCompile(`\b([A-Z][A-Za-z0-9_]*)\s*\([^)]*\)\s*(?:->|\.)\s*([A-Za-z_]\w*)\s*\(`)
+	returnedMethodCallRe         = regexp.MustCompile(`\b([A-Za-z_$][\w$]*)\s*\([^)]*\)\s*(?:->|\.)\s*([A-Za-z_]\w*)\s*\(`)
 )
 
 func chainedConstructorCalls(block string) []typedMethodCall {
@@ -3129,4 +3131,50 @@ func goFirstResultTypeForCallable(name string, from SymbolRecord, symbolsByShort
 		return agreed
 	}
 	return ""
+}
+
+// phpDocblockFuncRe pairs a docblock with the PHP function/method declared
+// immediately after it; phpDocReturnTagRe pulls the '@return' type out of
+// the docblock body.
+var (
+	phpDocblockFuncRe  = regexp.MustCompile(`(?s)/\*\*(.*?)\*/\s*(?:(?:abstract|final|public|protected|private|static)\s+)*function\s+&?([A-Za-z_]\w*)\s*\(`)
+	phpDocReturnTagRe  = regexp.MustCompile(`@return\s+([\\\w|]+)`)
+	phpDocPrimitiveSet = map[string]bool{
+		"array": true, "bool": true, "boolean": true, "callable": true,
+		"false": true, "float": true, "int": true, "integer": true,
+		"iterable": true, "mixed": true, "never": true, "null": true,
+		"object": true, "resource": true, "self": true, "static": true,
+		"string": true, "true": true, "void": true, "this": true,
+	}
+)
+
+// phpDocblockReturnTypes maps each PHP function/method name in a file to the
+// class-like '@return' type of its docblock. WordPress-era PHP declares
+// return types in docblocks rather than native hints, so this is the only
+// source for factory-return receiver inference there ('@return
+// WP_REST_Server' lets rest_get_server()->dispatch() resolve). Union types
+// take their first class-like member; FQCNs reduce to the short class name.
+func phpDocblockReturnTypes(content string) map[string]string {
+	out := map[string]string{}
+	for _, m := range phpDocblockFuncRe.FindAllStringSubmatch(content, -1) {
+		doc, name := m[1], m[2]
+		tag := phpDocReturnTagRe.FindStringSubmatch(doc)
+		if tag == nil {
+			continue
+		}
+		for _, alt := range strings.Split(tag[1], "|") {
+			alt = strings.TrimPrefix(alt, "\\")
+			if i := strings.LastIndex(alt, "\\"); i >= 0 {
+				alt = alt[i+1:]
+			}
+			if alt == "" || phpDocPrimitiveSet[strings.ToLower(alt)] || !isCapitalized(alt) {
+				continue
+			}
+			if _, exists := out[name]; !exists {
+				out[name] = alt
+			}
+			break
+		}
+	}
+	return out
 }

--- a/internal/sem/typescript.go
+++ b/internal/sem/typescript.go
@@ -1,0 +1,121 @@
+package sem
+
+import (
+	"regexp"
+	"strings"
+)
+
+// TypeScript-specific receiver typing. The generic localVarTypes scanner only
+// understands constructor assignments, while TypeScript projects often route
+// important receiver calls through explicit annotations or DI field
+// initializers (`const router: Router = ...`, `private router = inject(Router)`).
+// These helpers are intentionally conservative: only capitalized short type
+// names are kept, and conflicting bindings are dropped by the caller.
+
+var (
+	typeScriptTypedLocalRe   = regexp.MustCompile(`\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*[!?]?\s*:\s*([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?(?:<[^>\n]*>)?)`)
+	typeScriptInjectLocalRe  = regexp.MustCompile(`\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*inject\s*(?:<[^>\n]*>)?\(\s*([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?)\b`)
+	typeScriptCtorPropertyRe = regexp.MustCompile(`\b(?:(?:public|protected|private|readonly|override)\s+)+([A-Za-z_$][\w$]*)\s*[!?]?\s*:\s*([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?(?:<[^>\n]*>)?)`)
+)
+
+func typeScriptTypeName(ref string) string {
+	ref = strings.TrimSpace(ref)
+	ref = strings.TrimPrefix(ref, "readonly ")
+	ref = strings.TrimPrefix(ref, "?")
+	ref = strings.TrimSuffix(ref, "?")
+	ref = strings.TrimSuffix(ref, "!")
+	ref = stripGenerics(ref)
+	name := lastTypeSegment(ref)
+	if !isCapitalized(name) {
+		return ""
+	}
+	return name
+}
+
+func typeScriptLocalVarTypes(block string) map[string]string {
+	stripped := stripCodeLiteralsAndComments(block)
+	out := map[string]string{}
+	conflicted := map[string]bool{}
+	record := func(name, typeName string) {
+		typeName = typeScriptTypeName(typeName)
+		if name == "" || typeName == "" {
+			return
+		}
+		if existing, ok := out[name]; ok && existing != typeName {
+			conflicted[name] = true
+			return
+		}
+		out[name] = typeName
+	}
+	for _, m := range typeScriptTypedLocalRe.FindAllStringSubmatch(stripped, -1) {
+		record(m[1], m[2])
+	}
+	for _, m := range typeScriptInjectLocalRe.FindAllStringSubmatch(stripped, -1) {
+		record(m[1], m[2])
+	}
+	for name := range conflicted {
+		delete(out, name)
+	}
+	return out
+}
+
+// typeScriptPropertyTypes infers field -> type from parser-confirmed class
+// field symbols plus constructor parameter properties. Restricting initializer
+// parsing to emitted field line ranges avoids classifying method-local
+// `const x = inject(Foo)` bindings as class properties.
+func typeScriptPropertyTypes(content string, fields []SymbolRecord) map[string]string {
+	stripped := stripCodeLiteralsAndComments(content)
+	lines := strings.Split(stripped, "\n")
+	out := map[string]string{}
+	conflicted := map[string]bool{}
+	record := func(name, typeName string) {
+		typeName = typeScriptTypeName(typeName)
+		if name == "" || typeName == "" {
+			return
+		}
+		if existing, ok := out[name]; ok && existing != typeName {
+			conflicted[name] = true
+			return
+		}
+		out[name] = typeName
+	}
+	for _, field := range fields {
+		if field.Kind != "field" || field.Language != "TypeScript" {
+			continue
+		}
+		if field.Signature != "" && strings.Contains(field.Signature, ":") {
+			if _, typ, ok := strings.Cut(field.Signature, ":"); ok {
+				record(field.Name, typ)
+			}
+		}
+		start := maxInt(1, field.StartLine)
+		end := maxInt(start, field.EndLine)
+		if start > len(lines) {
+			continue
+		}
+		if end > len(lines) {
+			end = len(lines)
+		}
+		block := strings.Join(lines[start-1:end], "\n")
+		escaped := regexp.QuoteMeta(field.Name)
+		typed := regexp.MustCompile(`\b` + escaped + `\s*[!?]?\s*:\s*([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?(?:<[^>\n]*>)?)`)
+		if m := typed.FindStringSubmatch(block); m != nil {
+			record(field.Name, m[1])
+		}
+		inject := regexp.MustCompile(`\b` + escaped + `\s*[!?]?\s*=\s*inject\s*(?:<[^>\n]*>)?\(\s*([A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)?)\b`)
+		if m := inject.FindStringSubmatch(block); m != nil {
+			record(field.Name, m[1])
+		}
+		ctor := regexp.MustCompile(`\b` + escaped + `\s*[!?]?\s*=\s*new\s+([A-Z][A-Za-z0-9_$]*)\s*\(`)
+		if m := ctor.FindStringSubmatch(block); m != nil {
+			record(field.Name, m[1])
+		}
+	}
+	for _, m := range typeScriptCtorPropertyRe.FindAllStringSubmatch(stripped, -1) {
+		record(m[1], m[2])
+	}
+	for name := range conflicted {
+		delete(out, name)
+	}
+	return out
+}

--- a/internal/sem/typescript_test.go
+++ b/internal/sem/typescript_test.go
@@ -1,0 +1,107 @@
+package sem
+
+import "testing"
+
+func TestTypeScriptReceiverTypesFromLocalsAndInjectProperties(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "src/url_handling_strategy.ts", `export abstract class UrlHandlingStrategy {
+  abstract merge(newUrlPart: UrlTree, rawUrl: UrlTree): UrlTree;
+}
+
+export class DefaultUrlHandlingStrategy implements UrlHandlingStrategy {
+  merge(newUrlPart: UrlTree, rawUrl: UrlTree): UrlTree {
+    return newUrlPart;
+  }
+}
+
+export class UrlTree {}
+`)
+	writeFile(t, repo, "src/router.ts", `import {DefaultUrlHandlingStrategy, UrlHandlingStrategy, UrlTree} from './url_handling_strategy';
+
+declare function inject<T>(token: unknown): T;
+
+export class Router {
+  private readonly urlHandlingStrategy = inject(UrlHandlingStrategy);
+
+  navigateByUrl(url: string | UrlTree): Promise<boolean> {
+    const tree = url instanceof UrlTree ? url : this.parseUrl(url);
+    const merged = this.urlHandlingStrategy.merge(tree, tree);
+    return this.scheduleNavigation(merged);
+  }
+
+  parseUrl(url: string): UrlTree {
+    return new UrlTree();
+  }
+
+  private scheduleNavigation(url: UrlTree): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+}
+
+new DefaultUrlHandlingStrategy();
+`)
+	writeFile(t, repo, "src/router_link.ts", `import {Router} from './router';
+
+declare function inject<T>(token: unknown): T;
+
+export class RouterLink {
+  private readonly router = inject(Router);
+
+  onClick() {
+    this.router.navigateByUrl('/home');
+  }
+}
+`)
+	writeFile(t, repo, "src/upgrade.ts", `import {Router} from './router';
+
+export interface UpgradeModule {
+  injector: { get<T>(token: unknown): T };
+}
+
+export function setUpLocationSync(ngUpgrade: UpgradeModule) {
+  const router: Router = ngUpgrade.injector.get(Router);
+  router.navigateByUrl('/legacy');
+}
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := map[string]RelationRecord{}
+	for _, r := range snapshot.Relations {
+		if r.Type == "CALLS" {
+			calls[lastSegment(r.FromID)+"->"+lastSegment(r.ToID)] = r
+		}
+	}
+	for _, want := range []string{
+		"RouterLink.onClick->Router.navigateByUrl",
+		"setUpLocationSync->Router.navigateByUrl",
+		"Router.navigateByUrl->DefaultUrlHandlingStrategy.merge",
+	} {
+		if _, ok := calls[want]; !ok {
+			t.Fatalf("missing TypeScript receiver call %s in %#v", want, calls)
+		}
+	}
+	if got := calls["Router.navigateByUrl->DefaultUrlHandlingStrategy.merge"].Reason; got != "interface-typed receiver call resolved to the unique TypeScript implementation" {
+		t.Fatalf("merge resolved for the wrong reason %q", got)
+	}
+}
+
+func TestTypeScriptTypeInferenceDropsConflictingProperties(t *testing.T) {
+	content := `class A {
+  private readonly service = inject(ServiceA);
+}
+
+class B {
+  private readonly service = inject(ServiceB);
+}
+`
+	fields := []SymbolRecord{
+		{Kind: "field", Language: "TypeScript", Name: "service", StartLine: 2, EndLine: 2},
+		{Kind: "field", Language: "TypeScript", Name: "service", StartLine: 6, EndLine: 6},
+	}
+	if got := typeScriptPropertyTypes(content, fields); len(got) != 0 {
+		t.Fatalf("conflicting property types should be dropped, got %#v", got)
+	}
+}


### PR DESCRIPTION
Five extraction bugs diagnosed from the brain-bench C#/PHP significance batch (dotnet/runtime, dotnet/roslyn, laravel/framework, WordPress/wordpress-develop), rebased onto main. Each fix commit carries a regression test.

## C#

1. **Vendor tree-sitter-c-sharp v0.23.5 at ABI 14** (`76d59ec`) — the bundled grammar predates C# 12/13; a single `params ReadOnlySpan<Task>` overload in runtime's `Task.cs` swallowed the enclosing `class Task` and every later member (177 of ~800 symbols). Corpus parse-failure counts: runtime 3920, roslyn 1593, efcore 945, aspnetcore 544. `Task.cs` now parses with zero ERROR nodes; roslyn's failures drop 1593 → 286. Masks for primary constructors and collection expressions are removed (grammar-native now); preprocessor masking stays, plus a new length-preserving mask for `*(T*)&x` pointer-deref casts, the one construct the new grammar still rejects.
2. **Out-declaration / nullable-local receiver types** (`8f9b3e4`) — `out HttpConnectionPool? pool` and `Type? local;` now feed receiver-type inference; parameter modifiers (`out/ref/in/params/this/scoped/readonly`) no longer corrupt signature-derived types.
3. **Static calls across partial classes** (`d01e5aa`) — type-name resolution prefers the partial declaration that actually defines the called method; roslyn's `Contract.ThrowIfFalse(...)` (declared in Contract.cs, shadowed by the lexically-first Contract.InterpolatedStringHandlers.cs) now resolves `type_inferred` 0.82.

## PHP

4. **Closure-body receiver inference** (`cfe0e78`) — an untyped receiver named after the enclosing type resolves to it (method-existence gated): laravel's `Container.getClosure` now emits CALLS to `Container.build` and `Container.resolve`.
5. **Ambiguous bare calls + docblock return types** (`568a423`) — ambiguous name-only calls emit ranked candidate edges instead of silence (WordPress `apply_filters`, 3 declarations); the chained-call regex family accepts `->`; `@return` docblock types drive `rest_get_server()->dispatch()` resolution; nullable `: ?Type` hints are stripped correctly.

Plus `1ec76d0`: regression tests pinning two bugs found by self-measuring the benchmark corpus (jq's C typedef-return misnaming, Go self-module package imports) whose fixes had already landed on main independently.

## Verification

Full `go test ./...` passes on the rebased branch. Brain-bench re-measurement with this binary: roslyn 17/18 → **18/18**, framework 20/21 → **21/21**, wordpress-develop 18/20 → **20/20** (runtime re-measure in flight). Score artifacts land in a separate brain-bench PR, cross-linked here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EaiZeA5H6EvrrG8jjtXTRB