### PR TITLE
Fix remaining live graph extraction gaps

### DIFF
--- a/internal/sem/call_resolution_precision_test.go
+++ b/internal/sem/call_resolution_precision_test.go
@@ -1,0 +1,432 @@
+package sem
+
+import (
+	"strings"
+	"testing"
+)
+
+// runCallsFrom returns every CALLS relation whose from-symbol short name is the
+// given name.
+func runCallsFrom(snapshot ProviderSnapshot, from string) []RelationRecord {
+	var out []RelationRecord
+	for _, r := range snapshot.Relations {
+		if r.Type == "CALLS" && lastSegment(r.FromID) == from {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// A dotted call whose terminal name resolves to an in-repo class method
+// (`from myapp import models; models.User.save()`) must NOT fabricate an
+// external CALLS edge. The method is kind-gated out of the dotted local edge,
+// but the call targets an in-repo member — the generic receiver path already
+// emits the correct local edge, and the dotted external fallback must stay
+// silent (precision > recall: a wrong external edge is worse than none).
+func TestPythonDottedFromImportKindGatedMethodEmitsNoExternal(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "myapp/__init__.py", "")
+	writeFile(t, repo, "myapp/models.py", `class User:
+    @classmethod
+    def save(cls):
+        return 1
+`)
+	writeFile(t, repo, "consumer.py", `from myapp import models
+
+
+def go():
+    return models.User.save()
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range runCallsFrom(snapshot, "go") {
+		if r.TargetKind == "external" || strings.HasPrefix(r.ToID, "external:symbol:") {
+			t.Fatalf("dotted path fabricated external CALLS go -> %s for an in-repo method", r.ToID)
+		}
+	}
+	// The correct in-repo edge from the generic receiver path must still exist.
+	if !hasRelationBySymbolNameAndFile(snapshot, "CALLS", "go", "consumer.py", "save", "myapp/models.py") {
+		t.Fatalf("missing in-repo CALLS go -> save @ myapp/models.py: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}
+
+// The alias-import spelling `import myapp.models as models` composes the same
+// `myapp.models.User` module qualifier as the from-import form, so it must emit
+// the same result: no fabricated external edge, and the in-repo edge preserved.
+func TestPythonDottedAliasKindGatedMethodEmitsNoExternal(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "myapp/__init__.py", "")
+	writeFile(t, repo, "myapp/models.py", `class User:
+    @classmethod
+    def save(cls):
+        return 1
+`)
+	writeFile(t, repo, "consumer.py", `import myapp.models as models
+
+
+def go():
+    return models.User.save()
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range runCallsFrom(snapshot, "go") {
+		if r.TargetKind == "external" || strings.HasPrefix(r.ToID, "external:symbol:") {
+			t.Fatalf("dotted path fabricated external CALLS go -> %s for an in-repo method", r.ToID)
+		}
+	}
+	if !hasRelationBySymbolNameAndFile(snapshot, "CALLS", "go", "consumer.py", "save", "myapp/models.py") {
+		t.Fatalf("missing in-repo CALLS go -> save @ myapp/models.py: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}
+
+// A dotted call into a genuinely external package (`import requests;
+// requests.sessions.session()`) has no in-repo symbol of the terminal name, so
+// the external fallback must still fire. The suppression is scoped to in-repo
+// targets only and must not silence real external edges.
+func TestPythonDottedGenuineExternalStillEmitted(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "app.py", `import requests
+
+
+def go():
+    return requests.sessions.session()
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, r := range runCallsFrom(snapshot, "go") {
+		if r.ToID == externalID("symbol", "requests.sessions.session") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("missing genuine external CALLS go -> requests.sessions.session: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}
+
+// A `from pkg import Name` binding where Name is a re-exported repo class is
+// string-identical to a submodule import in importsByName, but `Name.attr.fn()`
+// is class-attribute access, not a `pkg.attr` submodule path. The composer must
+// recognise that Name is a repo class defined under pkg and compose nothing, so
+// no CALLS edge is fabricated to an unrelated sibling module whose filename
+// coincides with the attribute (myapp/settings.py here). Precision > recall: the
+// true target (Config.settings being a Settings instance) is unresolved, and no
+// edge is better than a wrong one.
+func TestPythonDottedReExportedClassAttributeEmitsNoEdge(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "myapp/__init__.py", "from myapp._impl import Config\n")
+	writeFile(t, repo, "myapp/_impl.py", `class Settings:
+    def load(self):
+        return 1
+
+
+class Config:
+    settings = Settings()
+`)
+	writeFile(t, repo, "myapp/settings.py", `def load():
+    return 2
+`)
+	writeFile(t, repo, "consumer.py", `from myapp import Config
+
+
+def go():
+    return Config.settings.load()
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if edges := runCallsFrom(snapshot, "go"); len(edges) != 0 {
+		t.Fatalf("re-exported class attribute access must emit no CALLS edge from go, got %#v", edges)
+	}
+}
+
+// Repro B (the ubiquitous Flask-SQLAlchemy idiom): `from app import db` where
+// app/__init__.py binds a module-level singleton `db = SQLAlchemy()`. `db` is
+// not a submodule, so `db.session.query()` is instance-attribute access, not an
+// `app.session` submodule path. The from-import form composes nothing (no
+// app.db submodule), so no CALLS edge is fabricated — in particular no spurious
+// external `app.session.query`. Precision > recall.
+func TestPythonFromImportSingletonChainedCallEmitsNoEdge(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "app/__init__.py", "db = SQLAlchemy()\n")
+	writeFile(t, repo, "c.py", `from app import db
+
+
+def caller():
+    return db.session.query()
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if edges := runCallsFrom(snapshot, "caller"); len(edges) != 0 {
+		t.Fatalf("from-imported module-level singleton chained call must emit no CALLS edge from caller, got %#v", edges)
+	}
+}
+
+// Repro A: pkg/__init__.py binds a module-level singleton `service = Service()`.
+// `from pkg import service` then `service.helper.fn()` is instance-attribute
+// access on that singleton, NOT the pkg.helper submodule. With no pkg.service
+// submodule the from-import form composes nothing, so the coincidentally-named
+// sibling pkg/helper.py must NOT receive a fabricated local edge.
+func TestPythonFromImportSingletonDoesNotResolveToSiblingModule(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "pkg/__init__.py", "from pkg.impl import Service\nservice = Service()\n")
+	writeFile(t, repo, "pkg/impl.py", `class Service:
+    pass
+`)
+	writeFile(t, repo, "pkg/helper.py", `def fn():
+    return 1
+`)
+	writeFile(t, repo, "c.py", `from pkg import service
+
+
+def caller():
+    return service.helper.fn()
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if edges := runCallsFrom(snapshot, "caller"); len(edges) != 0 {
+		t.Fatalf("from-imported singleton attribute call must emit no CALLS edge from caller, got %#v", edges)
+	}
+}
+
+// `import x.y as x` binds the local `x` to module x.y — an alias rename that
+// happens to shadow its own leading segment. `x.z.fn()` therefore means
+// x.y.z.fn and must resolve to x/y/z.py, never the sibling x/z.py that a
+// leading-segment reading would name, even though both define fn. Exactly one
+// edge, to x/y/z.py.
+func TestPythonSelfShadowAliasRenameResolvesToRenamedModule(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "x/__init__.py", "")
+	writeFile(t, repo, "x/z.py", `def fn():
+    return 1
+`)
+	writeFile(t, repo, "x/y/__init__.py", "")
+	writeFile(t, repo, "x/y/z.py", `def fn():
+    return 2
+`)
+	writeFile(t, repo, "consumer.py", `import x.y as x
+
+
+def go():
+    return x.z.fn()
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	var targets []string
+	for _, r := range runCallsFrom(snapshot, "go") {
+		if to, ok := symbolsByID[r.ToID]; ok && to.Name == "fn" {
+			targets = append(targets, to.FilePath)
+		}
+	}
+	if len(targets) != 1 || targets[0] != "x/y/z.py" {
+		t.Fatalf("`import x.y as x` + x.z.fn() targets = %#v, want exactly [x/y/z.py]", targets)
+	}
+}
+
+// A reassignment of an already-typed local nested inside a fluent chain's
+// method-call arguments (`$u->set($w = get())`) must still invalidate that
+// local: $w is reassigned away from its Foo ctor type, so the later single-hop
+// `$w->render` must NOT emit a type_inferred edge to Foo::render. The chain's
+// consumed span protects the typer's own `$v =` lead but excludes the
+// argument-paren interior where the foreign write lives. Positive control: the
+// same chain with a write-free argument keeps every type, so `$w->render` still
+// resolves.
+func TestPerlNestedChainArgWriteDropsInferredType(t *testing.T) {
+	fooBar := map[string]string{
+		"lib/Foo.pm": `package Foo;
+
+sub new {
+  return bless {}, shift;
+}
+
+sub render {
+  return 1;
+}
+`,
+		"lib/Bar.pm": `package Bar;
+
+sub new {
+  return bless {}, shift;
+}
+
+sub set {
+  return shift;
+}
+
+sub go {
+  return shift;
+}
+`,
+	}
+
+	// Negative: the nested `$w = get()` invalidates $w, so no type_inferred edge.
+	nested := t.TempDir()
+	writeFile(t, nested, "lib/App.pm", `package App;
+
+sub run {
+  my $w = Foo->new;
+  my $u = Bar->new;
+  my $v = $u->set($w = get())->go;
+  $w->render;
+}
+`)
+	for p, c := range fooBar {
+		writeFile(t, nested, p, c)
+	}
+	nestedSnap, err := BuildProviderSnapshotWithOptions(t.Context(), nested, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range runCallsFrom(nestedSnap, "run") {
+		if r.Resolution == "type_inferred" && lastSegment(r.ToID) == "render" {
+			t.Fatalf("stale $w type fabricated a type_inferred CALLS run -> render: %#v", r)
+		}
+	}
+
+	// Positive control: a write-free argument keeps $w typed Foo, so the
+	// single-hop $w->render still resolves via the inferred package type.
+	clean := t.TempDir()
+	writeFile(t, clean, "lib/App.pm", `package App;
+
+sub run {
+  my $w = Foo->new;
+  my $u = Bar->new;
+  my $v = $u->set(cfg())->go;
+  $w->render;
+}
+`)
+	for p, c := range fooBar {
+		writeFile(t, clean, p, c)
+	}
+	cleanSnap, err := BuildProviderSnapshotWithOptions(t.Context(), clean, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, r := range runCallsFrom(cleanSnap, "run") {
+		if r.Resolution == "type_inferred" && lastSegment(r.ToID) == "render" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("write-free chain argument must keep $w typed: expected type_inferred CALLS run -> render, got %#v", relationsOfType(cleanSnap.Relations, "CALLS"))
+	}
+}
+
+// A Perl-inferred receiver type (`my $x = Foo->new`) must never reach the
+// language-agnostic generic type-inference loop. When Foo.pm has no `render`
+// sub but a TypeScript `class Foo { render() }` exists, the Perl receiver must
+// NOT resolve cross-language to the TS method: the Perl-only type map is
+// consumed solely by the language-gated Perl resolver, so no edge is emitted.
+func TestPerlInferredTypeDoesNotLeakToCrossLanguageClass(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "lib/App.pm", `package App;
+
+sub run {
+  my $x = Foo->new;
+  $x->render;
+}
+`)
+	writeFile(t, repo, "lib/Foo.pm", `package Foo;
+
+sub new {
+  return bless {}, shift;
+}
+`)
+	writeFile(t, repo, "web/foo.ts", `export class Foo {
+  render(): number {
+    return 1;
+  }
+}
+`)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	for _, r := range runCallsFrom(snapshot, "run") {
+		if to, ok := symbolsByID[r.ToID]; ok && to.Name == "render" {
+			t.Fatalf("Perl inferred type leaked into a cross-language edge: run -> render @ %s (%s)", to.FilePath, to.Language)
+		}
+	}
+}
+
+// When both a Perl `Foo::go` and a TypeScript `Foo.go` exist, a Perl receiver
+// typed `Foo` must resolve to exactly ONE edge — the Perl one. The generic loop
+// must never see the Perl-inferred type and double-emit a second edge to the TS
+// class.
+func TestPerlInferredTypePrefersPerlOverCollidingClass(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "lib/App.pm", `package App;
+
+sub run {
+  my $x = Foo->new;
+  $x->go;
+}
+`)
+	writeFile(t, repo, "lib/Foo.pm", `package Foo;
+
+sub new {
+  return bless {}, shift;
+}
+
+sub go {
+  return 1;
+}
+`)
+	writeFile(t, repo, "web/foo.ts", `export class Foo {
+  go(): number {
+    return 1;
+  }
+}
+`)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	var goEdges []RelationRecord
+	for _, r := range runCallsFrom(snapshot, "run") {
+		if to, ok := symbolsByID[r.ToID]; ok && to.Name == "go" {
+			goEdges = append(goEdges, r)
+		}
+	}
+	if len(goEdges) != 1 {
+		t.Fatalf("expected exactly one CALLS run -> go edge, got %d: %#v", len(goEdges), goEdges)
+	}
+	if to := symbolsByID[goEdges[0].ToID]; to.Language != "Perl" || to.FilePath != "lib/Foo.pm" {
+		t.Fatalf("run -> go resolved to the wrong target: %#v", to)
+	}
+}

--- a/internal/sem/dart.go
+++ b/internal/sem/dart.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-var dartSetterAssignmentRe = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_$]*)\s*\.\s*([A-Za-z_][A-Za-z0-9_]*)\s*=`)
+var dartSetterAssignmentRe = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_$]*)\s*\.\s*([A-Za-z_][A-Za-z0-9_$]*)\s*=`)
 
 func dartSetterAssignmentCalls(block string) []receiverCall {
 	stripped := stripCodeLiteralsAndComments(block)

--- a/internal/sem/dart.go
+++ b/internal/sem/dart.go
@@ -1,0 +1,34 @@
+package sem
+
+import (
+	"regexp"
+	"strings"
+)
+
+var dartSetterAssignmentRe = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_$]*)\s*\.\s*([A-Za-z_][A-Za-z0-9_]*)\s*=`)
+
+func dartSetterAssignmentCalls(block string) []receiverCall {
+	stripped := stripCodeLiteralsAndComments(block)
+	var out []receiverCall
+	seen := map[string]bool{}
+	for _, m := range dartSetterAssignmentRe.FindAllStringSubmatchIndex(stripped, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		if m[1] < len(stripped) {
+			switch stripped[m[1]] {
+			case '=', '>':
+				continue
+			}
+		}
+		receiver := strings.TrimSpace(stripped[m[2]:m[3]])
+		method := strings.TrimSpace(stripped[m[4]:m[5]])
+		key := receiver + "." + method
+		if receiver == "" || method == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, receiverCall{Receiver: receiver, Method: method})
+	}
+	return out
+}

--- a/internal/sem/dart.go
+++ b/internal/sem/dart.go
@@ -8,7 +8,7 @@ import (
 var dartSetterAssignmentRe = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_$]*)\s*\.\s*([A-Za-z_][A-Za-z0-9_$]*)\s*=`)
 
 func dartSetterAssignmentCalls(block string) []receiverCall {
-	stripped := stripCodeLiteralsAndComments(block)
+	stripped := stripCodeLiteralsAndComments(maskDartMultilineStrings(block))
 	var out []receiverCall
 	seen := map[string]bool{}
 	for _, m := range dartSetterAssignmentRe.FindAllStringSubmatchIndex(stripped, -1) {
@@ -31,4 +31,35 @@ func dartSetterAssignmentCalls(block string) []receiverCall {
 		out = append(out, receiverCall{Receiver: receiver, Method: method})
 	}
 	return out
+}
+
+func maskDartMultilineStrings(content string) string {
+	bytes := []byte(content)
+	for i := 0; i+2 < len(bytes); i++ {
+		start := i
+		quotePos := i
+		if (bytes[i] == 'r' || bytes[i] == 'R') && i+3 < len(bytes) && isDartTripleQuote(bytes[i+1:]) {
+			quotePos = i + 1
+		} else if !isDartTripleQuote(bytes[i:]) {
+			continue
+		}
+		quote := bytes[quotePos]
+		j := quotePos + 3
+		for j+2 < len(bytes) && !(bytes[j] == quote && bytes[j+1] == quote && bytes[j+2] == quote) {
+			j++
+		}
+		if j+2 < len(bytes) {
+			j += 3
+		}
+		maskBytes(bytes, start, j)
+		i = j - 1
+	}
+	return string(bytes)
+}
+
+func isDartTripleQuote(bytes []byte) bool {
+	if len(bytes) < 3 {
+		return false
+	}
+	return (bytes[0] == '\'' || bytes[0] == '"') && bytes[1] == bytes[0] && bytes[2] == bytes[0]
 }

--- a/internal/sem/dart.go
+++ b/internal/sem/dart.go
@@ -21,6 +21,18 @@ func dartSetterAssignmentCalls(block string) []receiverCall {
 				continue
 			}
 		}
+		// Reject a receiver preceded (after optional whitespace) by `.`/`?.`/`..`:
+		// a nested field assignment (`a.cfg.value = 1`) matches at the intermediate
+		// segment `cfg`, whose true receiver is `a.cfg`, not `cfg`. Emitting
+		// {cfg,value} could resolve against a same-named differently-typed local, so
+		// nested field assignments emit nothing (recall loss OK; precision first).
+		j := m[0] - 1
+		for j >= 0 && (stripped[j] == ' ' || stripped[j] == '\t') {
+			j--
+		}
+		if j >= 0 && stripped[j] == '.' {
+			continue
+		}
 		receiver := strings.TrimSpace(stripped[m[2]:m[3]])
 		method := strings.TrimSpace(stripped[m[4]:m[5]])
 		key := receiver + "." + method
@@ -28,9 +40,47 @@ func dartSetterAssignmentCalls(block string) []receiverCall {
 			continue
 		}
 		seen[key] = true
-		out = append(out, receiverCall{Receiver: receiver, Method: method})
+		out = append(out, receiverCall{Receiver: receiver, Method: method, SetterAssign: true})
 	}
 	return out
+}
+
+// dartSetterSignatureRe matches a Dart setter declaration head (`set name(...)`,
+// optionally with leading modifiers such as `static`). A getter head
+// (`Type get name`) carries no parameter list, so the trailing `(` cleanly
+// excludes it.
+var dartSetterSignatureRe = regexp.MustCompile(`(?:^|[^\w$])set[ \t]+([A-Za-z_$][\w$]*)[ \t]*\(`)
+
+// dartIsSetterAccessor reports whether a Dart method symbol's signature declares
+// the setter accessor named `name`.
+func dartIsSetterAccessor(signature, name string) bool {
+	for _, m := range dartSetterSignatureRe.FindAllStringSubmatch(signature, -1) {
+		if m[1] == name {
+			return true
+		}
+	}
+	return false
+}
+
+// dartSetterAccessor finds the setter accessor named `name` reachable from
+// container `start` up its super chain, scanning the workspace short-name index
+// (records == symbolsByShortName[name]). The short-name method index keyed by
+// container collapses a read-write property's getter and setter to whichever was
+// declared last, so a setter-assignment call resolves through this dedicated
+// lookup to target the setter deterministically. Returns the setter and whether
+// it was found on a base type (inherited).
+func dartSetterAccessor(start, name string, records []SymbolRecord, superContainerByID map[string]string) (SymbolRecord, bool, bool) {
+	for c := start; c != ""; c = superContainerByID[c] {
+		for _, s := range records {
+			if s.Language != "Dart" || s.ContainerID != c {
+				continue
+			}
+			if dartIsSetterAccessor(s.Signature, name) {
+				return s, c != start, true
+			}
+		}
+	}
+	return SymbolRecord{}, false, false
 }
 
 func maskDartMultilineStrings(content string) string {

--- a/internal/sem/dart_test.go
+++ b/internal/sem/dart_test.go
@@ -1,0 +1,72 @@
+package sem
+
+import "testing"
+
+// A nested field assignment (`a.cfg.value = 1`) matches at the intermediate
+// chain segment `cfg`, whose true receiver is `a.cfg`. Emitting {cfg, value}
+// could resolve against a same-named but differently-typed local, so nested
+// setter assignments must produce no receiver call (recall loss OK; precision
+// first). A flat `request.bodyFields = body` still yields the setter call.
+func TestDartSetterAssignmentRejectsNestedReceiver(t *testing.T) {
+	if got := dartSetterAssignmentCalls("a.cfg.value = 1"); len(got) != 0 {
+		t.Fatalf("nested field assignment must emit no receiver call, got %#v", got)
+	}
+	// Optional-chained and cascade-nested receivers are rejected the same way.
+	for _, src := range []string{"a?.cfg.value = 1", "a..cfg.value = 1", "a . cfg . value = 1"} {
+		if got := dartSetterAssignmentCalls(src); len(got) != 0 {
+			t.Fatalf("nested receiver %q must emit no receiver call, got %#v", src, got)
+		}
+	}
+
+	flat := dartSetterAssignmentCalls("request.bodyFields = body")
+	if len(flat) != 1 || flat[0].Receiver != "request" || flat[0].Method != "bodyFields" {
+		t.Fatalf("flat property assignment should emit {request, bodyFields}, got %#v", flat)
+	}
+	if !flat[0].SetterAssign {
+		t.Fatalf("property-assignment call must be marked SetterAssign, got %#v", flat[0])
+	}
+}
+
+// A read-write property declares a same-named getter and setter. Both are Dart
+// `method` symbols with the same short name, so the container's method index
+// collapses to whichever is declared last. A property-assignment call invokes
+// the SETTER, so it must resolve to the setter accessor regardless of
+// declaration order — not to the getter about half the time.
+func TestDartReadWritePropertyAssignmentResolvesToSetter(t *testing.T) {
+	// setter declared first (getter last) is the order that previously mis-resolved
+	// to the getter; the getter-first order is the determinism control.
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"setter-first", "  set value(int v) {}\n  int get value => 0;\n"},
+		{"getter-first", "  int get value => 0;\n  set value(int v) {}\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			writeFile(t, repo, "lib/box.dart", "class Box {\n"+tc.body+"}\n\n"+
+				"void go() {\n  var b = Box();\n  b.value = 1;\n}\n")
+
+			snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+			if err != nil {
+				t.Fatal(err)
+			}
+			setterID := ""
+			for _, s := range snapshot.Symbols {
+				if s.Name == "value" && dartIsSetterAccessor(s.Signature, "value") {
+					setterID = s.ID
+				}
+			}
+			if setterID == "" {
+				t.Fatal("no setter symbol found for property value")
+			}
+			edges := runCallsFrom(snapshot, "go")
+			if len(edges) != 1 {
+				t.Fatalf("expected exactly one CALLS edge from go, got %#v", edges)
+			}
+			if edges[0].ToID != setterID {
+				t.Fatalf("property-assignment must resolve to the setter %s, got %s", setterID, edges[0].ToID)
+			}
+		})
+	}
+}

--- a/internal/sem/haskell.go
+++ b/internal/sem/haskell.go
@@ -409,6 +409,57 @@ func haskellApplied(s string, start, end int) bool {
 	return op || haskellArgumentFollows(s, end)
 }
 
+func haskellFirstArgHigherOrder(word string) bool {
+	switch word {
+	case "all", "any", "filter", "find", "foldl", "foldl'", "foldr",
+		"fmap", "map", "mapM", "mapM_", "sortOn", "traverse", "traverse_":
+		return true
+	}
+	return false
+}
+
+func haskellHigherOrderArgSite(s string, end int, inBinder func(int) bool, binderNames map[string]bool) (haskellCallSite, bool) {
+	i := skipHaskellSpace(s, end)
+	if i >= len(s) {
+		return haskellCallSite{}, false
+	}
+	paren := false
+	if s[i] == '(' {
+		paren = true
+		i = skipHaskellSpace(s, i+1)
+	}
+	if i >= len(s) || inBinder(i) {
+		return haskellCallSite{}, false
+	}
+	if m := haskellQualifiedRe.FindStringSubmatchIndex(s[i:]); m != nil && m[0] == 0 {
+		absEnd := i + m[1]
+		if paren {
+			j := skipHaskellSpace(s, absEnd)
+			if j >= len(s) || s[j] != ')' {
+				return haskellCallSite{}, false
+			}
+		}
+		return haskellCallSite{Path: s[i+m[2] : i+m[3]], Name: s[i+m[4] : i+m[5]]}, true
+	}
+	if m := haskellIdentRe.FindStringIndex(s[i:]); m != nil && m[0] == 0 {
+		name := s[i : i+m[1]]
+		if name[0] >= 'A' && name[0] <= 'Z' {
+			return haskellCallSite{}, false
+		}
+		if haskellKeyword(name) || binderNames[name] {
+			return haskellCallSite{}, false
+		}
+		if paren {
+			j := skipHaskellSpace(s, i+m[1])
+			if j >= len(s) || s[j] != ')' {
+				return haskellCallSite{}, false
+			}
+		}
+		return haskellCallSite{Name: name}, true
+	}
+	return haskellCallSite{}, false
+}
+
 // haskellCallSites scans a Haskell block for application expressions,
 // deduplicated and in deterministic order. Qualified applications
 // (`Alias.fn args`) are matched anywhere in expression position; bare
@@ -434,6 +485,28 @@ func haskellCallSites(block string) []haskellCallSite {
 			continue // value reference or operator operand, not an application
 		}
 		seen[haskellCallSite{Path: stripped[m[2]:m[3]], Name: stripped[m[4]:m[5]]}] = true
+	}
+	for _, m := range haskellIdentRe.FindAllStringIndex(stripped, -1) {
+		start, end := m[0], m[1]
+		word := stripped[start:end]
+		if !haskellFirstArgHigherOrder(word) || qualifiedAt[start] {
+			continue
+		}
+		if inBinder(start) || binderNames[word] {
+			continue
+		}
+		if start > 0 {
+			switch stripped[start-1] {
+			case '.', '\'', '@', '~', '#', '\\':
+				continue
+			}
+		}
+		if !haskellApplied(stripped, start, end) {
+			continue
+		}
+		if site, ok := haskellHigherOrderArgSite(stripped, end, inBinder, binderNames); ok {
+			seen[site] = true
+		}
 	}
 	for _, m := range haskellIdentRe.FindAllStringIndex(stripped, -1) {
 		start, end := m[0], m[1]

--- a/internal/sem/haskell.go
+++ b/internal/sem/haskell.go
@@ -36,10 +36,38 @@ var (
 	// `Mod.fn`, `Mod.Sub.fn`. An Uppercase terminal is a constructor or module
 	// reference, not a value, and is deliberately not matched.
 	haskellQualifiedRe = regexp.MustCompile(`([A-Z][A-Za-z0-9_']*(?:\.[A-Z][A-Za-z0-9_']*)*)\.([a-z_][A-Za-z0-9_']*)`)
-	haskellIdentRe     = regexp.MustCompile(`[A-Za-z_][A-Za-z0-9_']*`)
-	haskellModuleRe    = regexp.MustCompile(`[A-Z][A-Za-z0-9_']*(?:\.[A-Z][A-Za-z0-9_']*)*`)
-	haskellLowerRe     = regexp.MustCompile(`\b[a-z_][A-Za-z0-9_']*`)
-	haskellImportRe    = regexp.MustCompile(`(?m)^import[ \t]`)
+	// Anchored variant used when only a match at the start of the slice matters:
+	// unanchored FindStringSubmatchIndex would scan to the next qualified name
+	// anywhere ahead (potentially to EOF) before the caller discards it for not
+	// starting at 0. Anchoring makes the negative case O(1) and is otherwise
+	// identical (the caller already requires m[0] == 0).
+	haskellQualifiedAnchoredRe = regexp.MustCompile(`^([A-Z][A-Za-z0-9_']*(?:\.[A-Z][A-Za-z0-9_']*)*)\.([a-z_][A-Za-z0-9_']*)`)
+	haskellIdentRe             = regexp.MustCompile(`[A-Za-z_][A-Za-z0-9_']*`)
+	haskellModuleRe            = regexp.MustCompile(`[A-Z][A-Za-z0-9_']*(?:\.[A-Z][A-Za-z0-9_']*)*`)
+	haskellLowerRe             = regexp.MustCompile(`\b[a-z_][A-Za-z0-9_']*`)
+	haskellImportRe            = regexp.MustCompile(`(?m)^import[ \t]`)
+	// The first identifier after a `let` keyword is always the name being
+	// bound (a value/function binding LHS or a do/list-comp `let`), never a
+	// call. Requiring whitespace after `let` avoids matching primed names such
+	// as `let'`; the brace form `let { name = ... }` puts a `{` between the
+	// keyword and the leading binder, so it needs its own pattern.
+	haskellLetBinderRe      = regexp.MustCompile(`\blet[ \t\r\n]+([a-z_][A-Za-z0-9_']*)`)
+	haskellLetBraceBinderRe = regexp.MustCompile(`\blet[ \t\r\n]*\{[ \t\r\n]*([a-z_][A-Za-z0-9_']*)`)
+	// Subsequent bindings in a single-line group are `; name =` (let/where) or
+	// `; name <-` (do-bind); both bind name. The `=` guard excludes `==`.
+	haskellSemiBinderRe = regexp.MustCompile(`;[ \t]*([a-z_][A-Za-z0-9_']*)[ \t]*(?:<-|=(?:[^=]|$))`)
+	// A let/where group's pattern LHS runs from the keyword up to its binding
+	// `=` and is entirely binders, so every lowercase identifier in that chunk
+	// is a bound name — covering tuple/list/constructor destructuring
+	// (`let (a, render) = ...`, `let [g] = ...`, `let (Just x) = ...`) that the
+	// single-leading-identifier patterns above cannot reach. `[^=\n]` keeps the
+	// chunk on one line and stops before the binding `=`.
+	haskellLetPatternBinderRe = regexp.MustCompile(`\b(?:let|where)\b([^=\n]*)=`)
+	// A `;`-separated continuation of a let/where group (`; (a, b) = ...`) with
+	// the same whole-chunk-is-binders rule. `[^=\n<]` also excludes a
+	// `;`-separated do-bind (`; x <- ...`), whose LHS is handled by the do-bind
+	// pattern.
+	haskellSemiPatternBinderRe = regexp.MustCompile(`;([^=\n<]*)=(?:[^=]|$)`)
 )
 
 // haskellKeyword reports Haskell reserved words. `_` is included: it matches
@@ -207,15 +235,162 @@ func haskellBinderRegions(stripped string) (func(int) bool, map[string]bool) {
 		}
 		lineStart = i + 1
 	}
+	// The spans are appended in increasing lineStart order and never overlap
+	// (one span per physical line), so a binary search on the sorted starts
+	// finds the only span that could contain `at` — O(log spans) per query
+	// instead of a linear scan, which the two block-wide identifier sweeps call
+	// once per identifier.
+	starts := make([]int, len(spans))
+	ends := make([]int, len(spans))
+	for i, s := range spans {
+		starts[i] = s.start
+		ends[i] = s.end
+	}
 	inBinder := func(at int) bool {
-		for _, s := range spans {
-			if s.start <= at && at < s.end {
-				return true
-			}
-		}
-		return false
+		idx := sort.Search(len(starts), func(i int) bool { return starts[i] > at }) - 1
+		return idx >= 0 && at < ends[idx]
 	}
 	return inBinder, names
+}
+
+// haskellHigherOrderBinderNames extends the block-wide binder set with the
+// locally-bound names the physical-line binder scan cannot reach, for the sole
+// use of the higher-order argument pass. A function handed as the first
+// argument of `map`/`mapM_`/`filter`/… is reported as a call site, so a local
+// that shadows a same-named top-level function must be excluded even when it is
+// the leading binder of a braced or single-line `do`/`let` block
+// (`do { fn <- ...; mapM_ fn }`, `let { f = ...; ... } in map f xs`) that the
+// line-head scan steps over. This set is deliberately kept out of the
+// bare-application resolver: registering these names block-wide there would
+// suppress a genuine head-position call to a same-named imported function
+// elsewhere in the block. Over-suppressing inside the higher-order pass only
+// costs a higher-order edge, which the precision-first policy prefers to a
+// wrong one.
+func haskellHigherOrderBinderNames(stripped string, base map[string]bool) map[string]bool {
+	names := make(map[string]bool, len(base))
+	for name := range base {
+		names[name] = true
+	}
+	add := func(name string) {
+		if !haskellKeyword(name) {
+			names[name] = true
+		}
+	}
+	// `let`-group `=` binders: inline `let x = ... in`, the leading binder of a
+	// brace-let `let { x = ...`, and `;`-separated continuations of a let/where
+	// group.
+	for _, m := range haskellLetBinderRe.FindAllStringSubmatch(stripped, -1) {
+		add(m[1])
+	}
+	for _, m := range haskellLetBraceBinderRe.FindAllStringSubmatch(stripped, -1) {
+		add(m[1])
+	}
+	for _, m := range haskellSemiBinderRe.FindAllStringSubmatch(stripped, -1) {
+		add(m[1])
+	}
+	// Pattern-destructuring `=` binders (`let (a, render) = ...`, `let [g] = ...`,
+	// `; (a, b) = ...`): the whole LHS chunk is binders, so add every lowercase
+	// identifier in it. Over-inclusion here only costs a higher-order edge, never
+	// emits a wrong one.
+	addAll := func(chunk string) {
+		for _, name := range haskellLowerRe.FindAllString(chunk, -1) {
+			add(name)
+		}
+	}
+	for _, m := range haskellLetPatternBinderRe.FindAllStringSubmatch(stripped, -1) {
+		addAll(m[1])
+	}
+	for _, m := range haskellSemiPatternBinderRe.FindAllStringSubmatch(stripped, -1) {
+		addAll(m[1])
+	}
+	// Arrow-preceded binding forms — do/list-comprehension generators
+	// (`(fn, ys) <- pairs`), lambda parameters (`\(a, b) ->`), and
+	// case/`\case`/multi-way-if alternatives (`case x of { Just f -> ... }`) —
+	// bind their pattern variables on the LEFT of a `<-` or `->` at a bracket
+	// depth the line-head scan cannot reach in the single-line brace form.
+	// haskellArrowBinders collects them all in one linear pass.
+	haskellArrowBinders(stripped, add)
+	return names
+}
+
+// haskellArrowBinders reports, via add, every lowercase identifier bound on the
+// LEFT of a `<-` or `->` arrow anywhere in the stripped block. It replaces the
+// former per-arrow backward walk — which re-scanned a growing prefix for every
+// arrow and so ran in O(n^2) on a long single-line span of arrows (a wide
+// `foo :: A -> B -> ... -> Z` type signature) — with a single linear pass.
+//
+// The block is split into segments at the binder boundaries `;`, `{`, `|`, `\`,
+// and newline (an arrow never binds a name across one of those). Within a
+// segment an identifier is a binder iff the nearest arrow-or-`case`/`of` token
+// to its right is an arrow: an intervening `case`/`of` marks the identifier as
+// part of a case scrutinee (`case x of Pat -> …` — `x` is not a binder), not a
+// pattern. That is exactly the union of the old per-arrow left-walk spans (with
+// the scrutinee trimmed), computed in O(n). Over-inclusion only costs a
+// higher-order edge, never emits a wrong one.
+func haskellArrowBinders(stripped string, add func(string)) {
+	flushSegment := func(seg string) {
+		// One left-to-right tokenization into arrows, `case`/`of` markers, and
+		// lowercase identifiers, then a right-to-left sweep so each identifier
+		// sees its nearest following token in O(1).
+		type htoken struct {
+			arrow bool
+			caseK bool
+			name  string
+		}
+		var toks []htoken
+		for i := 0; i < len(seg); {
+			c := seg[i]
+			switch {
+			case (c == '-' && i+1 < len(seg) && seg[i+1] == '>') ||
+				(c == '<' && i+1 < len(seg) && seg[i+1] == '-'):
+				toks = append(toks, htoken{arrow: true})
+				i += 2
+			case c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'):
+				j := i + 1
+				for j < len(seg) {
+					d := seg[j]
+					if d == '_' || d == '\'' || (d >= 'a' && d <= 'z') || (d >= 'A' && d <= 'Z') || (d >= '0' && d <= '9') {
+						j++
+						continue
+					}
+					break
+				}
+				word := seg[i:j]
+				switch {
+				case word == "case" || word == "of":
+					toks = append(toks, htoken{caseK: true})
+				case word[0] == '_' || (word[0] >= 'a' && word[0] <= 'z'):
+					toks = append(toks, htoken{name: word})
+				}
+				i = j
+			default:
+				i++
+			}
+		}
+		nextIsArrow := false
+		for k := len(toks) - 1; k >= 0; k-- {
+			switch {
+			case toks[k].arrow:
+				nextIsArrow = true
+			case toks[k].caseK:
+				nextIsArrow = false
+			case toks[k].name != "" && nextIsArrow:
+				add(toks[k].name)
+			}
+		}
+	}
+	segStart := 0
+	for i := 0; i <= len(stripped); i++ {
+		if i == len(stripped) {
+			flushSegment(stripped[segStart:i])
+			break
+		}
+		switch stripped[i] {
+		case ';', '{', '|', '\\', '\n':
+			flushSegment(stripped[segStart:i])
+			segStart = i + 1
+		}
+	}
 }
 
 // haskellBinderHeadEnd scans one physical line for the earliest stand-alone
@@ -431,7 +606,7 @@ func haskellHigherOrderArgSite(s string, end int, inBinder func(int) bool, binde
 	if i >= len(s) || inBinder(i) {
 		return haskellCallSite{}, false
 	}
-	if m := haskellQualifiedRe.FindStringSubmatchIndex(s[i:]); m != nil && m[0] == 0 {
+	if m := haskellQualifiedAnchoredRe.FindStringSubmatchIndex(s[i:]); m != nil && m[0] == 0 {
 		absEnd := i + m[1]
 		if paren {
 			j := skipHaskellSpace(s, absEnd)
@@ -466,9 +641,20 @@ func haskellHigherOrderArgSite(s string, end int, inBinder func(int) bool, binde
 // applications are reported for any lowercase identifier in application
 // position that is not a keyword, a binder, or a use of a shadowing local
 // binder — resolution decides which of them name real symbols.
-func haskellCallSites(block string) []haskellCallSite {
+//
+// The higher-order first-argument pass (which treats `map f xs` as a call to
+// `f`) fires only for the library combinator names in
+// haskellFirstArgHigherOrder. hofUserDefined reports whether the workspace
+// defines its own function/bind of that name; when it does, the name is
+// suppressed from the HOF pass — the combinator heuristic must not run on a
+// user function whose first argument is ordinary data (`find db key` would
+// otherwise fabricate a call to `db`). It may be nil (pure-string unit tests),
+// which forgoes the suppression. The bare/qualified passes are unaffected, so a
+// call to the user's own combinator-named function still resolves normally.
+func haskellCallSites(block string, hofUserDefined func(name string) bool) []haskellCallSite {
 	stripped := stripHaskellCodeText(block)
 	inBinder, binderNames := haskellBinderRegions(stripped)
+	hoBinderNames := haskellHigherOrderBinderNames(stripped, binderNames)
 	seen := map[haskellCallSite]bool{}
 	qualifiedAt := map[int]bool{}
 	for _, m := range haskellQualifiedRe.FindAllStringSubmatchIndex(stripped, -1) {
@@ -492,7 +678,14 @@ func haskellCallSites(block string) []haskellCallSite {
 		if !haskellFirstArgHigherOrder(word) || qualifiedAt[start] {
 			continue
 		}
-		if inBinder(start) || binderNames[word] {
+		if hofUserDefined != nil && hofUserDefined(word) {
+			// The workspace defines its own `word`, so this application is a call
+			// to the user function, not the library combinator; its first argument
+			// is data, not a callback. Skip the HOF site (the bare pass still
+			// resolves the call to the user's function).
+			continue
+		}
+		if inBinder(start) || hoBinderNames[word] {
 			continue
 		}
 		if start > 0 {
@@ -504,7 +697,7 @@ func haskellCallSites(block string) []haskellCallSite {
 		if !haskellApplied(stripped, start, end) {
 			continue
 		}
-		if site, ok := haskellHigherOrderArgSite(stripped, end, inBinder, binderNames); ok {
+		if site, ok := haskellHigherOrderArgSite(stripped, end, inBinder, hoBinderNames); ok {
 			seen[site] = true
 		}
 	}
@@ -696,7 +889,18 @@ func haskellCallableKind(kind string) bool {
 // skipped.
 func haskellCallRelations(from SymbolRecord, block string, sameFile []SymbolRecord, symbolsByShortName map[string][]SymbolRecord, imports haskellFileImports) []RelationRecord {
 	var relations []RelationRecord
-	for _, site := range haskellCallSites(block) {
+	// A combinator name the workspace defines itself (`find`, `map`, ...) must
+	// not trigger the higher-order first-argument pass: on the user's own
+	// function the first argument is data, not a callback.
+	hofUserDefined := func(name string) bool {
+		for _, s := range symbolsByShortName[name] {
+			if s.Language == "Haskell" && haskellCallableKind(s.Kind) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, site := range haskellCallSites(block, hofUserDefined) {
 		var targets []resolvedCallTarget
 		if site.Path != "" {
 			module := imports.aliases[site.Path]

--- a/internal/sem/haskell_test.go
+++ b/internal/sem/haskell_test.go
@@ -56,6 +56,10 @@ func TestHaskellCallSites(t *testing.T) {
   case res of
     Just cfg -> useConfig cfg
     Nothing -> pure ()
+  pure (map tshow res)
+  pure (map Text.pack labels)
+  let shadowed = id
+  pure (map shadowed res)
   pure $ combine res ` + "`orElse`" + ` fallback
   where
     i = interpretSymbolicPath mbWorkDir
@@ -86,6 +90,10 @@ func TestHaskellCallSites(t *testing.T) {
 		// Calls on the right-hand side of where bindings.
 		{Name: "interpretSymbolicPath"},
 		{Name: "localPackage"},
+		// Higher-order library calls can apply a function supplied as an
+		// argument, as in `map tshow xs`.
+		{Name: "tshow"},
+		{Path: "Text", Name: "pack"},
 	} {
 		if !got[want] {
 			t.Fatalf("missing call site %+v in %+v", want, sites)
@@ -107,6 +115,7 @@ func TestHaskellCallSites(t *testing.T) {
 		{Name: "i"},
 		{Name: "pkgId"},
 		{Name: "fallback"},
+		{Name: "shadowed"},
 	} {
 		if got[bogus] {
 			t.Fatalf("bogus call site %+v in %+v", bogus, sites)

--- a/internal/sem/haskell_test.go
+++ b/internal/sem/haskell_test.go
@@ -64,8 +64,9 @@ func TestHaskellCallSites(t *testing.T) {
   where
     i = interpretSymbolicPath mbWorkDir
     pkgId = localPackage lbi
+process xs = let helper = negate in map helper xs
 `
-	sites := haskellCallSites(block)
+	sites := haskellCallSites(block, nil)
 	got := map[haskellCallSite]bool{}
 	for _, site := range sites {
 		got[site] = true
@@ -116,10 +117,328 @@ func TestHaskellCallSites(t *testing.T) {
 		{Name: "pkgId"},
 		{Name: "fallback"},
 		{Name: "shadowed"},
+		// `helper` is bound by an inline single-line `let ... in`, so the
+		// higher-order pass (`map helper xs`) must not surface it as a call.
+		{Name: "helper"},
 	} {
 		if got[bogus] {
 			t.Fatalf("bogus call site %+v in %+v", bogus, sites)
 		}
+	}
+}
+
+// The higher-order argument pass reports a function passed as the first
+// argument of map/mapM_/filter/… as a call site. The FIRST binder of a braced
+// or single-line do/let block is stepped over by the physical-line binder scan
+// (it follows `do {`/`do `/`let {`, not a `;` and not a bare `let `), so the
+// higher-order pass must consult its own binder set to avoid surfacing that
+// do-bound or let-bound local as a call site (it would otherwise resolve to a
+// same-named top-level function — a wrong CALLS edge). Each block is a single
+// symbol's definition, exactly as the pipeline slices them.
+func TestHaskellHigherOrderShadowedLeadingBinder(t *testing.T) {
+	cases := []struct {
+		block string
+		bogus haskellCallSite
+	}{
+		// Braced single-line do; leading `<-` binder.
+		{"run env msgs = do { logger <- getLogger env; mapM_ logger msgs }\n", haskellCallSite{Name: "logger"}},
+		// Brace-less single-line do; leading `<-` binder.
+		{"run items = do fn <- getFn; mapM_ fn items\n", haskellCallSite{Name: "fn"}},
+		// Brace-let; leading `=` binder.
+		{"process xs = let { f = getFn; g = other } in map f xs\n", haskellCallSite{Name: "f"}},
+	}
+	for _, tc := range cases {
+		got := map[haskellCallSite]bool{}
+		for _, site := range haskellCallSites(tc.block, nil) {
+			got[site] = true
+		}
+		if got[tc.bogus] {
+			t.Fatalf("higher-order pass surfaced shadowed local %+v for block %q -> %+v", tc.bogus, tc.block, got)
+		}
+	}
+}
+
+// The higher-order binder set must also cover locals bound by single-line
+// pattern destructuring (`let (a, render) = ...`) and lambda parameters
+// (`\handler -> ...`). The physical-line binder scan steps over both (they sit
+// after the equation's own `=`), so without them the higher-order pass would
+// surface the shadowing local as a first-argument call site and resolve it to
+// a same-named top-level function — a wrong CALLS edge. Each block is a single
+// symbol's definition, as the pipeline slices them.
+func TestHaskellHigherOrderShadowedPatternAndLambdaBinder(t *testing.T) {
+	cases := []struct {
+		block string
+		bogus haskellCallSite
+	}{
+		// Tuple-destructuring let-pattern binder handed to `map`.
+		{"draw xs = let (a, render) = prepare xs in map render xs\n", haskellCallSite{Name: "render"}},
+		// List-destructuring let-pattern binder.
+		{"draw xs = let [render] = prepare xs in map render xs\n", haskellCallSite{Name: "render"}},
+		// Constructor-destructuring let-pattern binder.
+		{"draw xs = let (Just render) = prepare xs in map render xs\n", haskellCallSite{Name: "render"}},
+		// Lambda parameter handed to `mapM_`.
+		{"runAll = \\handler -> mapM_ handler queue\n", haskellCallSite{Name: "handler"}},
+	}
+	for _, tc := range cases {
+		got := map[haskellCallSite]bool{}
+		for _, site := range haskellCallSites(tc.block, nil) {
+			got[site] = true
+		}
+		if got[tc.bogus] {
+			t.Fatalf("higher-order pass surfaced shadowed local %+v for block %q -> %+v", tc.bogus, tc.block, got)
+		}
+	}
+}
+
+// The higher-order binder set must also cover case / \case alternative pattern
+// binders in the single-line brace form (`case x of { Just f -> map f xs }`).
+// The physical-line binder scan stops at the equation's own `=`, so the
+// alternative's `Pat ->` head — at bracket depth >= 1 inside the braces — is
+// never reached; without the arrow-LHS coverage the higher-order pass would
+// surface the case-bound local as a first-argument call site and resolve it to
+// a same-named top-level function (a wrong CALLS edge). Each block is one
+// symbol's definition, as the pipeline slices them.
+func TestHaskellHigherOrderShadowedArrowLHSBinder(t *testing.T) {
+	cases := []struct {
+		block string
+		bogus haskellCallSite
+	}{
+		// Single-line brace `case of` alternative binder handed to `mapM_`.
+		{"process cb xs = case cb of { Just render -> mapM_ render xs; Nothing -> pure () }\n", haskellCallSite{Name: "render"}},
+		// `\case` alternative binder handed to `map`.
+		{"process = \\case { Just render -> map render xs; Nothing -> [] }\n", haskellCallSite{Name: "render"}},
+		// Multi-way-if guard binder handed to `filter`.
+		{"pick p xs = if | Just render <- p -> filter render xs | otherwise -> xs\n", haskellCallSite{Name: "render"}},
+	}
+	for _, tc := range cases {
+		got := map[haskellCallSite]bool{}
+		for _, site := range haskellCallSites(tc.block, nil) {
+			got[site] = true
+		}
+		if got[tc.bogus] {
+			t.Fatalf("higher-order pass surfaced shadowed arrow-LHS local %+v for block %q -> %+v", tc.bogus, tc.block, got)
+		}
+	}
+}
+
+// End-to-end guard for the confirmed case-alternative false edge: a case-bound
+// local that shadows a same-file top-level function, applied as a higher-order
+// first argument inside a single-line brace `case of`, must not fabricate a
+// CALLS edge to that top-level function through the higher-order argument pass.
+func TestHaskellHigherOrderShadowedCaseBinderNoEdge(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "src/App.hs", `module App where
+
+render :: Int -> IO ()
+render n = print n
+
+process :: Maybe (Int -> IO ()) -> [Int] -> IO ()
+process cb xs = case cb of { Just render -> mapM_ render xs; Nothing -> pure () }
+
+report :: [Int] -> [String]
+report xs = map draw xs
+
+draw :: Int -> String
+draw n = show n
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	type edge struct{ from, to string }
+	calls := map[edge]bool{}
+	for _, r := range snapshot.Relations {
+		if r.Type != "CALLS" {
+			continue
+		}
+		from, okF := symbolsByID[r.FromID]
+		to, okT := symbolsByID[r.ToID]
+		if !okF || !okT {
+			continue
+		}
+		calls[edge{from.Name, to.Name}] = true
+	}
+	// The `render` in `mapM_ render xs` is the case-bound local, not the
+	// top-level `render` function: no edge.
+	if calls[edge{"process", "render"}] {
+		t.Fatalf("shadowed case-bound local fabricated CALLS edge process -> render in %v", calls)
+	}
+	// The higher-order pass still resolves a genuine top-level function passed
+	// to `map`, so the guard above is not vacuous.
+	if !calls[edge{"report", "draw"}] {
+		t.Fatalf("missing legitimate higher-order CALLS edge report -> draw in %v", calls)
+	}
+}
+
+// The pattern/lambda binder extension must not suppress a legitimate
+// higher-order call: `map render xs` with no shadowing local still resolves
+// `render` to a top-level function.
+func TestHaskellHigherOrderLegitimateCallNotSuppressed(t *testing.T) {
+	block := "report xs = map render xs\n"
+	got := map[haskellCallSite]bool{}
+	for _, site := range haskellCallSites(block, nil) {
+		got[site] = true
+	}
+	if !got[(haskellCallSite{Name: "render"})] {
+		t.Fatalf("legitimate higher-order call `render` was suppressed: %+v", got)
+	}
+}
+
+// When the workspace defines its own function whose name collides with a
+// library combinator (`find`), the higher-order first-argument pass must be
+// suppressed for that name: `find db key` calls the user's `find` with `db` as
+// ordinary data, so the data argument must not be surfaced as a call site. The
+// bare application pass still reports `find` itself.
+func TestHaskellCallSitesHOFSuppressedForUserDefinedName(t *testing.T) {
+	block := "go key = find db key\n"
+	userDefined := func(name string) bool { return name == "find" }
+	got := map[haskellCallSite]bool{}
+	for _, site := range haskellCallSites(block, userDefined) {
+		got[site] = true
+	}
+	if got[(haskellCallSite{Name: "db"})] {
+		t.Fatalf("HOF pass surfaced data argument `db` for user-defined `find`: %+v", got)
+	}
+	if !got[(haskellCallSite{Name: "find"})] {
+		t.Fatalf("bare call `find` was dropped: %+v", got)
+	}
+	// Positive control: without the predicate the HOF pass DOES surface `db`, so
+	// the suppression above is what removes it (the guard is not vacuous).
+	base := map[haskellCallSite]bool{}
+	for _, site := range haskellCallSites(block, nil) {
+		base[site] = true
+	}
+	if !base[(haskellCallSite{Name: "db"})] {
+		t.Fatalf("expected HOF pass to surface `db` when `find` is not user-defined: %+v", base)
+	}
+}
+
+// End-to-end: a user-defined function whose name collides with a library
+// higher-order combinator (`find`) must not trigger the first-argument pass,
+// so its data argument (`db`) is never fabricated as a CALLS target, while the
+// genuine call to the user's `find` still resolves. A sibling `map render xs`
+// with no user-defined `map` is the positive control: the HOF pass still fires
+// for a real library combinator.
+func TestHaskellHigherOrderUserDefinedCombinatorNoDataEdge(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "src/App.hs", `module App where
+
+db :: Int
+db = 0
+
+find :: Int -> Int -> Int
+find a b = a + b
+
+go :: Int -> Int
+go key = find db key
+
+render :: Int -> String
+render n = show n
+
+report :: [Int] -> [String]
+report xs = map render xs
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	type edge struct{ from, to string }
+	calls := map[edge]bool{}
+	for _, r := range snapshot.Relations {
+		if r.Type != "CALLS" {
+			continue
+		}
+		from, okF := symbolsByID[r.FromID]
+		to, okT := symbolsByID[r.ToID]
+		if !okF || !okT {
+			continue
+		}
+		calls[edge{from.Name, to.Name}] = true
+	}
+	if calls[edge{"go", "db"}] {
+		t.Fatalf("HOF pass fabricated CALLS go -> db for user-defined `find` in %v", calls)
+	}
+	if !calls[edge{"go", "find"}] {
+		t.Fatalf("missing genuine CALLS go -> find in %v", calls)
+	}
+	if !calls[edge{"report", "render"}] {
+		t.Fatalf("positive control missing: CALLS report -> render (map render) in %v", calls)
+	}
+}
+
+// Scoping the higher-order binder names separately means a local bound by a
+// nested do-bind or inline let no longer suppresses a legitimate head-position
+// bare call to a same-named symbol elsewhere in the block (the bare-application
+// pass keeps consuming the original block-wide binder set only).
+func TestHaskellBareCallNotSuppressedByNestedBinder(t *testing.T) {
+	block := "run n = wrap (parse n)\n  where\n    aux = do { a <- get; parse <- other; pure parse }\n"
+	got := map[haskellCallSite]bool{}
+	for _, site := range haskellCallSites(block, nil) {
+		got[site] = true
+	}
+	if !got[(haskellCallSite{Name: "parse"})] {
+		t.Fatalf("head-position bare call `parse` suppressed by nested do-bind of the same name: %+v", got)
+	}
+}
+
+// End-to-end guard for the confirmed false edge: a do-bound local that shadows
+// a same-file top-level function, bound as the leading binder of a braced
+// single-line do, must not fabricate a CALLS edge to that top-level function
+// through the higher-order argument pass.
+func TestHaskellHigherOrderShadowedLocalNoEdge(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "src/App.hs", `module App where
+
+logger :: String -> IO ()
+logger msg = putStrLn msg
+
+render :: Int -> String
+render n = show n
+
+run :: env -> [String] -> IO ()
+run env msgs = do { logger <- getLogger env; mapM_ logger msgs }
+
+report :: [Int] -> [String]
+report xs = map render xs
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	type edge struct{ from, to string }
+	calls := map[edge]bool{}
+	for _, r := range snapshot.Relations {
+		if r.Type != "CALLS" {
+			continue
+		}
+		from, okF := symbolsByID[r.FromID]
+		to, okT := symbolsByID[r.ToID]
+		if !okF || !okT {
+			continue
+		}
+		calls[edge{from.Name, to.Name}] = true
+	}
+	// The `logger` in `mapM_ logger msgs` is the do-bound local, not the
+	// top-level `logger` function: no edge.
+	if calls[edge{"run", "logger"}] {
+		t.Fatalf("shadowed do-bound local fabricated CALLS edge run -> logger in %v", calls)
+	}
+	// The higher-order pass still resolves a genuine top-level function passed
+	// to `map`, so the guard above is not vacuous.
+	if !calls[edge{"report", "render"}] {
+		t.Fatalf("missing legitimate higher-order CALLS edge report -> render in %v", calls)
 	}
 }
 

--- a/internal/sem/parser.go
+++ b/internal/sem/parser.go
@@ -6646,21 +6646,46 @@ func rAssignmentEntity(node *sitter.Node, src []byte, scope string) (string, str
 	if name == "" {
 		return "", "", false
 	}
+	kind, ok := rAssignedValueKind(value, src)
+	if !ok {
+		return "", "", false
+	}
+	if kind == "function" && scope != "" {
+		return "method", qualify(scope, name), true
+	}
+	return kind, name, true
+}
+
+func rAssignedValueKind(value *sitter.Node, src []byte) (string, bool) {
+	if !validNode(value) {
+		return "", false
+	}
 	switch value.Type() {
 	case "function_definition":
-		if scope != "" {
-			return "method", qualify(scope, name), true
-		}
-		return "function", name, true
+		return "function", true
 	case "call":
 		if fn := value.ChildByFieldName("function"); validNode(fn) {
 			callee := strings.TrimSpace(fn.Content(src))
 			if callee == "R6Class" || callee == "R6::R6Class" || callee == "setRefClass" || callee == "methods::setRefClass" {
-				return "class", name, true
+				return "class", true
 			}
 		}
+	case "binary_operator":
+		operator := value.ChildByFieldName("operator")
+		if !validNode(operator) {
+			return "", false
+		}
+		assigned := value.ChildByFieldName("rhs")
+		switch operator.Type() {
+		case "<-", "<<-", "=":
+		case "->", "->>":
+			assigned = value.ChildByFieldName("lhs")
+		default:
+			return "", false
+		}
+		return rAssignedValueKind(assigned, src)
 	}
-	return "", "", false
+	return "", false
 }
 
 // rAssignmentTargetName returns the defined name from the target side of an R

--- a/internal/sem/parser.go
+++ b/internal/sem/parser.go
@@ -3523,8 +3523,25 @@ func walkEntitiesScoped(node *sitter.Node, src []byte, language, scope string, i
 			childScope = entity.Name
 		}
 		if entity.Kind == "function" || entity.Kind == "method" {
-			childInFunc = true // descendants of this callable are function-local
+			// In R a callable is named by assignment (a binary_operator), and a
+			// chained assignment `a <- b <- function() ...` binds every target
+			// name at THIS scope — a and b are peers, not nested. The terminal
+			// function_definition is the only real body; the intermediate
+			// binary_operator/identifier nodes are sibling bindings. Flagging the
+			// whole binary_operator subtree function-local would mis-mark those
+			// inner targets Local and hide them from cross-scope resolution, so
+			// for R defer the flag to the function_definition node (below).
+			if language != "R" || node.Type() != "binary_operator" {
+				childInFunc = true // descendants of this callable are function-local
+			}
 		}
+	}
+	// In R the function body lives under the anonymous function_definition node
+	// (the name is on the enclosing assignment, handled above). Entering it marks
+	// descendants function-local — matching the generic named-callable-body rule
+	// while leaving chained-assignment sibling targets at the outer scope.
+	if language == "R" && node.Type() == "function_definition" {
+		childInFunc = true
 	}
 	// A Rust `impl Foo {}` / `impl Trait for Foo {}` block is not a symbol itself,
 	// but it scopes its functions to the implementing type: without this they'd be
@@ -6625,6 +6642,13 @@ func scopesChildren(kind string) bool {
 // function; an R6Class/setRefClass call value yields a class (the trivial
 // S4/R6 idiom). The name side may be an identifier or a string, as in
 // syntactic names like `"myop<-" <- function(x, value) ...`.
+//
+// The value classification (rAssignedValueKind) recurses through a chained
+// assignment: when the value side is itself a binary_operator over the same
+// `<-`/`<<-`/`=`/`->`/`->>` operator set (`a <- b <- function() ...`, or the
+// right-assign `function() ... -> b -> a`), it unwraps the inner assignment's
+// value — rhs, or lhs for the right-assign forms — until it reaches the
+// terminal function/class definition, so the outer name inherits that kind.
 func rAssignmentEntity(node *sitter.Node, src []byte, scope string) (string, string, bool) {
 	operator := node.ChildByFieldName("operator")
 	if !validNode(operator) {

--- a/internal/sem/perl.go
+++ b/internal/sem/perl.go
@@ -22,7 +22,8 @@ func perlReceiverCalls(block string) []receiverCall {
 	seen := map[string]bool{}
 	for _, loc := range perlReceiverChainRe.FindAllStringIndex(stripped, -1) {
 		chain := stripped[loc[0]:loc[1]]
-		segments := perlReceiverSegmentRe.FindAllStringSubmatch(chain, -1)
+		topLevelChain := maskPerlParenthesizedArgumentContents(chain)
+		segments := perlReceiverSegmentRe.FindAllStringSubmatch(topLevelChain, -1)
 		if len(segments) == 0 {
 			continue
 		}
@@ -30,7 +31,7 @@ func perlReceiverCalls(block string) []receiverCall {
 		if method == "" || method == "new" {
 			continue
 		}
-		receiver := strings.TrimSpace(strings.SplitN(chain, "->", 2)[0])
+		receiver := strings.TrimSpace(strings.SplitN(topLevelChain, "->", 2)[0])
 		receiver = strings.TrimPrefix(receiver, "$")
 		if receiver == "" {
 			continue
@@ -72,7 +73,7 @@ func perlLocalVarTypes(block string) map[string]string {
 			// same-object assignments. This covers idioms such as
 			// `$base = $url->base(...)->base->userinfo(...)` without typing
 			// single-hop value getters like `$path = $url->path`.
-			if len(perlReceiverSegmentRe.FindAllStringSubmatch(chain, -1)) < 2 {
+			if len(perlReceiverSegmentRe.FindAllStringSubmatch(maskPerlParenthesizedArgumentContents(chain), -1)) < 2 {
 				continue
 			}
 			out[dst] = receiverType
@@ -118,6 +119,34 @@ func stripPerlCodeLiteralsAndComments(content string) string {
 	return string(bytes)
 }
 
+func maskPerlParenthesizedArgumentContents(content string) string {
+	bytes := []byte(content)
+	depth := 0
+	start := -1
+	for i, ch := range bytes {
+		switch ch {
+		case '(':
+			if depth == 0 {
+				start = i + 1
+			}
+			depth++
+		case ')':
+			if depth == 0 {
+				continue
+			}
+			depth--
+			if depth == 0 && start >= 0 {
+				maskBytes(bytes, start, i)
+				start = -1
+			}
+		}
+	}
+	if depth > 0 && start >= 0 {
+		maskBytes(bytes, start, len(bytes))
+	}
+	return string(bytes)
+}
+
 func perlHashStartsComment(bytes []byte, pos int) bool {
 	if pos == 0 {
 		return true
@@ -147,6 +176,9 @@ func perlHashStartsRegexLiteral(bytes []byte, pos int) bool {
 	if strings.HasSuffix(prefix, "=~") || strings.HasSuffix(prefix, "!~") {
 		return true
 	}
+	if opener == '/' && perlRegexAtExpressionStart(prefix) {
+		return true
+	}
 	for _, operator := range []string{"qr", "tr", "s", "m", "y"} {
 		if !strings.HasSuffix(prefix, operator) {
 			continue
@@ -157,6 +189,20 @@ func perlHashStartsRegexLiteral(bytes []byte, pos int) bool {
 		}
 	}
 	return false
+}
+
+func perlRegexAtExpressionStart(prefix string) bool {
+	trimmed := strings.TrimSpace(prefix)
+	if trimmed == "" {
+		return true
+	}
+	last := trimmed[len(trimmed)-1]
+	switch last {
+	case '(', '[', '{', ',', ';', '=', '!', '~', '?', ':':
+		return true
+	default:
+		return false
+	}
 }
 
 func perlRegexOpeningDelimiter(delimiter byte) bool {

--- a/internal/sem/perl.go
+++ b/internal/sem/perl.go
@@ -73,7 +73,7 @@ func perlLocalVarTypes(block string) map[string]string {
 			// same-object assignments. This covers idioms such as
 			// `$base = $url->base(...)->base->userinfo(...)` without typing
 			// single-hop value getters like `$path = $url->path`.
-			if len(perlReceiverSegmentRe.FindAllStringSubmatch(maskPerlParenthesizedArgumentContents(chain), -1)) < 2 {
+			if !perlOuterReceiverChainOnly(chain) {
 				continue
 			}
 			out[dst] = receiverType
@@ -117,6 +117,46 @@ func stripPerlCodeLiteralsAndComments(content string) string {
 		}
 	}
 	return string(bytes)
+}
+
+func perlOuterReceiverChainOnly(chain string) bool {
+	masked := maskPerlParenthesizedArgumentContents(chain)
+	i := 0
+	segments := 0
+	for {
+		for i < len(masked) && (masked[i] == ' ' || masked[i] == '\t') {
+			i++
+		}
+		if !strings.HasPrefix(masked[i:], "->") {
+			break
+		}
+		i += 2
+		for i < len(masked) && (masked[i] == ' ' || masked[i] == '\t') {
+			i++
+		}
+		if i >= len(masked) || !perlIdentStartByte(masked[i]) {
+			return false
+		}
+		i++
+		for i < len(masked) && isASCIIIdentifierByte(masked[i]) {
+			i++
+		}
+		for i < len(masked) && (masked[i] == ' ' || masked[i] == '\t') {
+			i++
+		}
+		if i < len(masked) && masked[i] == '(' {
+			close := findMatchingStaticDelimiter(masked, i, '(', ')')
+			if close < 0 {
+				return false
+			}
+			i = close + 1
+		}
+		segments++
+	}
+	for i < len(masked) && (masked[i] == ' ' || masked[i] == '\t') {
+		i++
+	}
+	return i == len(masked) && segments >= 2
 }
 
 func maskPerlParenthesizedArgumentContents(content string) string {
@@ -253,6 +293,10 @@ func perlRegexOpeningDelimiter(delimiter byte) bool {
 
 func perlIdentByte(ch byte) bool {
 	return ch == '_' || ch >= '0' && ch <= '9' || ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z'
+}
+
+func perlIdentStartByte(ch byte) bool {
+	return ch == '_' || ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z'
 }
 
 func perlCallableForType(typeName, method string, candidates []SymbolRecord) (SymbolRecord, bool) {

--- a/internal/sem/perl.go
+++ b/internal/sem/perl.go
@@ -122,13 +122,54 @@ func perlHashStartsComment(bytes []byte, pos int) bool {
 	if pos == 0 {
 		return true
 	}
-	prev := bytes[pos-1]
-	switch prev {
-	case '\n', '\r', ' ', '\t', ';':
+	if bytes[pos-1] == '$' {
+		return false
+	}
+	if perlHashStartsRegexLiteral(bytes, pos) {
+		return false
+	}
+	return true
+}
+
+func perlHashStartsRegexLiteral(bytes []byte, pos int) bool {
+	if pos == 0 {
+		return false
+	}
+	opener := bytes[pos-1]
+	if !perlRegexOpeningDelimiter(opener) {
+		return false
+	}
+	lineStart := pos - 1
+	for lineStart > 0 && bytes[lineStart-1] != '\n' && bytes[lineStart-1] != '\r' {
+		lineStart--
+	}
+	prefix := strings.TrimRight(string(bytes[lineStart:pos-1]), " \t")
+	if strings.HasSuffix(prefix, "=~") || strings.HasSuffix(prefix, "!~") {
+		return true
+	}
+	for _, operator := range []string{"qr", "tr", "s", "m", "y"} {
+		if !strings.HasSuffix(prefix, operator) {
+			continue
+		}
+		start := len(prefix) - len(operator)
+		if start == 0 || !perlIdentByte(prefix[start-1]) {
+			return true
+		}
+	}
+	return false
+}
+
+func perlRegexOpeningDelimiter(delimiter byte) bool {
+	switch delimiter {
+	case '/', '{', '(', '[', '<':
 		return true
 	default:
 		return false
 	}
+}
+
+func perlIdentByte(ch byte) bool {
+	return ch == '_' || ch >= '0' && ch <= '9' || ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z'
 }
 
 func perlCallableForType(typeName, method string, candidates []SymbolRecord) (SymbolRecord, bool) {

--- a/internal/sem/perl.go
+++ b/internal/sem/perl.go
@@ -85,7 +85,7 @@ func perlLocalVarTypes(block string) map[string]string {
 func stripPerlCodeLiteralsAndComments(content string) string {
 	bytes := []byte(stripCodeLiteralsAndComments(content))
 	for i := 0; i < len(bytes); i++ {
-		if bytes[i] != '#' {
+		if bytes[i] != '#' || !perlHashStartsComment(bytes, i) {
 			continue
 		}
 		j := i + 1
@@ -96,6 +96,19 @@ func stripPerlCodeLiteralsAndComments(content string) string {
 		i = j
 	}
 	return string(bytes)
+}
+
+func perlHashStartsComment(bytes []byte, pos int) bool {
+	if pos == 0 {
+		return true
+	}
+	prev := bytes[pos-1]
+	switch prev {
+	case '\n', '\r', ' ', '\t', ';', '{', '}', '(', ')':
+		return true
+	default:
+		return false
+	}
 }
 
 func perlCallableForType(typeName, method string, candidates []SymbolRecord) (SymbolRecord, bool) {

--- a/internal/sem/perl.go
+++ b/internal/sem/perl.go
@@ -1,6 +1,7 @@
 package sem
 
 import (
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -9,8 +10,39 @@ import (
 var (
 	perlReceiverChainRe   = regexp.MustCompile(`(?:\$?[A-Za-z_]\w*|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)[ \t]*(?:->[ \t]*[A-Za-z_]\w*[ \t]*(?:\([^()\n]*\))?[ \t]*)+`)
 	perlReceiverSegmentRe = regexp.MustCompile(`->[ \t]*([A-Za-z_]\w*)`)
-	perlCtorAssignRe      = regexp.MustCompile(`(?m)(?:^|[^\S\n])(?:(?:my|our|state)\s+)?\$([A-Za-z_]\w*)\s*=\s*([A-Z][A-Za-z0-9_]*(?:::[A-Za-z_]\w*)*)\s*->[ \t]*new\b`)
-	perlChainAssignRe     = regexp.MustCompile(`(?m)(?:^|[^\S\n])(?:(?:my|our|state)\s+)?\$([A-Za-z_]\w*)\s*=\s*\$([A-Za-z_]\w*)([^\n;]*)`)
+	// Both assignment leads accept a keywordless target (`$x = ...`, no
+	// my/our/state) anchored to a line start or a non-newline whitespace char, so
+	// a bare reassignment at column 0 is still recognised. Capture groups are
+	// unchanged from the keyword-required form (group 1 = target, ctor group 2 =
+	// package / chain group 2 = receiver, chain group 3 = tail), so the
+	// offset-based span bookkeeping below is unaffected.
+	perlCtorAssignRe  = regexp.MustCompile(`(?m)(?:^|[^\S\n])(?:(?:my|our|state)\s+)?\$([A-Za-z_]\w*)\s*=\s*([A-Z][A-Za-z0-9_]*(?:::[A-Za-z_]\w*)*)\s*->[ \t]*new\b`)
+	perlChainAssignRe = regexp.MustCompile(`(?m)(?:^|[^\S\n])(?:(?:my|our|state)\s+)?\$([A-Za-z_]\w*)\s*=\s*\$([A-Za-z_]\w*)([^\n;]*)`)
+	// perlAssignOpRe locates every write-shaped scalar-assignment lead: `$name`
+	// (captured), optional whitespace (`\s*`, not `[ \t]*`, so a continuation-line
+	// `=` still counts), an optional compound-assignment operator chunk, then `=`.
+	// The chunk covers the multi-byte operators (`**= ||= //= &&= <<= >>=`) and the
+	// single-byte ones (`+= -= *= /= %= .= x= |= &= ^=`); the empty-chunk case is a
+	// plain `$name =`. The chunk char class deliberately excludes `<`, `>`, `!`,
+	// and `=`, so no comparison operator (`<=`, `>=`, `!=`, `<=>`, `==`) can ever
+	// form the lead. The reassignment-invalidation pass additionally filters the
+	// byte immediately after the trailing `=` to reject `==`, `=~`, and `=>`, which
+	// share the `=` byte but are not assignments.
+	perlAssignOpRe = regexp.MustCompile(`\$([A-Za-z_]\w*)\s*(?:\*\*|\|\||//|&&|<<|>>|[-+*/%.x|&^])?=`)
+	// perlListAssignRe matches a parenthesized group followed by `=` — a
+	// list-assignment LHS (`($x, $y) = fetch()`, `my ($self) = @_`). Every scalar
+	// inside the group is a write target. The byte after `=` is filtered the same
+	// way as perlAssignOpRe so `($x) == 3` and `($x) => 1` are not writes.
+	perlListAssignRe = regexp.MustCompile(`\(([^()\n]*)\)\s*=`)
+	// perlScalarVarRe finds bare scalar variable names, used to pull the write
+	// targets out of a list-assignment group.
+	perlScalarVarRe = regexp.MustCompile(`\$([A-Za-z_]\w*)`)
+	// perlForeachAliasRe / perlForAliasRe match foreach-loop aliasing, which binds
+	// the loop variable to each element of the list (a write, not a read):
+	// `foreach my $x (@list)` and `for my $x (@list)`. `for` requires the trailing
+	// `(` to distinguish the foreach alias from a C-style `for (my $i = 0; ...)`.
+	perlForeachAliasRe = regexp.MustCompile(`\bforeach\s+(?:my\s+)?\$([A-Za-z_]\w*)\b`)
+	perlForAliasRe     = regexp.MustCompile(`\bfor\s+(?:my\s+)?\$([A-Za-z_]\w*)\s*\(`)
 )
 
 // perlReceiverCalls extracts terminal `$obj->method` call sites. Perl commonly
@@ -22,6 +54,10 @@ func perlReceiverCalls(block string) []receiverCall {
 	seen := map[string]bool{}
 	for _, loc := range perlReceiverChainRe.FindAllStringIndex(stripped, -1) {
 		chain := stripped[loc[0]:loc[1]]
+		// Mask argument-paren interiors so a nested receiver chain inside a hop's
+		// arguments (`$url->base($req->url->base->clone)`) contributes no
+		// segments: only the outer `->method` hops applied directly to the head
+		// receiver are counted, and the terminal method is the last outer hop.
 		topLevelChain := maskPerlParenthesizedArgumentContents(chain)
 		segments := perlReceiverSegmentRe.FindAllStringSubmatch(topLevelChain, -1)
 		if len(segments) == 0 {
@@ -41,27 +77,125 @@ func perlReceiverCalls(block string) []receiverCall {
 			continue
 		}
 		seen[key] = true
-		out = append(out, receiverCall{Receiver: receiver, Method: method})
+		// Hops records how many `->` segments the flattened chain carried. A
+		// single-hop `$receiver->method` (Hops==1) invokes method directly on
+		// receiver; a multi-hop chain (`$url->path->to_string`, Hops>=2) reports
+		// the terminal method against the head receiver even though it runs on an
+		// intermediate object, so the type-inference consumer skips those.
+		out = append(out, receiverCall{Receiver: receiver, Method: method, Hops: len(segments)})
 	}
 	return out
 }
 
-func perlLocalVarTypes(block string) map[string]string {
+// perlLocalVarTypes infers each local's package type from `my $x = Pkg->new`
+// constructors and from fluent assignment chains on an already-typed receiver.
+// hopResolvable(hop, pkgType) reports whether a method name `hop` is defined as
+// a sub in the file of package `pkgType`; it gates the fluent rule (see below)
+// and may be nil in pure-string unit tests, which forgoes fluent typing.
+//
+// A local keeps its inferred type only while every assignment to it in the
+// block is one the typer itself modeled. If the block reassigns the local
+// through anything the typer does not understand — `$x = build_widget()`, `$x =
+// shift`, `$x = $h->{k}`, a compound assignment (`$x .= ...`, `$x ||= ...`), a
+// list assignment (`($x, $y) = ...`), foreach aliasing (`foreach my $x (...)`),
+// or a redeclaration to a different constructor package — the earlier inference
+// is stale and the local is dropped from the map, so a later single-hop
+// `$x->method` cannot be resolved against a package the value no longer holds
+// (precision-first: a missing edge beats a wrong one). The scan is deliberately
+// conservative: it invalidates on any write-shaped occurrence of the variable
+// that does not fall inside a span the ctor/chain passes consumed, and never on
+// a plain read (`foo($x)`, `$x->m`, string interpolation).
+func perlLocalVarTypes(block string, hopResolvable func(hop, pkgType string) bool) map[string]string {
 	stripped := stripPerlCodeLiteralsAndComments(block)
 	out := map[string]string{}
-	for _, m := range perlCtorAssignRe.FindAllStringSubmatch(stripped, -1) {
-		if len(m) != 3 {
+	// consumedSpans records the [start,end) byte offsets, within stripped, of
+	// every assignment the typer modeled (a ctor assignment that set a type, or a
+	// fluent chain assignment that propagated one). The reassignment scan below
+	// treats any `$name =` to a typed local that falls OUTSIDE these spans as an
+	// untracked reassignment and drops the local.
+	var consumedSpans [][2]int
+	// ctorPkgs collects the distinct constructor packages bound to each local.
+	// Two different packages (`$x = Foo->new; $x = Bar->new`) is ambiguous — both
+	// are consumed ctor spans, so the reassignment scan cannot catch it — and the
+	// local is dropped rather than left bound to whichever assignment ran last.
+	ctorPkgs := map[string]map[string]bool{}
+	recordCtor := func(dst, pkg string, start, end int) {
+		out[dst] = pkg
+		if ctorPkgs[dst] == nil {
+			ctorPkgs[dst] = map[string]bool{}
+		}
+		ctorPkgs[dst][pkg] = true
+		consumedSpans = append(consumedSpans, [2]int{start, end})
+	}
+	// Package-membership gate shared by the fluent chain-assign rule and the
+	// chained-constructor rule below. It reports whether a depth-0 hop chain on a
+	// receiver of type receiverType stays entirely inside receiverType's package:
+	// a genuine fluent chain returns `$self` so every hop is a sub in the
+	// receiver's file (`$base->base->userinfo` all live in Mojo/URL.pm), whereas
+	// getter navigation returns a different object so some hop escapes the package
+	// (`$tx->req->url`: `url` is not a Mojo::Transaction sub). At least two hops
+	// are required — a single hop is an ambiguous getter-vs-fluent — and a nil
+	// resolver (pure-string unit tests) forgoes the propagation. Only hops applied
+	// directly to the receiver count: a getter argument that is itself a method
+	// chain (`$url->path($u->host->port->scheme)`) lives inside argument parens at
+	// depth >= 1 and must not inflate the hop count. The effective chain (up to a
+	// depth-0 comma that starts a new same-line statement) must also be a PURE
+	// outer receiver chain (perlOuterReceiverChainOnly): the >=2 hops have to
+	// consume it with nothing trailing, so a mixed expression (`$url->base($req) +
+	// $other->x`) whose depth-0 scan would otherwise see two hops is rejected — it
+	// is not a fluent same-object assignment — while a trailing comma-separated
+	// statement (`$y->a->b, $z = build()`) still types the LHS from `$y->a->b`.
+	packageStableChain := func(chain, receiverType string) bool {
+		effective := perlChainBeforeStatementComma(chain)
+		if !perlOuterReceiverChainOnly(effective) {
+			return false
+		}
+		hops := perlReceiverSegmentRe.FindAllStringSubmatch(perlDepthZeroChain(effective), -1)
+		for _, hop := range hops {
+			if hopResolvable == nil || !hopResolvable(hop[1], receiverType) {
+				return false
+			}
+		}
+		return true
+	}
+	// Constructor assignments. A bare `$x = Pkg->new` (optionally `->new(...)`)
+	// types $x as Pkg. A constructor immediately chained into further hops
+	// (`$x = Pkg->new->request`) is NOT typed from the constructor alone: the
+	// returned object is whatever the trailing hops navigate to, not necessarily
+	// Pkg. It types $x as Pkg only when every depth-0 hop after `new` stays inside
+	// Pkg (the fluent-builder shape `Pkg->new->set(...)->set(...)`); if any hop
+	// escapes the package — or there is a single ambiguous hop — $x is left
+	// untyped rather than mistyped as the constructor class (the same
+	// getter-navigation mistype the fluent chain-assign path guards against).
+	for _, loc := range perlCtorAssignRe.FindAllStringSubmatchIndex(stripped, -1) {
+		dst := stripped[loc[2]:loc[3]]
+		pkg := stripped[loc[4]:loc[5]]
+		rest := perlSkipCtorNewCall(stripped[loc[1]:])
+		if strings.HasPrefix(rest, "->") {
+			chain := rest
+			if end := strings.IndexAny(chain, "\n;"); end >= 0 {
+				chain = chain[:end]
+			}
+			if packageStableChain(chain, pkg) {
+				recordCtor(dst, pkg, loc[0], loc[1])
+			}
 			continue
 		}
-		out[m[1]] = m[2]
+		recordCtor(dst, pkg, loc[0], loc[1])
 	}
+	// The stripped block is immutable across passes, so scan the chain
+	// assignments once and iterate the cached matches inside the fixed point.
+	// The index form lets each typed assignment record its span as consumed.
+	chainMatches := perlChainAssignRe.FindAllStringSubmatchIndex(stripped, -1)
 	for changed := true; changed; {
 		changed = false
-		for _, m := range perlChainAssignRe.FindAllStringSubmatch(stripped, -1) {
-			if len(m) != 4 {
+		for _, m := range chainMatches {
+			if len(m) < 8 {
 				continue
 			}
-			dst, receiver, chain := m[1], m[2], m[3]
+			dst := stripped[m[2]:m[3]]
+			receiver := stripped[m[4]:m[5]]
+			chain := stripped[m[6]:m[7]]
 			if _, exists := out[dst]; exists {
 				continue
 			}
@@ -69,18 +203,335 @@ func perlLocalVarTypes(block string) map[string]string {
 			if receiverType == "" {
 				continue
 			}
-			// Treat multi-hop chains on a typed Perl receiver as fluent
-			// same-object assignments. This covers idioms such as
-			// `$base = $url->base(...)->base->userinfo(...)` without typing
-			// single-hop value getters like `$path = $url->path`.
-			if !perlOuterReceiverChainOnly(chain) {
+			if !packageStableChain(chain, receiverType) {
 				continue
 			}
 			out[dst] = receiverType
+			// perlChainAssignRe's tail (group 3, `[^\n;]*`) greedily spans the whole
+			// physical line, so a same-line trailing statement (`$y->a->b, $z =
+			// build()`) is captured but NOT consumed by the typer. Record only up to
+			// the end of the depth-0 hop chain the typer actually consumed, and punch
+			// out each hop's argument-paren interior, so both the trailing `$z =`
+			// write and a reassignment of another local nested inside a hop's args
+			// (`$u->set($w = get())`) stay visible to the invalidation scan.
+			hopEnd, argInteriors := perlHopChainEnd(chain)
+			consumedSpans = append(consumedSpans, perlChainConsumedSpans(m[0], m[6], hopEnd, argInteriors)...)
 			changed = true
 		}
 	}
+	// Drop locals bound to more than one constructor package: the value's type
+	// is ambiguous, and both assignments are consumed ctor spans so the
+	// reassignment scan below would otherwise leave the stale binding in place.
+	for dst, pkgs := range ctorPkgs {
+		if len(pkgs) > 1 {
+			delete(out, dst)
+		}
+	}
+	// Invalidate any typed local the block also reassigns through a form the typer
+	// did not model. The rule is not a list of assignment spellings but a single
+	// question — does the variable occur in a write-shaped position outside the
+	// spans the ctor/chain passes already consumed? Three write shapes are
+	// recognised: (a) a generalized scalar assignment `$name <op>= ...` (plain or
+	// compound), (b) a list-assignment LHS `(... $name ...) = ...`, and (c)
+	// foreach aliasing `foreach my $name (...)`. Any of these, outside a consumed
+	// span, drops the local. Reads never do: `$name->m`, `foo($name)`, and string
+	// interpolation (already masked to spaces by stripCodeLiteralsAndComments)
+	// carry no `= ` after the name and no enclosing `(...) =`, so they are ignored.
+	// Over-invalidation is preferred to a wrong edge (precision-first).
+	if len(out) > 0 {
+		untracked := map[string]bool{}
+		// markWrite drops a typed local when the write occurrence at [start,end) is
+		// not inside a consumed ctor/chain span (which would be the assignment that
+		// established the type, not an untracked reassignment).
+		markWrite := func(name string, start, end int) {
+			if _, typed := out[name]; !typed {
+				return
+			}
+			if perlSpansContain(consumedSpans, start, end) {
+				return
+			}
+			untracked[name] = true
+		}
+		// afterByteRejects reports whether the byte after a trailing `=` at index
+		// end makes the match a non-assignment (`==`, `=~`, `=>`).
+		afterByteRejects := func(end int) bool {
+			if end < len(stripped) {
+				switch stripped[end] {
+				case '=', '~', '>':
+					return true
+				}
+			}
+			return false
+		}
+		// (a) Generalized scalar assignment: `$name` + optional operator chunk + `=`.
+		for _, m := range perlAssignOpRe.FindAllStringSubmatchIndex(stripped, -1) {
+			if afterByteRejects(m[1]) {
+				continue
+			}
+			markWrite(stripped[m[2]:m[3]], m[0], m[1])
+		}
+		// (b) List-assignment LHS: every scalar inside a `(...) =` group is written.
+		for _, m := range perlListAssignRe.FindAllStringSubmatchIndex(stripped, -1) {
+			if afterByteRejects(m[1]) {
+				continue
+			}
+			group := stripped[m[2]:m[3]]
+			for _, v := range perlScalarVarRe.FindAllStringSubmatchIndex(group, -1) {
+				markWrite(group[v[2]:v[3]], m[2]+v[0], m[2]+v[1])
+			}
+		}
+		// (c) foreach aliasing binds the loop variable to each element (a write).
+		for _, re := range []*regexp.Regexp{perlForeachAliasRe, perlForAliasRe} {
+			for _, m := range re.FindAllStringSubmatchIndex(stripped, -1) {
+				markWrite(stripped[m[2]:m[3]], m[2], m[3])
+			}
+		}
+		for name := range untracked {
+			delete(out, name)
+		}
+	}
 	return out
+}
+
+// perlSpansContain reports whether [start,end) lies wholly inside one of the
+// consumed assignment spans.
+func perlSpansContain(spans [][2]int, start, end int) bool {
+	for _, s := range spans {
+		if start >= s[0] && end <= s[1] {
+			return true
+		}
+	}
+	return false
+}
+
+// perlSkipCtorNewCall trims leading whitespace and an optional balanced argument
+// list of a constructor call (`->new` matched, then `( ... )`) from the text
+// after a perlCtorAssignRe match, so the caller can test whether the constructor
+// is immediately chained into further hops. `Pkg->new(cfg)->request` and
+// `Pkg->new ->request` both leave a `->request` remainder; `Pkg->new(cfg);`
+// leaves `;`.
+func perlSkipCtorNewCall(rest string) string {
+	rest = strings.TrimLeft(rest, " \t")
+	if strings.HasPrefix(rest, "(") {
+		depth := 0
+		for i := 0; i < len(rest); i++ {
+			switch rest[i] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+				if depth == 0 {
+					return strings.TrimLeft(rest[i+1:], " \t")
+				}
+			}
+		}
+		return "" // unbalanced: no discernible trailing chain
+	}
+	return rest
+}
+
+// perlDepthZeroChain drops the spans nested inside argument parentheses from a
+// captured fluent chain, keeping only the characters at paren depth 0 (the
+// `->method` hops applied directly to the receiver). Counting hops on the
+// result keeps a single-hop getter whose argument is itself a method chain
+// (`->path($u->host->port->scheme)`) from being mistaken for a multi-hop fluent
+// assignment and mistyped as the receiver's package.
+// perlHopChainEnd returns the byte offset within a chain-assign tail (group 3 of
+// perlChainAssignRe: everything after `$receiver` up to the next `;`/newline) at
+// which the contiguous depth-0 `->method(...)` hop chain ends, together with the
+// chain-relative interior ranges of each hop's argument parens. The tail is
+// greedy, so any same-line text past the hops (`->a->b, $z = build()`) is
+// captured but not part of the chain the typer consumed; recording the consumed
+// span only up to this offset keeps that trailing text visible to the
+// write-shaped invalidation scan. The argument-paren interiors are reported so
+// the caller can exclude them from the consumed span too: a write to a DIFFERENT
+// local nested inside a hop's arguments (`$u->set($w = get())`) was never the
+// typer's own write and must stay visible to that scan. A hop is `->`, an
+// identifier, then an optional balanced argument list; whitespace between tokens
+// is allowed.
+func perlHopChainEnd(chain string) (int, [][2]int) {
+	isIdentStart := func(b byte) bool {
+		return b == '_' || (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z')
+	}
+	isIdentChar := func(b byte) bool {
+		return isIdentStart(b) || (b >= '0' && b <= '9')
+	}
+	skipSpace := func(i int) int {
+		for i < len(chain) && (chain[i] == ' ' || chain[i] == '\t') {
+			i++
+		}
+		return i
+	}
+	end := 0
+	var argInteriors [][2]int
+	for i := 0; ; {
+		j := skipSpace(i)
+		if j+1 >= len(chain) || chain[j] != '-' || chain[j+1] != '>' {
+			break
+		}
+		j = skipSpace(j + 2)
+		if j >= len(chain) || !isIdentStart(chain[j]) {
+			break
+		}
+		for j < len(chain) && isIdentChar(chain[j]) {
+			j++
+		}
+		// Optional balanced argument list applied directly to this hop.
+		if openIdx := skipSpace(j); openIdx < len(chain) && chain[openIdx] == '(' {
+			depth, closed, k := 0, false, openIdx
+			for ; k < len(chain); k++ {
+				switch chain[k] {
+				case '(':
+					depth++
+				case ')':
+					depth--
+					if depth == 0 {
+						k++
+						closed = true
+					}
+				}
+				if closed {
+					break
+				}
+			}
+			if !closed {
+				break // unbalanced parens: do not consume past them
+			}
+			// k is the index just past the matching ')'; the paren interior is
+			// (openIdx, k-1) — the bytes strictly between the outer parens.
+			if k-1 > openIdx+1 {
+				argInteriors = append(argInteriors, [2]int{openIdx + 1, k - 1})
+			}
+			j = k
+		}
+		end = j
+		i = j
+	}
+	return end, argInteriors
+}
+
+// perlChainConsumedSpans returns the structural byte spans of a fluent
+// chain-assign that the typer consumed, with each hop argument-paren interior
+// PUNCHED OUT. The consumed protection exists so the typer's own `$dst =` lead
+// is not read as a self-invalidating reassignment; a write to a different local
+// nested inside a hop's arguments was never the typer's write, so excluding the
+// arg interiors keeps those reassignments visible to the invalidation scan.
+// spanStart is the match start (m[0]), chainBase is the chain tail's offset
+// (m[6]), hopEnd is perlHopChainEnd's end offset within the chain, and
+// argInteriors are the chain-relative interior ranges perlHopChainEnd emitted.
+func perlChainConsumedSpans(spanStart, chainBase, hopEnd int, argInteriors [][2]int) [][2]int {
+	spanEnd := chainBase + hopEnd
+	var spans [][2]int
+	cursor := spanStart
+	for _, ai := range argInteriors {
+		start := chainBase + ai[0]
+		if start > cursor {
+			spans = append(spans, [2]int{cursor, start})
+		}
+		if end := chainBase + ai[1]; end > cursor {
+			cursor = end
+		}
+	}
+	if cursor < spanEnd {
+		spans = append(spans, [2]int{cursor, spanEnd})
+	}
+	return spans
+}
+
+func perlDepthZeroChain(chain string) string {
+	var b strings.Builder
+	depth := 0
+	for i := 0; i < len(chain); i++ {
+		switch chain[i] {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		default:
+			if depth == 0 {
+				b.WriteByte(chain[i])
+			}
+		}
+	}
+	return b.String()
+}
+
+// perlChainBeforeStatementComma truncates a captured chain-assign tail at the
+// first comma that sits at bracket depth 0. Perl's `=` binds tighter than the
+// comma operator, so `$x = $y->a->b, $z = build()` assigns `$y->a->b` to $x and
+// then evaluates `$z = build()` as a separate comma-expression: only the text
+// before that comma is $x's fluent value. Commas nested inside a hop's argument
+// list (`->base($a, $b)`) are at depth >= 1 and are not statement separators.
+func perlChainBeforeStatementComma(chain string) string {
+	depth := 0
+	for i := 0; i < len(chain); i++ {
+		switch chain[i] {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				return chain[:i]
+			}
+		}
+	}
+	return chain
+}
+
+func perlCallableForType(typeName, method string, candidates []SymbolRecord) (SymbolRecord, bool) {
+	var matches []SymbolRecord
+	for _, candidate := range candidates {
+		if candidate.Language != "Perl" || candidate.Name != method {
+			continue
+		}
+		if candidate.Kind != "function" && candidate.Kind != "method" {
+			continue
+		}
+		if perlSymbolFileMatchesType(candidate.FilePath, typeName) {
+			matches = append(matches, candidate)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], true
+	}
+	return SymbolRecord{}, false
+}
+
+func perlSymbolFileMatchesType(filePath, typeName string) bool {
+	filePath = filepath.ToSlash(filePath)
+	typeName = strings.TrimSpace(typeName)
+	typePath := strings.ReplaceAll(typeName, "::", "/")
+	if typePath == "" {
+		return false
+	}
+	// Require a path-component boundary: `Mojo::URL` (-> Mojo/URL) matches
+	// lib/Mojo/URL.pm but not a same-basename file at another depth. Without
+	// the leading "/" a bare `Foo` would loosely match any *Foo.pm (e.g.
+	// XFoo.pm), so anchor on a directory separator or the whole path.
+	if filePath != typePath+".pm" && !strings.HasSuffix(filePath, "/"+typePath+".pm") {
+		return false
+	}
+	// A bare type (no `::`) names a top-level package, whose file sits directly
+	// under a source root (lib/Foo.pm, Foo.pm) — never under a namespace
+	// directory. lib/Deep/Foo.pm is package Deep::Foo, not Foo: the Perl sub
+	// record carries no package (statement-form `package Name;` leaves subs
+	// unqualified), so an uppercase parent directory is the signal that the
+	// file belongs to a deeper namespace and must not match a bare receiver
+	// type. Perl namespace components are conventionally capitalised while
+	// source roots (lib, blib, t, script) are lower-case.
+	if !strings.Contains(typeName, "::") {
+		if parent := path.Base(path.Dir(filePath)); parent != "." && parent != "/" && parent != "" {
+			if c := parent[0]; c >= 'A' && c <= 'Z' {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func stripPerlCodeLiteralsAndComments(content string) string {
@@ -297,38 +748,4 @@ func perlIdentByte(ch byte) bool {
 
 func perlIdentStartByte(ch byte) bool {
 	return ch == '_' || ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z'
-}
-
-func perlCallableForType(typeName, method string, candidates []SymbolRecord) (SymbolRecord, bool) {
-	var matches []SymbolRecord
-	for _, candidate := range candidates {
-		if candidate.Language != "Perl" || candidate.Name != method {
-			continue
-		}
-		if candidate.Kind != "function" && candidate.Kind != "method" {
-			continue
-		}
-		if perlSymbolFileMatchesType(candidate.FilePath, typeName) {
-			matches = append(matches, candidate)
-		}
-	}
-	if len(matches) == 1 {
-		return matches[0], true
-	}
-	return SymbolRecord{}, false
-}
-
-func perlSymbolFileMatchesType(filePath, typeName string) bool {
-	filePath = filepath.ToSlash(filePath)
-	typePath := strings.ReplaceAll(strings.TrimSpace(typeName), "::", "/")
-	if typePath == "" {
-		return false
-	}
-	if strings.HasSuffix(filePath, typePath+".pm") {
-		return true
-	}
-	if strings.Contains(typeName, "::") {
-		return false
-	}
-	return filepath.Base(filePath) == typeName+".pm"
 }

--- a/internal/sem/perl.go
+++ b/internal/sem/perl.go
@@ -154,10 +154,47 @@ func perlHashStartsComment(bytes []byte, pos int) bool {
 	if bytes[pos-1] == '$' {
 		return false
 	}
+	if perlHashInHashDelimitedRegex(bytes, pos) {
+		return false
+	}
 	if perlHashStartsRegexLiteral(bytes, pos) {
 		return false
 	}
 	return true
+}
+
+func perlHashInHashDelimitedRegex(bytes []byte, pos int) bool {
+	lineStart := pos
+	for lineStart > 0 && bytes[lineStart-1] != '\n' && bytes[lineStart-1] != '\r' {
+		lineStart--
+	}
+	line := string(bytes[lineStart : pos+1])
+	for i := 0; i < len(line); i++ {
+		for _, operator := range []string{"qr", "tr", "s", "m", "y"} {
+			if !strings.HasPrefix(line[i:], operator+"#") {
+				continue
+			}
+			if i > 0 && perlIdentByte(line[i-1]) {
+				continue
+			}
+			segment := line[i:]
+			if semi := strings.IndexByte(segment, ';'); semi >= 0 && i+semi < pos-lineStart {
+				continue
+			}
+			hashes := strings.Count(segment, "#")
+			if hashes == 0 {
+				continue
+			}
+			limit := 2
+			if operator == "s" || operator == "tr" || operator == "y" {
+				limit = 3
+			}
+			if hashes <= limit {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func perlHashStartsRegexLiteral(bytes []byte, pos int) bool {

--- a/internal/sem/perl.go
+++ b/internal/sem/perl.go
@@ -1,6 +1,7 @@
 package sem
 
 import (
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -8,6 +9,8 @@ import (
 var (
 	perlReceiverChainRe   = regexp.MustCompile(`(?:\$?[A-Za-z_]\w*|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)[ \t]*(?:->[ \t]*[A-Za-z_]\w*[ \t]*(?:\([^()\n]*\))?[ \t]*)+`)
 	perlReceiverSegmentRe = regexp.MustCompile(`->[ \t]*([A-Za-z_]\w*)`)
+	perlCtorAssignRe      = regexp.MustCompile(`\b(?:my|our|state)?\s*\$([A-Za-z_]\w*)\s*=\s*([A-Z][A-Za-z0-9_]*(?:::[A-Za-z_]\w*)*)\s*->[ \t]*new\b`)
+	perlChainAssignRe     = regexp.MustCompile(`(?m)\b(?:my|our|state)?\s*\$([A-Za-z_]\w*)\s*=\s*\$([A-Za-z_]\w*)([^\n;]*)`)
 )
 
 // perlReceiverCalls extracts terminal `$obj->method` call sites. Perl commonly
@@ -40,4 +43,75 @@ func perlReceiverCalls(block string) []receiverCall {
 		out = append(out, receiverCall{Receiver: receiver, Method: method})
 	}
 	return out
+}
+
+func perlLocalVarTypes(block string) map[string]string {
+	stripped := stripCodeLiteralsAndComments(block)
+	out := map[string]string{}
+	for _, m := range perlCtorAssignRe.FindAllStringSubmatch(stripped, -1) {
+		if len(m) != 3 {
+			continue
+		}
+		out[m[1]] = m[2]
+	}
+	for changed := true; changed; {
+		changed = false
+		for _, m := range perlChainAssignRe.FindAllStringSubmatch(stripped, -1) {
+			if len(m) != 4 {
+				continue
+			}
+			dst, receiver, chain := m[1], m[2], m[3]
+			if _, exists := out[dst]; exists {
+				continue
+			}
+			receiverType := out[receiver]
+			if receiverType == "" {
+				continue
+			}
+			// Treat multi-hop chains on a typed Perl receiver as fluent
+			// same-object assignments. This covers idioms such as
+			// `$base = $url->base(...)->base->userinfo(...)` without typing
+			// single-hop value getters like `$path = $url->path`.
+			if len(perlReceiverSegmentRe.FindAllStringSubmatch(chain, -1)) < 2 {
+				continue
+			}
+			out[dst] = receiverType
+			changed = true
+		}
+	}
+	return out
+}
+
+func perlCallableForType(typeName, method string, candidates []SymbolRecord) (SymbolRecord, bool) {
+	var matches []SymbolRecord
+	for _, candidate := range candidates {
+		if candidate.Language != "Perl" || candidate.Name != method {
+			continue
+		}
+		if candidate.Kind != "function" && candidate.Kind != "method" {
+			continue
+		}
+		if perlSymbolFileMatchesType(candidate.FilePath, typeName) {
+			matches = append(matches, candidate)
+		}
+	}
+	if len(matches) == 1 {
+		return matches[0], true
+	}
+	return SymbolRecord{}, false
+}
+
+func perlSymbolFileMatchesType(filePath, typeName string) bool {
+	filePath = filepath.ToSlash(filePath)
+	typePath := strings.ReplaceAll(strings.TrimSpace(typeName), "::", "/")
+	if typePath == "" {
+		return false
+	}
+	if strings.HasSuffix(filePath, typePath+".pm") {
+		return true
+	}
+	if strings.Contains(typeName, "::") {
+		return false
+	}
+	return filepath.Base(filePath) == typeName+".pm"
 }

--- a/internal/sem/perl.go
+++ b/internal/sem/perl.go
@@ -124,7 +124,7 @@ func perlHashStartsComment(bytes []byte, pos int) bool {
 	}
 	prev := bytes[pos-1]
 	switch prev {
-	case '\n', '\r', ' ', '\t', ';', '{', '}', '(', ')':
+	case '\n', '\r', ' ', '\t', ';':
 		return true
 	default:
 		return false

--- a/internal/sem/perl.go
+++ b/internal/sem/perl.go
@@ -83,17 +83,37 @@ func perlLocalVarTypes(block string) map[string]string {
 }
 
 func stripPerlCodeLiteralsAndComments(content string) string {
-	bytes := []byte(stripCodeLiteralsAndComments(content))
+	bytes := []byte(content)
 	for i := 0; i < len(bytes); i++ {
-		if bytes[i] != '#' || !perlHashStartsComment(bytes, i) {
-			continue
+		switch bytes[i] {
+		case '"', '\'', '`':
+			quote := bytes[i]
+			for j := i + 1; j < len(bytes); j++ {
+				if bytes[j] == '\n' || bytes[j] == '\r' {
+					i = j
+					break
+				}
+				if bytes[j] == '\\' {
+					j++
+					continue
+				}
+				if bytes[j] == quote {
+					maskBytes(bytes, i, j+1)
+					i = j
+					break
+				}
+			}
+		case '#':
+			if !perlHashStartsComment(bytes, i) {
+				continue
+			}
+			j := i + 1
+			for j < len(bytes) && bytes[j] != '\n' && bytes[j] != '\r' {
+				j++
+			}
+			maskBytes(bytes, i, j)
+			i = j
 		}
-		j := i + 1
-		for j < len(bytes) && bytes[j] != '\n' && bytes[j] != '\r' {
-			j++
-		}
-		maskBytes(bytes, i, j)
-		i = j
 	}
 	return string(bytes)
 }

--- a/internal/sem/perl.go
+++ b/internal/sem/perl.go
@@ -9,8 +9,8 @@ import (
 var (
 	perlReceiverChainRe   = regexp.MustCompile(`(?:\$?[A-Za-z_]\w*|[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)[ \t]*(?:->[ \t]*[A-Za-z_]\w*[ \t]*(?:\([^()\n]*\))?[ \t]*)+`)
 	perlReceiverSegmentRe = regexp.MustCompile(`->[ \t]*([A-Za-z_]\w*)`)
-	perlCtorAssignRe      = regexp.MustCompile(`\b(?:my|our|state)?\s*\$([A-Za-z_]\w*)\s*=\s*([A-Z][A-Za-z0-9_]*(?:::[A-Za-z_]\w*)*)\s*->[ \t]*new\b`)
-	perlChainAssignRe     = regexp.MustCompile(`(?m)\b(?:my|our|state)?\s*\$([A-Za-z_]\w*)\s*=\s*\$([A-Za-z_]\w*)([^\n;]*)`)
+	perlCtorAssignRe      = regexp.MustCompile(`(?m)(?:^|[^\S\n])(?:(?:my|our|state)\s+)?\$([A-Za-z_]\w*)\s*=\s*([A-Z][A-Za-z0-9_]*(?:::[A-Za-z_]\w*)*)\s*->[ \t]*new\b`)
+	perlChainAssignRe     = regexp.MustCompile(`(?m)(?:^|[^\S\n])(?:(?:my|our|state)\s+)?\$([A-Za-z_]\w*)\s*=\s*\$([A-Za-z_]\w*)([^\n;]*)`)
 )
 
 // perlReceiverCalls extracts terminal `$obj->method` call sites. Perl commonly

--- a/internal/sem/perl.go
+++ b/internal/sem/perl.go
@@ -17,7 +17,7 @@ var (
 // omits parentheses for method calls (`$self->stash`, `$base->protocol`), so the
 // generic receiver scanner only sees a subset of real call sites.
 func perlReceiverCalls(block string) []receiverCall {
-	stripped := stripCodeLiteralsAndComments(block)
+	stripped := stripPerlCodeLiteralsAndComments(block)
 	var out []receiverCall
 	seen := map[string]bool{}
 	for _, loc := range perlReceiverChainRe.FindAllStringIndex(stripped, -1) {
@@ -46,7 +46,7 @@ func perlReceiverCalls(block string) []receiverCall {
 }
 
 func perlLocalVarTypes(block string) map[string]string {
-	stripped := stripCodeLiteralsAndComments(block)
+	stripped := stripPerlCodeLiteralsAndComments(block)
 	out := map[string]string{}
 	for _, m := range perlCtorAssignRe.FindAllStringSubmatch(stripped, -1) {
 		if len(m) != 3 {
@@ -80,6 +80,22 @@ func perlLocalVarTypes(block string) map[string]string {
 		}
 	}
 	return out
+}
+
+func stripPerlCodeLiteralsAndComments(content string) string {
+	bytes := []byte(stripCodeLiteralsAndComments(content))
+	for i := 0; i < len(bytes); i++ {
+		if bytes[i] != '#' {
+			continue
+		}
+		j := i + 1
+		for j < len(bytes) && bytes[j] != '\n' && bytes[j] != '\r' {
+			j++
+		}
+		maskBytes(bytes, i, j)
+		i = j
+	}
+	return string(bytes)
 }
 
 func perlCallableForType(typeName, method string, candidates []SymbolRecord) (SymbolRecord, bool) {

--- a/internal/sem/perl_test.go
+++ b/internal/sem/perl_test.go
@@ -1,0 +1,310 @@
+package sem
+
+import "testing"
+
+// perlLocalVarTypes types a local as its receiver's package only for a genuine
+// multi-hop fluent chain. A single-hop getter whose argument is itself a method
+// chain (`$u->path($u->host->port->scheme)`) must not be counted as multi-hop:
+// the nested `->` hops live inside argument parens, at paren depth >= 1.
+func TestPerlLocalVarTypesIgnoresParenNestedHops(t *testing.T) {
+	// Every hop resolves within its package, isolating this test to the
+	// paren-nesting rule (the package-membership gate is exercised separately).
+	allResolvable := func(hop, pkgType string) bool { return true }
+	single := perlLocalVarTypes("my $u = Mojo::URL->new;\n"+
+		"my $p = $u->path($u->host->port->scheme);\n", allResolvable)
+	if single["u"] != "Mojo::URL" {
+		t.Fatalf("receiver $u should be typed Mojo::URL, got %#v", single)
+	}
+	if got, ok := single["p"]; ok {
+		t.Fatalf("single-hop getter $p should not be typed, got %q", got)
+	}
+
+	// A real multi-hop fluent chain (depth-0 hops base->base->userinfo) still
+	// types the assignment target, even with a method chain as an argument.
+	fluent := perlLocalVarTypes("my $url = Mojo::URL->new;\n"+
+		"my $base = $url->base($req->url->base->clone)->base->userinfo(undef);\n", allResolvable)
+	if fluent["base"] != "Mojo::URL" {
+		t.Fatalf("fluent chain $base should be typed Mojo::URL, got %#v", fluent)
+	}
+}
+
+// The package-membership gate distinguishes a fluent same-object chain from
+// multi-hop getter navigation. `$tx->req->url` has two depth-0 hops (so the
+// count rule alone would type it), but `url` is not a sub of the receiver's
+// package Mojo::Transaction — it navigates to a different object — so dst must
+// NOT inherit the receiver's type. A genuine fluent chain whose every hop lives
+// in the receiver package is still typed.
+func TestPerlLocalVarTypesGatesFluentOnPackageMembership(t *testing.T) {
+	// `req` is a sub of Mojo::Transaction; `url` is not (it belongs to a
+	// different package the chain navigates into).
+	hopResolvable := func(hop, pkgType string) bool {
+		switch {
+		case pkgType == "Mojo::Transaction" && hop == "req":
+			return true
+		case pkgType == "Mojo::URL":
+			return true
+		default:
+			return false
+		}
+	}
+	navigation := perlLocalVarTypes("my $tx = Mojo::Transaction->new;\n"+
+		"my $url = $tx->req->url;\n", hopResolvable)
+	if got, ok := navigation["url"]; ok {
+		t.Fatalf("getter-navigation $url must not be typed as the receiver, got %q", got)
+	}
+	if navigation["tx"] != "Mojo::Transaction" {
+		t.Fatalf("receiver $tx should be typed Mojo::Transaction, got %#v", navigation)
+	}
+
+	fluent := perlLocalVarTypes("my $u = Mojo::URL->new;\n"+
+		"my $base = $u->base->userinfo;\n", hopResolvable)
+	if fluent["base"] != "Mojo::URL" {
+		t.Fatalf("in-package fluent chain $base should be typed Mojo::URL, got %#v", fluent)
+	}
+}
+
+// A constructor immediately chained into a type-escaping hop
+// (`Session->new->request`) must NOT type the local as the constructor class:
+// `->request` returns a different object, so typing $x as Session would route a
+// later `$x->send` to the wrong package. A single trailing hop is ambiguous, so
+// the gate leaves $x untyped; a genuine multi-hop fluent-builder chain whose
+// every hop stays in the constructor package still types the target.
+func TestPerlLocalVarTypesGatesChainedConstructor(t *testing.T) {
+	allResolvable := func(hop, pkgType string) bool { return true }
+
+	// Chained constructor with a single trailing hop: below the fluent threshold,
+	// so untyped regardless of whether the hop resolves.
+	single := perlLocalVarTypes("my $x = Session->new->request;\n", allResolvable)
+	if typ, ok := single["x"]; ok {
+		t.Fatalf("chained constructor $x must not be typed from the constructor alone, got %q", typ)
+	}
+
+	// A bare constructor (optionally with an empty argument list) still types the
+	// local.
+	bare := perlLocalVarTypes("my $u = Mojo::URL->new;\nmy $v = Mojo::URL->new();\n", allResolvable)
+	if bare["u"] != "Mojo::URL" || bare["v"] != "Mojo::URL" {
+		t.Fatalf("bare constructor should type the local Mojo::URL, got %#v", bare)
+	}
+
+	// A multi-hop fluent-builder chain whose every hop stays in the constructor
+	// package still types the target.
+	fluent := perlLocalVarTypes("my $b = Mojo::URL->new->scheme->host;\n", allResolvable)
+	if fluent["b"] != "Mojo::URL" {
+		t.Fatalf("fluent-builder constructor chain $b should be typed Mojo::URL, got %#v", fluent)
+	}
+
+	// If a hop after `new` escapes the constructor package, the target stays
+	// untyped even with two hops.
+	escapes := func(hop, pkgType string) bool { return hop != "request" }
+	nav := perlLocalVarTypes("my $y = Session->new->clone->request;\n", escapes)
+	if typ, ok := nav["y"]; ok {
+		t.Fatalf("constructor chain with an escaping hop must not type $y, got %q", typ)
+	}
+}
+
+// A constructor-typed local that is later reassigned through anything the typer
+// does not model (`$x = build_widget()`) must lose its inferred type, so a
+// following single-hop `$x->go` cannot be resolved against the stale
+// constructor package. Over-invalidation is preferred to a wrong edge.
+func TestPerlLocalVarTypesInvalidatesOnUntrackedReassignment(t *testing.T) {
+	allResolvable := func(hop, pkgType string) bool { return true }
+
+	// The core repro: ctor type Foo, then an opaque reassignment, then a call.
+	reassigned := perlLocalVarTypes("my $x = Foo->new;\n$x = build_widget();\n$x->go;\n", allResolvable)
+	if typ, ok := reassigned["x"]; ok {
+		t.Fatalf("reassigned $x must lose its inferred type, got %q", typ)
+	}
+
+	// Other opaque reassignment shapes invalidate the same way.
+	for _, rhs := range []string{"shift", "$h->{k}", "$other", "some::func()"} {
+		got := perlLocalVarTypes("my $x = Foo->new;\n$x = "+rhs+";\n$x->go;\n", allResolvable)
+		if typ, ok := got["x"]; ok {
+			t.Fatalf("reassignment `$x = %s` must invalidate $x, got %q", rhs, typ)
+		}
+	}
+
+	// Compound assignment operators are writes and must invalidate too — none of
+	// these has a bare scalar sigil immediately before the `=`, so the old
+	// scalar-only scan missed them and left the stale constructor type alive.
+	// (`//=` is intentionally omitted: stripCodeLiteralsAndComments masks Perl's
+	// `//` as a C++ line comment before this scan ever runs — a pre-existing strip
+	// limitation, not this pass's concern.)
+	for _, stmt := range []string{"$x .= q(z)", "$x ||= Bar->new", "$x += 1", "$x x= 2", "$x **= 2", "$x <<= 1"} {
+		got := perlLocalVarTypes("my $x = Foo->new;\n"+stmt+";\n$x->go;\n", allResolvable)
+		if typ, ok := got["x"]; ok {
+			t.Fatalf("compound reassignment `%s` must invalidate $x, got %q", stmt, typ)
+		}
+	}
+
+	// A list-assignment LHS writes every scalar in the group, so a
+	// constructor-typed local reassigned as `($x, $y) = fetch()` is dropped even
+	// though $x is followed by `,` (not `=`) and never matched the scalar scan.
+	list := perlLocalVarTypes("my $x = Foo->new;\n($x, $y) = fetch();\n$x->go;\n", allResolvable)
+	if typ, ok := list["x"]; ok {
+		t.Fatalf("list-assignment `($x, $y) = fetch()` must invalidate $x, got %q", typ)
+	}
+	// The typed local can be anywhere in the group, not just first.
+	listSecond := perlLocalVarTypes("my $x = Foo->new;\n($y, $x) = fetch();\n$x->go;\n", allResolvable)
+	if typ, ok := listSecond["x"]; ok {
+		t.Fatalf("list-assignment `($y, $x) = fetch()` must invalidate $x, got %q", typ)
+	}
+
+	// foreach aliasing rebinds the loop variable to each element (a write), so a
+	// prior constructor type is stale inside and after the loop.
+	for _, loop := range []string{"foreach my $x (@list) { }", "foreach $x (@list) { }", "for my $x (@list) { }", "for $x (@list) { }"} {
+		got := perlLocalVarTypes("my $x = Foo->new;\n"+loop+"\n$x->go;\n", allResolvable)
+		if typ, ok := got["x"]; ok {
+			t.Fatalf("foreach aliasing `%s` must invalidate $x, got %q", loop, typ)
+		}
+	}
+
+	// A continuation-line `=` is still a reassignment: the scan must cross
+	// the newline (`\s*`, not `[ \t]*`) or the stale ctor type survives.
+	continuation := perlLocalVarTypes("my $x = Foo->new;\n$x\n    = Bar->new;\n$x->go;\n", allResolvable)
+	if typ, ok := continuation["x"]; ok {
+		t.Fatalf("continuation-line reassignment must invalidate $x, got %q", typ)
+	}
+
+	// Two constructors of different packages is ambiguous (redeclaration keeps
+	// both as consumed ctor spans), so the local is dropped.
+	ambiguous := perlLocalVarTypes("my $x = Foo->new;\nmy $x = Bar->new;\n$x->go;\n", allResolvable)
+	if typ, ok := ambiguous["x"]; ok {
+		t.Fatalf("two different ctor packages must drop $x, got %q", typ)
+	}
+
+	// Re-declaring the same package is not ambiguous: both `my $x = Foo->new`
+	// are consumed ctor spans, so the local stays typed Foo.
+	sameCtor := perlLocalVarTypes("my $x = Foo->new;\nmy $x = Foo->new;\n$x->go;\n", allResolvable)
+	if sameCtor["x"] != "Foo" {
+		t.Fatalf("repeated same-package ctor should keep $x typed Foo, got %#v", sameCtor)
+	}
+
+	// A never-reassigned constructor local stays typed (positive control that
+	// the invalidation pass does not over-fire on the ctor assignment itself).
+	stable := perlLocalVarTypes("my $x = Foo->new;\n$x->go;\n", allResolvable)
+	if stable["x"] != "Foo" {
+		t.Fatalf("un-reassigned $x should stay typed Foo, got %#v", stable)
+	}
+}
+
+// A fluent chain-assign's consumed span must end at its hop chain, not at the end
+// of the physical line: perlChainAssignRe's greedy `[^\n;]*` tail also captures a
+// same-line trailing statement (comma operator or `if $z = ...` modifier), and if
+// that whole span were marked consumed the trailing `$z =` write would be hidden
+// from the invalidation scan, leaving $z bound to a stale ctor package a later
+// `$z->method` would resolve against.
+func TestPerlLocalVarTypesNarrowsChainAssignConsumedSpan(t *testing.T) {
+	hopResolvable := func(hop, pkgType string) bool {
+		return (hop == "a" || hop == "b") && pkgType == "Bar"
+	}
+
+	// The repro: `$z = build()` rides the same line as the chain-assign to $x via
+	// the comma operator. $x types Bar from the consumed hop chain, while $z must
+	// be dropped (its Foo ctor type is stale after the trailing reassignment).
+	got := perlLocalVarTypes("my $z = Foo->new;\nmy $y = Bar->new;\n"+
+		"my $x = $y->a->b, $z = build();\n$z->go;\n", hopResolvable)
+	if got["x"] != "Bar" {
+		t.Fatalf("chain-assigned $x should type Bar, got %#v", got)
+	}
+	if got["y"] != "Bar" {
+		t.Fatalf("$y should type Bar, got %#v", got)
+	}
+	if typ, ok := got["z"]; ok {
+		t.Fatalf("same-line trailing `$z = build()` must invalidate $z, got %q", typ)
+	}
+
+	// The idiomatic statement-modifier variant (`... if $z = build()`) is the same
+	// shape: the reassignment sits on the chain-assign line with no intervening `;`.
+	modifier := perlLocalVarTypes("my $z = Foo->new;\nmy $y = Bar->new;\n"+
+		"my $x = $y->a->b if $z = build();\n$z->go;\n", hopResolvable)
+	if typ, ok := modifier["z"]; ok {
+		t.Fatalf("statement-modifier `if $z = build()` must invalidate $z, got %q", typ)
+	}
+
+	// Positive control: with no trailing same-line write, the chain-assign still
+	// types $x Bar — narrowing the consumed span must not break fluent typing.
+	fluent := perlLocalVarTypes("my $y = Bar->new;\nmy $x = $y->a->b;\n$x->go;\n", hopResolvable)
+	if fluent["x"] != "Bar" {
+		t.Fatalf("fluent chain-assign should keep $x typed Bar, got %#v", fluent)
+	}
+}
+
+// A reassignment of a DIFFERENT already-typed local nested inside a fluent
+// chain's method-call argument parens (`$u->set($w = get())`) must still
+// invalidate that local. The chain-assign to $v records a consumed span whose
+// argument-paren interior is punched out, so the nested `$w = get()` stays
+// visible to the invalidation scan and drops $w's stale Foo ctor type while the
+// receiver $u and the chain target $v keep theirs.
+func TestPerlLocalVarTypesInvalidatesWriteNestedInChainArgs(t *testing.T) {
+	hopResolvable := func(hop, pkgType string) bool {
+		switch pkgType {
+		case "Bar":
+			return hop == "set" || hop == "go"
+		case "Foo":
+			return hop == "render"
+		}
+		return false
+	}
+
+	got := perlLocalVarTypes("my $w = Foo->new;\nmy $u = Bar->new;\n"+
+		"my $v = $u->set($w = get())->go;\n$w->render;\n", hopResolvable)
+	if typ, ok := got["w"]; ok {
+		t.Fatalf("write nested in chain args `$u->set($w = get())` must invalidate $w, got %q", typ)
+	}
+	if got["u"] != "Bar" {
+		t.Fatalf("receiver $u should stay typed Bar, got %#v", got)
+	}
+	if got["v"] != "Bar" {
+		t.Fatalf("chain-assigned $v should type Bar, got %#v", got)
+	}
+
+	// Positive control: the same chain with a write-free argument keeps every
+	// type — punching out the arg interior must not drop a local never written.
+	clean := perlLocalVarTypes("my $w = Foo->new;\nmy $u = Bar->new;\n"+
+		"my $v = $u->set(cfg())->go;\n$w->render;\n", hopResolvable)
+	if clean["w"] != "Foo" {
+		t.Fatalf("un-reassigned $w should stay typed Foo, got %#v", clean)
+	}
+	if clean["u"] != "Bar" || clean["v"] != "Bar" {
+		t.Fatalf("$u and $v should stay typed Bar, got %#v", clean)
+	}
+}
+
+// Operators that share the `=` lead byte are not assignments: `$x == $y`
+// comparison, `$x =~ /re/` bind, and a hash `$x => 1` fat comma must not be
+// read as reassignments and must not invalidate a constructor-typed local.
+func TestPerlLocalVarTypesIgnoresNonAssignmentOperators(t *testing.T) {
+	allResolvable := func(hop, pkgType string) bool { return true }
+
+	cmp := perlLocalVarTypes("my $x = Foo->new;\nif ($x == $y) { return; }\n$x->go;\n", allResolvable)
+	if cmp["x"] != "Foo" {
+		t.Fatalf("`$x == $y` comparison must not invalidate $x, got %#v", cmp)
+	}
+
+	bind := perlLocalVarTypes("my $x = Foo->new;\n$x =~ /re/;\n$x->go;\n", allResolvable)
+	if bind["x"] != "Foo" {
+		t.Fatalf("`$x =~ /re/` bind must not invalidate $x, got %#v", bind)
+	}
+
+	fatComma := perlLocalVarTypes("my $x = Foo->new;\nmy %h = ($x => 1);\n$x->go;\n", allResolvable)
+	if fatComma["x"] != "Foo" {
+		t.Fatalf("`$x => 1` fat comma must not invalidate $x, got %#v", fatComma)
+	}
+
+	// Comparison operators that end in `=` (`<=`, `>=`, `!=`, `<=>`) are rejected
+	// by the operator chunk itself (`<`, `>`, `!` cannot form the assignment
+	// lead), never by the after-byte filter, so none of them invalidate $x.
+	for _, stmt := range []string{"if ($x <= 3) { }", "if ($x >= 3) { }", "if ($x != $y) { }", "my $c = $x <=> $y"} {
+		got := perlLocalVarTypes("my $x = Foo->new;\n"+stmt+";\n$x->go;\n", allResolvable)
+		if got["x"] != "Foo" {
+			t.Fatalf("comparison `%s` must not invalidate $x, got %#v", stmt, got)
+		}
+	}
+
+	// Pure reads never invalidate: an argument position, a method call on the
+	// receiver, and interpolation (masked before the scan) all keep $x typed.
+	reads := perlLocalVarTypes("my $x = Foo->new;\nprint foo($x);\n$x->probe;\nmy $s = \"got $x now\";\n$x->go;\n", allResolvable)
+	if reads["x"] != "Foo" {
+		t.Fatalf("reads `foo($x)`, `$x->probe`, interpolation must not invalidate $x, got %#v", reads)
+	}
+}

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -2584,6 +2584,18 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 						callNames[name] = struct{}{}
 					}
 				}
+				callImportsByName := importsByName
+				dottedPythonCallNames := map[string]bool{}
+				if file.Language == "Python" {
+					if dottedImports := pythonDottedCallImportedNames(callBlock, importsByName); len(dottedImports) > 0 {
+						callImportsByName = cloneStringSliceMap(importsByName)
+						for name, modules := range dottedImports {
+							callNames[name] = struct{}{}
+							dottedPythonCallNames[name] = true
+							callImportsByName[name] = uniqueStrings(append(callImportsByName[name], modules...))
+						}
+					}
+				}
 				for _, name := range sortedKeysOf(callNames) {
 					if name == from.Name {
 						continue
@@ -2595,7 +2607,7 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 					if childNamesByContainer[from.ID][name] {
 						continue
 					}
-					targets := resolveCallTargets(name, from, symbolsByShortName[name], currentFileSymbols, importsByName, false)
+					targets := resolveCallTargets(name, from, symbolsByShortName[name], currentFileSymbols, callImportsByName, false)
 					for _, to := range targets {
 						// Call to a type (class/struct/...) is a constructor/conversion, not a
 						// callable->callable call: keep it as CONSTRUCTS for agents, out of CALLS.
@@ -2657,7 +2669,10 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 						}
 					}
 					if len(targets) == 0 {
-						for _, relation := range importedExternalCallRelationsForName(from, name, importsByName[name]) {
+						if dottedPythonCallNames[name] {
+							continue
+						}
+						for _, relation := range importedExternalCallRelationsForName(from, name, callImportsByName[name]) {
 							emit(relation)
 						}
 					}
@@ -3426,6 +3441,12 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 	}
 	calls := receiverCalls(block)
 	allReceiverCalls := calls
+	if from.Language == "Dart" {
+		// Dart property assignment invokes a setter method when one exists
+		// (`request.bodyFields = bodyFields` calls `set bodyFields(...)`), but
+		// the generic receiver scanner only sees parenthesized calls.
+		calls = mergeReceiverCalls(calls, dartSetterAssignmentCalls(block))
+	}
 	if from.Language == "C#" {
 		// Chain tails (`Dependencies.MigrationsSqlGenerator.Generate(`) look
 		// like `MigrationsSqlGenerator.Generate(` to the generic scanner, and

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -2674,11 +2674,12 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 					}
 				}
 				if len(dottedCallImportsByName) > 0 {
+					dottedImports := make(map[string][]string, len(dottedCallImportsByName))
 					for _, name := range sortedKeysOf(dottedCallImportsByName) {
 						if name == from.Name {
 							continue
 						}
-						dottedImports := map[string][]string{name: dottedCallImportsByName[name]}
+						dottedImports[name] = dottedCallImportsByName[name]
 						targets := resolveImportedCallTargets(name, from, symbolsByShortName[name], dottedImports, false)
 						for _, to := range targets {
 							relType := "CALLS"

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -2251,6 +2251,32 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 	}
 	manifestImports := buildManifestImportResolver(files, readContent)
 
+	// pythonModuleExists reports whether the repo contains a Python file that the
+	// strict dotted-module matcher resolves `module` to (the module's own source
+	// file or that package's __init__). It disambiguates a `from pkg import sub`
+	// submodule import from an `import pkg as sub` alias rename — both record the
+	// identical importsByName entry — by asking whether the submodule actually
+	// exists. Results are memoized; the scan is restricted to Python files so a
+	// same-stem file in another language is never mistaken for a module.
+	pythonModuleFileExists := map[string]bool{}
+	pythonModuleExists := func(module string) bool {
+		if v, ok := pythonModuleFileExists[module]; ok {
+			return v
+		}
+		found := false
+		for p := range knownFiles {
+			if ext := path.Ext(p); ext != ".py" && ext != ".pyi" {
+				continue
+			}
+			if dottedModuleMatchesFileStrict(module, p) {
+				found = true
+				break
+			}
+		}
+		pythonModuleFileExists[module] = found
+		return found
+	}
+
 	// Package-level vars of package-qualified types, keyed by directory. A Go
 	// package spans every file in a directory and a var is commonly declared in
 	// one file but called in another, so this must be built before the per-file
@@ -2364,6 +2390,15 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 		}
 		importsByName := importedNamesFor(file.Path, content)
 		importsByName = resolvedImportedNameModules(file.Path, importsByName, manifestImports, knownFiles, readContent)
+		// The Python dotted-call composer resolves `alias.<tail>.fn()` from the
+		// syntactic form each import binding was recorded with (plain, alias
+		// rename, or from-import), keyed by [local name][module]. resolvedImported-
+		// NameModules only appends resolved file paths, so the original dotted
+		// modules the form map keys on survive in importsByName.
+		var pythonImportForms map[string]map[string]pythonImportForm
+		if file.Language == "Python" {
+			pythonImportForms = importedPythonImportForms(content)
+		}
 		if skipFastProfilePerSymbolScan(spec, file.Language) {
 			continue
 		}
@@ -2589,10 +2624,15 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 					}
 				}
 				callImportsByName := importsByName
-				var dottedCallImportsByName map[string][]string
+				// Python module-qualified dotted calls (`pkg.mod.fn()`) are resolved
+				// by a dedicated, strictly module-scoped path (emitted after the
+				// generic loop below): the generic resolver ignores the module
+				// qualifier and would mis-resolve to an unrelated same-named symbol.
+				var pythonDottedRelations []RelationRecord
 				if file.Language == "Python" {
-					if dottedImports := pythonDottedCallImportedNames(callBlock, importsByName); len(dottedImports) > 0 {
-						dottedCallImportsByName = dottedImports
+					allDotted, externalDotted := pythonDottedCallImportedNames(callBlock, importsByName, pythonImportForms, pythonModuleExists)
+					if len(allDotted) > 0 {
+						pythonDottedRelations = pythonDottedCallRelations(from, allDotted, externalDotted, importsByName, symbolsByShortName, childNamesByContainer[from.ID])
 					}
 				}
 				for _, name := range sortedKeysOf(callNames) {
@@ -2673,45 +2713,8 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 						}
 					}
 				}
-				if len(dottedCallImportsByName) > 0 {
-					dottedImports := make(map[string][]string, len(dottedCallImportsByName))
-					for _, name := range sortedKeysOf(dottedCallImportsByName) {
-						if name == from.Name {
-							continue
-						}
-						dottedImports[name] = dottedCallImportsByName[name]
-						targets := resolveImportedCallTargets(name, from, symbolsByShortName[name], dottedImports, false)
-						for _, to := range targets {
-							relType := "CALLS"
-							if typeLikeKind(to.Kind) {
-								relType = "CONSTRUCTS"
-							}
-							emit(RelationRecord{
-								RecordType:    "relation",
-								FromID:        from.ID,
-								ToID:          to.ID,
-								Type:          relType,
-								Confidence:    to.Confidence,
-								Reason:        to.Reason,
-								RelationScope: to.Scope,
-								Resolution:    to.Resolution,
-								TargetKind:    "symbol",
-								Evidence: []Evidence{{
-									Kind:      "call_site",
-									FilePath:  from.FilePath,
-									StartLine: from.StartLine,
-									EndLine:   from.EndLine,
-									Detail:    name,
-								}},
-								WarningCodes: []string{},
-							})
-						}
-						if len(targets) == 0 {
-							for _, relation := range importedExternalCallRelationsForName(from, name, dottedImports[name]) {
-								emit(relation)
-							}
-						}
-					}
+				for _, relation := range pythonDottedRelations {
+					emit(relation)
 				}
 			}
 			callableSymbol := !typeLikeKind(from.Kind)
@@ -3593,6 +3596,11 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 		}
 	}
 	localTypes := localVarTypes(block)
+	// perlVarTypes holds Perl-inferred receiver types. They are kept OUT of the
+	// shared localTypes/varTypes maps so a Perl package name can never resolve a
+	// receiver call in another language's context (and vice versa); only the
+	// language-gated Perl resolution loop below (perlCallableForType) reads them.
+	perlVarTypes := map[string]string{}
 	if from.Language == "Ruby" {
 		for name, typeName := range rubyLocalVarTypes(block) {
 			if _, exists := localTypes[name]; !exists {
@@ -3609,10 +3617,25 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 		}
 	}
 	if from.Language == "Perl" {
-		for name, typeName := range perlLocalVarTypes(block) {
-			if _, exists := localTypes[name]; !exists {
-				localTypes[name] = typeName
+		// A hop resolves within a package when some Perl sub of that name lives in
+		// the package's own file (perlSymbolFileMatchesType), which is how the
+		// fluent gate distinguishes a same-object chain from getter navigation.
+		hopResolvable := func(hop, pkgType string) bool {
+			for _, candidate := range symbolsByShortName[hop] {
+				if candidate.Language != "Perl" {
+					continue
+				}
+				if candidate.Kind != "function" && candidate.Kind != "method" {
+					continue
+				}
+				if perlSymbolFileMatchesType(candidate.FilePath, pkgType) {
+					return true
+				}
 			}
+			return false
+		}
+		for name, typeName := range perlLocalVarTypes(block, hopResolvable) {
+			perlVarTypes[name] = typeName
 		}
 	}
 	if from.Language == "Kotlin" {
@@ -3847,7 +3870,21 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 			if methodResolved[call.Receiver+"."+call.Method] {
 				continue
 			}
-			typeName := varTypes[call.Receiver]
+			// Type-inferred resolution attributes call.Method to the package of
+			// call.Receiver's inferred type, which is only sound when Method is
+			// invoked directly on Receiver. perlReceiverCalls flattens multi-hop
+			// chains (`$url->path->to_string`) to {head-receiver, terminal-method}
+			// with Hops>=2, where the terminal method actually runs on the
+			// intermediate object; resolving those here would emit a wrong CALLS
+			// edge to a same-named sub in the head receiver's package. Restrict to
+			// genuine single-hop calls (Hops<=1; the generic scanner's structurally
+			// single-hop calls carry the zero default).
+			if call.Hops > 1 {
+				continue
+			}
+			// Read ONLY the Perl-isolated map: the shared varTypes never carries
+			// Perl entries, so a same-named local of another language cannot leak in.
+			typeName := perlVarTypes[call.Receiver]
 			if typeName == "" {
 				continue
 			}
@@ -3963,6 +4000,16 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 			}
 		}
 		method, inherited, ok := lookupMethodUpChain(targetID, call.Method, methodsByContainer, superContainerByID)
+		if ok && call.SetterAssign && from.Language == "Dart" {
+			// A property-assignment call invokes the SETTER. For a read-write
+			// property the container's short-name method index holds only the
+			// last-declared accessor (getter or setter), so resolve the setter
+			// explicitly and prefer it — otherwise the edge lands on the getter
+			// about half the time (declaration-order dependent).
+			if setter, setterInherited, found := dartSetterAccessor(targetID, call.Method, symbolsByShortName[call.Method], superContainerByID); found {
+				method, inherited = setter, setterInherited
+			}
+		}
 		if !ok && from.Language == "Ruby" && call.Method == "new" {
 			// Ruby spells construction `Klass.new`; the constructor that runs is
 			// the class's initialize method.
@@ -11618,8 +11665,53 @@ func javascriptImportNames(item string) (string, string) {
 	return imported, local
 }
 
+// pythonImportForm records the syntactic shape of a Python import binding so the
+// dotted-call composer can resolve `alias.<tail>.fn()` from the form the binding
+// was written with instead of guessing it back from the recorded module string.
+// `from pkg import name` and `import pkg as name` record string-identical
+// importsByName entries but mean different things; the form disambiguates them.
+type pythonImportForm int
+
+const (
+	// pythonPlainImport: `import a.b` — the local name is the module's leading
+	// segment, so the literal dotted call path `local.<tail>` names the module.
+	// This is the zero value, so a nil/absent form map composes as a plain import
+	// (the pure-string unit tests rely on that default).
+	pythonPlainImport pythonImportForm = iota
+	// pythonAliasRename: `import a.b as c` — the local name IS the module a.b, so
+	// the terminal lives in module.<tail>.
+	pythonAliasRename
+	// pythonFromImport: `from pkg import name` — name is a member of pkg (a class,
+	// function, or module-level value) unless pkg.name is a real submodule.
+	pythonFromImport
+)
+
 func importedPythonNames(content string) map[string][]string {
+	names, _ := importedPythonNamesAndForms(content)
+	return names
+}
+
+// importedPythonImportForms returns the syntactic form of each Python import
+// binding, keyed by the local binding name and then by the recorded module
+// string (the same module strings importedPythonNames records), so the
+// dotted-call composer can look up forms[local][module].
+func importedPythonImportForms(content string) map[string]map[string]pythonImportForm {
+	_, forms := importedPythonNamesAndForms(content)
+	return forms
+}
+
+// importedPythonNamesAndForms is the single parser shared by importedPythonNames
+// and importedPythonImportForms, so the module strings and their recorded forms
+// can never drift apart.
+func importedPythonNamesAndForms(content string) (map[string][]string, map[string]map[string]pythonImportForm) {
 	imports := map[string][]string{}
+	forms := map[string]map[string]pythonImportForm{}
+	recordForm := func(local, module string, form pythonImportForm) {
+		if forms[local] == nil {
+			forms[local] = map[string]pythonImportForm{}
+		}
+		forms[local][module] = form
+	}
 	importRe := regexp.MustCompile(`^\s*import\s+(.+)$`)
 	fromRe := regexp.MustCompile(`^\s*from\s+(\.*(?:[A-Za-z_][A-Za-z0-9_\.]*)?)\s+import\s+(.+)$`)
 	scanner := bufio.NewScanner(strings.NewReader(content))
@@ -11635,10 +11727,13 @@ func importedPythonNames(content string) map[string][]string {
 					continue
 				}
 				local := alias
+				form := pythonAliasRename
 				if local == "" {
 					local = strings.Split(module, ".")[0]
+					form = pythonPlainImport
 				}
 				imports[local] = append(imports[local], module)
+				recordForm(local, module, form)
 			}
 			continue
 		}
@@ -11655,10 +11750,11 @@ func importedPythonNames(content string) map[string][]string {
 				}
 				importedModule := pythonFromImportModuleSpec(module, name)
 				imports[local] = append(imports[local], importedModule)
+				recordForm(local, importedModule, pythonFromImport)
 			}
 		}
 	}
-	return imports
+	return imports, forms
 }
 
 func parsePythonImportItem(item string) (name, alias string) {

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -3572,6 +3572,13 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 			localTypes[name] = typeName
 		}
 	}
+	if from.Language == "Perl" {
+		for name, typeName := range perlLocalVarTypes(block) {
+			if _, exists := localTypes[name]; !exists {
+				localTypes[name] = typeName
+			}
+		}
+	}
 	if from.Language == "Kotlin" {
 		// Declared-type locals (`val writerToClose: WebSocketWriter?`), which
 		// the generic constructor-assignment scan cannot type.
@@ -3798,6 +3805,45 @@ func receiverCallRelations(from SymbolRecord, block string, methodsByContainer m
 			WarningCodes: []string{},
 		})
 		methodResolved[call.Receiver+"."+call.Method] = true
+	}
+	if from.Language == "Perl" {
+		for _, call := range calls {
+			if methodResolved[call.Receiver+"."+call.Method] {
+				continue
+			}
+			typeName := varTypes[call.Receiver]
+			if typeName == "" {
+				continue
+			}
+			target, ok := perlCallableForType(typeName, call.Method, symbolsByShortName[call.Method])
+			if !ok || target.ID == from.ID {
+				continue
+			}
+			scope := "file"
+			if target.FilePath != from.FilePath {
+				scope = "module"
+			}
+			relations = append(relations, RelationRecord{
+				RecordType:    "relation",
+				FromID:        from.ID,
+				ToID:          target.ID,
+				Type:          "CALLS",
+				Confidence:    0.76,
+				Reason:        "Perl receiver call resolved via inferred package receiver type",
+				RelationScope: scope,
+				Resolution:    "type_inferred",
+				TargetKind:    "symbol",
+				Evidence: []Evidence{{
+					Kind:      "call_site",
+					FilePath:  from.FilePath,
+					StartLine: from.StartLine,
+					EndLine:   from.EndLine,
+					Detail:    call.Receiver + "." + call.Method,
+				}},
+				WarningCodes: []string{},
+			})
+			methodResolved[call.Receiver+"."+call.Method] = true
+		}
 	}
 	for _, call := range calls {
 		var targetID string

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -2585,13 +2585,11 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 					}
 				}
 				callImportsByName := importsByName
-				dottedPythonCallNames := map[string]bool{}
 				if file.Language == "Python" {
 					if dottedImports := pythonDottedCallImportedNames(callBlock, importsByName); len(dottedImports) > 0 {
 						callImportsByName = cloneStringSliceMap(importsByName)
 						for name, modules := range dottedImports {
 							callNames[name] = struct{}{}
-							dottedPythonCallNames[name] = true
 							callImportsByName[name] = uniqueStrings(append(callImportsByName[name], modules...))
 						}
 					}
@@ -2669,9 +2667,6 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 						}
 					}
 					if len(targets) == 0 {
-						if dottedPythonCallNames[name] {
-							continue
-						}
 						for _, relation := range importedExternalCallRelationsForName(from, name, callImportsByName[name]) {
 							emit(relation)
 						}

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -1525,25 +1525,7 @@ func resolveCallTargets(name string, from SymbolRecord, candidates, sameFile []S
 		return []resolvedCallTarget{best}
 	}
 
-	var imported []resolvedCallTarget
-	for _, to := range candidates {
-		if to.ID == from.ID || to.Kind == "field" || (to.Kind == "method" && !nameCallMayTargetMethod(from.Language) && !allowMethodTargets) || !localReachable(from, to) {
-			continue
-		}
-		if importedNameMatchesFile(importsByName[name], from.FilePath, to.FilePath) {
-			imported = append(imported, resolvedCallTarget{
-				SymbolRecord: to,
-				Confidence:   0.86,
-				Reason:       "direct call expression resolved through import path",
-				Resolution:   "import_resolved",
-				Scope:        "module",
-			})
-		}
-	}
-	if len(imported) == 0 {
-		imported = jsExportedImportFallbackTargets(name, from, candidates, importsByName[name], allowMethodTargets)
-	}
-	if len(imported) > 0 {
+	if imported := resolveImportedCallTargets(name, from, candidates, importsByName, allowMethodTargets); len(imported) > 0 {
 		return imported
 	}
 
@@ -1661,6 +1643,28 @@ func resolveCallTargets(name string, from SymbolRecord, candidates, sameFile []S
 		}
 	}
 	return nil
+}
+
+func resolveImportedCallTargets(name string, from SymbolRecord, candidates []SymbolRecord, importsByName map[string][]string, allowMethodTargets bool) []resolvedCallTarget {
+	var imported []resolvedCallTarget
+	for _, to := range candidates {
+		if to.ID == from.ID || to.Kind == "field" || (to.Kind == "method" && !nameCallMayTargetMethod(from.Language) && !allowMethodTargets) || !localReachable(from, to) {
+			continue
+		}
+		if importedNameMatchesFile(importsByName[name], from.FilePath, to.FilePath) {
+			imported = append(imported, resolvedCallTarget{
+				SymbolRecord: to,
+				Confidence:   0.86,
+				Reason:       "direct call expression resolved through import path",
+				Resolution:   "import_resolved",
+				Scope:        "module",
+			})
+		}
+	}
+	if len(imported) == 0 {
+		imported = jsExportedImportFallbackTargets(name, from, candidates, importsByName[name], allowMethodTargets)
+	}
+	return imported
 }
 
 func jsExportedImportFallbackTargets(name string, from SymbolRecord, candidates []SymbolRecord, modules []string, allowMethodTargets bool) []resolvedCallTarget {
@@ -2585,13 +2589,10 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 					}
 				}
 				callImportsByName := importsByName
+				var dottedCallImportsByName map[string][]string
 				if file.Language == "Python" {
 					if dottedImports := pythonDottedCallImportedNames(callBlock, importsByName); len(dottedImports) > 0 {
-						callImportsByName = cloneStringSliceMap(importsByName)
-						for name, modules := range dottedImports {
-							callNames[name] = struct{}{}
-							callImportsByName[name] = uniqueStrings(append(callImportsByName[name], modules...))
-						}
+						dottedCallImportsByName = dottedImports
 					}
 				}
 				for _, name := range sortedKeysOf(callNames) {
@@ -2669,6 +2670,45 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 					if len(targets) == 0 {
 						for _, relation := range importedExternalCallRelationsForName(from, name, callImportsByName[name]) {
 							emit(relation)
+						}
+					}
+				}
+				if len(dottedCallImportsByName) > 0 {
+					for _, name := range sortedKeysOf(dottedCallImportsByName) {
+						if name == from.Name {
+							continue
+						}
+						dottedImports := map[string][]string{name: dottedCallImportsByName[name]}
+						targets := resolveImportedCallTargets(name, from, symbolsByShortName[name], dottedImports, false)
+						for _, to := range targets {
+							relType := "CALLS"
+							if typeLikeKind(to.Kind) {
+								relType = "CONSTRUCTS"
+							}
+							emit(RelationRecord{
+								RecordType:    "relation",
+								FromID:        from.ID,
+								ToID:          to.ID,
+								Type:          relType,
+								Confidence:    to.Confidence,
+								Reason:        to.Reason,
+								RelationScope: to.Scope,
+								Resolution:    to.Resolution,
+								TargetKind:    "symbol",
+								Evidence: []Evidence{{
+									Kind:      "call_site",
+									FilePath:  from.FilePath,
+									StartLine: from.StartLine,
+									EndLine:   from.EndLine,
+									Detail:    name,
+								}},
+								WarningCodes: []string{},
+							})
+						}
+						if len(targets) == 0 {
+							for _, relation := range importedExternalCallRelationsForName(from, name, dottedImports[name]) {
+								emit(relation)
+							}
 						}
 					}
 				}

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -1128,6 +1128,40 @@ def request():
 	}
 }
 
+func TestPythonDottedImportedModuleCallsResolveToLocalSymbols(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "src/acme_pkg/__init__.py", "")
+	writeFile(t, repo, "src/acme_pkg/service.py", `def run():
+    return "ok"
+`)
+	writeFile(t, repo, "src/acme_pkg/consumer.py", `import acme_pkg.service
+
+def call_service():
+    return acme_pkg.service.run()
+`)
+	writeFile(t, repo, "Lib/genericpath.py", `def isdir(path):
+    return False
+`)
+	writeFile(t, repo, "Lib/shutil.py", `import os
+
+def copy2(src, dst):
+    if os.path.isdir(dst):
+        return dst
+    return src
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasRelationBySymbolNameAndFile(snapshot, "CALLS", "call_service", "src/acme_pkg/consumer.py", "run", "src/acme_pkg/service.py") {
+		t.Fatalf("missing package.module.function dotted Python call: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+	if !hasRelationBySymbolNameAndFile(snapshot, "CALLS", "copy2", "Lib/shutil.py", "isdir", "Lib/genericpath.py") {
+		t.Fatalf("missing os.path.isdir -> genericpath.isdir call: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}
+
 func TestSetupCFGNameParsingNormalizesPythonPackage(t *testing.T) {
 	name := parseSetupCFGName(`[metadata]
 Name = acme-tools
@@ -11441,6 +11475,7 @@ abstract mixin class BaseClient implements Client {
       {Object? body, Encoding? encoding}) async {
     var request = Request(method, url);
     if (headers != null) request.headers.addAll(headers);
+    if (body is Map<String, String>) request.bodyFields = body;
     return Response.fromStream(await send(request));
   }
 
@@ -11449,6 +11484,8 @@ abstract mixin class BaseClient implements Client {
 `)
 	writeFile(t, repo, "lib/src/request.dart", `class Request extends BaseRequest {
   Request(super.method, super.url);
+
+  set bodyFields(Map<String, String> fields) {}
 }
 `)
 	writeFile(t, repo, "lib/src/response.dart", `class Response extends BaseResponse {
@@ -11497,6 +11534,9 @@ abstract mixin class BaseClient implements Client {
 	if _, ok := edges["CALLS BaseClient._sendUnstreamed->Response.fromStream"]; !ok {
 		t.Fatalf("missing _sendUnstreamed->Response.fromStream call: %#v", edges)
 	}
+	if _, ok := edges["CALLS BaseClient._sendUnstreamed->Request.bodyFields"]; !ok {
+		t.Fatalf("missing _sendUnstreamed->Request.bodyFields setter call: %#v", edges)
+	}
 	// Constructor call to a class in another file: a call to a type-like symbol
 	// is recorded as CONSTRUCTS (the convention shared with Go/TS), the name
 	// Request must not be dropped by the JS-builtin ignore list in Dart, and the
@@ -11536,6 +11576,10 @@ Person <- R6::R6Class("Person", public = list(
   greet = function() cat("hi")
 ))
 
+build_ggplot <- S7::method(plot_theme, class_theme) <- function(x, y) {
+  helper(x)
+}
+
 render <- function(x) {
   helper(x)
 }
@@ -11561,6 +11605,9 @@ render <- function(x) {
 	}
 	if kinds["Person"] != "class" {
 		t.Fatalf("R R6 class not extracted: %#v", kinds)
+	}
+	if kinds["build_ggplot"] != "function" {
+		t.Fatalf("R chained assignment function not extracted: %#v", kinds)
 	}
 	// Anonymous function_definition nodes must not invent symbols named after
 	// their first parameter.

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12208,12 +12208,16 @@ func TestPerlLocalVarTypesIgnoreArgumentReceiverChains(t *testing.T) {
 	types := perlLocalVarTypes(`$url = Mojo::URL->new;
 $path = $url->base($req->url->base->clone);
 $base = $url->base($req->url)->userinfo;
+$mixed = $url->base($req) + $other->x;
 `)
 	if got := types["path"]; got != "" {
 		t.Fatalf("single outer receiver call with nested argument chain inferred path type %q from %#v", got, types)
 	}
 	if got := types["base"]; got != "Mojo::URL" {
 		t.Fatalf("multi-hop outer fluent assignment inferred base type %q from %#v", got, types)
+	}
+	if got := types["mixed"]; got != "" {
+		t.Fatalf("mixed expression inferred fluent type %q from %#v", got, types)
 	}
 }
 

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12109,6 +12109,8 @@ $value =~ s/#/x/;
 $value =~ s{#}{x}; $obj->method;
 $value =~ m{#};
 $value =~ /#/;
+/#/; $obj->implicit;
+if (/#/) { $obj->grouped; }
 $obj->real; foo()# $obj->fake
 $value = $maybe // $fallback;
 $base = $url->base # ->userinfo
@@ -12128,6 +12130,12 @@ $base = $url->base # ->userinfo
 	if !strings.Contains(stripped, "/#/") {
 		t.Fatalf("Perl binding regex hash was masked: %q", stripped)
 	}
+	if !strings.Contains(stripped, "$obj->implicit") {
+		t.Fatalf("Perl expression-start regex hash masked following code: %q", stripped)
+	}
+	if !strings.Contains(stripped, "$obj->grouped") {
+		t.Fatalf("Perl grouped regex hash masked following code: %q", stripped)
+	}
 	if !strings.Contains(stripped, "// $fallback") {
 		t.Fatalf("Perl defined-or operator was masked: %q", stripped)
 	}
@@ -12140,6 +12148,34 @@ $base = $url->base # ->userinfo
 	calls := perlReceiverCalls(`$value =~ s{#}{x}; $obj->method;`)
 	if len(calls) != 1 || calls[0].Receiver != "obj" || calls[0].Method != "method" {
 		t.Fatalf("Perl receiver call after brace-delimited regex was masked: %#v", calls)
+	}
+}
+
+func TestPerlReceiverChainsIgnoreArgumentReceiverChains(t *testing.T) {
+	calls := perlReceiverCalls(`$url->base($req->url->base->clone);
+$url->base($req->url)->userinfo;
+`)
+	if len(calls) != 2 {
+		t.Fatalf("perlReceiverCalls() = %#v, want two outer calls", calls)
+	}
+	if calls[0].Receiver != "url" || calls[0].Method != "base" {
+		t.Fatalf("single outer call used nested argument receiver segment: %#v", calls[0])
+	}
+	if calls[1].Receiver != "url" || calls[1].Method != "userinfo" {
+		t.Fatalf("multi-hop outer call not preserved: %#v", calls[1])
+	}
+}
+
+func TestPerlLocalVarTypesIgnoreArgumentReceiverChains(t *testing.T) {
+	types := perlLocalVarTypes(`$url = Mojo::URL->new;
+$path = $url->base($req->url->base->clone);
+$base = $url->base($req->url)->userinfo;
+`)
+	if got := types["path"]; got != "" {
+		t.Fatalf("single outer receiver call with nested argument chain inferred path type %q from %#v", got, types)
+	}
+	if got := types["base"]; got != "Mojo::URL" {
+		t.Fatalf("multi-hop outer fluent assignment inferred base type %q from %#v", got, types)
 	}
 }
 

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12107,6 +12107,9 @@ func TestPerlCommentStrippingPreservesHashSyntax(t *testing.T) {
 	stripped := stripPerlCodeLiteralsAndComments(`my $last = $#items;
 $value =~ s/#/x/;
 $value =~ s{#}{x}; $obj->method;
+$value =~ m{#};
+$value =~ /#/;
+$obj->real; foo()# $obj->fake
 $value = $maybe // $fallback;
 $base = $url->base # ->userinfo
 `)
@@ -12119,11 +12122,20 @@ $base = $url->base # ->userinfo
 	if !strings.Contains(stripped, "s{#}{x}; $obj->method") {
 		t.Fatalf("Perl brace-delimited regex hash masked following code: %q", stripped)
 	}
+	if !strings.Contains(stripped, "m{#}") {
+		t.Fatalf("Perl match regex hash was masked: %q", stripped)
+	}
+	if !strings.Contains(stripped, "/#/") {
+		t.Fatalf("Perl binding regex hash was masked: %q", stripped)
+	}
 	if !strings.Contains(stripped, "// $fallback") {
 		t.Fatalf("Perl defined-or operator was masked: %q", stripped)
 	}
 	if strings.Contains(stripped, "userinfo") {
 		t.Fatalf("Perl line comment was not masked: %q", stripped)
+	}
+	if strings.Contains(stripped, "fake") {
+		t.Fatalf("Perl trailing line comment was not masked: %q", stripped)
 	}
 	calls := perlReceiverCalls(`$value =~ s{#}{x}; $obj->method;`)
 	if len(calls) != 1 || calls[0].Receiver != "obj" || calls[0].Method != "method" {

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -1135,6 +1135,26 @@ func TestPythonDottedCallModulesDoesNotDuplicateResolvedTail(t *testing.T) {
 	}
 }
 
+func TestPythonDottedImportedCallsAllowSingleSelectorAlias(t *testing.T) {
+	got := pythonDottedCallImportedNames(
+		"json.dumps({})\nok = path.isdir(dst)\nsvc.run()\n",
+		map[string][]string{
+			"json": {"json"},
+			"path": {"os"},
+			"svc":  {"acme_pkg.service"},
+		},
+	)
+	if _, ok := got["dumps"]; ok {
+		t.Fatalf("plain import json; json.dumps() should not synthesize a bare dumps hint: %#v", got)
+	}
+	if !slices.Contains(got["isdir"], "genericpath") {
+		t.Fatalf("path.isdir() did not include genericpath hint: %#v", got)
+	}
+	if !slices.Contains(got["run"], "acme_pkg.service") {
+		t.Fatalf("svc.run() did not include imported module hint: %#v", got)
+	}
+}
+
 func TestPythonDottedImportedModuleCallsResolveToLocalSymbols(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, repo, "src/acme_pkg/__init__.py", "")
@@ -1166,6 +1186,13 @@ def copy2(src, dst):
 	}
 	if !hasRelationBySymbolNameAndFile(snapshot, "CALLS", "copy2", "Lib/shutil.py", "isdir", "Lib/genericpath.py") {
 		t.Fatalf("missing os.path.isdir -> genericpath.isdir call: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}
+
+func TestDartSetterAssignmentCallsAllowDollarSetterNames(t *testing.T) {
+	got := dartSetterAssignmentCalls("obj._$field = value;\n")
+	if len(got) != 1 || got[0].Receiver != "obj" || got[0].Method != "_$field" {
+		t.Fatalf("dartSetterAssignmentCalls() = %#v, want obj._$field", got)
 	}
 }
 

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -1135,6 +1135,19 @@ func TestPythonDottedCallModulesDoesNotDuplicateResolvedTail(t *testing.T) {
 	}
 }
 
+func TestPythonDottedCallModulesUseAddressedParentForDeepImports(t *testing.T) {
+	got := pythonDottedCallImportedNames(
+		"pkg.sub.fn()\npkg.sub.mod.call()\n",
+		map[string][]string{"pkg": {"pkg.sub.mod"}},
+	)
+	if want := []string{"pkg.sub"}; !reflect.DeepEqual(got["fn"], want) {
+		t.Fatalf("pkg.sub.fn() modules = %#v, want %#v", got["fn"], want)
+	}
+	if want := []string{"pkg.sub.mod"}; !reflect.DeepEqual(got["call"], want) {
+		t.Fatalf("pkg.sub.mod.call() modules = %#v, want %#v", got["call"], want)
+	}
+}
+
 func TestPythonDottedImportedCallsAllowSingleSelectorAlias(t *testing.T) {
 	got := pythonDottedCallImportedNames(
 		"json.dumps({})\nok = path.isdir(dst)\nsvc.run()\n# leak.call()\n\"\"\"leak.call()\"\"\"\n",
@@ -1197,6 +1210,20 @@ func TestDartSetterAssignmentCallsAllowDollarSetterNames(t *testing.T) {
 	got := dartSetterAssignmentCalls("obj._$field = value;\n")
 	if len(got) != 1 || got[0].Receiver != "obj" || got[0].Method != "_$field" {
 		t.Fatalf("dartSetterAssignmentCalls() = %#v, want obj._$field", got)
+	}
+}
+
+func TestDartSetterAssignmentCallsIgnoreMultilineStrings(t *testing.T) {
+	got := dartSetterAssignmentCalls(`final text = '''
+obj.fake = 1;
+''';
+real.value = 2;
+final raw = r"""
+raw.fake = 3;
+""";
+`)
+	if len(got) != 1 || got[0].Receiver != "real" || got[0].Method != "value" {
+		t.Fatalf("dartSetterAssignmentCalls() = %#v, want real.value only", got)
 	}
 }
 

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12044,6 +12044,22 @@ sub protocol {
 	}
 }
 
+func TestPerlCommentArrowsDoNotAffectReceiverTypeInference(t *testing.T) {
+	block := `my $url = Mojo::URL->new;
+my $path = $url->path # ->base->userinfo
+;
+# $path->protocol
+`
+	types := perlLocalVarTypes(block)
+	if got := types["path"]; got != "" {
+		t.Fatalf("commented receiver chain inferred path type %q from %#v", got, types)
+	}
+	calls := perlReceiverCalls(block)
+	if len(calls) != 1 || calls[0].Receiver != "url" || calls[0].Method != "path" {
+		t.Fatalf("commented receiver call should be ignored while real call remains, got %#v", calls)
+	}
+}
+
 func TestHaskellSemanticExtraction(t *testing.T) {
 	// Haskell was promoted from inventory to the semantic tier (vendored
 	// grammar); it must now extract top-level function bindings (one symbol

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12107,7 +12107,9 @@ func TestPerlCommentStrippingPreservesHashSyntax(t *testing.T) {
 	stripped := stripPerlCodeLiteralsAndComments(`my $last = $#items;
 $value =~ s/#/x/;
 $value =~ s{#}{x}; $obj->method;
+$value =~ s#foo#bar#; $obj->hashSub;
 $value =~ m{#};
+$value =~ m#foo#; $obj->hashMatch;
 $value =~ /#/;
 /#/; $obj->implicit;
 if (/#/) { $obj->grouped; }
@@ -12124,8 +12126,14 @@ $base = $url->base # ->userinfo
 	if !strings.Contains(stripped, "s{#}{x}; $obj->method") {
 		t.Fatalf("Perl brace-delimited regex hash masked following code: %q", stripped)
 	}
+	if !strings.Contains(stripped, "$obj->hashSub") {
+		t.Fatalf("Perl hash-delimited substitution masked following code: %q", stripped)
+	}
 	if !strings.Contains(stripped, "m{#}") {
 		t.Fatalf("Perl match regex hash was masked: %q", stripped)
+	}
+	if !strings.Contains(stripped, "$obj->hashMatch") {
+		t.Fatalf("Perl hash-delimited match masked following code: %q", stripped)
 	}
 	if !strings.Contains(stripped, "/#/") {
 		t.Fatalf("Perl binding regex hash was masked: %q", stripped)

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12072,6 +12072,22 @@ $base = $url->base->userinfo;
 	}
 }
 
+func TestPerlCommentStrippingPreservesHashSyntax(t *testing.T) {
+	stripped := stripPerlCodeLiteralsAndComments(`my $last = $#items;
+$value =~ s/#/x/;
+$base = $url->base # ->userinfo
+`)
+	if !strings.Contains(stripped, "$#items") {
+		t.Fatalf("Perl array-last-index token was masked: %q", stripped)
+	}
+	if !strings.Contains(stripped, "s/#/x/") {
+		t.Fatalf("Perl regex hash was masked: %q", stripped)
+	}
+	if strings.Contains(stripped, "userinfo") {
+		t.Fatalf("Perl line comment was not masked: %q", stripped)
+	}
+}
+
 func TestHaskellSemanticExtraction(t *testing.T) {
 	// Haskell was promoted from inventory to the semantic tier (vendored
 	// grammar); it must now extract top-level function bindings (one symbol

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -1164,6 +1164,9 @@ func TestPythonDottedImportedCallsAllowSingleSelectorAlias(t *testing.T) {
 	if !slices.Contains(got["isdir"], "genericpath") {
 		t.Fatalf("path.isdir() did not include genericpath hint: %#v", got)
 	}
+	if slices.Contains(got["isdir"], "os") {
+		t.Fatalf("path.isdir() emitted bare os module hint: %#v", got)
+	}
 	if !slices.Contains(got["run"], "acme_pkg.service") {
 		t.Fatalf("svc.run() did not include imported module hint: %#v", got)
 	}
@@ -1203,6 +1206,33 @@ def copy2(src, dst):
 	}
 	if !hasRelationBySymbolNameAndFile(snapshot, "CALLS", "copy2", "Lib/shutil.py", "isdir", "Lib/genericpath.py") {
 		t.Fatalf("missing os.path.isdir -> genericpath.isdir call: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}
+
+func TestPythonDottedImportedCallsDoNotResolveToSameFileBareName(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "src/pkg/__init__.py", "")
+	writeFile(t, repo, "src/pkg/sub.py", `def fn():
+    return "remote"
+`)
+	writeFile(t, repo, "src/consumer.py", `import pkg.sub
+
+def fn():
+    return "local"
+
+def call_remote():
+    return pkg.sub.fn()
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasRelationBySymbolNameAndFile(snapshot, "CALLS", "call_remote", "src/consumer.py", "fn", "src/pkg/sub.py") {
+		t.Fatalf("missing dotted imported call to remote fn: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+	if hasRelationBySymbolNameAndFile(snapshot, "CALLS", "call_remote", "src/consumer.py", "fn", "src/consumer.py") {
+		t.Fatalf("dotted imported call resolved to same-file bare fn: %#v", relationsOfType(snapshot.Relations, "CALLS"))
 	}
 }
 

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -1137,9 +1137,10 @@ func TestPythonDottedCallModulesDoesNotDuplicateResolvedTail(t *testing.T) {
 
 func TestPythonDottedImportedCallsAllowSingleSelectorAlias(t *testing.T) {
 	got := pythonDottedCallImportedNames(
-		"json.dumps({})\nok = path.isdir(dst)\nsvc.run()\n",
+		"json.dumps({})\nok = path.isdir(dst)\nsvc.run()\n# leak.call()\n\"\"\"leak.call()\"\"\"\n",
 		map[string][]string{
 			"json": {"json"},
+			"leak": {"bad.module"},
 			"path": {"os"},
 			"svc":  {"acme_pkg.service"},
 		},
@@ -1152,6 +1153,9 @@ func TestPythonDottedImportedCallsAllowSingleSelectorAlias(t *testing.T) {
 	}
 	if !slices.Contains(got["run"], "acme_pkg.service") {
 		t.Fatalf("svc.run() did not include imported module hint: %#v", got)
+	}
+	if _, ok := got["call"]; ok {
+		t.Fatalf("comment/docstring dotted call synthesized import hints: %#v", got)
 	}
 }
 
@@ -12075,6 +12079,7 @@ $base = $url->base->userinfo;
 func TestPerlCommentStrippingPreservesHashSyntax(t *testing.T) {
 	stripped := stripPerlCodeLiteralsAndComments(`my $last = $#items;
 $value =~ s/#/x/;
+$value = $maybe // $fallback;
 $base = $url->base # ->userinfo
 `)
 	if !strings.Contains(stripped, "$#items") {
@@ -12082,6 +12087,9 @@ $base = $url->base # ->userinfo
 	}
 	if !strings.Contains(stripped, "s/#/x/") {
 		t.Fatalf("Perl regex hash was masked: %q", stripped)
+	}
+	if !strings.Contains(stripped, "// $fallback") {
+		t.Fatalf("Perl defined-or operator was masked: %q", stripped)
 	}
 	if strings.Contains(stripped, "userinfo") {
 		t.Fatalf("Perl line comment was not masked: %q", stripped)

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -1128,6 +1128,13 @@ def request():
 	}
 }
 
+func TestPythonDottedCallModulesDoesNotDuplicateResolvedTail(t *testing.T) {
+	got := pythonDottedCallModules("acme_pkg", []string{"service"}, []string{"acme_pkg.service"})
+	if want := []string{"acme_pkg.service"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("pythonDottedCallModules resolved tail = %#v, want %#v", got, want)
+	}
+}
+
 func TestPythonDottedImportedModuleCallsResolveToLocalSymbols(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, repo, "src/acme_pkg/__init__.py", "")
@@ -7296,9 +7303,13 @@ func Clean(value string) string {
 }
 `)
 	writeFile(t, repo, "encode.py", `import json
+import requests.sessions
 
 def encode(value):
     return json.dumps(value)
+
+def open_session():
+    return requests.sessions.session()
 `)
 	writeFile(t, repo, "read.ts", `import { readFileSync } from "fs"
 import * as path from "path"
@@ -7341,6 +7352,7 @@ export function readConfig(name: string): string {
 	}{
 		{from: "Clean", target: "strings.TrimSpace", detail: "strings.TrimSpace"},
 		{from: "encode", target: "json.dumps", detail: "json.dumps"},
+		{from: "open_session", target: "requests.sessions.session", detail: "session"},
 		{from: "readConfig", target: "fs.readFileSync", detail: "readFileSync"},
 		{from: "readConfig", target: "path.join", detail: "path.join"},
 		{from: "readConfig", target: "axios.get", detail: "axios.get"},

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -1129,16 +1129,50 @@ def request():
 }
 
 func TestPythonDottedCallModulesDoesNotDuplicateResolvedTail(t *testing.T) {
-	got := pythonDottedCallModules("acme_pkg", []string{"service"}, []string{"acme_pkg.service"})
+	got, _ := pythonDottedCallModules("acme_pkg", []string{"service"}, []string{"acme_pkg.service"}, nil, nil)
 	if want := []string{"acme_pkg.service"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("pythonDottedCallModules resolved tail = %#v, want %#v", got, want)
 	}
 }
 
+// When the imported module is a proper prefix shorter than the call's dotted
+// tail (`import pkg.a` binds pkg -> pkg.a, then `pkg.a.b.fn()`), the composed
+// candidate must be the full literal call path (pkg.a.b) with the shared `a`
+// segment stripped — never the doubled pkg.a.a.b, and never the too-short pkg.a.
+func TestPythonDottedCallModulesStripsSharedPrefixOverlap(t *testing.T) {
+	cases := []struct {
+		name  string
+		alias string
+		tail  []string
+		imp   []string
+		want  []string
+	}{
+		// The finding's repro: import pkg.a + pkg.a.b.fn().
+		{"prefix-overlap", "pkg", []string{"a", "b"}, []string{"pkg.a"}, []string{"pkg.a.b"}},
+		// module == alias (plain `import a`): full literal path.
+		{"module-eq-alias", "a", []string{"b", "c"}, []string{"a"}, []string{"a.b.c"}},
+		// module == "a.b", tail = [b, c]: strip the shared `b`.
+		{"one-segment-overlap", "a", []string{"b", "c"}, []string{"a.b"}, []string{"a.b.c"}},
+		// module == "a.b.c" but the call only reaches a.b: the literal call path
+		// (a.b) is authoritative, no `a.b.c.b` doubling.
+		{"module-deeper-than-call", "a", []string{"b"}, []string{"a.b.c"}, []string{"a.b"}},
+	}
+	for _, c := range cases {
+		all, external := pythonDottedCallModules(c.alias, c.tail, c.imp, nil, nil)
+		if !reflect.DeepEqual(all, c.want) {
+			t.Errorf("%s: pythonDottedCallModules(%q, %v, %v) all = %#v, want %#v", c.name, c.alias, c.tail, c.imp, all, c.want)
+		}
+		if !reflect.DeepEqual(external, c.want) {
+			t.Errorf("%s: pythonDottedCallModules(%q, %v, %v) external = %#v, want %#v", c.name, c.alias, c.tail, c.imp, external, c.want)
+		}
+	}
+}
+
 func TestPythonDottedCallModulesUseAddressedParentForDeepImports(t *testing.T) {
-	got := pythonDottedCallImportedNames(
+	got, _ := pythonDottedCallImportedNames(
 		"pkg.sub.fn()\npkg.sub.mod.call()\n",
 		map[string][]string{"pkg": {"pkg.sub.mod"}},
+		nil, nil,
 	)
 	if want := []string{"pkg.sub"}; !reflect.DeepEqual(got["fn"], want) {
 		t.Fatalf("pkg.sub.fn() modules = %#v, want %#v", got["fn"], want)
@@ -1149,7 +1183,7 @@ func TestPythonDottedCallModulesUseAddressedParentForDeepImports(t *testing.T) {
 }
 
 func TestPythonDottedImportedCallsAllowSingleSelectorAlias(t *testing.T) {
-	got := pythonDottedCallImportedNames(
+	got, _ := pythonDottedCallImportedNames(
 		"json.dumps({})\nok = path.isdir(dst)\nsvc.run()\n# leak.call()\n\"\"\"leak.call()\"\"\"\n",
 		map[string][]string{
 			"json": {"json"},
@@ -1157,6 +1191,7 @@ func TestPythonDottedImportedCallsAllowSingleSelectorAlias(t *testing.T) {
 			"path": {"os"},
 			"svc":  {"acme_pkg.service"},
 		},
+		nil, nil,
 	)
 	if _, ok := got["dumps"]; ok {
 		t.Fatalf("plain import json; json.dumps() should not synthesize a bare dumps hint: %#v", got)
@@ -12111,7 +12146,7 @@ my $path = $url->path # ->base->userinfo
 ;
 # $path->protocol
 `
-	types := perlLocalVarTypes(block)
+	types := perlLocalVarTypes(block, func(hop, pkgType string) bool { return true })
 	if got := types["path"]; got != "" {
 		t.Fatalf("commented receiver chain inferred path type %q from %#v", got, types)
 	}
@@ -12124,7 +12159,7 @@ my $path = $url->path # ->base->userinfo
 func TestPerlLocalVarTypesAllowKeywordlessAssignments(t *testing.T) {
 	types := perlLocalVarTypes(`$url = Mojo::URL->new;
 $base = $url->base->userinfo;
-`)
+`, func(hop, pkgType string) bool { return true })
 	if got := types["url"]; got != "Mojo::URL" {
 		t.Fatalf("keywordless constructor inferred url type %q from %#v", got, types)
 	}
@@ -12209,7 +12244,7 @@ func TestPerlLocalVarTypesIgnoreArgumentReceiverChains(t *testing.T) {
 $path = $url->base($req->url->base->clone);
 $base = $url->base($req->url)->userinfo;
 $mixed = $url->base($req) + $other->x;
-`)
+`, func(hop, pkgType string) bool { return true })
 	if got := types["path"]; got != "" {
 		t.Fatalf("single outer receiver call with nested argument chain inferred path type %q from %#v", got, types)
 	}
@@ -13617,5 +13652,857 @@ func runProviderRecords(repo string) error {
 	}
 	if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "runProviderRecords", "StreamSnapshot") {
 		t.Errorf("missing CALLS runProviderRecords->StreamSnapshot via self-module import: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}
+
+// A module-qualified dotted call (`acme.mod.run()`) must resolve to the named
+// submodule ONLY. A sibling submodule (acme/service.py) that defines the same
+// terminal name must NOT receive an edge via any parent-directory fallback: the
+// dedicated dotted path uses a strict module-file matcher (the module's own
+// source file or that package's __init__), so exactly one edge — to acme/mod.py
+// — is emitted.
+func TestPythonDottedSubmoduleCallDoesNotResolveToSibling(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "acme/__init__.py", "")
+	writeFile(t, repo, "acme/mod.py", `def run():
+    return 1
+`)
+	writeFile(t, repo, "acme/service.py", `def run():
+    return 2
+`)
+	writeFile(t, repo, "consumer.py", `import acme.mod
+
+
+def call_it():
+    return acme.mod.run()
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	var runTargets []string
+	for _, r := range snapshot.Relations {
+		if r.Type != "CALLS" || lastSegment(r.FromID) != "call_it" {
+			continue
+		}
+		if to, ok := symbolsByID[r.ToID]; ok && to.Name == "run" {
+			runTargets = append(runTargets, to.FilePath)
+		}
+	}
+	if len(runTargets) != 1 || runTargets[0] != "acme/mod.py" {
+		t.Fatalf("call_it run targets = %#v, want exactly [acme/mod.py]", runTargets)
+	}
+}
+
+// callItTargetsNamed collects the file paths of every CALLS target of `call_it`
+// whose terminal name matches `name`, for the from-import composition tests.
+func callItTargetsNamed(t *testing.T, snapshot ProviderSnapshot, name string) []string {
+	t.Helper()
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	var targets []string
+	for _, r := range snapshot.Relations {
+		if r.Type != "CALLS" || lastSegment(r.FromID) != "call_it" {
+			continue
+		}
+		if to, ok := symbolsByID[r.ToID]; ok && to.Name == name {
+			targets = append(targets, to.FilePath)
+		}
+	}
+	return targets
+}
+
+// `from pkg import service` records importsByName["service"]=["pkg"] (the
+// submodule name is dropped), identical to `import pkg as service`. When the
+// repo actually contains the submodule pkg/service/, the from-import reading is
+// authoritative: `service.helper.fn()` must resolve to pkg/service/helper.py,
+// never to the sibling pkg/helper.py that the alias-rename reading would name.
+func TestPythonFromImportSubmoduleDottedCallResolvesToSubmodule(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "pkg/__init__.py", "")
+	writeFile(t, repo, "pkg/helper.py", `def fn():
+    return 1
+`)
+	writeFile(t, repo, "pkg/service/__init__.py", "")
+	writeFile(t, repo, "pkg/service/helper.py", `def fn():
+    return 2
+`)
+	writeFile(t, repo, "consumer.py", `from pkg import service
+
+
+def call_it():
+    return service.helper.fn()
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	targets := callItTargetsNamed(t, snapshot, "fn")
+	if len(targets) != 1 || targets[0] != "pkg/service/helper.py" {
+		t.Fatalf("call_it fn targets = %#v, want exactly [pkg/service/helper.py]", targets)
+	}
+}
+
+// `import pkg as service` is an alias rename: `service.helper.fn()` means
+// pkg.helper.fn. With only pkg/helper.py present, the edge resolves there.
+func TestPythonAliasRenameDottedCallResolvesToRenamedModule(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "pkg/__init__.py", "")
+	writeFile(t, repo, "pkg/helper.py", `def fn():
+    return 1
+`)
+	writeFile(t, repo, "consumer.py", `import pkg as service
+
+
+def call_it():
+    return service.helper.fn()
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	targets := callItTargetsNamed(t, snapshot, "fn")
+	if len(targets) != 1 || targets[0] != "pkg/helper.py" {
+		t.Fatalf("call_it fn targets = %#v, want exactly [pkg/helper.py]", targets)
+	}
+}
+
+// The genuinely ambiguous case: `import pkg as service` where BOTH pkg/helper.py
+// and pkg/service/helper.py exist, but there is NO submodule marker for
+// pkg.service (no pkg/service/__init__.py, no pkg/service.py). The from-import
+// reading has no repo grounding, so the alias-rename reading wins and the edge
+// resolves to pkg/helper.py — never the pkg/service/helper.py that a bare
+// both-candidates composition would also (wrongly) match.
+func TestPythonAliasRenameWinsWithoutSubmoduleMarker(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "pkg/__init__.py", "")
+	writeFile(t, repo, "pkg/helper.py", `def fn():
+    return 1
+`)
+	// A pkg/service/ directory with a same-named submodule file but NO __init__:
+	// not a package the discriminator recognizes.
+	writeFile(t, repo, "pkg/service/helper.py", `def fn():
+    return 2
+`)
+	writeFile(t, repo, "consumer.py", `import pkg as service
+
+
+def call_it():
+    return service.helper.fn()
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	targets := callItTargetsNamed(t, snapshot, "fn")
+	if len(targets) != 1 || targets[0] != "pkg/helper.py" {
+		t.Fatalf("call_it fn targets = %#v, want exactly [pkg/helper.py]", targets)
+	}
+}
+
+// A Python dotted call (`acme.mod.run()`) must resolve only to a Python symbol.
+// symbolsByShortName is a workspace-wide, cross-language index and the strict
+// module matcher trims the file extension, so a same-stem file in another
+// language (acme/mod.go with `func run`) also matches the module path; without a
+// language gate the dotted call would fabricate a cross-language edge to the Go
+// `run`. The gate keeps resolution on the Python acme/mod.py target.
+func TestPythonDottedCallDoesNotResolveCrossLanguage(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "acme/__init__.py", "")
+	writeFile(t, repo, "acme/mod.py", `def run():
+    return "py"
+`)
+	writeFile(t, repo, "acme/mod.go", `package acme
+
+func run() string {
+	return "go"
+}
+`)
+	writeFile(t, repo, "consumer.py", `import acme.mod
+
+
+def call_it():
+    return acme.mod.run()
+`)
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasRelationBySymbolNameAndFile(snapshot, "CALLS", "call_it", "consumer.py", "run", "acme/mod.go") {
+		t.Fatalf("dotted Python call fabricated cross-language edge to Go run: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+	if !hasRelationBySymbolNameAndFile(snapshot, "CALLS", "call_it", "consumer.py", "run", "acme/mod.py") {
+		t.Fatalf("missing dotted Python call to acme/mod.py run: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}
+
+// In an ordinary repo (no vendored CPython stdlib) os.path.* calls must emit
+// only the os.path external edge — never a bare os.<name> edge, nor a
+// genericpath/posixpath/ntpath fan-out edge.
+func TestPythonOSPathDottedCallsEmitOnlyOSPathExternals(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "app.py", `import os
+
+
+def use(x):
+    if os.path.isdir(x):
+        return os.path.join(x, "y")
+    return x
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, r := range snapshot.Relations {
+		if r.Type != "CALLS" || lastSegment(r.FromID) != "use" {
+			continue
+		}
+		if strings.HasPrefix(r.ToID, "external:symbol:") {
+			got[strings.TrimPrefix(r.ToID, "external:symbol:")] = true
+		}
+	}
+	want := map[string]bool{"os.path.isdir": true, "os.path.join": true}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("os.path external CALLS edges = %#v, want %#v", got, want)
+	}
+}
+
+// A bare imported call (`from mymod import run; run(y)`) must keep its external
+// edge even when a dotted call in the same block (`acme.mod.run()`) shares the
+// terminal name and resolves locally. The name-keyed dotted merge must not
+// steal the bare call's resolution.
+func TestPythonDottedCallCollisionKeepsBareExternalEdge(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "acme/__init__.py", "")
+	writeFile(t, repo, "acme/mod.py", `def run():
+    return 1
+`)
+	// A second run() elsewhere makes the name non-globally-unique, so the bare
+	// call relies on the external fallback rather than a unique-name match.
+	writeFile(t, repo, "other/thing.py", `def run():
+    return 2
+`)
+	writeFile(t, repo, "app.py", `import acme.mod
+from mymod import run
+
+
+def f(x, y):
+    acme.mod.run()
+    return run(y)
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, r := range snapshot.Relations {
+		if r.Type == "CALLS" && lastSegment(r.FromID) == "f" && r.ToID == externalID("symbol", "mymod.run") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("missing external CALLS f -> mymod.run: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}
+
+// A submodule-qualified dotted call (`acme_pkg.service.run()`) targets the
+// submodule only. If the package __init__.py also defines the terminal name it
+// must not receive an edge via the parent-directory fallback.
+func TestPythonDottedSubmoduleCallDoesNotResolveToPackageInit(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "acme_pkg/__init__.py", `def run():
+    return "init"
+`)
+	writeFile(t, repo, "acme_pkg/service.py", `def run():
+    return "service"
+`)
+	writeFile(t, repo, "consumer.py", `import acme_pkg.service
+
+
+def call_service():
+    return acme_pkg.service.run()
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	var runTargets []string
+	for _, r := range snapshot.Relations {
+		if r.Type != "CALLS" || lastSegment(r.FromID) != "call_service" {
+			continue
+		}
+		if to, ok := symbolsByID[r.ToID]; ok && to.Name == "run" {
+			runTargets = append(runTargets, to.FilePath)
+		}
+	}
+	if len(runTargets) != 1 || runTargets[0] != "acme_pkg/service.py" {
+		t.Fatalf("call_service run targets = %#v, want exactly [acme_pkg/service.py]", runTargets)
+	}
+}
+
+// A module-qualified dotted call (`acme.mod.helper()`) resolves through the
+// imported module only. A same-file function of the same name must NOT capture
+// it: the dedicated dotted-call path never consults same-file symbols unless
+// the file matches the imported module, so the module target wins.
+func TestPythonDottedImportedCallPrefersModuleOverSameFileDef(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "acme/__init__.py", "")
+	writeFile(t, repo, "acme/mod.py", `def helper():
+    return "remote"
+`)
+	writeFile(t, repo, "app.py", `import acme.mod
+
+
+def helper():
+    return "local"
+
+
+def caller():
+    return acme.mod.helper()
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasRelationBySymbolNameAndFile(snapshot, "CALLS", "caller", "app.py", "helper", "acme/mod.py") {
+		t.Fatalf("dotted call must resolve to acme/mod.py:helper: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+	if hasRelationBySymbolNameAndFile(snapshot, "CALLS", "caller", "app.py", "helper", "app.py") {
+		t.Fatalf("dotted call wrongly captured by same-file app.py:helper: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}
+
+// A submodule-qualified dotted call (`acme.service.zonk()`) whose terminal name
+// is NOT defined in the imported submodule must not fabricate an edge to a
+// globally unique same-named symbol elsewhere in the workspace (here the
+// package __init__.py). The dedicated path never reaches the globally-unique
+// fallback; with no module-scoped local target it emits only the external edge.
+func TestPythonDottedCallDoesNotFabricateGloballyUniqueEdge(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "acme/__init__.py", `def zonk():
+    return "init"
+`)
+	writeFile(t, repo, "acme/service.py", `def other():
+    return 1
+`)
+	writeFile(t, repo, "consumer.py", `import acme.service
+
+
+def call_it():
+    return acme.service.zonk()
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	for _, r := range snapshot.Relations {
+		if r.Type != "CALLS" || lastSegment(r.FromID) != "call_it" {
+			continue
+		}
+		if to, ok := symbolsByID[r.ToID]; ok && to.Name == "zonk" {
+			t.Fatalf("dotted call fabricated wrong edge call_it -> zonk @ %s (service.py has no zonk)", to.FilePath)
+		}
+	}
+	found := false
+	for _, r := range snapshot.Relations {
+		if r.Type == "CALLS" && lastSegment(r.FromID) == "call_it" && r.ToID == externalID("symbol", "acme.service.zonk") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("missing external CALLS call_it -> acme.service.zonk: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+}
+
+// A chained R assignment `a <- b <- function() ...` binds BOTH names at the
+// same scope: a and b are peers, not nested. Emitting the outer name must not
+// walk the inner assignment target as if it lived inside a function body — that
+// mis-marked the inner binding Local and hid it from cross-file resolution,
+// rerouting its callers to an unrelated same-named decoy.
+func TestRChainedAssignmentInnerBindingTopLevel(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "R/a.R", `helper <- validate <- function(x) x + 1
+
+g <- function() {
+  validate(10)
+}
+`)
+	// A same-named decoy in another file: if `validate@a.R` is wrongly marked
+	// Local, g's call reroutes here (name_only) instead of resolving in-file.
+	writeFile(t, repo, "R/b.R", `validate <- function(x) x * 999
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	symByNameFile := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		if s.Language == "R" {
+			symByNameFile[s.Name+"@"+s.FilePath] = s
+		}
+	}
+	for _, key := range []string{"helper@R/a.R", "validate@R/a.R"} {
+		s, ok := symByNameFile[key]
+		if !ok {
+			t.Fatalf("R chained-assignment symbol %s not extracted: %#v", key, symByNameFile)
+		}
+		if s.Kind != "function" {
+			t.Fatalf("R chained-assignment symbol %s should be a function, got %q", key, s.Kind)
+		}
+		// Both names bind at top level; neither may be Local (which would exclude
+		// it from cross-scope/cross-file name-match resolution).
+		if s.Local {
+			t.Fatalf("R chained-assignment symbol %s wrongly marked Local (hidden from resolution)", key)
+		}
+	}
+
+	var toSameFile, toDecoy bool
+	for _, r := range snapshot.Relations {
+		if r.Type != "CALLS" || lastSegment(r.FromID) != "g" || lastSegment(r.ToID) != "validate" {
+			continue
+		}
+		switch {
+		case strings.Contains(r.ToID, "R/a.R"):
+			toSameFile = true
+			if r.Resolution != "exact" {
+				t.Fatalf("g -> validate@a.R should resolve exact, got %q", r.Resolution)
+			}
+		case strings.Contains(r.ToID, "R/b.R"):
+			toDecoy = true
+		}
+	}
+	if !toSameFile {
+		t.Fatalf("expected g -> validate@a.R (exact same-file CALLS edge), got none: %#v", snapshot.Relations)
+	}
+	if toDecoy {
+		t.Fatalf("g must not resolve to the decoy validate@b.R; the in-file binding was wrongly hidden")
+	}
+}
+
+// A three-level chain `x <- y <- z <- function() ...` must leave every
+// plain-identifier target non-Local (all bind at the same top-level scope).
+func TestRChainedAssignmentThreeLevelTopLevel(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "R/chain.R", `x <- y <- z <- function() {
+  1
+}
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		if s.Language == "R" {
+			seen[s.Name] = s
+		}
+	}
+	for _, name := range []string{"x", "y", "z"} {
+		s, ok := seen[name]
+		if !ok {
+			t.Fatalf("three-level chain target %q not extracted: %#v", name, seen)
+		}
+		if s.Kind != "function" {
+			t.Fatalf("three-level chain target %q should be a function, got %q", name, s.Kind)
+		}
+		if s.Local {
+			t.Fatalf("three-level chain target %q wrongly marked Local", name)
+		}
+	}
+}
+
+// A constructor immediately chained into a type-escaping hop
+// (`my $x = Session->new->request`) must not type $x as the constructor class:
+// $x is really an HTTP::Request (what `->request` returns), so `$x->send` must
+// not resolve to Session::send. Because `send` is defined in two packages there
+// is no globally-unique fallback either, so the correct outcome is NO send edge.
+func TestPerlChainedConstructorDoesNotMistypeReceiver(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "lib/App.pm", `package App;
+
+sub run {
+  my $x = Session->new->request;
+  $x->send;
+}
+`)
+	writeFile(t, repo, "lib/Session.pm", `package Session;
+
+sub new { return bless {}, shift }
+
+sub request { return HTTP::Request->new }
+
+sub send { return 1 }
+`)
+	writeFile(t, repo, "lib/HTTP/Request.pm", `package HTTP::Request;
+
+sub new { return bless {}, shift }
+
+sub send { return 2 }
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	for _, r := range snapshot.Relations {
+		if r.Type != "CALLS" || lastSegment(r.FromID) != "run" {
+			continue
+		}
+		if to, ok := symbolsByID[r.ToID]; ok && to.Name == "send" {
+			t.Fatalf("chained-constructor mistype fabricated CALLS run -> send @ %s (reason %q)", to.FilePath, r.Reason)
+		}
+	}
+}
+
+// A constructor-typed local that is reassigned through an untracked call
+// (`my $x = Foo->new; $x = build_widget(); $x->go`) must not keep the stale
+// constructor type: $x really holds a Widget, so `$x->go` must not resolve to
+// Foo::go. With go defined in both Foo and Widget there is no globally-unique
+// fallback either, so the correct outcome is NO run -> go edge.
+func TestPerlReassignedLocalDoesNotResolveViaStaleType(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "lib/App.pm", `package App;
+
+sub run {
+  my $x = Foo->new;
+  $x = build_widget();
+  $x->go;
+}
+`)
+	writeFile(t, repo, "lib/Foo.pm", `package Foo;
+
+sub new { return bless {}, shift }
+
+sub go { return 1 }
+`)
+	writeFile(t, repo, "lib/Widget.pm", `package Widget;
+
+sub new { return bless {}, shift }
+
+sub go { return 2 }
+
+sub build_widget { return Widget->new }
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	for _, r := range snapshot.Relations {
+		if r.Type != "CALLS" || lastSegment(r.FromID) != "run" {
+			continue
+		}
+		if to, ok := symbolsByID[r.ToID]; ok && to.Name == "go" {
+			t.Fatalf("stale-type reassignment fabricated CALLS run -> go @ %s (reason %q)", to.FilePath, r.Reason)
+		}
+	}
+}
+
+// A constructor-typed local reassigned through a list assignment
+// (`my $x = Foo->new; ($x, $y) = fetch(); $x->greet`) must not keep the stale
+// constructor type: $x really holds fetch()'s first return value, not a Foo, so
+// `$x->greet` must not resolve to Foo::greet. With greet defined in both Foo and
+// Bar there is no globally-unique name-only fallback either, so the correct
+// outcome is NO run -> greet edge. This is the exact end-to-end repro that the
+// scalar-only reassignment scan missed (list-assignment LHS has no bare `$x =`).
+func TestPerlListReassignedLocalDoesNotResolveViaStaleType(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "lib/App.pm", `package App;
+
+sub run {
+  my $x = Foo->new;
+  ($x, $y) = fetch();
+  return $x->greet;
+}
+
+sub fetch { return (1, 2); }
+`)
+	writeFile(t, repo, "lib/Foo.pm", `package Foo;
+
+sub new { return bless {}, shift }
+
+sub greet { return 1 }
+`)
+	writeFile(t, repo, "lib/Bar.pm", `package Bar;
+
+sub greet { return 2 }
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	for _, r := range snapshot.Relations {
+		if r.Type != "CALLS" || lastSegment(r.FromID) != "run" {
+			continue
+		}
+		if to, ok := symbolsByID[r.ToID]; ok && to.Name == "greet" {
+			t.Fatalf("list-assignment stale-type fabricated CALLS run -> greet @ %s (reason %q)", to.FilePath, r.Reason)
+		}
+	}
+}
+
+// A multi-hop getter chain (`$url->path->to_string`) must not have its terminal
+// method attributed to the head receiver's package. perlReceiverCalls flattens
+// the chain to {url, to_string}, but to_string is invoked on the Mojo::Path
+// returned by $url->path, not on $url, so type-inferred resolution must skip it.
+// With to_string defined in both Mojo::URL and Mojo::Path there is no
+// globally-unique fallback either, so the correct outcome is NO to_string edge.
+// A genuine single-hop `$url->clone` in the same sub (clone also duplicated
+// across both packages, so only type inference can resolve it) is the positive
+// control that the head-receiver type is still used for real single-hop calls.
+func TestPerlMultiHopChainDoesNotAttributeTerminalToHead(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "lib/App.pm", `package App;
+
+sub build {
+  my $url = Mojo::URL->new;
+  $url->clone;
+  return $url->path->to_string;
+}
+`)
+	writeFile(t, repo, "lib/Mojo/URL.pm", `package Mojo::URL;
+
+sub new { return bless {}, shift }
+
+sub path { return Mojo::Path->new }
+
+sub clone { return shift }
+
+sub to_string { return 'url' }
+`)
+	writeFile(t, repo, "lib/Mojo/Path.pm", `package Mojo::Path;
+
+sub new { return bless {}, shift }
+
+sub clone { return shift }
+
+sub to_string { return 'path' }
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	sawClone := false
+	for _, r := range snapshot.Relations {
+		if r.Type != "CALLS" || lastSegment(r.FromID) != "build" {
+			continue
+		}
+		to, ok := symbolsByID[r.ToID]
+		if !ok {
+			continue
+		}
+		if to.Name == "to_string" {
+			t.Fatalf("multi-hop terminal misattributed: CALLS build -> to_string @ %s (reason %q)", to.FilePath, r.Reason)
+		}
+		if to.Name == "clone" {
+			if to.FilePath != "lib/Mojo/URL.pm" || r.Resolution != "type_inferred" {
+				t.Fatalf("single-hop $url->clone resolved wrong: %s (%s)", to.FilePath, r.Resolution)
+			}
+			sawClone = true
+		}
+	}
+	if !sawClone {
+		t.Fatal("genuine single-hop CALLS build -> clone @ lib/Mojo/URL.pm was dropped")
+	}
+}
+
+// Minimal reproduction of the multi-hop misattribution: `$w->child->name` with
+// name defined in both Widget and Container must not fabricate run -> name in
+// the head receiver Widget's package (the real target is Container::name).
+func TestPerlMultiHopChainMinimalReproNoEdge(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "lib/Run.pm", `package Run;
+
+sub run {
+  my $w = Widget->new;
+  $w->child->name;
+}
+`)
+	writeFile(t, repo, "lib/Widget.pm", `package Widget;
+
+sub new { return bless {}, shift }
+
+sub child { return Container->new }
+
+sub name { return 'widget' }
+`)
+	writeFile(t, repo, "lib/Container.pm", `package Container;
+
+sub new { return bless {}, shift }
+
+sub name { return 'container' }
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	for _, r := range snapshot.Relations {
+		if r.Type != "CALLS" || lastSegment(r.FromID) != "run" {
+			continue
+		}
+		if to, ok := symbolsByID[r.ToID]; ok && to.Name == "name" {
+			t.Fatalf("multi-hop terminal misattributed: CALLS run -> name @ %s (reason %q)", to.FilePath, r.Reason)
+		}
+	}
+}
+
+// A bare receiver type (`Foo`) must resolve only to a top-level package file
+// (lib/Foo.pm), never to a same-basename file in a deeper namespace
+// (lib/Deep/Foo.pm is package Deep::Foo). A `::` type must still match its
+// full namespaced path.
+func TestPerlSymbolFileMatchesTypeRequiresPathBoundary(t *testing.T) {
+	if perlSymbolFileMatchesType("lib/Deep/Foo.pm", "Foo") {
+		t.Fatal("bare type Foo must not match namespaced lib/Deep/Foo.pm")
+	}
+	if !perlSymbolFileMatchesType("lib/Mojo/URL.pm", "Mojo::URL") {
+		t.Fatal("type Mojo::URL must match lib/Mojo/URL.pm")
+	}
+	if !perlSymbolFileMatchesType("lib/Foo.pm", "Foo") {
+		t.Fatal("bare type Foo must match top-level lib/Foo.pm")
+	}
+}
+
+func TestPerlBareReceiverTypeDoesNotMatchNamespacedFile(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "lib/App.pm", `package App;
+
+sub run {
+  my $x = Foo->new;
+  $x->render;
+}
+`)
+	writeFile(t, repo, "lib/Foo.pm", `package Foo;
+
+sub new {
+  return bless {}, shift;
+}
+`)
+	writeFile(t, repo, "lib/Deep/Foo.pm", `package Deep::Foo;
+
+sub render {
+  return 1;
+}
+`)
+	writeFile(t, repo, "lib/Other.pm", `package Other;
+
+sub render {
+  return 2;
+}
+`)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	for _, r := range snapshot.Relations {
+		if r.Type != "CALLS" || lastSegment(r.FromID) != "run" {
+			continue
+		}
+		if to, ok := symbolsByID[r.ToID]; ok && to.Name == "render" {
+			t.Fatalf("emitted wrong CALLS run -> render @ %s (Foo has no render sub)", to.FilePath)
+		}
+	}
+}
+
+// A multi-hop getter-navigation chain (`$tx->req->url`) returns a different
+// object than the receiver, so its assignment target must NOT inherit the
+// receiver's package type. `url` is not a sub of Mojo::Transaction, so the
+// package-membership gate rejects the fluent shortcut and $url stays untyped;
+// a later `$url->path` therefore emits no edge (rather than a wrong edge to
+// Mojo::Transaction::path). `path` is defined in two packages so it cannot
+// resolve via the globally-unique fallback either.
+func TestPerlGetterNavigationChainDoesNotInheritReceiverType(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "lib/App.pm", `package App;
+
+sub run {
+  my $tx  = Mojo::Transaction->new;
+  my $url = $tx->req->url;
+  $url->path;
+}
+`)
+	writeFile(t, repo, "lib/Mojo/Transaction.pm", `package Mojo::Transaction;
+
+sub new {
+  return bless {}, shift;
+}
+
+sub req {
+  return bless {}, 'Mojo::Message::Request';
+}
+
+sub path {
+  return '/tx';
+}
+`)
+	writeFile(t, repo, "lib/Mojo/URL.pm", `package Mojo::URL;
+
+sub path {
+  return '/url';
+}
+`)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, s := range snapshot.Symbols {
+		symbolsByID[s.ID] = s
+	}
+	for _, r := range snapshot.Relations {
+		if r.Type != "CALLS" || lastSegment(r.FromID) != "run" {
+			continue
+		}
+		if to, ok := symbolsByID[r.ToID]; ok && to.Name == "path" {
+			t.Fatalf("getter-navigation chain fabricated CALLS run -> path @ %s", to.FilePath)
+		}
 	}
 }

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -11929,8 +11929,9 @@ sub stash { return {} }
 
 sub url_for {
   my ($self, $target) = (shift, shift // '');
+  my $url  = Mojo::URL->new;
   my $req  = $self->req;
-  my $base = $self->base;
+  my $base = $url->base($req->url->base->clone)->base->userinfo(undef);
 
   if (defined(my $prefix = $self->stash->{path})) {
     my $real = $req->url->path->to_route;
@@ -11947,8 +11948,26 @@ sub to_route {
 `)
 	writeFile(t, repo, "lib/Mojo/URL.pm", `package Mojo::URL;
 
+sub new {
+  return bless {}, shift;
+}
+
+sub base {
+  return shift;
+}
+
+sub userinfo {
+  return shift;
+}
+
 sub protocol {
   return 'http';
+}
+`)
+	writeFile(t, repo, "lib/Mojo/Transaction/WebSocket.pm", `package Mojo::Transaction::WebSocket;
+
+sub protocol {
+  return 'websocket';
 }
 `)
 	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
@@ -11965,20 +11984,23 @@ sub protocol {
 			calls[lastSegment(r.FromID)+"->"+lastSegment(r.ToID)] = r
 		}
 	}
-	for _, want := range []string{
-		"url_for->stash",
-		"url_for->to_route",
-		"url_for->protocol",
-	} {
+	for _, want := range []string{"url_for->stash", "url_for->to_route", "url_for->protocol"} {
 		r, ok := calls[want]
 		if !ok {
 			t.Fatalf("missing Perl receiver call %s in %#v", want, calls)
 		}
-		if got := r.Reason; got != "Perl receiver call matched globally unique subroutine name" {
-			t.Fatalf("%s reason = %q", want, got)
+		wantReason := "Perl receiver call matched globally unique subroutine name"
+		if want == "url_for->protocol" {
+			wantReason = "Perl receiver call resolved via inferred package receiver type"
+		}
+		if got := r.Reason; got != wantReason {
+			t.Fatalf("%s reason = %q, want %q", want, got, wantReason)
 		}
 		if symbolsByID[r.ToID].Language != "Perl" {
 			t.Fatalf("%s resolved to non-Perl target: %#v", want, symbolsByID[r.ToID])
+		}
+		if want == "url_for->protocol" && symbolsByID[r.ToID].FilePath != "lib/Mojo/URL.pm" {
+			t.Fatalf("%s resolved to wrong Perl protocol target: %#v", want, symbolsByID[r.ToID])
 		}
 	}
 }

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12106,6 +12106,7 @@ $base = $url->base->userinfo;
 func TestPerlCommentStrippingPreservesHashSyntax(t *testing.T) {
 	stripped := stripPerlCodeLiteralsAndComments(`my $last = $#items;
 $value =~ s/#/x/;
+$value =~ s{#}{x}; $obj->method;
 $value = $maybe // $fallback;
 $base = $url->base # ->userinfo
 `)
@@ -12115,11 +12116,18 @@ $base = $url->base # ->userinfo
 	if !strings.Contains(stripped, "s/#/x/") {
 		t.Fatalf("Perl regex hash was masked: %q", stripped)
 	}
+	if !strings.Contains(stripped, "s{#}{x}; $obj->method") {
+		t.Fatalf("Perl brace-delimited regex hash masked following code: %q", stripped)
+	}
 	if !strings.Contains(stripped, "// $fallback") {
 		t.Fatalf("Perl defined-or operator was masked: %q", stripped)
 	}
 	if strings.Contains(stripped, "userinfo") {
 		t.Fatalf("Perl line comment was not masked: %q", stripped)
+	}
+	calls := perlReceiverCalls(`$value =~ s{#}{x}; $obj->method;`)
+	if len(calls) != 1 || calls[0].Receiver != "obj" || calls[0].Method != "method" {
+		t.Fatalf("Perl receiver call after brace-delimited regex was masked: %#v", calls)
 	}
 }
 

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12060,6 +12060,18 @@ my $path = $url->path # ->base->userinfo
 	}
 }
 
+func TestPerlLocalVarTypesAllowKeywordlessAssignments(t *testing.T) {
+	types := perlLocalVarTypes(`$url = Mojo::URL->new;
+$base = $url->base->userinfo;
+`)
+	if got := types["url"]; got != "Mojo::URL" {
+		t.Fatalf("keywordless constructor inferred url type %q from %#v", got, types)
+	}
+	if got := types["base"]; got != "Mojo::URL" {
+		t.Fatalf("keywordless fluent assignment inferred base type %q from %#v", got, types)
+	}
+}
+
 func TestHaskellSemanticExtraction(t *testing.T) {
 	// Haskell was promoted from inventory to the semantic tier (vendored
 	// grammar); it must now extract top-level function bindings (one symbol

--- a/internal/sem/python_calls.go
+++ b/internal/sem/python_calls.go
@@ -25,7 +25,7 @@ func pythonDottedCallImportedNames(block string, importsByName map[string][]stri
 		}
 		name := parts[len(parts)-1]
 		tail := parts[1 : len(parts)-1]
-		if len(tail) == 0 {
+		if len(tail) == 0 && !pythonSingleSelectorAliasCall(alias, imported) {
 			continue
 		}
 		for _, module := range pythonDottedCallModules(alias, tail, imported) {
@@ -55,6 +55,19 @@ func pythonDottedPathParts(path string) []string {
 		parts = append(parts, part)
 	}
 	return parts
+}
+
+func pythonSingleSelectorAliasCall(alias string, imported []string) bool {
+	for _, module := range imported {
+		module = strings.TrimSpace(module)
+		if module == "" {
+			continue
+		}
+		if module != alias || pythonOSPathDottedCall(alias, nil, module) {
+			return true
+		}
+	}
+	return false
 }
 
 func pythonDottedCallModules(alias string, tail []string, imported []string) []string {

--- a/internal/sem/python_calls.go
+++ b/internal/sem/python_calls.go
@@ -130,12 +130,23 @@ func pythonDottedCallModules(alias string, tail []string, imported []string) []s
 		if module == "" {
 			continue
 		}
-		add(module)
 		if len(tail) > 0 && !strings.Contains(module, "/") {
 			tailSpec := strings.Join(tail, ".")
-			if module == alias || !strings.HasSuffix(module, "."+tailSpec) {
-				add(module + "." + tailSpec)
+			selectorModule := alias + "." + tailSpec
+			switch {
+			case module == alias:
+				add(selectorModule)
+			case module == selectorModule || strings.HasPrefix(module, selectorModule+"."):
+				add(selectorModule)
+			case strings.Split(module, ".")[0] != alias:
+				if strings.HasSuffix(module, "."+tailSpec) {
+					add(module)
+				} else {
+					add(module + "." + tailSpec)
+				}
 			}
+		} else {
+			add(module)
 		}
 		if pythonOSPathDottedCall(alias, tail, module) {
 			add("genericpath")

--- a/internal/sem/python_calls.go
+++ b/internal/sem/python_calls.go
@@ -1,0 +1,99 @@
+package sem
+
+import (
+	"regexp"
+	"strings"
+)
+
+var pythonDottedCallRe = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_]*(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_]*)+)\s*\(`)
+
+func pythonDottedCallImportedNames(block string, importsByName map[string][]string) map[string][]string {
+	stripped := stripCodeLiteralsAndComments(block)
+	out := map[string][]string{}
+	for _, m := range pythonDottedCallRe.FindAllStringSubmatchIndex(stripped, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		parts := pythonDottedPathParts(stripped[m[2]:m[3]])
+		if len(parts) < 2 {
+			continue
+		}
+		alias := parts[0]
+		imported := importsByName[alias]
+		if len(imported) == 0 {
+			continue
+		}
+		name := parts[len(parts)-1]
+		tail := parts[1 : len(parts)-1]
+		for _, module := range pythonDottedCallModules(alias, tail, imported) {
+			out[name] = append(out[name], module)
+		}
+		out[name] = uniqueStrings(out[name])
+	}
+	return out
+}
+
+func cloneStringSliceMap(in map[string][]string) map[string][]string {
+	out := make(map[string][]string, len(in))
+	for key, values := range in {
+		out[key] = append([]string(nil), values...)
+	}
+	return out
+}
+
+func pythonDottedPathParts(path string) []string {
+	raw := strings.Split(path, ".")
+	parts := make([]string, 0, len(raw))
+	for _, part := range raw {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil
+		}
+		parts = append(parts, part)
+	}
+	return parts
+}
+
+func pythonDottedCallModules(alias string, tail []string, imported []string) []string {
+	var modules []string
+	add := func(module string) {
+		module = strings.TrimSpace(module)
+		if module != "" {
+			modules = append(modules, module)
+		}
+	}
+	for _, module := range imported {
+		module = strings.TrimSpace(module)
+		if module == "" {
+			continue
+		}
+		add(module)
+		if len(tail) > 0 && !strings.Contains(module, "/") {
+			tailSpec := strings.Join(tail, ".")
+			add(module + "." + tailSpec)
+			if module == alias || strings.HasSuffix(module, "."+tailSpec) {
+				add(module)
+			}
+		}
+		if pythonOSPathDottedCall(alias, tail, module) {
+			add("genericpath")
+			add("posixpath")
+			add("ntpath")
+		}
+	}
+	return uniqueStrings(modules)
+}
+
+func pythonOSPathDottedCall(alias string, tail []string, module string) bool {
+	module = strings.TrimSpace(module)
+	switch {
+	case module == "os.path":
+		return true
+	case module == "os" && alias == "os" && len(tail) > 0 && tail[0] == "path":
+		return true
+	case module == "os" && alias == "path" && len(tail) == 0:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/sem/python_calls.go
+++ b/internal/sem/python_calls.go
@@ -145,6 +145,8 @@ func pythonDottedCallModules(alias string, tail []string, imported []string) []s
 					add(module + "." + tailSpec)
 				}
 			}
+		} else if module == "os" && alias == "path" && len(tail) == 0 {
+			add("os.path")
 		} else {
 			add(module)
 		}

--- a/internal/sem/python_calls.go
+++ b/internal/sem/python_calls.go
@@ -25,6 +25,9 @@ func pythonDottedCallImportedNames(block string, importsByName map[string][]stri
 		}
 		name := parts[len(parts)-1]
 		tail := parts[1 : len(parts)-1]
+		if len(tail) == 0 {
+			continue
+		}
 		for _, module := range pythonDottedCallModules(alias, tail, imported) {
 			out[name] = append(out[name], module)
 		}
@@ -70,9 +73,8 @@ func pythonDottedCallModules(alias string, tail []string, imported []string) []s
 		add(module)
 		if len(tail) > 0 && !strings.Contains(module, "/") {
 			tailSpec := strings.Join(tail, ".")
-			add(module + "." + tailSpec)
-			if module == alias || strings.HasSuffix(module, "."+tailSpec) {
-				add(module)
+			if module == alias || !strings.HasSuffix(module, "."+tailSpec) {
+				add(module + "." + tailSpec)
 			}
 		}
 		if pythonOSPathDottedCall(alias, tail, module) {

--- a/internal/sem/python_calls.go
+++ b/internal/sem/python_calls.go
@@ -83,14 +83,6 @@ func stripPythonLiteralsAndComments(content string) string {
 	return string(bytes)
 }
 
-func cloneStringSliceMap(in map[string][]string) map[string][]string {
-	out := make(map[string][]string, len(in))
-	for key, values := range in {
-		out[key] = append([]string(nil), values...)
-	}
-	return out
-}
-
 func pythonDottedPathParts(path string) []string {
 	raw := strings.Split(path, ".")
 	parts := make([]string, 0, len(raw))

--- a/internal/sem/python_calls.go
+++ b/internal/sem/python_calls.go
@@ -8,7 +8,7 @@ import (
 var pythonDottedCallRe = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_]*(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_]*)+)\s*\(`)
 
 func pythonDottedCallImportedNames(block string, importsByName map[string][]string) map[string][]string {
-	stripped := stripCodeLiteralsAndComments(block)
+	stripped := stripPythonLiteralsAndComments(block)
 	out := map[string][]string{}
 	for _, m := range pythonDottedCallRe.FindAllStringSubmatchIndex(stripped, -1) {
 		if len(m) < 4 {
@@ -36,6 +36,51 @@ func pythonDottedCallImportedNames(block string, importsByName map[string][]stri
 		out[name] = uniqueStrings(out[name])
 	}
 	return out
+}
+
+func stripPythonLiteralsAndComments(content string) string {
+	bytes := []byte(content)
+	for i := 0; i < len(bytes); i++ {
+		switch bytes[i] {
+		case '"', '\'':
+			quote := bytes[i]
+			if i+2 < len(bytes) && bytes[i+1] == quote && bytes[i+2] == quote {
+				j := i + 3
+				for j+2 < len(bytes) && !(bytes[j] == quote && bytes[j+1] == quote && bytes[j+2] == quote) {
+					j++
+				}
+				if j+2 < len(bytes) {
+					j += 3
+				}
+				maskBytes(bytes, i, j)
+				i = j - 1
+				continue
+			}
+			for j := i + 1; j < len(bytes); j++ {
+				if bytes[j] == '\n' || bytes[j] == '\r' {
+					i = j
+					break
+				}
+				if bytes[j] == '\\' {
+					j++
+					continue
+				}
+				if bytes[j] == quote {
+					maskBytes(bytes, i, j+1)
+					i = j
+					break
+				}
+			}
+		case '#':
+			j := i + 1
+			for j < len(bytes) && bytes[j] != '\n' && bytes[j] != '\r' {
+				j++
+			}
+			maskBytes(bytes, i, j)
+			i = j
+		}
+	}
+	return string(bytes)
 }
 
 func cloneStringSliceMap(in map[string][]string) map[string][]string {

--- a/internal/sem/python_calls.go
+++ b/internal/sem/python_calls.go
@@ -1,15 +1,23 @@
 package sem
 
 import (
+	"path"
 	"regexp"
 	"strings"
 )
 
 var pythonDottedCallRe = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_]*(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_]*)+)\s*\(`)
 
-func pythonDottedCallImportedNames(block string, importsByName map[string][]string) map[string][]string {
+// pythonDottedCallImportedNames maps each dotted call's terminal name to the
+// candidate modules its callable could live in. It returns two maps keyed by
+// that terminal name: allModules feeds local symbol resolution (it includes
+// the os.path stdlib fan-out), while externalModules feeds the imported
+// external-symbol fallback (it excludes the fan-out, which must never become a
+// speculative external edge in an ordinary repo).
+func pythonDottedCallImportedNames(block string, importsByName map[string][]string, importFormsByName map[string]map[string]pythonImportForm, moduleExists func(module string) bool) (allModules, externalModules map[string][]string) {
 	stripped := stripPythonLiteralsAndComments(block)
-	out := map[string][]string{}
+	allModules = map[string][]string{}
+	externalModules = map[string][]string{}
 	for _, m := range pythonDottedCallRe.FindAllStringSubmatchIndex(stripped, -1) {
 		if len(m) < 4 {
 			continue
@@ -25,17 +33,358 @@ func pythonDottedCallImportedNames(block string, importsByName map[string][]stri
 		}
 		name := parts[len(parts)-1]
 		tail := parts[1 : len(parts)-1]
+		// An empty tail is a single-selector call `alias.name()`. It only names a
+		// module the terminal lives in when the alias renames a module (`import x.y
+		// as alias`) or is the os.path facade (`from os import path`); a plain
+		// `import json; json.dumps()` (module == alias) is a member call resolved
+		// elsewhere. pythonSingleSelectorAliasCall makes that distinction.
 		if len(tail) == 0 && !pythonSingleSelectorAliasCall(alias, imported) {
 			continue
 		}
-		for _, module := range pythonDottedCallModules(alias, tail, imported) {
-			out[name] = append(out[name], module)
+		all, external := pythonDottedCallModules(alias, tail, imported, importFormsByName[alias], moduleExists)
+		allModules[name] = uniqueStrings(append(allModules[name], all...))
+		externalModules[name] = uniqueStrings(append(externalModules[name], external...))
+	}
+	return allModules, externalModules
+}
+
+// pythonDottedCallRelations resolves dotted imported-module calls
+// (`pkg.mod.fn()`) through a strictly module-scoped path, independent of the
+// generic bare-call resolver. The module qualifier is authoritative: a local
+// target is accepted only when its file matches one of the imported modules via
+// dottedImportedModuleMatchesFile, a dedicated STRICT matcher that admits only
+// the module's own source file or that package's __init__ — no parent-directory
+// or basename fallback, so a sibling submodule (`acme.mod.run` resolving to
+// acme/service.py) can never match. Because this path never consults same-file
+// symbols, the globally-unique-name fallback, the parent-directory package, or
+// any sibling submodule, none of those can capture a dotted call whose terminal
+// name happens to match an unrelated local, workspace-unique, sibling, or
+// package-init symbol. When no file matches the imported module the call falls
+// back to an imported external edge, exactly as the bare imported-call fallback
+// does. A terminal name that has its own bare import binding is left to the
+// generic path so a bare-imported call keeps its established behavior.
+func pythonDottedCallRelations(from SymbolRecord, allModules, externalModules, importsByName map[string][]string, symbolsByShortName map[string][]SymbolRecord, childNames map[string]bool) []RelationRecord {
+	if typeLikeKind(from.Kind) {
+		return nil
+	}
+	var relations []RelationRecord
+	for _, name := range sortedKeysOf(allModules) {
+		if name == from.Name || childNames[name] {
+			continue
+		}
+		// Collision rule: a bare import of the terminal name owns the name's
+		// resolution and external fallback; forgo the dotted edge so the bare
+		// call keeps its established (pre-dotted-call) behavior.
+		if len(importsByName[name]) > 0 {
+			continue
+		}
+		modules := allModules[name]
+		var local []RelationRecord
+		// hadLocalCandidate records whether ANY reachable in-repo Python symbol of
+		// the terminal name lives in the imported module or one of its ancestor
+		// packages — a genuine in-repo target of this dotted call — BEFORE the kind
+		// gate below excludes methods/fields. The dotted tail of
+		// `pkg.mod.Class.method()` mixes submodule and class segments; the strict
+		// module matcher treats every tail segment as a module path, so a method
+		// whose class is a trailing tail segment resolves against an ANCESTOR
+		// module's file (`myapp.models.User.save` -> myapp/models.py). When such a
+		// member matched but was kind-gated out of the local edge, the external
+		// fallback must NOT fire: the call targets an in-repo member and the
+		// generic receiver path already emits the correct edge for it.
+		hadLocalCandidate := false
+		for _, to := range symbolsByShortName[name] {
+			// symbolsByShortName is a workspace-wide index across every language, so
+			// a Python dotted call whose terminal name and dotted module stem
+			// collide with a same-path symbol in another language (`acme.mod.run()`
+			// vs a Go `func run` in acme/mod.go) would otherwise resolve
+			// cross-language — the sibling Haskell and Perl structural paths gate on
+			// to.Language for the same reason, so require the target itself be
+			// Python here. An unreachable nested/closure local is never a candidate.
+			if to.ID == from.ID || to.Language != "Python" || !localReachable(from, to) {
+				continue
+			}
+			// A local Python symbol of ANY kind whose own SOURCE file is the imported
+			// module or an ancestor module (a class member's file, reached by
+			// dropping trailing class segments of the dotted tail) is an in-repo
+			// target of this dotted call. Record it before the kind gate so a
+			// kind-excluded method/field cannot be relabeled as an external call by
+			// the fallback below.
+			if dottedImportedModuleSourceFileIsAncestor(modules, to.FilePath) {
+				hadLocalCandidate = true
+			}
+			// A bare `name()` call is a function, not a class method (methods carry
+			// an explicit receiver and are resolved elsewhere), so mirror the
+			// generic resolver's kind gate for Python.
+			if to.Kind == "field" || to.Kind == "method" {
+				continue
+			}
+			if !dottedImportedModuleMatchesFile(modules, to.FilePath) {
+				continue
+			}
+			relType := "CALLS"
+			if typeLikeKind(to.Kind) {
+				relType = "CONSTRUCTS"
+			}
+			local = append(local, RelationRecord{
+				RecordType:    "relation",
+				FromID:        from.ID,
+				ToID:          to.ID,
+				Type:          relType,
+				Confidence:    0.86,
+				Reason:        "direct call expression resolved through import path",
+				RelationScope: "module",
+				Resolution:    "import_resolved",
+				TargetKind:    "symbol",
+				Evidence: []Evidence{{
+					Kind:      "call_site",
+					FilePath:  from.FilePath,
+					StartLine: from.StartLine,
+					EndLine:   from.EndLine,
+					Detail:    name,
+				}},
+				WarningCodes: []string{},
+			})
+		}
+		if len(local) > 0 {
+			relations = append(relations, local...)
+			continue
+		}
+		if hadLocalCandidate {
+			// A local Python symbol matched the imported module (or an ancestor
+			// package) and the terminal name but was excluded from the dotted edge
+			// by the kind gate (a method/field, resolved through the generic
+			// receiver path). The call targets an in-repo member, so the dotted path
+			// emits nothing rather than fabricate an external edge to an in-repo
+			// target — the generic pipeline still emits the correct local edge.
+			continue
+		}
+		relations = append(relations, importedExternalCallRelationsForName(from, name, externalModules[name])...)
+	}
+	return relations
+}
+
+func pythonDottedPathParts(path string) []string {
+	raw := strings.Split(path, ".")
+	parts := make([]string, 0, len(raw))
+	for _, part := range raw {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil
+		}
+		parts = append(parts, part)
+	}
+	return parts
+}
+
+// pythonDottedCallModules resolves the candidate modules for a dotted call's
+// terminal name. It returns (all, external): all is the full candidate set used
+// for local resolution; external is the subset eligible to become an imported
+// external-symbol edge. They differ only in the os.path stdlib fan-out, which
+// is local-only.
+//
+// The syntactic FORM of each import, recorded at parse time (forms[module]),
+// drives composition without guessing it back from the module string — three
+// audit rounds of false edges came from that guess. `from pkg import service`
+// and `import pkg as service` record string-identical importsByName bindings but
+// mean different things; the form disambiguates them at the source:
+//
+//   - pythonPlainImport (`import a.b`, alias is the module's leading segment):
+//     the literal dotted call path `alias.<tail>` IS the module the terminal
+//     lives in (`import pkg.a` + pkg.a.b.fn -> pkg.a.b, never the doubled
+//     pkg.a.a.b). This is the zero value, so a nil/absent form map composes as a
+//     plain import — the pure-string unit tests rely on that default.
+//   - pythonAliasRename (`import a.b as c`): the local name IS the module a.b,
+//     so the terminal lives in module.<tail> (`import x.y as x` + x.z.fn ->
+//     x.y.z; `import pkg as service` + service.helper.fn -> pkg.helper).
+//   - pythonFromImport (`from pkg import name`): name is a MEMBER of pkg. It is a
+//     submodule path only when `pkg.name` is a real submodule file (moduleExists,
+//     a repo-grounded predicate; nil in pure-string unit tests); then the
+//     terminal lives in pkg.name.<tail>. Otherwise name is a class, a function,
+//     or a module-level value (a singleton such as `db = SQLAlchemy()`), and
+//     `name.attr.fn()` is attribute access, not a `pkg.attr` submodule path —
+//     compose NOTHING (no local candidate, no external candidate; precision >
+//     recall). This covers every member kind uniformly, so no re-export or
+//     callable-kind gate is needed.
+func pythonDottedCallModules(alias string, tail []string, imported []string, forms map[string]pythonImportForm, moduleExists func(module string) bool) (all, external []string) {
+	addBoth := func(module string) {
+		module = strings.TrimSpace(module)
+		if module != "" {
+			all = append(all, module)
+			external = append(external, module)
 		}
 	}
-	for name := range out {
-		out[name] = uniqueStrings(out[name])
+	addLocalOnly := func(module string) {
+		module = strings.TrimSpace(module)
+		if module != "" {
+			all = append(all, module)
+		}
 	}
-	return out
+	for _, module := range imported {
+		module = strings.TrimSpace(module)
+		if module == "" {
+			continue
+		}
+		// The terminal name's defining module is what we must name. `import os`
+		// calling `os.path.isdir(x)` looks up isdir under the dotted tail
+		// (os.path), never in the bare `os` package, so we compose the module
+		// from the alias/module and the tail per the recorded import form rather
+		// than adding the bare module on its own.
+		if len(tail) > 0 && !strings.Contains(module, "/") {
+			tailSpec := strings.Join(tail, ".")
+			switch forms[module] {
+			case pythonAliasRename:
+				// The local name IS the module (`import x.y as x` binds x to x.y),
+				// so the terminal lives in module.<tail>.
+				addBoth(module + "." + tailSpec)
+			case pythonFromImport:
+				// The name is a member of `module` and only names a submodule path
+				// when module.alias is a real submodule file; otherwise it is a
+				// class/function/module-level value and `alias.<tail>.fn()` is
+				// attribute access — compose nothing.
+				if moduleExists != nil && moduleExists(module+"."+alias) {
+					addBoth(module + "." + alias + "." + tailSpec)
+				}
+			default:
+				// pythonPlainImport: the literal dotted call path `alias.<tail>` is
+				// the module. Compose that directly instead of appending the tail
+				// onto `module`, which would double the shared leading segment(s).
+				addBoth(alias + "." + tailSpec)
+			}
+		} else if len(tail) == 0 {
+			// Single-selector call `alias.name()` that reached here past
+			// pythonSingleSelectorAliasCall. The os.path facade (`from os import
+			// path; path.isdir()`) addresses os.path; otherwise the alias renames a
+			// module (`import x.y as alias`) so name is a member of that module.
+			if module == "os" && alias == "path" {
+				addBoth("os.path")
+			} else if module != alias {
+				addBoth(module)
+			}
+		}
+		if pythonOSPathDottedCall(alias, tail, module) {
+			// The os.path facade is really posixpath/ntpath (genericpath for the
+			// shared parts). These candidates exist so os.path.* calls resolve
+			// against a vendored CPython stdlib during LOCAL resolution; a normal
+			// repo has no genericpath/posixpath/ntpath files, so they must never
+			// feed the external-symbol fallback.
+			addLocalOnly("genericpath")
+			addLocalOnly("posixpath")
+			addLocalOnly("ntpath")
+		}
+	}
+	return uniqueStrings(all), uniqueStrings(external)
+}
+
+func pythonOSPathDottedCall(alias string, tail []string, module string) bool {
+	module = strings.TrimSpace(module)
+	switch {
+	case module == "os.path":
+		return true
+	case module == "os" && alias == "os" && len(tail) > 0 && tail[0] == "path":
+		return true
+	case module == "os" && alias == "path" && len(tail) == 0:
+		// `from os import path; path.isdir()` — the single-selector os.path facade.
+		return true
+	default:
+		return false
+	}
+}
+
+// dottedImportedModuleMatchesFile reports whether any candidate module resolves
+// to targetPath under the STRICT module-file rule used exclusively by the
+// dotted-call path.
+func dottedImportedModuleMatchesFile(modules []string, targetPath string) bool {
+	for _, module := range modules {
+		if dottedModuleMatchesFileStrict(module, targetPath) {
+			return true
+		}
+	}
+	return false
+}
+
+// dottedImportedModuleSourceFileIsAncestor reports whether targetPath is the
+// module SOURCE file (`.py`/`.pyi`, never an __init__ package file) for one of
+// the candidate modules or for one of its ancestor modules. The dotted tail of
+// `pkg.mod.Class.method()` mixes submodule and CLASS segments, but the strict
+// matcher treats every tail segment as a module path; a class-member call
+// therefore resolves against an ancestor module's own source file
+// (`myapp.models.User.save` -> myapp/models.py, dropping the class segment
+// `User`). Matching is restricted to the module's own source file so that only
+// trailing CLASS segments may be dropped: dropping a real submodule segment to a
+// package __init__ (a sibling such as `acme.service.zonk` -> acme/__init__.py)
+// is NOT a match, and that call's genuine external edge survives. Only the
+// external-fallback SUPPRESSION uses this ancestor-aware match; the local EDGE
+// emission keeps the strict module matcher.
+func dottedImportedModuleSourceFileIsAncestor(modules []string, targetPath string) bool {
+	for _, module := range modules {
+		for m := strings.TrimSpace(module); m != ""; {
+			if dottedModuleSourceFileMatches(m, targetPath) {
+				return true
+			}
+			idx := strings.LastIndex(m, ".")
+			if idx < 0 {
+				break
+			}
+			m = m[:idx]
+		}
+	}
+	return false
+}
+
+// dottedModuleSourceFileMatches is the module's-own-source-file half of
+// dottedModuleMatchesFileStrict, WITHOUT the __init__ package-directory rule:
+// module "a.b" matches F iff F's slash-path stem equals "a/b" or ends with
+// "/a/b" (which absorbs a source-root prefix such as src/ or Lib/).
+func dottedModuleSourceFileMatches(module, targetPath string) bool {
+	module = strings.TrimSpace(module)
+	if module == "" {
+		return false
+	}
+	moduleStem := strings.ReplaceAll(module, ".", "/")
+	target := path.Clean(strings.ReplaceAll(targetPath, "\\", "/"))
+	stem := strings.TrimSuffix(target, path.Ext(target))
+	return stem == moduleStem || strings.HasSuffix(stem, "/"+moduleStem)
+}
+
+// dottedModuleMatchesFileStrict matches a dotted Python module ("a.b") to a
+// file for the dedicated dotted-call path ONLY. Unlike importModuleMatchesFile
+// it has no parent-directory or basename fallback (that fallback matched any
+// sibling submodule): module "a.b" matches F iff F's slash-path stem equals
+// "a/b" or ends with "/a/b" — which naturally absorbs a source-root prefix such
+// as src/ or Lib/ on the "/" boundary — OR F is ".../a/b/__init__.py" (the
+// module IS that package). Nothing else.
+func dottedModuleMatchesFileStrict(module, targetPath string) bool {
+	module = strings.TrimSpace(module)
+	if module == "" {
+		return false
+	}
+	moduleStem := strings.ReplaceAll(module, ".", "/")
+	target := path.Clean(strings.ReplaceAll(targetPath, "\\", "/"))
+	// F is the module's own source file: .../a/b.py or .../a/b.pyi.
+	if stem := strings.TrimSuffix(target, path.Ext(target)); stem == moduleStem || strings.HasSuffix(stem, "/"+moduleStem) {
+		return true
+	}
+	// F is the package's __init__: .../a/b/__init__.py — the module IS the
+	// package directory.
+	if base := path.Base(target); base == "__init__.py" || base == "__init__.pyi" {
+		if dir := path.Dir(target); dir == moduleStem || strings.HasSuffix(dir, "/"+moduleStem) {
+			return true
+		}
+	}
+	return false
+}
+
+func pythonSingleSelectorAliasCall(alias string, imported []string) bool {
+	for _, module := range imported {
+		module = strings.TrimSpace(module)
+		if module == "" {
+			continue
+		}
+		if module != alias || pythonOSPathDottedCall(alias, nil, module) {
+			return true
+		}
+	}
+	return false
 }
 
 func stripPythonLiteralsAndComments(content string) string {
@@ -81,86 +430,4 @@ func stripPythonLiteralsAndComments(content string) string {
 		}
 	}
 	return string(bytes)
-}
-
-func pythonDottedPathParts(path string) []string {
-	raw := strings.Split(path, ".")
-	parts := make([]string, 0, len(raw))
-	for _, part := range raw {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			return nil
-		}
-		parts = append(parts, part)
-	}
-	return parts
-}
-
-func pythonSingleSelectorAliasCall(alias string, imported []string) bool {
-	for _, module := range imported {
-		module = strings.TrimSpace(module)
-		if module == "" {
-			continue
-		}
-		if module != alias || pythonOSPathDottedCall(alias, nil, module) {
-			return true
-		}
-	}
-	return false
-}
-
-func pythonDottedCallModules(alias string, tail []string, imported []string) []string {
-	var modules []string
-	add := func(module string) {
-		module = strings.TrimSpace(module)
-		if module != "" {
-			modules = append(modules, module)
-		}
-	}
-	for _, module := range imported {
-		module = strings.TrimSpace(module)
-		if module == "" {
-			continue
-		}
-		if len(tail) > 0 && !strings.Contains(module, "/") {
-			tailSpec := strings.Join(tail, ".")
-			selectorModule := alias + "." + tailSpec
-			switch {
-			case module == alias:
-				add(selectorModule)
-			case module == selectorModule || strings.HasPrefix(module, selectorModule+"."):
-				add(selectorModule)
-			case strings.Split(module, ".")[0] != alias:
-				if strings.HasSuffix(module, "."+tailSpec) {
-					add(module)
-				} else {
-					add(module + "." + tailSpec)
-				}
-			}
-		} else if module == "os" && alias == "path" && len(tail) == 0 {
-			add("os.path")
-		} else {
-			add(module)
-		}
-		if pythonOSPathDottedCall(alias, tail, module) {
-			add("genericpath")
-			add("posixpath")
-			add("ntpath")
-		}
-	}
-	return uniqueStrings(modules)
-}
-
-func pythonOSPathDottedCall(alias string, tail []string, module string) bool {
-	module = strings.TrimSpace(module)
-	switch {
-	case module == "os.path":
-		return true
-	case module == "os" && alias == "os" && len(tail) > 0 && tail[0] == "path":
-		return true
-	case module == "os" && alias == "path" && len(tail) == 0:
-		return true
-	default:
-		return false
-	}
 }

--- a/internal/sem/python_calls.go
+++ b/internal/sem/python_calls.go
@@ -31,6 +31,8 @@ func pythonDottedCallImportedNames(block string, importsByName map[string][]stri
 		for _, module := range pythonDottedCallModules(alias, tail, imported) {
 			out[name] = append(out[name], module)
 		}
+	}
+	for name := range out {
 		out[name] = uniqueStrings(out[name])
 	}
 	return out

--- a/internal/sem/types.go
+++ b/internal/sem/types.go
@@ -2379,6 +2379,23 @@ type receiverCall struct {
 	Receiver string
 	Method   string
 	Args     string
+	// Hops is the number of `->`/`.` method segments in the flattened receiver
+	// chain that produced this call. It is set only by perlReceiverCalls, which
+	// flattens a whole chain (`$url->path->to_string`) to {head-receiver,
+	// terminal-method}: a value of 2 or more means Method is NOT invoked directly
+	// on Receiver but on an intermediate object, so type-inferred receiver
+	// resolution must not attribute Method to Receiver's package. Every other
+	// extractor leaves Hops at its zero value 0, which denotes a structurally
+	// single-hop `receiver.method` call — receiverCallRe and the language
+	// scanners capture adjacent receiver/method tokens — and is treated as
+	// single-hop-eligible.
+	Hops int
+	// SetterAssign marks a call synthesized from a property-assignment
+	// (`obj.prop = x`), set only by dartSetterAssignmentCalls. Such a call
+	// invokes the SETTER accessor; for a read-write property (same-named getter
+	// and setter) the shared short-name method index collapses to one accessor,
+	// so the resolver consults this flag to prefer the setter deterministically.
+	SetterAssign bool
 }
 
 var receiverCallRe = regexp.MustCompile(`([A-Za-z_$][\w$]*)\s*(?:->|\.)\s*([A-Za-z_]\w*)\s*(?:<[^>\n;{}()]*>)?\(`)


### PR DESCRIPTION
## What changed

- Adds general extractor support for the remaining live graph miss clusters: Python dotted imported module calls, R chained-assignment function values, Dart setter assignments, Haskell higher-order function arguments, and Perl receiver-call resolution via inferred receiver types.
- Keeps the fixes language-level and regression-tested rather than repository-specific.

## Why

The 2026-07-06 live parity rerun left seven narrow entire-live miss clusters. This PR fixes the extractor-side clusters that were confirmed as real provider gaps.

## Validation

- `go test ./...`
- Targeted brain-bench cleanup run on the affected graph/path/hub cases passed 26/26 cases and 183/183 scored items with 0 errors when paired with the brain-bench harness/expectation fixes.
