### PR TITLE
Add native hybrid source search

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,9 @@ semantic graph rather than human-oriented diff text.
 - `symbols --format ndjson` emits the same header followed by symbol records.
 - `edges --format ndjson` emits the same header followed by relation records.
 - `search --query ...` emits ranked, qrel-blind source regions as JSON, NDJSON,
-  or text without network access or a hosted model.
+  or text without network access or a hosted model. Search output is bounded to
+  16 KiB of serialized result context by default; use `--max-context-bytes 0`
+  for an unbounded diagnostic ranking.
 
 Snapshot headers include the schema version, provider version, repository key,
 `HEAD` commit and tree when available, parsed languages, capability labels,

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ entire sem capabilities --json
 entire sem snapshot --repo . --format ndjson
 entire sem symbols --repo . --format ndjson
 entire sem edges --repo . --format ndjson
+entire sem search --repo . --query "where is service config disabled?"
 entire sem snapshot --repo . --format ndjson --worktree --ignore-file .brainignore
 entire sem snapshot --repo . --format ndjson --worktree --include-file .seminclude
 ```
@@ -110,6 +111,31 @@ See [docs/operations.md](docs/operations.md) for target and cgo details.
 
 ## Commands
 
+Search the live working tree for ranked source regions:
+
+```sh
+entire sem search --repo . --query "where is service config disabled?" --top-k 20
+```
+
+`search` combines source-body matching, identifier splitting, symbol names and
+signatures, paths, conceptual issue-to-API terms, and diversity-aware region
+selection. It can return several non-overlapping regions from one file. Results
+include broad source provenance plus a focused, bounded snippet for direct agent
+context.
+
+Interactive search reads the working tree by default so agents see dirty edits.
+Use `--head` for immutable committed-tree semantics. Cold search first scans
+files without parsing, then indexes at most 96 query-relevant files; use
+`--max-indexed-files` to change the bound or `--index-all-files` for exhaustive
+parsing. The default `syntax-only` profile avoids synchronous whole-repository
+graph construction. `--profile fast` adds local relation expansion when deeper
+semantic indexing is worth the cost.
+
+When Entire supplies `ENTIRE_PLUGIN_DATA_DIR`, committed-tree searches reuse a
+tree-keyed compressed index. Direct callers can set `--cache-dir`; `--no-cache`
+disables persistence. Worktree searches do not reuse committed indexes, avoiding
+stale results after edits.
+
 Compare one commit against its first parent:
 
 ```sh
@@ -182,6 +208,8 @@ semantic graph rather than human-oriented diff text.
   symbol, and relation records.
 - `symbols --format ndjson` emits the same header followed by symbol records.
 - `edges --format ndjson` emits the same header followed by relation records.
+- `search --query ...` emits ranked, qrel-blind source regions as JSON, NDJSON,
+  or text without network access or a hosted model.
 
 Snapshot headers include the schema version, provider version, repository key,
 `HEAD` commit and tree when available, parsed languages, capability labels,

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -98,7 +98,7 @@ Usage:
   entire sem snapshot --repo . --format ndjson [--worktree] [--progress] [--ignore-file path] [--include-file path]
   entire sem symbols --repo . --format ndjson [--worktree] [--progress] [--ignore-file path] [--include-file path]
   entire sem edges --repo . --format ndjson [--worktree] [--progress] [--ignore-file path] [--include-file path]
-  entire sem search --query "issue or concept" --repo . [--format json|ndjson|text] [--top-k 20] [--head] [--profile syntax-only|fast|full] [--max-indexed-files 96|--index-all-files] [--cache-dir path|--no-cache]`)
+  entire sem search --query "issue or concept" --repo . [--format json|ndjson|text] [--top-k 20] [--max-context-bytes 16384] [--head] [--profile syntax-only|fast|full] [--max-indexed-files 96|--index-all-files] [--cache-dir path|--no-cache]`)
 }
 
 func runDoctor(ctx context.Context, opts Options, args []string) error {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -65,6 +65,8 @@ func Run(ctx context.Context, opts Options, args []string) error {
 		return runProviderRecords(ctx, opts, args[1:], "symbols")
 	case "edges":
 		return runProviderRecords(ctx, opts, args[1:], "edges")
+	case "search":
+		return runSearch(ctx, opts, args[1:])
 	case "version", "--version", "-v":
 		if len(args) > 1 && args[1] == "--json" {
 			return json.NewEncoder(opts.Stdout).Encode(map[string]string{
@@ -95,7 +97,8 @@ Usage:
   entire sem capabilities --json
   entire sem snapshot --repo . --format ndjson [--worktree] [--progress] [--ignore-file path] [--include-file path]
   entire sem symbols --repo . --format ndjson [--worktree] [--progress] [--ignore-file path] [--include-file path]
-  entire sem edges --repo . --format ndjson [--worktree] [--progress] [--ignore-file path] [--include-file path]`)
+  entire sem edges --repo . --format ndjson [--worktree] [--progress] [--ignore-file path] [--include-file path]
+  entire sem search --query "issue or concept" --repo . [--format json|ndjson|text] [--top-k 20] [--head] [--profile syntax-only|fast|full] [--max-indexed-files 96|--index-all-files] [--cache-dir path|--no-cache]`)
 }
 
 func runDoctor(ctx context.Context, opts Options, args []string) error {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -243,6 +243,41 @@ func TestSnapshotAcceptsWorktree(t *testing.T) {
 	}
 }
 
+func TestSearchCommandReturnsRankedJSON(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, "auth.py", `def validate_token(token):
+    """Validate a signed authentication token."""
+    return bool(token)
+`)
+
+	var out bytes.Buffer
+	err := Run(t.Context(), Options{Version: "0.1.0", Env: EntireEnv{RepoRoot: repo}, Stdout: &out}, []string{
+		"search",
+		"--repo", repo,
+		"--query", "validate authentication token",
+		"--format", "json",
+		"--profile", "syntax-only",
+		"--worktree",
+		"--top-k", "3",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var response struct {
+		Results []struct {
+			Rank       int    `json:"rank"`
+			FilePath   string `json:"file_path"`
+			SymbolName string `json:"symbol_name"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &response); err != nil {
+		t.Fatalf("invalid search JSON: %v\n%s", err, out.String())
+	}
+	if len(response.Results) == 0 || response.Results[0].Rank != 1 || response.Results[0].FilePath != "auth.py" || response.Results[0].SymbolName != "validate_token" {
+		t.Fatalf("search response = %#v", response)
+	}
+}
+
 func TestProviderCommandsAcceptIgnoreFile(t *testing.T) {
 	repo := t.TempDir()
 	write(t, repo, ".brainignore", "ignored/\n")

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -269,12 +269,19 @@ func TestSearchCommandReturnsRankedJSON(t *testing.T) {
 			FilePath   string `json:"file_path"`
 			SymbolName string `json:"symbol_name"`
 		} `json:"results"`
+		Stats struct {
+			ContextBudgetBytes int `json:"context_budget_bytes"`
+			ResultBytes        int `json:"result_bytes"`
+		} `json:"stats"`
 	}
 	if err := json.Unmarshal(out.Bytes(), &response); err != nil {
 		t.Fatalf("invalid search JSON: %v\n%s", err, out.String())
 	}
 	if len(response.Results) == 0 || response.Results[0].Rank != 1 || response.Results[0].FilePath != "auth.py" || response.Results[0].SymbolName != "validate_token" {
 		t.Fatalf("search response = %#v", response)
+	}
+	if response.Stats.ContextBudgetBytes != 16*1024 || response.Stats.ResultBytes > response.Stats.ContextBudgetBytes {
+		t.Fatalf("search context budget = %#v", response.Stats)
 	}
 }
 

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -1,0 +1,254 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/entireio/entire-sem/internal/sem"
+)
+
+type searchFlags struct {
+	Repo              string
+	Query             string
+	Format            string
+	Profile           string
+	Worktree          bool
+	TopK              int
+	ContextLines      int
+	MaxRegionLines    int
+	MaxSnippetLines   int
+	MaxRegionsPerFile int
+	IgnoreFiles       []string
+	IncludeFiles      []string
+	CacheDir          string
+	DisableCache      bool
+	MaxIndexedFiles   int
+	IndexAllFiles     bool
+}
+
+func runSearch(ctx context.Context, opts Options, args []string) error {
+	flags, rest, err := parseSearchFlags(args)
+	if err != nil {
+		return err
+	}
+	if len(rest) != 0 {
+		return fmt.Errorf("search received unexpected arguments: %s", strings.Join(rest, " "))
+	}
+	if strings.TrimSpace(flags.Query) == "" {
+		return errors.New("search requires --query")
+	}
+	profile, err := parseProfile(flags.Profile)
+	if err != nil {
+		return err
+	}
+	repo, err := resolveRepo(ctx, opts.Env, flags.Repo)
+	if err != nil {
+		return err
+	}
+	cacheDir := flags.CacheDir
+	if cacheDir == "" {
+		cacheDir = opts.Env.PluginDataDir
+	}
+	response, err := sem.SearchRepository(ctx, repo, opts.Version, flags.Query, sem.SearchOptions{
+		Worktree:          flags.Worktree,
+		IgnoreFiles:       flags.IgnoreFiles,
+		IncludeFiles:      flags.IncludeFiles,
+		Profile:           profile,
+		TopK:              flags.TopK,
+		ContextLines:      flags.ContextLines,
+		MaxRegionLines:    flags.MaxRegionLines,
+		MaxSnippetLines:   flags.MaxSnippetLines,
+		MaxRegionsPerFile: flags.MaxRegionsPerFile,
+		CacheDir:          cacheDir,
+		DisableCache:      flags.DisableCache,
+		MaxIndexedFiles:   flags.MaxIndexedFiles,
+		IndexAllFiles:     flags.IndexAllFiles,
+	})
+	if err != nil {
+		return err
+	}
+	if err := response.Validate(); err != nil {
+		return err
+	}
+	switch flags.Format {
+	case "json":
+		encoder := json.NewEncoder(opts.Stdout)
+		encoder.SetEscapeHTML(false)
+		return encoder.Encode(response)
+	case "ndjson":
+		encoder := json.NewEncoder(opts.Stdout)
+		encoder.SetEscapeHTML(false)
+		if err := encoder.Encode(map[string]any{
+			"record_type": "search_header",
+			"query":       response.Query,
+			"repo_root":   response.RepoRoot,
+			"commit":      response.Commit,
+			"tree":        response.Tree,
+			"profile":     response.Profile,
+		}); err != nil {
+			return err
+		}
+		for _, result := range response.Results {
+			if err := encoder.Encode(struct {
+				RecordType string `json:"record_type"`
+				sem.SearchResult
+			}{RecordType: "search_result", SearchResult: result}); err != nil {
+				return err
+			}
+		}
+		return encoder.Encode(map[string]any{
+			"record_type": "search_summary",
+			"stats":       response.Stats,
+			"warnings":    response.Warnings,
+		})
+	case "text":
+		for _, result := range response.Results {
+			name := result.QualifiedName
+			if name == "" {
+				name = result.SymbolName
+			}
+			fmt.Fprintf(opts.Stdout, "%d. %s:%d-%d score=%.4f", result.Rank, result.FilePath, result.StartLine, result.EndLine, result.Score)
+			if name != "" {
+				fmt.Fprintf(opts.Stdout, " symbol=%s", name)
+			}
+			fmt.Fprintf(opts.Stdout, " signals=%s\n%s\n\n", strings.Join(result.Signals, ","), result.Snippet)
+		}
+		return nil
+	default:
+		return fmt.Errorf("search --format must be json, ndjson, or text, got %q", flags.Format)
+	}
+}
+
+func parseSearchFlags(args []string) (searchFlags, []string, error) {
+	flags := searchFlags{Format: "json", Profile: "syntax-only", Worktree: true}
+	var rest []string
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--repo":
+			value, next, err := searchFlagValue(args, i)
+			if err != nil {
+				return flags, nil, err
+			}
+			flags.Repo, i = value, next
+		case "--query":
+			value, next, err := searchFlagValue(args, i)
+			if err != nil {
+				return flags, nil, err
+			}
+			flags.Query, i = value, next
+		case "--format":
+			value, next, err := searchFlagValue(args, i)
+			if err != nil {
+				return flags, nil, err
+			}
+			flags.Format, i = value, next
+		case "--profile":
+			value, next, err := searchFlagValue(args, i)
+			if err != nil {
+				return flags, nil, err
+			}
+			flags.Profile, i = value, next
+		case "--top-k":
+			value, next, err := searchPositiveIntFlag(args, i)
+			if err != nil {
+				return flags, nil, err
+			}
+			flags.TopK, i = value, next
+		case "--context-lines":
+			value, next, err := searchNonNegativeIntFlag(args, i)
+			if err != nil {
+				return flags, nil, err
+			}
+			flags.ContextLines, i = value, next
+		case "--max-region-lines":
+			value, next, err := searchPositiveIntFlag(args, i)
+			if err != nil {
+				return flags, nil, err
+			}
+			flags.MaxRegionLines, i = value, next
+		case "--max-snippet-lines":
+			value, next, err := searchPositiveIntFlag(args, i)
+			if err != nil {
+				return flags, nil, err
+			}
+			flags.MaxSnippetLines, i = value, next
+		case "--max-regions-per-file":
+			value, next, err := searchPositiveIntFlag(args, i)
+			if err != nil {
+				return flags, nil, err
+			}
+			flags.MaxRegionsPerFile, i = value, next
+		case "--ignore-file":
+			value, next, err := searchFlagValue(args, i)
+			if err != nil {
+				return flags, nil, err
+			}
+			flags.IgnoreFiles, i = append(flags.IgnoreFiles, value), next
+		case "--include-file":
+			value, next, err := searchFlagValue(args, i)
+			if err != nil {
+				return flags, nil, err
+			}
+			flags.IncludeFiles, i = append(flags.IncludeFiles, value), next
+		case "--cache-dir":
+			value, next, err := searchFlagValue(args, i)
+			if err != nil {
+				return flags, nil, err
+			}
+			flags.CacheDir, i = value, next
+		case "--no-cache":
+			flags.DisableCache = true
+		case "--max-indexed-files":
+			value, next, err := searchPositiveIntFlag(args, i)
+			if err != nil {
+				return flags, nil, err
+			}
+			flags.MaxIndexedFiles, i = value, next
+		case "--index-all-files":
+			flags.IndexAllFiles = true
+		case "--worktree", "--no-network":
+			if args[i] == "--worktree" {
+				flags.Worktree = true
+			}
+		case "--head":
+			flags.Worktree = false
+		default:
+			rest = append(rest, args[i])
+		}
+	}
+	return flags, rest, nil
+}
+
+func searchFlagValue(args []string, index int) (string, int, error) {
+	if index+1 >= len(args) {
+		return "", index, fmt.Errorf("%s requires a value", args[index])
+	}
+	return args[index+1], index + 1, nil
+}
+
+func searchPositiveIntFlag(args []string, index int) (int, int, error) {
+	value, next, err := searchNonNegativeIntFlag(args, index)
+	if err != nil {
+		return 0, index, err
+	}
+	if value == 0 {
+		return 0, index, fmt.Errorf("%s must be positive", args[index])
+	}
+	return value, next, nil
+}
+
+func searchNonNegativeIntFlag(args []string, index int) (int, int, error) {
+	raw, next, err := searchFlagValue(args, index)
+	if err != nil {
+		return 0, index, err
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < 0 {
+		return 0, index, fmt.Errorf("%s requires a non-negative integer", args[index])
+	}
+	return value, next, nil
+}

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -28,6 +28,7 @@ type searchFlags struct {
 	DisableCache      bool
 	MaxIndexedFiles   int
 	IndexAllFiles     bool
+	MaxContextBytes   int
 }
 
 func runSearch(ctx context.Context, opts Options, args []string) error {
@@ -67,6 +68,7 @@ func runSearch(ctx context.Context, opts Options, args []string) error {
 		DisableCache:      flags.DisableCache,
 		MaxIndexedFiles:   flags.MaxIndexedFiles,
 		IndexAllFiles:     flags.IndexAllFiles,
+		MaxContextBytes:   flags.MaxContextBytes,
 	})
 	if err != nil {
 		return err
@@ -124,7 +126,7 @@ func runSearch(ctx context.Context, opts Options, args []string) error {
 }
 
 func parseSearchFlags(args []string) (searchFlags, []string, error) {
-	flags := searchFlags{Format: "json", Profile: "syntax-only", Worktree: true}
+	flags := searchFlags{Format: "json", Profile: "syntax-only", Worktree: true, MaxContextBytes: 16 * 1024}
 	var rest []string
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
@@ -210,6 +212,12 @@ func parseSearchFlags(args []string) (searchFlags, []string, error) {
 			flags.MaxIndexedFiles, i = value, next
 		case "--index-all-files":
 			flags.IndexAllFiles = true
+		case "--max-context-bytes":
+			value, next, err := searchNonNegativeIntFlag(args, i)
+			if err != nil {
+				return flags, nil, err
+			}
+			flags.MaxContextBytes, i = value, next
 		case "--worktree", "--no-network":
 			if args[i] == "--worktree" {
 				flags.Worktree = true

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -23,6 +24,12 @@ type FileCochange struct {
 	Left  string
 	Right string
 	Count int
+}
+
+// GrepMatch is one tracked-worktree line returned by a fixed-string grep.
+type GrepMatch struct {
+	Path string
+	Text string
 }
 
 func RepoRoot(ctx context.Context, cwd string) (string, error) {
@@ -91,6 +98,68 @@ func ListIndexFiles(ctx context.Context, repo string) ([]string, error) {
 		}
 	}
 	return files, nil
+}
+
+// GrepIndexMatches returns a bounded sample of matched terms per tracked
+// worktree file. Fixed strings and NUL-delimited paths keep query terms and
+// unusual paths from changing grep semantics.
+func GrepIndexMatches(ctx context.Context, repo string, patterns []string, maxPerFile int) ([]GrepMatch, error) {
+	if len(patterns) == 0 {
+		return []GrepMatch{}, nil
+	}
+	if maxPerFile <= 0 {
+		maxPerFile = 32
+	}
+	args := []string{"grep", "-z", "-I", "-i", "-F", "-o", "-m", strconv.Itoa(maxPerFile)}
+	for _, pattern := range patterns {
+		if pattern != "" {
+			args = append(args, "-e", pattern)
+		}
+	}
+	if len(args) == 8 {
+		return []GrepMatch{}, nil
+	}
+	args = append(args, "--")
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = repo
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) && exitError.ExitCode() == 1 && stderr.Len() == 0 {
+			return []GrepMatch{}, nil
+		}
+		message := strings.TrimSpace(stderr.String())
+		if message == "" {
+			message = err.Error()
+		}
+		return nil, fmt.Errorf("git %s: %s", strings.Join(args, " "), message)
+	}
+
+	data := stdout.Bytes()
+	matches := make([]GrepMatch, 0)
+	for len(data) > 0 {
+		pathEnd := bytes.IndexByte(data, 0)
+		if pathEnd < 0 {
+			return nil, fmt.Errorf("git grep returned malformed path metadata")
+		}
+		path := string(data[:pathEnd])
+		data = data[pathEnd+1:]
+		textEnd := bytes.IndexByte(data, '\n')
+		if textEnd < 0 {
+			textEnd = len(data)
+		}
+		matches = append(matches, GrepMatch{Path: path, Text: string(data[:textEnd])})
+		if textEnd == len(data) {
+			data = nil
+		} else {
+			data = data[textEnd+1:]
+		}
+	}
+	return matches, nil
 }
 
 func ChangedFiles(ctx context.Context, repo, base, head string, paths []string) ([]ChangedFile, error) {

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -26,7 +26,7 @@ type FileCochange struct {
 	Count int
 }
 
-// GrepMatch is one tracked-worktree line returned by a fixed-string grep.
+// GrepMatch is one matched substring from a tracked-worktree fixed-string grep.
 type GrepMatch struct {
 	Path string
 	Text string

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -39,6 +39,45 @@ func TestListFilesHandlesNewlinesInPaths(t *testing.T) {
 	}
 }
 
+func TestGrepIndexFilesUsesFixedStringsAndUnstagedContent(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Sem Test")
+	git(t, repo, "config", "user.email", "sem@example.com")
+	for path, content := range map[string]string{
+		"src/target.go": "package source\nfunc Initial() {}\n",
+		"src/other.go":  "package source\nfunc Other() {}\n",
+	} {
+		full := filepath.Join(repo, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	if err := os.WriteFile(filepath.Join(repo, "src/target.go"), []byte("package source\nfunc NeedlePattern() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	matches, err := GrepIndexMatches(t.Context(), repo, []string{"NeedlePattern"}, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 || matches[0].Path != "src/target.go" || !strings.Contains(matches[0].Text, "NeedlePattern") {
+		t.Fatalf("grep matches = %#v", matches)
+	}
+	empty, err := GrepIndexMatches(t.Context(), repo, []string{"absent-fixed-string"}, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("no-match grep results = %#v", empty)
+	}
+}
+
 func TestChangedFilesHandlesNewlinesAndTabsInPaths(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows filenames cannot contain newlines")

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -58,7 +58,7 @@ func TestGrepIndexFilesUsesFixedStringsAndUnstagedContent(t *testing.T) {
 	}
 	git(t, repo, "add", ".")
 	git(t, repo, "commit", "-m", "initial")
-	if err := os.WriteFile(filepath.Join(repo, "src/target.go"), []byte("package source\nfunc NeedlePattern() {}\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(repo, "src/target.go"), []byte("package source\nfunc NeedlePattern() {}\nfunc AnotherNeedlePattern() {}\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -66,8 +66,13 @@ func TestGrepIndexFilesUsesFixedStringsAndUnstagedContent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(matches) != 1 || matches[0].Path != "src/target.go" || !strings.Contains(matches[0].Text, "NeedlePattern") {
-		t.Fatalf("grep matches = %#v", matches)
+	if len(matches) != 2 {
+		t.Fatalf("grep match count = %d, want 2: %#v", len(matches), matches)
+	}
+	for _, match := range matches {
+		if match.Path != "src/target.go" || match.Text != "NeedlePattern" {
+			t.Fatalf("grep match = %#v, want path src/target.go and exact fixed-string text", match)
+		}
 	}
 	empty, err := GrepIndexMatches(t.Context(), repo, []string{"absent-fixed-string"}, 2)
 	if err != nil {

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -39,7 +39,7 @@ func TestListFilesHandlesNewlinesInPaths(t *testing.T) {
 	}
 }
 
-func TestGrepIndexFilesUsesFixedStringsAndUnstagedContent(t *testing.T) {
+func TestGrepIndexMatchesUsesFixedStringsAndUnstagedContent(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")
 	git(t, repo, "config", "user.name", "Entire Sem Test")

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -288,6 +288,10 @@ type ProviderSnapshotOptions struct {
 	Worktree     bool
 	IgnoreFiles  []string
 	IncludeFiles []string
+	// OnlyFiles restricts parsing to these exact repository-relative paths.
+	// Empty means all discovered files. It is intended for query-time selective
+	// indexing; ignore and vendored-file rules still apply first.
+	OnlyFiles []string
 	// MaxParseBytes caps parser input per file. Zero uses the provider default;
 	// negative disables the cap. Oversized files still emit file records and a
 	// partial failure, but symbol parsing is skipped.
@@ -446,6 +450,7 @@ func Capabilities() CapabilityReport {
 			"stable_symbol_ids":    true,
 			"semantic_diff":        true,
 			"ndjson_snapshot":      true,
+			"hybrid_source_search": true,
 			"near_clone_detection": true,
 			"git_cochange_edges":   true,
 		},
@@ -1223,6 +1228,19 @@ func prepareSource(ctx context.Context, repo string, options ProviderSnapshotOpt
 	paths, read, readPrefix, closeSource, err := openSource(ctx, absRepo, useHead, options.IgnoreFiles, options.IncludeFiles)
 	if err != nil {
 		return sourceContext{}, err
+	}
+	if len(options.OnlyFiles) > 0 {
+		allowed := make(map[string]bool, len(options.OnlyFiles))
+		for _, filePath := range options.OnlyFiles {
+			allowed[filepath.ToSlash(filepath.Clean(filePath))] = true
+		}
+		filtered := paths[:0]
+		for _, filePath := range paths {
+			if allowed[filepath.ToSlash(filePath)] {
+				filtered = append(filtered, filePath)
+			}
+		}
+		paths = filtered
 	}
 
 	var warnings []ProviderWarning

--- a/internal/sem/search.go
+++ b/internal/sem/search.go
@@ -160,31 +160,30 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 	}
 	searchStarted := time.Now()
 	preselectStarted := time.Now()
-	selectedFiles, discoveredFiles, filesContentRead, err := preselectSearchFiles(ctx, repo, q, options)
+	selection, err := preselectSearchFiles(ctx, repo, q, options)
 	if err != nil {
 		return SearchResponse{}, err
 	}
 	preselectLatency := time.Since(preselectStarted)
+	selectedFiles := selection.files
 	if len(selectedFiles) == 0 {
-		absRepo, absErr := filepath.Abs(repo)
-		if absErr != nil {
-			return SearchResponse{}, absErr
-		}
 		return SearchResponse{
 			Query:    query,
-			RepoRoot: absRepo,
+			RepoRoot: selection.repoRoot,
+			Commit:   selection.commit,
+			Tree:     selection.tree,
 			Profile:  string(options.Profile),
 			Results:  []SearchResult{},
 			Stats: SearchStats{
-				FilesScanned:       discoveredFiles,
-				FilesContentRead:   filesContentRead,
+				FilesScanned:       selection.filesScanned,
+				FilesContentRead:   selection.filesContentRead,
 				FilesIndexed:       0,
 				ResultBytes:        serializedSearchResultBytes([]SearchResult{}),
 				ContextBudgetBytes: options.MaxContextBytes,
 				PreselectLatencyMS: preselectLatency.Milliseconds(),
 				SearchLatencyMS:    time.Since(searchStarted).Milliseconds(),
 			},
-			Warnings: []ProviderWarning{},
+			Warnings: selection.warnings,
 		}, nil
 	}
 
@@ -257,8 +256,8 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 	}
 
 	stats := SearchStats{
-		FilesScanned:       discoveredFiles,
-		FilesContentRead:   filesContentRead,
+		FilesScanned:       selection.filesScanned,
+		FilesContentRead:   selection.filesContentRead,
 		FilesIndexed:       len(selectedFiles),
 		SymbolsConsidered:  len(snapshot.Symbols),
 		LexicalCandidates:  len(candidates),
@@ -417,7 +416,17 @@ type searchFileCandidate struct {
 	score float64
 }
 
-func preselectSearchFiles(ctx context.Context, repo string, q searchQuery, options SearchOptions) ([]string, int, int, error) {
+type searchFileSelection struct {
+	files            []string
+	repoRoot         string
+	commit           string
+	tree             string
+	warnings         []ProviderWarning
+	filesScanned     int
+	filesContentRead int
+}
+
+func preselectSearchFiles(ctx context.Context, repo string, q searchQuery, options SearchOptions) (searchFileSelection, error) {
 	source, err := prepareSource(ctx, repo, ProviderSnapshotOptions{
 		NoNetwork:    true,
 		Worktree:     options.Worktree,
@@ -425,13 +434,21 @@ func preselectSearchFiles(ctx context.Context, repo string, q searchQuery, optio
 		IncludeFiles: options.IncludeFiles,
 	})
 	if err != nil {
-		return nil, 0, 0, err
+		return searchFileSelection{}, err
 	}
 	if source.close != nil {
 		defer source.close()
 	}
+	selection := searchFileSelection{
+		repoRoot:     source.absRepo,
+		commit:       source.commit,
+		tree:         source.tree,
+		warnings:     append([]ProviderWarning{}, source.warnings...),
+		filesScanned: len(source.paths),
+	}
 	if options.IndexAllFiles || len(source.paths) <= options.MaxIndexedFiles {
-		return append([]string(nil), source.paths...), len(source.paths), 0, nil
+		selection.files = append([]string(nil), source.paths...)
+		return selection, nil
 	}
 	queryWeight := 0.0
 	for _, weight := range q.weights {
@@ -576,7 +593,7 @@ func preselectSearchFiles(ctx context.Context, repo string, q searchQuery, optio
 		}
 	}
 	if err := ctx.Err(); err != nil {
-		return nil, len(source.paths), len(scanPaths), err
+		return searchFileSelection{}, err
 	}
 	sort.Slice(files, func(i, j int) bool {
 		if files[i].score != files[j].score {
@@ -591,7 +608,9 @@ func preselectSearchFiles(ctx context.Context, repo string, q searchQuery, optio
 	for i, file := range files {
 		selected[i] = file.path
 	}
-	return selected, len(source.paths), len(scanPaths), nil
+	selection.files = selected
+	selection.filesContentRead = len(scanPaths)
+	return selection, nil
 }
 
 func shouldUseGitGrepPreselection(worktree bool, fileCount int) bool {

--- a/internal/sem/search.go
+++ b/internal/sem/search.go
@@ -2,6 +2,7 @@ package sem
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -13,6 +14,8 @@ import (
 	"sync"
 	"time"
 	"unicode"
+
+	"github.com/entireio/entire-sem/internal/gitutil"
 )
 
 const (
@@ -23,6 +26,7 @@ const (
 	defaultSearchMaxRegionsPerFile = 3
 	defaultSearchMaxIndexedFiles   = 96
 	maxSearchQueryTerms            = 48
+	minGitGrepPreselectionFiles    = 10_000
 )
 
 // SearchOptions controls local issue-to-code retrieval. Search reads the same
@@ -42,6 +46,7 @@ type SearchOptions struct {
 	DisableCache      bool
 	MaxIndexedFiles   int
 	IndexAllFiles     bool
+	MaxContextBytes   int
 }
 
 // SearchResult is a ranked source region suitable for direct agent context.
@@ -66,11 +71,16 @@ type SearchResult struct {
 
 type SearchStats struct {
 	FilesScanned       int   `json:"files_scanned"`
+	FilesContentRead   int   `json:"files_content_read_during_preselection"`
 	FilesIndexed       int   `json:"files_indexed"`
 	SymbolsConsidered  int   `json:"symbols_considered"`
 	LexicalCandidates  int   `json:"lexical_candidates"`
 	GraphCandidates    int   `json:"graph_candidates"`
 	CandidatesSelected int   `json:"candidates_selected"`
+	ResultBytes        int   `json:"result_bytes"`
+	ContextBudgetBytes int   `json:"context_budget_bytes,omitempty"`
+	ResultsDropped     int   `json:"results_dropped_by_budget,omitempty"`
+	SnippetsTruncated  int   `json:"snippets_truncated_by_budget,omitempty"`
 	IndexCacheHit      bool  `json:"index_cache_hit"`
 	IndexLatencyMS     int64 `json:"index_latency_ms"`
 	SearchLatencyMS    int64 `json:"search_latency_ms"`
@@ -117,29 +127,6 @@ var searchStopWords = map[string]bool{
 	"with": true, "without": true,
 }
 
-// Issue descriptions use prose where APIs use terse verbs. These generic
-// concept expansions carry less weight than terms the user supplied.
-var searchConceptTerms = map[string][]string{
-	"authentication":  {"auth", "login", "credential"},
-	"configuration":   {"config", "option", "setting"},
-	"deserialization": {"deserialize", "reader", "read", "parse", "decode"},
-	"directory":       {"dir", "cwd", "folder", "path"},
-	"disabled":        {"disable", "off"},
-	"documentation":   {"docs", "doc", "readme"},
-	"enabled":         {"enable", "on"},
-	"failure":         {"fail", "error"},
-	"indentation":     {"indent", "spacing"},
-	"initialization":  {"initialize", "init", "create"},
-	"lookup":          {"resolve", "resolver", "resolution"},
-	"minified":        {"minify", "compact"},
-	"nonexistent":     {"missing", "absent", "exist", "existing", "create"},
-	"pretty":          {"prettify", "prettification", "indent", "formatter", "format", "formatted"},
-	"printing":        {"print", "output", "render"},
-	"serialization":   {"serialize", "writer", "write", "marshal", "encode"},
-	"spaces":          {"space", "spacing"},
-	"validation":      {"validate", "check", "verify"},
-}
-
 // SearchRepository performs local hybrid lexical/semantic retrieval. It uses
 // no qrels, hosted models, embeddings, or network access.
 func SearchRepository(ctx context.Context, repo, providerVersion, query string, options SearchOptions) (SearchResponse, error) {
@@ -173,7 +160,7 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 	}
 	searchStarted := time.Now()
 	preselectStarted := time.Now()
-	selectedFiles, discoveredFiles, err := preselectSearchFiles(ctx, repo, q, options)
+	selectedFiles, discoveredFiles, filesContentRead, err := preselectSearchFiles(ctx, repo, q, options)
 	if err != nil {
 		return SearchResponse{}, err
 	}
@@ -190,7 +177,10 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 			Results:  []SearchResult{},
 			Stats: SearchStats{
 				FilesScanned:       discoveredFiles,
+				FilesContentRead:   filesContentRead,
 				FilesIndexed:       0,
+				ResultBytes:        serializedSearchResultBytes([]SearchResult{}),
+				ContextBudgetBytes: options.MaxContextBytes,
 				PreselectLatencyMS: preselectLatency.Milliseconds(),
 				SearchLatencyMS:    time.Since(searchStarted).Milliseconds(),
 			},
@@ -268,6 +258,7 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 
 	stats := SearchStats{
 		FilesScanned:       discoveredFiles,
+		FilesContentRead:   filesContentRead,
 		FilesIndexed:       len(selectedFiles),
 		SymbolsConsidered:  len(snapshot.Symbols),
 		LexicalCandidates:  len(candidates),
@@ -292,7 +283,12 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 		}
 		results = append(results, selected[i].result)
 	}
+	results, resultBytes, dropped, truncated := fitSearchResultsToBudget(results, q, options.MaxContextBytes)
 	stats.CandidatesSelected = len(results)
+	stats.ResultBytes = resultBytes
+	stats.ContextBudgetBytes = options.MaxContextBytes
+	stats.ResultsDropped = dropped
+	stats.SnippetsTruncated = truncated
 	stats.SearchLatencyMS = time.Since(searchStarted).Milliseconds()
 	if results == nil {
 		results = []SearchResult{}
@@ -309,12 +305,119 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 	}, nil
 }
 
+func fitSearchResultsToBudget(results []SearchResult, q searchQuery, budget int) ([]SearchResult, int, int, int) {
+	originalCount := len(results)
+	if budget <= 0 || len(results) == 0 {
+		return results, serializedSearchResultBytes(results), 0, 0
+	}
+
+	for count := len(results); count > 0; count-- {
+		perResult := maxInt(256, (budget-2-(count-1))/count)
+		compacted := make([]SearchResult, count)
+		truncated := 0
+		for index := range compacted {
+			compacted[index], _ = compactSearchResultToBytes(results[index], q, perResult)
+			if compacted[index].Snippet != results[index].Snippet || compacted[index].Signature != results[index].Signature {
+				truncated++
+			}
+		}
+		resultBytes := serializedSearchResultBytes(compacted)
+		if resultBytes <= budget {
+			return compacted, resultBytes, originalCount - count, truncated
+		}
+	}
+	return []SearchResult{}, serializedSearchResultBytes([]SearchResult{}), originalCount, 0
+}
+
+func compactSearchResultToBytes(result SearchResult, q searchQuery, budget int) (SearchResult, int) {
+	if size := serializedSearchResultBytes(result); size <= budget {
+		return result, size
+	}
+	result.Signature = truncateSearchText(result.Signature, 192, q)
+	if size := serializedSearchResultBytes(result); size <= budget {
+		return result, size
+	}
+
+	lines := strings.Split(result.Snippet, "\n")
+	focus := result.FocusLine - result.SnippetStartLine
+	if focus < 0 || focus >= len(lines) {
+		focus = len(lines) / 2
+	}
+	left, right := focus, focus
+	for {
+		candidate := result
+		candidate.SnippetStartLine = result.SnippetStartLine + left
+		candidate.SnippetEndLine = result.SnippetStartLine + right
+		candidate.Snippet = strings.Join(lines[left:right+1], "\n")
+		size := serializedSearchResultBytes(candidate)
+		if size <= budget {
+			return candidate, size
+		}
+		if left == right {
+			candidate.Snippet = truncateSearchText(candidate.Snippet, maxInt(16, budget/3), q)
+			return candidate, serializedSearchResultBytes(candidate)
+		}
+		if right-focus >= focus-left {
+			right--
+		} else {
+			left++
+		}
+	}
+}
+
+func truncateSearchText(value string, maxBytes int, q searchQuery) string {
+	if maxBytes <= 0 || len(value) <= maxBytes {
+		return value
+	}
+	center := len(value) / 2
+	lower := strings.ToLower(value)
+	for _, term := range q.terms {
+		if index := strings.Index(lower, term); index >= 0 {
+			center = index + len(term)/2
+			break
+		}
+	}
+	window := maxBytes - len(" ... ")
+	if window <= 0 {
+		return ""
+	}
+	start := maxInt(0, center-window/2)
+	end := minInt(len(value), start+window)
+	start = maxInt(0, end-window)
+	for start < end && !utf8RuneStart(value[start]) {
+		start++
+	}
+	for end > start && end < len(value) && !utf8RuneStart(value[end]) {
+		end--
+	}
+	prefix, suffix := "", ""
+	if start > 0 {
+		prefix = "... "
+	}
+	if end < len(value) {
+		suffix = " ..."
+	}
+	return prefix + value[start:end] + suffix
+}
+
+func utf8RuneStart(value byte) bool {
+	return value&0xc0 != 0x80
+}
+
+func serializedSearchResultBytes(value any) int {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return 0
+	}
+	return len(encoded)
+}
+
 type searchFileCandidate struct {
 	path  string
 	score float64
 }
 
-func preselectSearchFiles(ctx context.Context, repo string, q searchQuery, options SearchOptions) ([]string, int, error) {
+func preselectSearchFiles(ctx context.Context, repo string, q searchQuery, options SearchOptions) ([]string, int, int, error) {
 	source, err := prepareSource(ctx, repo, ProviderSnapshotOptions{
 		NoNetwork:    true,
 		Worktree:     options.Worktree,
@@ -322,19 +425,93 @@ func preselectSearchFiles(ctx context.Context, repo string, q searchQuery, optio
 		IncludeFiles: options.IncludeFiles,
 	})
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, 0, err
 	}
 	if source.close != nil {
 		defer source.close()
 	}
 	if options.IndexAllFiles || len(source.paths) <= options.MaxIndexedFiles {
-		return append([]string(nil), source.paths...), len(source.paths), nil
+		return append([]string(nil), source.paths...), len(source.paths), 0, nil
 	}
 	queryWeight := 0.0
 	for _, weight := range q.weights {
 		queryWeight += weight
 	}
 	matcher := newSearchTermMatcher(q.terms)
+	scanPaths := source.paths
+	if shouldUseGitGrepPreselection(options.Worktree, len(source.paths)) {
+		matches, grepErr := gitutil.GrepIndexMatches(ctx, source.absRepo, searchPreselectionPatterns(q), 32)
+		tracked, trackedErr := gitutil.ListIndexFiles(ctx, source.absRepo)
+		if grepErr == nil && trackedErr == nil {
+			allowed := make(map[string]bool, len(source.paths))
+			for _, filePath := range source.paths {
+				allowed[filePath] = true
+			}
+			trackedSet := make(map[string]bool, len(tracked))
+			for _, filePath := range tracked {
+				trackedSet[filePath] = true
+			}
+			termMatches := make(map[string][]bool)
+			for _, match := range matches {
+				if !allowed[match.Path] {
+					continue
+				}
+				seen := termMatches[match.Path]
+				if seen == nil {
+					seen = make([]bool, len(q.terms))
+				}
+				for index, matched := range matcher.match(match.Text) {
+					seen[index] = seen[index] || matched
+				}
+				termMatches[match.Path] = seen
+			}
+			provisional := make([]searchFileCandidate, 0, len(termMatches)+16)
+			for filePath, seen := range termMatches {
+				matchedWeight := 0.0
+				for index, matched := range seen {
+					if matched {
+						matchedWeight += q.weights[q.terms[index]]
+					}
+				}
+				pathScore := pathSearchScore(q, filePath)
+				score := 2*pathScore + matchedWeight + searchPathPrior(q, filePath)
+				if queryWeight > 0 {
+					score += 4 * matchedWeight / queryWeight
+				}
+				provisional = append(provisional, searchFileCandidate{path: filePath, score: score})
+			}
+			untracked := make([]string, 0, 16)
+			for _, filePath := range source.paths {
+				if !trackedSet[filePath] {
+					untracked = append(untracked, filePath)
+					continue
+				}
+				if _, exists := termMatches[filePath]; !exists {
+					if pathScore := pathSearchScore(q, filePath); pathScore > 0 {
+						provisional = append(provisional, searchFileCandidate{
+							path:  filePath,
+							score: 2*pathScore + searchPathPrior(q, filePath),
+						})
+					}
+				}
+			}
+			sort.Slice(provisional, func(i, j int) bool {
+				if provisional[i].score != provisional[j].score {
+					return provisional[i].score > provisional[j].score
+				}
+				return provisional[i].path < provisional[j].path
+			})
+			poolLimit := minInt(len(provisional), options.MaxIndexedFiles*4)
+			scanPaths = make([]string, 0, poolLimit+len(untracked))
+			for _, candidate := range provisional[:poolLimit] {
+				scanPaths = append(scanPaths, candidate.path)
+			}
+			scanPaths = append(scanPaths, untracked...)
+			if len(scanPaths) == 0 {
+				scanPaths = source.paths
+			}
+		}
+	}
 	scoreFile := func(filePath string) (searchFileCandidate, bool) {
 		if err := ctx.Err(); err != nil {
 			return searchFileCandidate{}, false
@@ -343,19 +520,19 @@ func preselectSearchFiles(ctx context.Context, repo string, q searchQuery, optio
 		if !ok || strings.IndexByte(content, 0) >= 0 {
 			return searchFileCandidate{}, false
 		}
-		score := 2*pathSearchScore(q, filePath) + searchPathPrior(q, filePath)
+		pathScore := pathSearchScore(q, filePath)
 		matchedWeight := 0.0
 		for index, matched := range matcher.match(content) {
 			if matched {
 				term := q.terms[index]
 				weight := q.weights[term]
-				score += weight
 				matchedWeight += weight
 			}
 		}
-		if score == 0 {
+		if pathScore == 0 && matchedWeight == 0 {
 			return searchFileCandidate{}, false
 		}
+		score := 2*pathScore + matchedWeight + searchPathPrior(q, filePath)
 		if queryWeight > 0 {
 			score += 4 * matchedWeight / queryWeight
 		}
@@ -380,7 +557,7 @@ func preselectSearchFiles(ctx context.Context, repo string, q searchQuery, optio
 		}
 		go func() {
 			defer close(jobs)
-			for _, filePath := range source.paths {
+			for _, filePath := range scanPaths {
 				jobs <- filePath
 			}
 		}()
@@ -392,14 +569,14 @@ func preselectSearchFiles(ctx context.Context, repo string, q searchQuery, optio
 			files = append(files, candidate)
 		}
 	} else {
-		for _, filePath := range source.paths {
+		for _, filePath := range scanPaths {
 			if candidate, ok := scoreFile(filePath); ok {
 				files = append(files, candidate)
 			}
 		}
 	}
 	if err := ctx.Err(); err != nil {
-		return nil, len(source.paths), err
+		return nil, len(source.paths), len(scanPaths), err
 	}
 	sort.Slice(files, func(i, j int) bool {
 		if files[i].score != files[j].score {
@@ -414,7 +591,51 @@ func preselectSearchFiles(ctx context.Context, repo string, q searchQuery, optio
 	for i, file := range files {
 		selected[i] = file.path
 	}
-	return selected, len(source.paths), nil
+	return selected, len(source.paths), len(scanPaths), nil
+}
+
+func shouldUseGitGrepPreselection(worktree bool, fileCount int) bool {
+	return worktree && fileCount >= minGitGrepPreselectionFiles
+}
+
+func searchPreselectionPatterns(q searchQuery) []string {
+	patterns := make([]string, 0, 12)
+	seen := make(map[string]bool, cap(patterns))
+	for _, term := range q.terms {
+		if q.weights[term] >= 2 {
+			patterns = append(patterns, term)
+			seen[term] = true
+			if len(patterns) == cap(patterns) {
+				return patterns
+			}
+		}
+	}
+	if len(patterns) == 0 {
+		for _, term := range q.terms {
+			if q.weights[term] >= 1.25 {
+				patterns = append(patterns, term)
+				seen[term] = true
+				if len(patterns) == cap(patterns) {
+					return patterns
+				}
+			}
+		}
+	}
+	target := cap(patterns)
+	if len(patterns) > 0 {
+		target = minInt(target, len(patterns)+4)
+	}
+	for _, term := range q.terms {
+		if q.weights[term] != 1 || seen[term] {
+			continue
+		}
+		patterns = append(patterns, term)
+		seen[term] = true
+		if len(patterns) == target {
+			break
+		}
+	}
+	return patterns
 }
 
 func candidatesForFile(q searchQuery, filePath, language string, lines []string, symbols []SymbolRecord, options SearchOptions) []searchCandidate {
@@ -537,9 +758,10 @@ func makeSearchCandidate(q searchQuery, filePath, language string, lines []strin
 	}
 	snippetStart, snippetEnd := focusedSnippetRegion(start, end, focus, maxSnippetLines)
 	snippet := strings.Join(lines[snippetStart-1:snippetEnd], "\n")
-	base := pathSearchScore(q, filePath) + searchPathPrior(q, filePath)
+	pathScore := pathSearchScore(q, filePath)
+	base := pathScore
 	signals := []string{}
-	if base > 0 {
+	if pathScore > 0 {
 		signals = append(signals, "path")
 	}
 	if len(counts) > 0 {
@@ -550,9 +772,10 @@ func makeSearchCandidate(q searchQuery, filePath, language string, lines []strin
 		base += nameScore
 		signals = append(signals, nameSignals...)
 	}
-	if len(counts) == 0 && base == 0 {
+	if len(counts) == 0 && pathScore == 0 && len(signals) == 0 {
 		return searchCandidate{}, false
 	}
+	base += searchPathPrior(q, filePath)
 	return searchCandidate{
 		result: SearchResult{
 			FilePath:         filePath,
@@ -875,9 +1098,6 @@ func buildSearchQuery(query string) searchQuery {
 		originalTerms = append(originalTerms, term)
 	}
 	for _, term := range originalTerms {
-		for _, related := range searchConceptTerms[term] {
-			add(related, 0.5)
-		}
 		for _, related := range morphologicalSearchTerms(term) {
 			add(related, 0.55)
 		}
@@ -1076,6 +1296,9 @@ func pathSearchScore(q searchQuery, filePath string) float64 {
 	score := 0.0
 	for _, term := range q.terms {
 		weight := q.weights[term]
+		if weight != 1 && weight < 1.25 {
+			continue
+		}
 		if strings.Contains(base, term) {
 			score += 2.5 * weight
 		} else if strings.Contains(lower, term) {
@@ -1096,15 +1319,6 @@ func searchPathPrior(q searchQuery, filePath string) float64 {
 	}
 	if strings.Contains(lower, "/dependencies/") || strings.Contains(lower, "/third_party/") || strings.Contains(lower, "/third-party/") {
 		score -= 5
-	}
-	if strings.Contains(lower, "/singleheader/") && !searchQuerySupplied(q, "singleheader", "amalgamation") {
-		score -= 3
-	}
-	if strings.Contains(lower, "/benchmark/") && !searchQuerySupplied(q, "benchmark", "performance", "speed") {
-		score -= 2
-	}
-	if (strings.Contains(lower, "/tests/") || strings.Contains(lower, "/test/")) && !searchQuerySupplied(q, "test", "tests", "testing", "regression") {
-		score -= 1.5
 	}
 	return score
 }
@@ -1194,6 +1408,12 @@ func appendUnique(values []string, additions ...string) []string {
 }
 
 func (response SearchResponse) Validate() error {
+	if actual := serializedSearchResultBytes(response.Results); response.Stats.ResultBytes != actual {
+		return fmt.Errorf("search result byte accounting mismatch: %d != %d", response.Stats.ResultBytes, actual)
+	}
+	if response.Stats.ContextBudgetBytes > 0 && response.Stats.ResultBytes > response.Stats.ContextBudgetBytes {
+		return fmt.Errorf("search result context exceeds byte budget: %d > %d", response.Stats.ResultBytes, response.Stats.ContextBudgetBytes)
+	}
 	for index, result := range response.Results {
 		if result.Rank != index+1 {
 			return fmt.Errorf("search result rank %d at index %d", result.Rank, index)

--- a/internal/sem/search.go
+++ b/internal/sem/search.go
@@ -697,10 +697,15 @@ func candidatesForFile(q searchQuery, filePath, language string, lines []string,
 
 	if len(out) == 0 && textMatchesSearchQuery(q, filepath.ToSlash(filePath)) {
 		end := minInt(len(lines), maxInt(1, options.ContextLines*2+1))
-		candidate, _ := makeSearchCandidate(q, filePath, language, lines, 1, end, SymbolRecord{}, options.MaxSnippetLines)
-		candidate.baseScore += pathSearchScore(q, filePath)
-		candidate.result.Signals = appendUnique(candidate.result.Signals, "path")
-		out = append(out, candidate)
+		// A path can match only through weak derived fragments (compound
+		// identifier parts or morphological variants) that pathSearchScore
+		// does not treat as evidence. Such files produce no valid candidate
+		// and must be skipped, not emitted as zero-value results.
+		if candidate, ok := makeSearchCandidate(q, filePath, language, lines, 1, end, SymbolRecord{}, options.MaxSnippetLines); ok {
+			candidate.baseScore += pathSearchScore(q, filePath)
+			candidate.result.Signals = appendUnique(candidate.result.Signals, "path")
+			out = append(out, candidate)
+		}
 	}
 	return out
 }

--- a/internal/sem/search.go
+++ b/internal/sem/search.go
@@ -342,26 +342,38 @@ func compactSearchResultToBytes(result SearchResult, q searchQuery, budget int) 
 	if focus < 0 || focus >= len(lines) {
 		focus = len(lines) / 2
 	}
-	left, right := focus, focus
-	for {
-		candidate := result
-		candidate.SnippetStartLine = result.SnippetStartLine + left
-		candidate.SnippetEndLine = result.SnippetStartLine + right
-		candidate.Snippet = strings.Join(lines[left:right+1], "\n")
-		size := serializedSearchResultBytes(candidate)
-		if size <= budget {
-			return candidate, size
-		}
-		if left == right {
-			candidate.Snippet = truncateSearchText(candidate.Snippet, maxInt(16, budget/3), q)
-			return candidate, serializedSearchResultBytes(candidate)
-		}
-		if right-focus >= focus-left {
-			right--
-		} else {
-			left++
+	bestSpan, bestBalance := 0, len(lines)+1
+	var best SearchResult
+	bestSize := 0
+	for left := 0; left <= focus; left++ {
+		for right := focus; right < len(lines); right++ {
+			candidate := result
+			candidate.SnippetStartLine = result.SnippetStartLine + left
+			candidate.SnippetEndLine = result.SnippetStartLine + right
+			candidate.Snippet = strings.Join(lines[left:right+1], "\n")
+			size := serializedSearchResultBytes(candidate)
+			if size > budget {
+				continue
+			}
+			span := right - left + 1
+			balance := (focus - left) - (right - focus)
+			if balance < 0 {
+				balance = -balance
+			}
+			if span > bestSpan || (span == bestSpan && balance < bestBalance) {
+				best, bestSize = candidate, size
+				bestSpan, bestBalance = span, balance
+			}
 		}
 	}
+	if bestSpan > 0 {
+		return best, bestSize
+	}
+	candidate := result
+	candidate.SnippetStartLine = result.SnippetStartLine + focus
+	candidate.SnippetEndLine = candidate.SnippetStartLine
+	candidate.Snippet = truncateSearchText(lines[focus], maxInt(16, budget/3), q)
+	return candidate, serializedSearchResultBytes(candidate)
 }
 
 func truncateSearchText(value string, maxBytes int, q searchQuery) string {
@@ -555,43 +567,11 @@ func preselectSearchFiles(ctx context.Context, repo string, q searchQuery, optio
 		}
 		return searchFileCandidate{path: filePath, score: score}, true
 	}
-	files := make([]searchFileCandidate, 0, options.MaxIndexedFiles*2)
+	workers := 1
 	if options.Worktree {
-		workers := minInt(8, maxInt(1, runtime.GOMAXPROCS(0)))
-		jobs := make(chan string)
-		results := make(chan searchFileCandidate)
-		var wait sync.WaitGroup
-		for worker := 0; worker < workers; worker++ {
-			wait.Add(1)
-			go func() {
-				defer wait.Done()
-				for filePath := range jobs {
-					if candidate, ok := scoreFile(filePath); ok {
-						results <- candidate
-					}
-				}
-			}()
-		}
-		go func() {
-			defer close(jobs)
-			for _, filePath := range scanPaths {
-				jobs <- filePath
-			}
-		}()
-		go func() {
-			wait.Wait()
-			close(results)
-		}()
-		for candidate := range results {
-			files = append(files, candidate)
-		}
-	} else {
-		for _, filePath := range scanPaths {
-			if candidate, ok := scoreFile(filePath); ok {
-				files = append(files, candidate)
-			}
-		}
+		workers = minInt(8, maxInt(1, runtime.GOMAXPROCS(0)))
 	}
+	files := scoreSearchPaths(ctx, scanPaths, workers, scoreFile)
 	if err := ctx.Err(); err != nil {
 		return searchFileSelection{}, err
 	}
@@ -611,6 +591,65 @@ func preselectSearchFiles(ctx context.Context, repo string, q searchQuery, optio
 	selection.files = selected
 	selection.filesContentRead = len(scanPaths)
 	return selection, nil
+}
+
+func scoreSearchPaths(
+	ctx context.Context,
+	paths []string,
+	workers int,
+	score func(string) (searchFileCandidate, bool),
+) []searchFileCandidate {
+	initialCapacity := minInt(len(paths), 1024)
+	if workers <= 1 {
+		files := make([]searchFileCandidate, 0, initialCapacity)
+		for _, filePath := range paths {
+			if ctx.Err() != nil {
+				break
+			}
+			if candidate, ok := score(filePath); ok {
+				files = append(files, candidate)
+			}
+		}
+		return files
+	}
+
+	jobs := make(chan string)
+	results := make(chan searchFileCandidate)
+	var wait sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			for filePath := range jobs {
+				if candidate, ok := score(filePath); ok {
+					select {
+					case results <- candidate:
+					case <-ctx.Done():
+						return
+					}
+				}
+			}
+		}()
+	}
+	go func() {
+		defer close(jobs)
+		for _, filePath := range paths {
+			select {
+			case jobs <- filePath:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	go func() {
+		wait.Wait()
+		close(results)
+	}()
+	files := make([]searchFileCandidate, 0, initialCapacity)
+	for candidate := range results {
+		files = append(files, candidate)
+	}
+	return files
 }
 
 func shouldUseGitGrepPreselection(worktree bool, fileCount int) bool {

--- a/internal/sem/search.go
+++ b/internal/sem/search.go
@@ -1,0 +1,1206 @@
+package sem
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+)
+
+const (
+	defaultSearchTopK              = 20
+	defaultSearchContextLines      = 8
+	defaultSearchMaxRegionLines    = 120
+	defaultSearchMaxSnippetLines   = 40
+	defaultSearchMaxRegionsPerFile = 3
+	defaultSearchMaxIndexedFiles   = 96
+	maxSearchQueryTerms            = 48
+)
+
+// SearchOptions controls local issue-to-code retrieval. Search reads the same
+// HEAD/worktree view and ignore rules as provider snapshots.
+type SearchOptions struct {
+	Worktree          bool
+	IgnoreFiles       []string
+	IncludeFiles      []string
+	Profile           Profile
+	TopK              int
+	ContextLines      int
+	MaxRegionLines    int
+	MaxSnippetLines   int
+	MaxRegionsPerFile int
+	MaxParseBytes     int
+	CacheDir          string
+	DisableCache      bool
+	MaxIndexedFiles   int
+	IndexAllFiles     bool
+}
+
+// SearchResult is a ranked source region suitable for direct agent context.
+type SearchResult struct {
+	Rank             int      `json:"rank"`
+	Score            float64  `json:"score"`
+	FilePath         string   `json:"file_path"`
+	StartLine        int      `json:"start_line"`
+	EndLine          int      `json:"end_line"`
+	FocusLine        int      `json:"focus_line"`
+	SnippetStartLine int      `json:"snippet_start_line"`
+	SnippetEndLine   int      `json:"snippet_end_line"`
+	Language         string   `json:"language,omitempty"`
+	Kind             string   `json:"kind,omitempty"`
+	SymbolID         string   `json:"symbol_id,omitempty"`
+	SymbolName       string   `json:"symbol_name,omitempty"`
+	QualifiedName    string   `json:"qualified_name,omitempty"`
+	Signature        string   `json:"signature,omitempty"`
+	Signals          []string `json:"signals"`
+	Snippet          string   `json:"snippet"`
+}
+
+type SearchStats struct {
+	FilesScanned       int   `json:"files_scanned"`
+	FilesIndexed       int   `json:"files_indexed"`
+	SymbolsConsidered  int   `json:"symbols_considered"`
+	LexicalCandidates  int   `json:"lexical_candidates"`
+	GraphCandidates    int   `json:"graph_candidates"`
+	CandidatesSelected int   `json:"candidates_selected"`
+	IndexCacheHit      bool  `json:"index_cache_hit"`
+	IndexLatencyMS     int64 `json:"index_latency_ms"`
+	SearchLatencyMS    int64 `json:"search_latency_ms"`
+	PreselectLatencyMS int64 `json:"preselect_latency_ms"`
+}
+
+type SearchResponse struct {
+	Query    string            `json:"query"`
+	RepoRoot string            `json:"repo_root"`
+	Commit   string            `json:"commit,omitempty"`
+	Tree     string            `json:"tree,omitempty"`
+	Profile  string            `json:"profile"`
+	Results  []SearchResult    `json:"results"`
+	Stats    SearchStats       `json:"stats"`
+	Warnings []ProviderWarning `json:"warnings"`
+}
+
+type searchQuery struct {
+	rawLower string
+	terms    []string
+	termSet  map[string]bool
+	weights  map[string]float64
+}
+
+type searchCandidate struct {
+	result     SearchResult
+	termCounts map[string]int
+	docLength  int
+	baseScore  float64
+	score      float64
+}
+
+var searchWordPattern = regexp.MustCompile(`[[:alnum:]_./:+-]+`)
+
+var searchStopWords = map[string]bool{
+	"a": true, "an": true, "and": true, "are": true, "as": true,
+	"at": true, "be": true, "by": true, "can": true, "change": true,
+	"code": true, "does": true, "for": true, "from": true, "how": true,
+	"i": true, "in": true, "into": true, "is": true, "it": true,
+	"make": true, "of": true, "on": true, "or": true, "our": true,
+	"should": true, "support": true, "that": true, "the": true,
+	"this": true, "to": true, "use": true, "uses": true, "using": true,
+	"we": true, "what": true, "when": true, "where": true, "which": true,
+	"with": true, "without": true,
+}
+
+// Issue descriptions use prose where APIs use terse verbs. These generic
+// concept expansions carry less weight than terms the user supplied.
+var searchConceptTerms = map[string][]string{
+	"authentication":  {"auth", "login", "credential"},
+	"configuration":   {"config", "option", "setting"},
+	"deserialization": {"deserialize", "reader", "read", "parse", "decode"},
+	"directory":       {"dir", "cwd", "folder", "path"},
+	"disabled":        {"disable", "off"},
+	"documentation":   {"docs", "doc", "readme"},
+	"enabled":         {"enable", "on"},
+	"failure":         {"fail", "error"},
+	"indentation":     {"indent", "spacing"},
+	"initialization":  {"initialize", "init", "create"},
+	"lookup":          {"resolve", "resolver", "resolution"},
+	"minified":        {"minify", "compact"},
+	"nonexistent":     {"missing", "absent", "exist", "existing", "create"},
+	"pretty":          {"prettify", "prettification", "indent", "formatter", "format", "formatted"},
+	"printing":        {"print", "output", "render"},
+	"serialization":   {"serialize", "writer", "write", "marshal", "encode"},
+	"spaces":          {"space", "spacing"},
+	"validation":      {"validate", "check", "verify"},
+}
+
+// SearchRepository performs local hybrid lexical/semantic retrieval. It uses
+// no qrels, hosted models, embeddings, or network access.
+func SearchRepository(ctx context.Context, repo, providerVersion, query string, options SearchOptions) (SearchResponse, error) {
+	q := buildSearchQuery(query)
+	if len(q.terms) == 0 {
+		return SearchResponse{}, errors.New("search query has no meaningful terms")
+	}
+	if options.TopK <= 0 {
+		options.TopK = defaultSearchTopK
+	}
+	if options.ContextLines < 0 {
+		return SearchResponse{}, errors.New("search context lines cannot be negative")
+	}
+	if options.ContextLines == 0 {
+		options.ContextLines = defaultSearchContextLines
+	}
+	if options.MaxRegionLines <= 0 {
+		options.MaxRegionLines = defaultSearchMaxRegionLines
+	}
+	if options.MaxSnippetLines <= 0 {
+		options.MaxSnippetLines = defaultSearchMaxSnippetLines
+	}
+	if options.MaxRegionsPerFile <= 0 {
+		options.MaxRegionsPerFile = defaultSearchMaxRegionsPerFile
+	}
+	if options.MaxIndexedFiles <= 0 {
+		options.MaxIndexedFiles = defaultSearchMaxIndexedFiles
+	}
+	if options.Profile == "" {
+		options.Profile = ProfileSyntaxOnly
+	}
+	searchStarted := time.Now()
+	preselectStarted := time.Now()
+	selectedFiles, discoveredFiles, err := preselectSearchFiles(ctx, repo, q, options)
+	if err != nil {
+		return SearchResponse{}, err
+	}
+	preselectLatency := time.Since(preselectStarted)
+	if len(selectedFiles) == 0 {
+		absRepo, absErr := filepath.Abs(repo)
+		if absErr != nil {
+			return SearchResponse{}, absErr
+		}
+		return SearchResponse{
+			Query:    query,
+			RepoRoot: absRepo,
+			Profile:  string(options.Profile),
+			Results:  []SearchResult{},
+			Stats: SearchStats{
+				FilesScanned:       discoveredFiles,
+				FilesIndexed:       0,
+				PreselectLatencyMS: preselectLatency.Milliseconds(),
+				SearchLatencyMS:    time.Since(searchStarted).Milliseconds(),
+			},
+			Warnings: []ProviderWarning{},
+		}, nil
+	}
+
+	snapshotOptions := ProviderSnapshotOptions{
+		NoNetwork:     true,
+		Worktree:      options.Worktree,
+		IgnoreFiles:   options.IgnoreFiles,
+		IncludeFiles:  options.IncludeFiles,
+		MaxParseBytes: options.MaxParseBytes,
+		Profile:       options.Profile,
+		OnlyFiles:     selectedFiles,
+	}
+	indexStarted := time.Now()
+	snapshot, cacheHit, err := loadOrBuildSearchSnapshot(ctx, repo, providerVersion, snapshotOptions, options.CacheDir, options.DisableCache)
+	if err != nil {
+		return SearchResponse{}, err
+	}
+	indexLatency := time.Since(indexStarted)
+	useHead := !options.Worktree && snapshot.Header.Commit != ""
+	_, read, _, closeSource, err := openSource(ctx, repo, useHead, options.IgnoreFiles, options.IncludeFiles)
+	if err != nil {
+		return SearchResponse{}, err
+	}
+	if closeSource != nil {
+		defer closeSource()
+	}
+
+	symbolsByFile := make(map[string][]SymbolRecord)
+	symbolsByID := make(map[string]SymbolRecord, len(snapshot.Symbols))
+	for _, symbol := range snapshot.Symbols {
+		symbolsByFile[symbol.FilePath] = append(symbolsByFile[symbol.FilePath], symbol)
+		symbolsByID[symbol.ID] = symbol
+	}
+	for filePath := range symbolsByFile {
+		sort.Slice(symbolsByFile[filePath], func(i, j int) bool {
+			left, right := symbolsByFile[filePath][i], symbolsByFile[filePath][j]
+			if left.StartLine != right.StartLine {
+				return left.StartLine < right.StartLine
+			}
+			return left.EndLine < right.EndLine
+		})
+	}
+
+	fileLanguages := make(map[string]string, len(snapshot.Files))
+	for _, file := range snapshot.Files {
+		fileLanguages[file.Path] = file.Language
+	}
+
+	fileDF := make(map[string]int, len(q.terms))
+	var candidates []searchCandidate
+	for _, filePath := range selectedFiles {
+		if err := ctx.Err(); err != nil {
+			return SearchResponse{}, err
+		}
+		content, ok := read(filePath)
+		if !ok || strings.IndexByte(content, 0) >= 0 {
+			continue
+		}
+		lowerContent := strings.ToLower(content)
+		lowerPath := strings.ToLower(filepath.ToSlash(filePath))
+		for _, term := range q.terms {
+			if strings.Contains(lowerContent, term) || strings.Contains(lowerPath, term) {
+				fileDF[term]++
+			}
+		}
+		lines := strings.Split(content, "\n")
+		candidates = append(candidates, candidatesForFile(
+			q, filePath, fileLanguages[filePath], lines, symbolsByFile[filePath], options,
+		)...)
+	}
+
+	stats := SearchStats{
+		FilesScanned:       discoveredFiles,
+		FilesIndexed:       len(selectedFiles),
+		SymbolsConsidered:  len(snapshot.Symbols),
+		LexicalCandidates:  len(candidates),
+		IndexCacheHit:      cacheHit,
+		IndexLatencyMS:     indexLatency.Milliseconds(),
+		PreselectLatencyMS: preselectLatency.Milliseconds(),
+	}
+	scoreSearchCandidates(candidates, q, fileDF, maxInt(1, len(selectedFiles)))
+	sortSearchCandidates(candidates)
+
+	graphCandidates := expandGraphCandidates(candidates, snapshot.Relations, symbolsByID, read, fileLanguages, options)
+	stats.GraphCandidates = len(graphCandidates)
+	candidates = append(candidates, graphCandidates...)
+	sortSearchCandidates(candidates)
+	selected := selectDiverseCandidates(candidates, options.TopK, options.MaxRegionsPerFile)
+	results := make([]SearchResult, 0, len(selected))
+	for i := range selected {
+		selected[i].result.Rank = i + 1
+		selected[i].result.Score = math.Round(selected[i].score*10000) / 10000
+		if selected[i].result.Signals == nil {
+			selected[i].result.Signals = []string{}
+		}
+		results = append(results, selected[i].result)
+	}
+	stats.CandidatesSelected = len(results)
+	stats.SearchLatencyMS = time.Since(searchStarted).Milliseconds()
+	if results == nil {
+		results = []SearchResult{}
+	}
+	return SearchResponse{
+		Query:    query,
+		RepoRoot: snapshot.Header.RepoRoot,
+		Commit:   snapshot.Header.Commit,
+		Tree:     snapshot.Header.Tree,
+		Profile:  string(options.Profile),
+		Results:  results,
+		Stats:    stats,
+		Warnings: snapshot.Header.Warnings,
+	}, nil
+}
+
+type searchFileCandidate struct {
+	path  string
+	score float64
+}
+
+func preselectSearchFiles(ctx context.Context, repo string, q searchQuery, options SearchOptions) ([]string, int, error) {
+	source, err := prepareSource(ctx, repo, ProviderSnapshotOptions{
+		NoNetwork:    true,
+		Worktree:     options.Worktree,
+		IgnoreFiles:  options.IgnoreFiles,
+		IncludeFiles: options.IncludeFiles,
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	if source.close != nil {
+		defer source.close()
+	}
+	if options.IndexAllFiles || len(source.paths) <= options.MaxIndexedFiles {
+		return append([]string(nil), source.paths...), len(source.paths), nil
+	}
+	queryWeight := 0.0
+	for _, weight := range q.weights {
+		queryWeight += weight
+	}
+	matcher := newSearchTermMatcher(q.terms)
+	scoreFile := func(filePath string) (searchFileCandidate, bool) {
+		if err := ctx.Err(); err != nil {
+			return searchFileCandidate{}, false
+		}
+		content, ok := source.read(filePath)
+		if !ok || strings.IndexByte(content, 0) >= 0 {
+			return searchFileCandidate{}, false
+		}
+		score := 2*pathSearchScore(q, filePath) + searchPathPrior(q, filePath)
+		matchedWeight := 0.0
+		for index, matched := range matcher.match(content) {
+			if matched {
+				term := q.terms[index]
+				weight := q.weights[term]
+				score += weight
+				matchedWeight += weight
+			}
+		}
+		if score == 0 {
+			return searchFileCandidate{}, false
+		}
+		if queryWeight > 0 {
+			score += 4 * matchedWeight / queryWeight
+		}
+		return searchFileCandidate{path: filePath, score: score}, true
+	}
+	files := make([]searchFileCandidate, 0, options.MaxIndexedFiles*2)
+	if options.Worktree {
+		workers := minInt(8, maxInt(1, runtime.GOMAXPROCS(0)))
+		jobs := make(chan string)
+		results := make(chan searchFileCandidate)
+		var wait sync.WaitGroup
+		for worker := 0; worker < workers; worker++ {
+			wait.Add(1)
+			go func() {
+				defer wait.Done()
+				for filePath := range jobs {
+					if candidate, ok := scoreFile(filePath); ok {
+						results <- candidate
+					}
+				}
+			}()
+		}
+		go func() {
+			defer close(jobs)
+			for _, filePath := range source.paths {
+				jobs <- filePath
+			}
+		}()
+		go func() {
+			wait.Wait()
+			close(results)
+		}()
+		for candidate := range results {
+			files = append(files, candidate)
+		}
+	} else {
+		for _, filePath := range source.paths {
+			if candidate, ok := scoreFile(filePath); ok {
+				files = append(files, candidate)
+			}
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, len(source.paths), err
+	}
+	sort.Slice(files, func(i, j int) bool {
+		if files[i].score != files[j].score {
+			return files[i].score > files[j].score
+		}
+		return files[i].path < files[j].path
+	})
+	if len(files) > options.MaxIndexedFiles {
+		files = files[:options.MaxIndexedFiles]
+	}
+	selected := make([]string, len(files))
+	for i, file := range files {
+		selected[i] = file.path
+	}
+	return selected, len(source.paths), nil
+}
+
+func candidatesForFile(q searchQuery, filePath, language string, lines []string, symbols []SymbolRecord, options SearchOptions) []searchCandidate {
+	var out []searchCandidate
+	covered := make([]bool, len(lines)+1)
+	for _, symbol := range symbols {
+		start, end := clampRegion(symbol.StartLine, symbol.EndLine, len(lines))
+		if start == 0 {
+			continue
+		}
+		searchStart := precedingDocumentationStart(lines, start, options.ContextLines)
+		for line := searchStart; line <= end; line++ {
+			covered[line] = true
+		}
+		if end-searchStart+1 <= options.MaxRegionLines {
+			if candidate, ok := makeSearchCandidate(q, filePath, language, lines, searchStart, end, symbol, options.MaxSnippetLines); ok {
+				out = append(out, candidate)
+			}
+			continue
+		}
+		for _, region := range matchingLineRegions(q, lines, searchStart, end, options.ContextLines, options.MaxRegionLines) {
+			if candidate, ok := makeSearchCandidate(q, filePath, language, lines, region[0], region[1], symbol, options.MaxSnippetLines); ok {
+				out = append(out, candidate)
+			}
+		}
+	}
+
+	var uncoveredHits []int
+	for index, line := range lines {
+		lineNumber := index + 1
+		if !covered[lineNumber] && textMatchesSearchQuery(q, line) {
+			uncoveredHits = append(uncoveredHits, lineNumber)
+		}
+	}
+	for _, region := range uncoveredRegionsAroundHits(uncoveredHits, covered, len(lines), options.ContextLines, options.MaxRegionLines) {
+		if candidate, ok := makeSearchCandidate(q, filePath, language, lines, region[0], region[1], SymbolRecord{}, options.MaxSnippetLines); ok {
+			out = append(out, candidate)
+		}
+	}
+
+	if len(out) == 0 && textMatchesSearchQuery(q, filepath.ToSlash(filePath)) {
+		end := minInt(len(lines), maxInt(1, options.ContextLines*2+1))
+		candidate, _ := makeSearchCandidate(q, filePath, language, lines, 1, end, SymbolRecord{}, options.MaxSnippetLines)
+		candidate.baseScore += pathSearchScore(q, filePath)
+		candidate.result.Signals = appendUnique(candidate.result.Signals, "path")
+		out = append(out, candidate)
+	}
+	return out
+}
+
+func uncoveredRegionsAroundHits(hits []int, covered []bool, lineCount, context, maxLines int) [][2]int {
+	baseRegions := regionsAroundHits(hits, 1, lineCount, context, maxLines)
+	hitSet := make(map[int]bool, len(hits))
+	for _, hit := range hits {
+		hitSet[hit] = true
+	}
+	var out [][2]int
+	for _, region := range baseRegions {
+		runStart := 0
+		runHasHit := false
+		flush := func(end int) {
+			if runStart > 0 && runHasHit {
+				out = append(out, [2]int{runStart, end})
+			}
+			runStart = 0
+			runHasHit = false
+		}
+		for line := region[0]; line <= region[1]; line++ {
+			if line < len(covered) && covered[line] {
+				flush(line - 1)
+				continue
+			}
+			if runStart == 0 {
+				runStart = line
+			}
+			runHasHit = runHasHit || hitSet[line]
+		}
+		flush(region[1])
+	}
+	return out
+}
+
+func precedingDocumentationStart(lines []string, symbolStart, limit int) int {
+	start := symbolStart
+	if limit <= 0 {
+		return start
+	}
+	sawComment := false
+	for line := symbolStart - 1; line >= 1 && symbolStart-line <= limit; line-- {
+		trimmed := strings.TrimSpace(lines[line-1])
+		isComment := strings.HasPrefix(trimmed, "//") ||
+			strings.HasPrefix(trimmed, "#") ||
+			strings.HasPrefix(trimmed, "/*") ||
+			strings.HasPrefix(trimmed, "*") ||
+			strings.HasPrefix(trimmed, "--")
+		if isComment {
+			sawComment = true
+			start = line
+			continue
+		}
+		if trimmed == "" && sawComment {
+			start = line
+			continue
+		}
+		break
+	}
+	return start
+}
+
+func makeSearchCandidate(q searchQuery, filePath, language string, lines []string, start, end int, symbol SymbolRecord, maxSnippetLines int) (searchCandidate, bool) {
+	start, end = clampRegion(start, end, len(lines))
+	if start == 0 {
+		return searchCandidate{}, false
+	}
+	regionText := strings.Join(lines[start-1:end], "\n")
+	counts, length := searchTermCounts(regionText, q.termSet)
+	focus := searchFocusLine(q, lines, start, end)
+	if symbol.ID != "" {
+		focus = maxInt(focus, symbol.StartLine)
+	}
+	snippetStart, snippetEnd := focusedSnippetRegion(start, end, focus, maxSnippetLines)
+	snippet := strings.Join(lines[snippetStart-1:snippetEnd], "\n")
+	base := pathSearchScore(q, filePath) + searchPathPrior(q, filePath)
+	signals := []string{}
+	if base > 0 {
+		signals = append(signals, "path")
+	}
+	if len(counts) > 0 {
+		signals = append(signals, "body")
+	}
+	if symbol.ID != "" {
+		nameScore, nameSignals := symbolSearchScore(q, symbol)
+		base += nameScore
+		signals = append(signals, nameSignals...)
+	}
+	if len(counts) == 0 && base == 0 {
+		return searchCandidate{}, false
+	}
+	return searchCandidate{
+		result: SearchResult{
+			FilePath:         filePath,
+			StartLine:        start,
+			EndLine:          end,
+			FocusLine:        focus,
+			SnippetStartLine: snippetStart,
+			SnippetEndLine:   snippetEnd,
+			Language:         language,
+			Kind:             symbol.Kind,
+			SymbolID:         symbol.ID,
+			SymbolName:       symbol.Name,
+			QualifiedName:    symbol.QualifiedName,
+			Signature:        symbol.Signature,
+			Signals:          appendUnique(nil, signals...),
+			Snippet:          snippet,
+		},
+		termCounts: counts,
+		docLength:  length,
+		baseScore:  base,
+	}, true
+}
+
+func scoreSearchCandidates(candidates []searchCandidate, q searchQuery, fileDF map[string]int, fileCount int) {
+	if len(candidates) == 0 {
+		return
+	}
+	averageLength := 0.0
+	for _, candidate := range candidates {
+		averageLength += float64(maxInt(1, candidate.docLength))
+	}
+	averageLength /= float64(len(candidates))
+	queryWeight := 0.0
+	idf := make(map[string]float64, len(q.terms))
+	for _, term := range q.terms {
+		df := fileDF[term]
+		weight := math.Log(1+(float64(fileCount-df)+0.5)/(float64(df)+0.5)) * q.weights[term]
+		idf[term] = weight
+		queryWeight += weight
+	}
+	for i := range candidates {
+		candidate := &candidates[i]
+		bm25 := 0.0
+		coveredWeight := 0.0
+		codeTokenBonus := 0.0
+		for _, term := range q.terms {
+			frequency := candidate.termCounts[term]
+			if frequency == 0 {
+				continue
+			}
+			weight := idf[term]
+			coveredWeight += weight
+			if q.weights[term] >= 2 {
+				codeTokenBonus += 6 * q.weights[term]
+			}
+			denominator := float64(frequency) + 1.2*(0.25+0.75*float64(maxInt(1, candidate.docLength))/averageLength)
+			bm25 += weight * (float64(frequency) * 2.2 / denominator)
+		}
+		coverage := 0.0
+		if queryWeight > 0 {
+			coverage = coveredWeight / queryWeight
+		}
+		candidate.score = candidate.baseScore + bm25 + 7*coverage + minFloat64(24, codeTokenBonus)
+		if codeTokenBonus > 0 {
+			candidate.result.Signals = appendUnique(candidate.result.Signals, "exact-code-token")
+		}
+		if coverage == 1 {
+			candidate.score += 2
+			candidate.result.Signals = appendUnique(candidate.result.Signals, "all-query-terms")
+		}
+	}
+}
+
+func minFloat64(left, right float64) float64 {
+	if left < right {
+		return left
+	}
+	return right
+}
+
+func expandGraphCandidates(seeds []searchCandidate, relations []RelationRecord, symbolsByID map[string]SymbolRecord, read contentReader, languages map[string]string, options SearchOptions) []searchCandidate {
+	if len(seeds) == 0 || len(relations) == 0 {
+		return nil
+	}
+	seedScores := map[string]float64{}
+	for _, candidate := range seeds {
+		if len(seedScores) >= 10 {
+			break
+		}
+		if candidate.result.SymbolID != "" && candidate.score > seedScores[candidate.result.SymbolID] {
+			seedScores[candidate.result.SymbolID] = candidate.score
+		}
+	}
+	if len(seedScores) == 0 {
+		return nil
+	}
+	best := map[string]searchCandidate{}
+	contentCache := map[string][]string{}
+	for _, relation := range relations {
+		if relation.Confidence < 0.7 || !searchExpansionRelation(relation.Type) {
+			continue
+		}
+		pairs := [][3]string{{relation.FromID, relation.ToID, "outgoing"}, {relation.ToID, relation.FromID, "incoming"}}
+		for _, pair := range pairs {
+			seedScore, ok := seedScores[pair[0]]
+			if !ok {
+				continue
+			}
+			symbol, ok := symbolsByID[pair[1]]
+			if !ok || symbol.ID == pair[0] {
+				continue
+			}
+			lines, ok := contentCache[symbol.FilePath]
+			if !ok {
+				content, readable := read(symbol.FilePath)
+				if !readable {
+					continue
+				}
+				lines = strings.Split(content, "\n")
+				contentCache[symbol.FilePath] = lines
+			}
+			start, end := clampRegion(symbol.StartLine, symbol.EndLine, len(lines))
+			if end-start+1 > options.MaxRegionLines {
+				end = minInt(len(lines), start+options.MaxRegionLines-1)
+			}
+			snippetStart, snippetEnd := focusedSnippetRegion(start, end, start, options.MaxSnippetLines)
+			candidate := searchCandidate{
+				result: SearchResult{
+					FilePath:         symbol.FilePath,
+					StartLine:        start,
+					EndLine:          end,
+					FocusLine:        start,
+					SnippetStartLine: snippetStart,
+					SnippetEndLine:   snippetEnd,
+					Language:         languages[symbol.FilePath],
+					Kind:             symbol.Kind,
+					SymbolID:         symbol.ID,
+					SymbolName:       symbol.Name,
+					QualifiedName:    symbol.QualifiedName,
+					Signature:        symbol.Signature,
+					Snippet:          strings.Join(lines[snippetStart-1:snippetEnd], "\n"),
+				},
+			}
+			candidate.score = 0.28*seedScore + relation.Confidence
+			candidate.baseScore = candidate.score
+			candidate.result.Signals = appendUnique(candidate.result.Signals, "graph:"+strings.ToLower(relation.Type), "graph:"+pair[2])
+			if previous, exists := best[symbol.ID]; !exists || candidate.score > previous.score {
+				best[symbol.ID] = candidate
+			}
+		}
+	}
+	out := make([]searchCandidate, 0, len(best))
+	for _, candidate := range best {
+		out = append(out, candidate)
+	}
+	sortSearchCandidates(out)
+	if len(out) > 20 {
+		out = out[:20]
+	}
+	return out
+}
+
+func searchExpansionRelation(relation string) bool {
+	switch relation {
+	case "CALLS", "CONSTRUCTS", "ASYNC_CALLS", "IMPORTS", "EXTENDS", "INHERITS", "IMPLEMENTS", "OVERRIDES", "USES_TYPE", "TESTS", "CONFIGURES":
+		return true
+	default:
+		return false
+	}
+}
+
+func selectDiverseCandidates(candidates []searchCandidate, topK, maxPerFile int) []searchCandidate {
+	remaining := append([]searchCandidate(nil), candidates...)
+	selected := make([]searchCandidate, 0, minInt(topK, len(remaining)))
+	perFile := map[string]int{}
+	perSymbolName := map[string]int{}
+	perBaseName := map[string]int{}
+	for len(selected) < topK {
+		bestIndex := -1
+		bestAdjusted := -math.MaxFloat64
+		for i := range remaining {
+			candidate := remaining[i]
+			if perFile[candidate.result.FilePath] >= maxPerFile || overlapsSelected(candidate, selected) {
+				continue
+			}
+			symbolKey := strings.ToLower(candidate.result.QualifiedName)
+			if symbolKey == "" {
+				symbolKey = strings.ToLower(candidate.result.SymbolName)
+			}
+			symbolPenalty := 0.0
+			if symbolKey != "" {
+				symbolPenalty = 4 * float64(perSymbolName[symbolKey])
+			}
+			baseKey := strings.ToLower(filepath.Base(candidate.result.FilePath))
+			adjusted := candidate.score -
+				0.8*float64(perFile[candidate.result.FilePath]) -
+				symbolPenalty -
+				2*float64(perBaseName[baseKey])
+			if adjusted > bestAdjusted || (adjusted == bestAdjusted && searchCandidateLess(candidate, remaining[bestIndex])) {
+				bestIndex = i
+				bestAdjusted = adjusted
+			}
+		}
+		if bestIndex < 0 {
+			break
+		}
+		selected = append(selected, remaining[bestIndex])
+		chosen := remaining[bestIndex].result
+		perFile[chosen.FilePath]++
+		symbolKey := strings.ToLower(chosen.QualifiedName)
+		if symbolKey == "" {
+			symbolKey = strings.ToLower(chosen.SymbolName)
+		}
+		if symbolKey != "" {
+			perSymbolName[symbolKey]++
+		}
+		perBaseName[strings.ToLower(filepath.Base(chosen.FilePath))]++
+		remaining = append(remaining[:bestIndex], remaining[bestIndex+1:]...)
+	}
+	return selected
+}
+
+func overlapsSelected(candidate searchCandidate, selected []searchCandidate) bool {
+	for _, existing := range selected {
+		if candidate.result.FilePath != existing.result.FilePath {
+			continue
+		}
+		intersection := minInt(candidate.result.EndLine, existing.result.EndLine) - maxInt(candidate.result.StartLine, existing.result.StartLine) + 1
+		if intersection <= 0 {
+			continue
+		}
+		shorter := minInt(candidate.result.EndLine-candidate.result.StartLine+1, existing.result.EndLine-existing.result.StartLine+1)
+		if float64(intersection)/float64(shorter) >= 0.6 {
+			return true
+		}
+	}
+	return false
+}
+
+func sortSearchCandidates(candidates []searchCandidate) {
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].score != candidates[j].score {
+			return candidates[i].score > candidates[j].score
+		}
+		return searchCandidateLess(candidates[i], candidates[j])
+	})
+}
+
+func searchCandidateLess(left, right searchCandidate) bool {
+	if left.result.FilePath != right.result.FilePath {
+		return left.result.FilePath < right.result.FilePath
+	}
+	if left.result.StartLine != right.result.StartLine {
+		return left.result.StartLine < right.result.StartLine
+	}
+	return left.result.EndLine < right.result.EndLine
+}
+
+func matchingLineRegions(q searchQuery, lines []string, start, end, context, maxLines int) [][2]int {
+	var hits []int
+	for line := start; line <= end; line++ {
+		if textMatchesSearchQuery(q, lines[line-1]) {
+			hits = append(hits, line)
+		}
+	}
+	return regionsAroundHits(hits, start, end, context, maxLines)
+}
+
+func regionsAroundHits(hits []int, lower, upper, context, maxLines int) [][2]int {
+	if len(hits) == 0 {
+		return nil
+	}
+	var regions [][2]int
+	groupStart := hits[0]
+	groupEnd := hits[0]
+	flush := func() {
+		start := maxInt(lower, groupStart-context)
+		end := minInt(upper, groupEnd+context)
+		if end-start+1 > maxLines {
+			end = start + maxLines - 1
+		}
+		regions = append(regions, [2]int{start, end})
+	}
+	for _, hit := range hits[1:] {
+		if hit-groupEnd <= context*2+1 && hit-groupStart < maxLines {
+			groupEnd = hit
+			continue
+		}
+		flush()
+		groupStart, groupEnd = hit, hit
+	}
+	flush()
+	return regions
+}
+
+func buildSearchQuery(query string) searchQuery {
+	weights := map[string]float64{}
+	add := func(term string, weight float64) {
+		if len(term) < 2 || searchStopWords[term] {
+			return
+		}
+		if weight > weights[term] {
+			weights[term] = weight
+		}
+	}
+	for _, raw := range searchWordPattern.FindAllString(query, -1) {
+		codeLike := codeLikeSearchToken(raw)
+		for index, term := range searchTokenVariants(raw) {
+			weight := 1.0
+			if codeLike && index == 0 {
+				weight = codeLikeSearchWeight(raw)
+			} else if codeLike {
+				weight = 1.1
+			}
+			add(term, weight)
+		}
+	}
+	originalTerms := make([]string, 0, len(weights))
+	for term := range weights {
+		originalTerms = append(originalTerms, term)
+	}
+	for _, term := range originalTerms {
+		for _, related := range searchConceptTerms[term] {
+			add(related, 0.5)
+		}
+		for _, related := range morphologicalSearchTerms(term) {
+			add(related, 0.55)
+		}
+	}
+	termSet := make(map[string]bool, len(weights))
+	terms := make([]string, 0, len(weights))
+	for term := range weights {
+		termSet[term] = true
+		terms = append(terms, term)
+	}
+	sort.Slice(terms, func(i, j int) bool {
+		if weights[terms[i]] != weights[terms[j]] {
+			return weights[terms[i]] > weights[terms[j]]
+		}
+		if len(terms[i]) != len(terms[j]) {
+			return len(terms[i]) > len(terms[j])
+		}
+		return terms[i] < terms[j]
+	})
+	if len(terms) > maxSearchQueryTerms {
+		terms = terms[:maxSearchQueryTerms]
+		termSet = make(map[string]bool, len(terms))
+		trimmedWeights := make(map[string]float64, len(terms))
+		for _, term := range terms {
+			termSet[term] = true
+			trimmedWeights[term] = weights[term]
+		}
+		weights = trimmedWeights
+	}
+	return searchQuery{
+		rawLower: strings.ToLower(strings.TrimSpace(query)),
+		terms:    terms,
+		termSet:  termSet,
+		weights:  weights,
+	}
+}
+
+func codeLikeSearchWeight(raw string) float64 {
+	trimmed := strings.Trim(raw, "./:+-")
+	letters := 0
+	allUpper := true
+	for _, character := range trimmed {
+		if !unicode.IsLetter(character) {
+			continue
+		}
+		letters++
+		if unicode.IsLower(character) {
+			allUpper = false
+		}
+	}
+	if allUpper && letters > 0 && letters <= 4 {
+		return 1.4
+	}
+	return 2.5
+}
+
+func codeLikeSearchToken(raw string) bool {
+	trimmed := strings.Trim(raw, "./:+-")
+	if strings.ContainsAny(trimmed, "_./:$") || strings.HasPrefix(raw, "--") {
+		return true
+	}
+	uppercase := 0
+	lowercase := 0
+	for index, character := range trimmed {
+		if unicode.IsUpper(character) {
+			uppercase++
+			if index > 0 {
+				return true
+			}
+		} else if unicode.IsLower(character) {
+			lowercase++
+		}
+	}
+	return uppercase >= 2 && lowercase > 0
+}
+
+func morphologicalSearchTerms(term string) []string {
+	var out []string
+	switch {
+	case strings.HasSuffix(term, "ization") && len(term) > len("ization")+2:
+		out = append(out, strings.TrimSuffix(term, "ization")+"ize")
+	case strings.HasSuffix(term, "ification") && len(term) > len("ification")+2:
+		out = append(out, strings.TrimSuffix(term, "ification")+"ify")
+	case strings.HasSuffix(term, "ing") && len(term) > 5:
+		stem := strings.TrimSuffix(term, "ing")
+		out = append(out, stem, stem+"e")
+	case strings.HasSuffix(term, "ed") && len(term) > 4:
+		stem := strings.TrimSuffix(term, "ed")
+		out = append(out, stem, stem+"e")
+	}
+	if strings.HasSuffix(term, "s") && !strings.HasSuffix(term, "ss") && len(term) > 4 {
+		out = append(out, strings.TrimSuffix(term, "s"))
+	}
+	return appendUnique(nil, out...)
+}
+
+func searchTokenVariants(raw string) []string {
+	raw = strings.Trim(raw, "./:+-")
+	if raw == "" {
+		return nil
+	}
+	variants := []string{strings.ToLower(raw)}
+	for _, segment := range strings.FieldsFunc(raw, func(character rune) bool {
+		return !unicode.IsLetter(character) && !unicode.IsDigit(character)
+	}) {
+		variants = append(variants, strings.ToLower(segment))
+	}
+	var current []rune
+	runes := []rune(raw)
+	flush := func() {
+		if len(current) > 0 {
+			variants = append(variants, strings.ToLower(string(current)))
+			current = nil
+		}
+	}
+	for i, r := range runes {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			flush()
+			continue
+		}
+		if len(current) > 0 && unicode.IsUpper(r) {
+			previous := runes[i-1]
+			nextLower := i+1 < len(runes) && unicode.IsLower(runes[i+1])
+			if unicode.IsLower(previous) || unicode.IsDigit(previous) || (unicode.IsUpper(previous) && nextLower) {
+				flush()
+			}
+		}
+		current = append(current, r)
+	}
+	flush()
+	return appendUnique(nil, variants...)
+}
+
+func searchTermCounts(text string, queryTerms map[string]bool) (map[string]int, int) {
+	counts := map[string]int{}
+	length := 0
+	for _, raw := range searchWordPattern.FindAllString(text, -1) {
+		for _, token := range searchTokenVariants(raw) {
+			if len(token) < 2 {
+				continue
+			}
+			length++
+			if queryTerms[token] {
+				counts[token]++
+			}
+		}
+	}
+	return counts, length
+}
+
+func textMatchesSearchQuery(q searchQuery, text string) bool {
+	lower := strings.ToLower(text)
+	for _, term := range q.terms {
+		if strings.Contains(lower, term) {
+			return true
+		}
+	}
+	return false
+}
+
+func searchFocusLine(q searchQuery, lines []string, start, end int) int {
+	bestLine := start
+	bestMatches := 0.0
+	for line := start; line <= end; line++ {
+		lower := strings.ToLower(lines[line-1])
+		matches := 0.0
+		for _, term := range q.terms {
+			if strings.Contains(lower, term) {
+				matches += q.weights[term]
+			}
+		}
+		if matches > bestMatches {
+			bestLine = line
+			bestMatches = matches
+		}
+	}
+	return bestLine
+}
+
+func focusedSnippetRegion(start, end, focus, maxLines int) (int, int) {
+	if maxLines <= 0 || end-start+1 <= maxLines {
+		return start, end
+	}
+	half := maxLines / 2
+	snippetStart := maxInt(start, focus-half)
+	snippetEnd := minInt(end, snippetStart+maxLines-1)
+	if snippetEnd-snippetStart+1 < maxLines {
+		snippetStart = maxInt(start, snippetEnd-maxLines+1)
+	}
+	return snippetStart, snippetEnd
+}
+
+func pathSearchScore(q searchQuery, filePath string) float64 {
+	lower := strings.ToLower(filepath.ToSlash(filePath))
+	base := strings.ToLower(filepath.Base(filePath))
+	score := 0.0
+	for _, term := range q.terms {
+		weight := q.weights[term]
+		if strings.Contains(base, term) {
+			score += 2.5 * weight
+		} else if strings.Contains(lower, term) {
+			score += 1.25 * weight
+		}
+	}
+	return score
+}
+
+func searchPathPrior(q searchQuery, filePath string) float64 {
+	lower := "/" + strings.ToLower(filepath.ToSlash(filePath))
+	score := 0.0
+	if strings.Contains(lower, "/src/") || strings.Contains(lower, "/include/") || strings.Contains(lower, "/lib/") || strings.Contains(lower, "/packages/") {
+		score += 0.5
+	}
+	if strings.Contains(lower, "/.github/workflows/") && !searchQuerySupplied(q, "workflow", "pipeline", "ci", "action") {
+		score -= 6
+	}
+	if strings.Contains(lower, "/dependencies/") || strings.Contains(lower, "/third_party/") || strings.Contains(lower, "/third-party/") {
+		score -= 5
+	}
+	if strings.Contains(lower, "/singleheader/") && !searchQuerySupplied(q, "singleheader", "amalgamation") {
+		score -= 3
+	}
+	if strings.Contains(lower, "/benchmark/") && !searchQuerySupplied(q, "benchmark", "performance", "speed") {
+		score -= 2
+	}
+	if (strings.Contains(lower, "/tests/") || strings.Contains(lower, "/test/")) && !searchQuerySupplied(q, "test", "tests", "testing", "regression") {
+		score -= 1.5
+	}
+	return score
+}
+
+func searchQuerySupplied(q searchQuery, terms ...string) bool {
+	for _, term := range terms {
+		if q.weights[term] >= 1 {
+			return true
+		}
+	}
+	return false
+}
+
+func symbolSearchScore(q searchQuery, symbol SymbolRecord) (float64, []string) {
+	name := strings.ToLower(symbol.Name)
+	qualified := strings.ToLower(symbol.QualifiedName)
+	signature := strings.ToLower(symbol.Signature)
+	compactQuery := compactSearchIdentifier(q.rawLower)
+	compactName := compactSearchIdentifier(name)
+	score := 0.0
+	switch symbol.Kind {
+	case "function", "method":
+		score += 2
+	case "class", "interface", "struct", "trait", "type", "enum", "record", "object", "protocol":
+		score += 0.75
+	case "block", "workflow", "document":
+		score -= 1.5
+	case "section":
+		score -= 0.5
+	}
+	var signals []string
+	if compactQuery != "" && compactQuery == compactName {
+		score += 14
+		signals = append(signals, "exact-symbol")
+	}
+	for _, term := range q.terms {
+		weight := q.weights[term]
+		switch {
+		case name == term:
+			score += 6 * weight
+			signals = append(signals, "symbol-name")
+		case strings.Contains(name, term) || strings.Contains(qualified, term):
+			score += 3 * weight
+			signals = append(signals, "symbol-name")
+		case strings.Contains(signature, term):
+			score += 1.5 * weight
+			signals = append(signals, "signature")
+		}
+	}
+	return score, appendUnique(nil, signals...)
+}
+
+func compactSearchIdentifier(value string) string {
+	var out strings.Builder
+	for _, r := range value {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			out.WriteRune(unicode.ToLower(r))
+		}
+	}
+	return out.String()
+}
+
+func clampRegion(start, end, lineCount int) (int, int) {
+	if lineCount <= 0 {
+		return 0, 0
+	}
+	start = maxInt(1, start)
+	end = minInt(lineCount, maxInt(start, end))
+	if start > lineCount {
+		return 0, 0
+	}
+	return start, end
+}
+
+func appendUnique(values []string, additions ...string) []string {
+	seen := make(map[string]bool, len(values)+len(additions))
+	for _, value := range values {
+		seen[value] = true
+	}
+	for _, value := range additions {
+		if value != "" && !seen[value] {
+			seen[value] = true
+			values = append(values, value)
+		}
+	}
+	return values
+}
+
+func (response SearchResponse) Validate() error {
+	for index, result := range response.Results {
+		if result.Rank != index+1 {
+			return fmt.Errorf("search result rank %d at index %d", result.Rank, index)
+		}
+		if result.FilePath == "" || result.StartLine < 1 || result.EndLine < result.StartLine || result.FocusLine < result.StartLine || result.FocusLine > result.EndLine || result.SnippetStartLine < result.StartLine || result.SnippetEndLine > result.EndLine || result.SnippetEndLine < result.SnippetStartLine {
+			return fmt.Errorf("invalid search result at rank %d", result.Rank)
+		}
+	}
+	return nil
+}

--- a/internal/sem/search.go
+++ b/internal/sem/search.go
@@ -113,7 +113,7 @@ type searchCandidate struct {
 	score      float64
 }
 
-var searchWordPattern = regexp.MustCompile(`[[:alnum:]_./:+-]+`)
+var searchWordPattern = regexp.MustCompile(`[[:alnum:]_./:+#-]+`)
 
 var searchStopWords = map[string]bool{
 	"a": true, "an": true, "and": true, "are": true, "as": true,
@@ -1140,6 +1140,16 @@ func buildSearchQuery(query string) searchQuery {
 		if len(term) < 2 || searchStopWords[term] {
 			return
 		}
+		hasAlphanumeric := false
+		for _, character := range term {
+			if unicode.IsLetter(character) || unicode.IsDigit(character) {
+				hasAlphanumeric = true
+				break
+			}
+		}
+		if !hasAlphanumeric {
+			return
+		}
 		if weight > weights[term] {
 			weights[term] = weight
 		}
@@ -1218,8 +1228,8 @@ func codeLikeSearchWeight(raw string) float64 {
 }
 
 func codeLikeSearchToken(raw string) bool {
-	trimmed := strings.Trim(raw, "./:+-")
-	if strings.ContainsAny(trimmed, "_./:$") || strings.HasPrefix(raw, "--") {
+	trimmed := strings.Trim(raw, "./:-")
+	if strings.ContainsAny(trimmed, "_./:$+#") || strings.HasPrefix(raw, "--") {
 		return true
 	}
 	uppercase := 0
@@ -1258,7 +1268,7 @@ func morphologicalSearchTerms(term string) []string {
 }
 
 func searchTokenVariants(raw string) []string {
-	raw = strings.Trim(raw, "./:+-")
+	raw = strings.Trim(raw, "./:-")
 	if raw == "" {
 		return nil
 	}

--- a/internal/sem/search.go
+++ b/internal/sem/search.go
@@ -377,7 +377,10 @@ func compactSearchResultToBytes(result SearchResult, q searchQuery, budget int) 
 }
 
 func truncateSearchText(value string, maxBytes int, q searchQuery) string {
-	if maxBytes <= 0 || len(value) <= maxBytes {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(value) <= maxBytes {
 		return value
 	}
 	center := len(value) / 2
@@ -388,7 +391,7 @@ func truncateSearchText(value string, maxBytes int, q searchQuery) string {
 			break
 		}
 	}
-	window := maxBytes - len(" ... ")
+	window := maxBytes - len("... ") - len(" ...")
 	if window <= 0 {
 		return ""
 	}
@@ -400,6 +403,9 @@ func truncateSearchText(value string, maxBytes int, q searchQuery) string {
 	}
 	for end > start && end < len(value) && !utf8RuneStart(value[end]) {
 		end--
+	}
+	if start >= end {
+		return ""
 	}
 	prefix, suffix := "", ""
 	if start > 0 {
@@ -657,42 +663,51 @@ func shouldUseGitGrepPreselection(worktree bool, fileCount int) bool {
 }
 
 func searchPreselectionPatterns(q searchQuery) []string {
-	patterns := make([]string, 0, 12)
-	seen := make(map[string]bool, cap(patterns))
-	for _, term := range q.terms {
-		if q.weights[term] >= 2 {
+	const (
+		maxPatterns            = 12
+		maxPrimaryPatterns     = 8
+		maxInitialCodePatterns = 4
+		maxOriginalPatterns    = 4
+		maxMorphPatterns       = 2
+		maxFragmentTerms       = 2
+	)
+	patterns := make([]string, 0, maxPatterns)
+	seen := make(map[string]bool, maxPatterns)
+	appendTier := func(limit int, include func(float64) bool) {
+		if limit <= 0 {
+			return
+		}
+		added := 0
+		for _, term := range q.terms {
+			if seen[term] || !include(q.weights[term]) {
+				continue
+			}
 			patterns = append(patterns, term)
 			seen[term] = true
-			if len(patterns) == cap(patterns) {
-				return patterns
+			added++
+			if added == limit || len(patterns) == maxPatterns {
+				return
 			}
 		}
 	}
-	if len(patterns) == 0 {
-		for _, term := range q.terms {
-			if q.weights[term] >= 1.25 {
-				patterns = append(patterns, term)
-				seen[term] = true
-				if len(patterns) == cap(patterns) {
-					return patterns
-				}
-			}
-		}
-	}
-	target := cap(patterns)
-	if len(patterns) > 0 {
-		target = minInt(target, len(patterns)+4)
-	}
-	for _, term := range q.terms {
-		if q.weights[term] != 1 || seen[term] {
-			continue
-		}
-		patterns = append(patterns, term)
-		seen[term] = true
-		if len(patterns) == target {
-			break
-		}
-	}
+	appendTier(maxInitialCodePatterns, func(weight float64) bool {
+		return weight >= 1.25
+	})
+	appendTier(maxOriginalPatterns, func(weight float64) bool {
+		return weight == 1
+	})
+	appendTier(maxPrimaryPatterns-len(patterns), func(weight float64) bool {
+		return weight >= 1.25 || weight == 1
+	})
+	appendTier(maxMorphPatterns, func(weight float64) bool {
+		return weight < 1
+	})
+	appendTier(maxFragmentTerms, func(weight float64) bool {
+		return weight > 1 && weight < 1.25
+	})
+	appendTier(maxPatterns-len(patterns), func(weight float64) bool {
+		return weight >= 1.25 || weight == 1
+	})
 	return patterns
 }
 

--- a/internal/sem/search_cache.go
+++ b/internal/sem/search_cache.go
@@ -1,0 +1,193 @@
+package sem
+
+import (
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/entireio/entire-sem/internal/gitutil"
+)
+
+const searchSnapshotCacheVersion = "search-snapshot-v1"
+
+type cachedSearchSnapshot struct {
+	CacheVersion    string           `json:"cache_version"`
+	ProviderVersion string           `json:"provider_version"`
+	Tree            string           `json:"tree"`
+	Profile         Profile          `json:"profile"`
+	MaxParseBytes   int              `json:"max_parse_bytes"`
+	Snapshot        ProviderSnapshot `json:"snapshot"`
+}
+
+func loadOrBuildSearchSnapshot(
+	ctx context.Context,
+	repo, providerVersion string,
+	options ProviderSnapshotOptions,
+	cacheDir string,
+	disableCache bool,
+) (ProviderSnapshot, bool, error) {
+	if disableCache || cacheDir == "" || options.Worktree {
+		snapshot, err := BuildProviderSnapshotWithOptions(ctx, repo, providerVersion, options)
+		return snapshot, false, err
+	}
+	absRepo, err := filepath.Abs(repo)
+	if err != nil {
+		return ProviderSnapshot{}, false, err
+	}
+	tree, err := gitutil.RevParse(ctx, absRepo, "HEAD^{tree}")
+	if err != nil || tree == "" {
+		snapshot, buildErr := BuildProviderSnapshotWithOptions(ctx, repo, providerVersion, options)
+		return snapshot, false, buildErr
+	}
+	key, err := searchSnapshotKey(absRepo, providerVersion, tree, options)
+	if err != nil {
+		return ProviderSnapshot{}, false, err
+	}
+	path := filepath.Join(cacheDir, "search", searchSnapshotCacheVersion, key+".json.gz")
+	if cached, err := readSearchSnapshot(path); err == nil && validCachedSearchSnapshot(cached, providerVersion, tree, options) {
+		return cached.Snapshot, true, nil
+	}
+	snapshot, err := BuildProviderSnapshotWithOptions(ctx, repo, providerVersion, options)
+	if err != nil {
+		return ProviderSnapshot{}, false, err
+	}
+	cache := cachedSearchSnapshot{
+		CacheVersion:    searchSnapshotCacheVersion,
+		ProviderVersion: providerVersion,
+		Tree:            tree,
+		Profile:         options.Profile,
+		MaxParseBytes:   options.MaxParseBytes,
+		Snapshot:        snapshot,
+	}
+	// Cache persistence is best effort. Retrieval correctness never depends on
+	// a writable cache directory.
+	_ = writeSearchSnapshot(path, cache)
+	return snapshot, false, nil
+}
+
+func searchSnapshotKey(absRepo, providerVersion, tree string, options ProviderSnapshotOptions) (string, error) {
+	hash := sha256.New()
+	writePart := func(value string) {
+		_, _ = io.WriteString(hash, value)
+		_, _ = io.WriteString(hash, "\x00")
+	}
+	writePart(searchSnapshotCacheVersion)
+	writePart(absRepo)
+	writePart(providerVersion)
+	writePart(tree)
+	writePart(string(options.Profile))
+	writePart(fmt.Sprintf("%d", options.MaxParseBytes))
+	onlyFiles := append([]string(nil), options.OnlyFiles...)
+	sort.Strings(onlyFiles)
+	writePart("only-files")
+	for _, filePath := range onlyFiles {
+		writePart(filepath.ToSlash(filepath.Clean(filePath)))
+	}
+	for groupIndex, group := range [][]string{options.IgnoreFiles, options.IncludeFiles} {
+		writePart(fmt.Sprintf("path-group-%d", groupIndex))
+		paths := append([]string(nil), group...)
+		sort.Strings(paths)
+		for _, path := range paths {
+			resolved := path
+			if !filepath.IsAbs(resolved) {
+				resolved = filepath.Join(absRepo, resolved)
+			}
+			writePart(filepath.Clean(resolved))
+			content, err := os.ReadFile(resolved)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					writePart("missing")
+					continue
+				}
+				return "", err
+			}
+			_, _ = hash.Write(content)
+			writePart("")
+		}
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func validCachedSearchSnapshot(cache cachedSearchSnapshot, providerVersion, tree string, options ProviderSnapshotOptions) bool {
+	return cache.CacheVersion == searchSnapshotCacheVersion &&
+		cache.ProviderVersion == providerVersion &&
+		cache.Tree == tree &&
+		cache.Profile == options.Profile &&
+		cache.MaxParseBytes == options.MaxParseBytes &&
+		cache.Snapshot.Header.Tree == tree &&
+		cache.Snapshot.Header.Provider == ProviderName &&
+		cache.Snapshot.Header.Profile == string(options.Profile)
+}
+
+func readSearchSnapshot(path string) (cachedSearchSnapshot, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return cachedSearchSnapshot{}, err
+	}
+	defer file.Close()
+	reader, err := gzip.NewReader(file)
+	if err != nil {
+		return cachedSearchSnapshot{}, err
+	}
+	defer reader.Close()
+	var cache cachedSearchSnapshot
+	decoder := json.NewDecoder(reader)
+	if err := decoder.Decode(&cache); err != nil {
+		return cachedSearchSnapshot{}, err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return cachedSearchSnapshot{}, errors.New("search snapshot cache has trailing data")
+	}
+	return cache, nil
+}
+
+func writeSearchSnapshot(path string, cache cachedSearchSnapshot) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	temporary, err := os.CreateTemp(dir, ".snapshot-*.json.gz")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	removeTemporary := true
+	defer func() {
+		if removeTemporary {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if err := temporary.Chmod(0o600); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	writer := gzip.NewWriter(temporary)
+	encoder := json.NewEncoder(writer)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(cache); err != nil {
+		_ = writer.Close()
+		_ = temporary.Close()
+		return err
+	}
+	if err := writer.Close(); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return err
+	}
+	removeTemporary = false
+	return nil
+}

--- a/internal/sem/search_matcher.go
+++ b/internal/sem/search_matcher.go
@@ -1,0 +1,135 @@
+package sem
+
+import "strings"
+
+// searchTermMatcher is a compact ASCII case-insensitive Aho-Corasick matcher.
+// Issue and source identifiers are overwhelmingly ASCII; uncommon non-ASCII
+// terms use a separate Unicode-aware fallback.
+type searchTermMatcher struct {
+	nodes     []searchMatcherNode
+	fallback  []searchFallbackTerm
+	termCount int
+}
+
+type searchMatcherNode struct {
+	next    map[byte]int
+	failure int
+	outputs []int
+}
+
+type searchFallbackTerm struct {
+	index int
+	term  string
+}
+
+func newSearchTermMatcher(terms []string) searchTermMatcher {
+	matcher := searchTermMatcher{
+		nodes:     []searchMatcherNode{{next: map[byte]int{}}},
+		termCount: len(terms),
+	}
+	for index, term := range terms {
+		if term == "" || !asciiString(term) {
+			if term != "" {
+				matcher.fallback = append(matcher.fallback, searchFallbackTerm{index: index, term: term})
+			}
+			continue
+		}
+		state := 0
+		for offset := 0; offset < len(term); offset++ {
+			character := lowerASCII(term[offset])
+			next, ok := matcher.nodes[state].next[character]
+			if !ok {
+				next = len(matcher.nodes)
+				matcher.nodes[state].next[character] = next
+				matcher.nodes = append(matcher.nodes, searchMatcherNode{next: map[byte]int{}})
+			}
+			state = next
+		}
+		matcher.nodes[state].outputs = append(matcher.nodes[state].outputs, index)
+	}
+	matcher.buildFailures()
+	return matcher
+}
+
+func (matcher *searchTermMatcher) buildFailures() {
+	queue := make([]int, 0, len(matcher.nodes))
+	for _, state := range matcher.nodes[0].next {
+		queue = append(queue, state)
+	}
+	for len(queue) > 0 {
+		state := queue[0]
+		queue = queue[1:]
+		for character, next := range matcher.nodes[state].next {
+			queue = append(queue, next)
+			failure := matcher.nodes[state].failure
+			for failure != 0 {
+				if target, ok := matcher.nodes[failure].next[character]; ok {
+					failure = target
+					break
+				}
+				failure = matcher.nodes[failure].failure
+			}
+			if failure == 0 {
+				if target, ok := matcher.nodes[0].next[character]; ok && target != next {
+					failure = target
+				}
+			}
+			matcher.nodes[next].failure = failure
+			matcher.nodes[next].outputs = append(matcher.nodes[next].outputs, matcher.nodes[failure].outputs...)
+		}
+	}
+}
+
+func (matcher searchTermMatcher) match(text string) []bool {
+	found := make([]bool, matcher.termCount)
+	remaining := matcher.termCount
+	state := 0
+	for offset := 0; offset < len(text) && remaining > 0; offset++ {
+		character := text[offset]
+		if character >= 128 {
+			state = 0
+			continue
+		}
+		character = lowerASCII(character)
+		for state != 0 {
+			if _, ok := matcher.nodes[state].next[character]; ok {
+				break
+			}
+			state = matcher.nodes[state].failure
+		}
+		if next, ok := matcher.nodes[state].next[character]; ok {
+			state = next
+		}
+		for _, index := range matcher.nodes[state].outputs {
+			if !found[index] {
+				found[index] = true
+				remaining--
+			}
+		}
+	}
+	if len(matcher.fallback) > 0 {
+		lower := strings.ToLower(text)
+		for _, fallback := range matcher.fallback {
+			if !found[fallback.index] && strings.Contains(lower, fallback.term) {
+				found[fallback.index] = true
+			}
+		}
+	}
+	return found
+}
+
+func asciiString(value string) bool {
+	for offset := 0; offset < len(value); offset++ {
+		if value[offset] >= 128 {
+			return false
+		}
+	}
+	return true
+}
+
+func lowerASCII(value byte) byte {
+	if value >= 'A' && value <= 'Z' {
+		return value + ('a' - 'A')
+	}
+	return value
+}

--- a/internal/sem/search_test.go
+++ b/internal/sem/search_test.go
@@ -1,6 +1,7 @@
 package sem
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -123,20 +124,20 @@ type systemClock struct{}
 	}
 }
 
-func TestSearchRepositoryExpandsIssueConceptsToAPIVocabulary(t *testing.T) {
+func TestSearchRepositoryExpandsMorphologicalIssueTerms(t *testing.T) {
 	repo := t.TempDir()
 	write(t, repo, "reader/collection.go", `package reader
 
-// newCollectionReader selects the collection implementation, including EnumSet.
-func newCollectionReader(kind string) *CollectionReader { return &CollectionReader{} }
+// initializeCollectionReader selects the collection implementation.
+func initializeCollectionReader(kind string) *CollectionReader { return &CollectionReader{} }
 
-// readObject parses values from the input stream.
+// readObject reads values from the input stream.
 func (r *CollectionReader) readObject(input []byte) any { return nil }
 
 type CollectionReader struct{}
 `)
 
-	response, err := SearchRepository(t.Context(), repo, "test", "EnumSet deserialization failure", SearchOptions{
+	response, err := SearchRepository(t.Context(), repo, "test", "collection reader initialization", SearchOptions{
 		Worktree:          true,
 		Profile:           ProfileSyntaxOnly,
 		TopK:              10,
@@ -145,14 +146,14 @@ type CollectionReader struct{}
 	if err != nil {
 		t.Fatal(err)
 	}
-	seenReader := false
+	seenInitializer := false
 	for _, result := range response.Results {
-		if result.SymbolName == "readObject" {
-			seenReader = true
+		if result.SymbolName == "initializeCollectionReader" {
+			seenInitializer = true
 		}
 	}
-	if !seenReader {
-		t.Fatalf("deserialization did not expand to reader API vocabulary: %#v", response.Results)
+	if !seenInitializer {
+		t.Fatalf("initialization did not expand to initialize: %#v", response.Results)
 	}
 }
 
@@ -271,6 +272,63 @@ func NeedleTarget() bool { return true }
 	}
 }
 
+func TestSearchRepositoryDoesNotTreatPathPriorAsEvidence(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, "src/target.go", "package source\nfunc TargetNeedle() bool { return true }\n")
+	write(t, repo, "src/unrelated.go", "package source\nfunc UnrelatedOperation() bool { return false }\n")
+	response, err := SearchRepository(t.Context(), repo, "test", "TargetNeedle", SearchOptions{
+		Worktree: true,
+		Profile:  ProfileSyntaxOnly,
+		TopK:     10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, result := range response.Results {
+		if result.SymbolName == "UnrelatedOperation" {
+			t.Fatalf("source-directory prior created an unrelated candidate: %#v", response.Results)
+		}
+	}
+}
+
+func TestSearchRepositoryKeepsUntrackedFiles(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Sem Test")
+	git(t, repo, "config", "user.email", "sem@example.com")
+	for index := 0; index < 20; index++ {
+		write(t, repo, fmt.Sprintf("src/noise_%02d.go", index), fmt.Sprintf("package source\nfunc Noise%d() int { return %d }\n", index, index))
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "tracked source")
+	write(t, repo, "src/draft.go", "package source\nfunc DraftNeedle() bool { return true }\n")
+
+	response, err := SearchRepository(t.Context(), repo, "test", "DraftNeedle", SearchOptions{
+		Worktree:        true,
+		Profile:         ProfileSyntaxOnly,
+		TopK:            5,
+		MaxIndexedFiles: 4,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Results) == 0 || response.Results[0].SymbolName != "DraftNeedle" {
+		t.Fatalf("git preselection lost an untracked edit: %#v", response.Results)
+	}
+}
+
+func TestSearchGitPreselectionThresholdTargetsLargeWorktrees(t *testing.T) {
+	if shouldUseGitGrepPreselection(true, minGitGrepPreselectionFiles-1) {
+		t.Fatal("small worktree selected git-grep accelerator")
+	}
+	if !shouldUseGitGrepPreselection(true, minGitGrepPreselectionFiles) {
+		t.Fatal("large worktree did not select git-grep accelerator")
+	}
+	if shouldUseGitGrepPreselection(false, minGitGrepPreselectionFiles*2) {
+		t.Fatal("immutable tree selected worktree-only accelerator")
+	}
+}
+
 func TestSearchTermMatcherIsCaseInsensitiveAndFindsOverlaps(t *testing.T) {
 	terms := []string{"list", "listitem", "secondaryaction", "missing"}
 	matched := newSearchTermMatcher(terms).match("export const ListItemSecondaryAction = true")
@@ -281,6 +339,32 @@ func TestSearchTermMatcherIsCaseInsensitiveAndFindsOverlaps(t *testing.T) {
 	}
 	if matched[3] {
 		t.Fatalf("absent term matched: %#v", matched)
+	}
+}
+
+func TestSearchPreselectionPatternsPreferCodeShapedTerms(t *testing.T) {
+	query := buildSearchQuery("refactor RenderProfileButton documentation behavior with trailingAction")
+	patterns := searchPreselectionPatterns(query)
+	if !containsString(patterns, "renderprofilebutton") || !containsString(patterns, "trailingaction") {
+		t.Fatalf("preselection patterns = %#v", patterns)
+	}
+	for _, generic := range []string{"render", "profile", "button", "trailing", "action"} {
+		if containsString(patterns, generic) {
+			t.Fatalf("compound identifier fragment %q entered preselection: %#v", generic, patterns)
+		}
+	}
+	if len(patterns) > 12 {
+		t.Fatalf("preselection pattern count = %d", len(patterns))
+	}
+}
+
+func TestSearchPathScoreIgnoresDerivedURLAndIdentifierFragments(t *testing.T) {
+	query := buildSearchQuery("https://example.com/packages/ui-kit RenderProfileButton")
+	if got := pathSearchScore(query, "packages/ui-kit/src/unrelated.js"); got != 0 {
+		t.Fatalf("derived URL fragments created path evidence: %v", got)
+	}
+	if got := pathSearchScore(query, "packages/renderprofilebutton/implementation.js"); got == 0 {
+		t.Fatal("original compound identifier did not create path evidence")
 	}
 }
 
@@ -328,17 +412,51 @@ func TestDiverseSelectionDoesNotSpendBudgetOnClones(t *testing.T) {
 }
 
 func TestSearchPathPriorPrefersProductCodeUnlessWorkflowRequested(t *testing.T) {
-	issue := buildSearchQuery("pretty print DOM with documentation")
-	if source, workflow := searchPathPrior(issue, "include/dom/serialization.h"), searchPathPrior(issue, ".github/workflows/documentation.yml"); source <= workflow {
+	issue := buildSearchQuery("render account profile")
+	if source, workflow := searchPathPrior(issue, "src/profile/render.go"), searchPathPrior(issue, ".github/workflows/release.yml"); source <= workflow {
 		t.Fatalf("source prior %v did not exceed workflow prior %v", source, workflow)
 	}
 	workflowIssue := buildSearchQuery("fix CI workflow pipeline")
 	if got := searchPathPrior(workflowIssue, ".github/workflows/test.yml"); got < 0 {
 		t.Fatalf("explicit workflow query was penalized: %v", got)
 	}
-	testIssue := buildSearchQuery("add regression test for parser")
-	if got := searchPathPrior(testIssue, "tests/parser_test.go"); got < 0 {
-		t.Fatalf("explicit test query was penalized: %v", got)
+}
+
+func TestSearchResultContextBudgetPreservesDiverseFocusedResults(t *testing.T) {
+	results := make([]SearchResult, 10)
+	for index := range results {
+		results[index] = SearchResult{
+			Rank:             index + 1,
+			FilePath:         fmt.Sprintf("src/component_%d.go", index),
+			StartLine:        1,
+			EndLine:          40,
+			FocusLine:        20,
+			SnippetStartLine: 1,
+			SnippetEndLine:   40,
+			Signature:        "func HandleConfigurationRequestWithManyArguments(input string, output string, retries int) error",
+			Signals:          []string{"body", "exact-code-token"},
+			Snippet:          strings.Repeat("configuration request handler with implementation detail\n", 40),
+		}
+	}
+	const budget = 4096
+	compacted, resultBytes, dropped, truncated := fitSearchResultsToBudget(results, buildSearchQuery("configuration handler"), budget)
+	encoded, err := json.Marshal(compacted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resultBytes != len(encoded) || resultBytes > budget {
+		t.Fatalf("budget accounting = %d, encoded = %d, budget = %d", resultBytes, len(encoded), budget)
+	}
+	if len(compacted) < 2 || compacted[0].FilePath != results[0].FilePath {
+		t.Fatalf("budgeting lost ranked diversity: %#v", compacted)
+	}
+	if dropped != len(results)-len(compacted) || truncated == 0 {
+		t.Fatalf("unexpected budget stats: dropped=%d truncated=%d results=%d", dropped, truncated, len(compacted))
+	}
+	for _, result := range compacted {
+		if result.FocusLine < result.SnippetStartLine || result.FocusLine > result.SnippetEndLine {
+			t.Fatalf("focus line fell outside compacted snippet: %#v", result)
+		}
 	}
 }
 

--- a/internal/sem/search_test.go
+++ b/internal/sem/search_test.go
@@ -367,6 +367,66 @@ func TestSearchRepositoryDoesNotTreatPathPriorAsEvidence(t *testing.T) {
 	}
 }
 
+func TestSearchRepositoryDropsWeakFragmentPathOnlyCandidates(t *testing.T) {
+	repo := t.TempDir()
+	// "config" is only a derived fragment (weight 1.1) of the compound query
+	// identifier, and the file body contains no query tokens: the file must
+	// not produce a candidate at all, and in particular must not produce a
+	// zero-value result that fails response validation.
+	write(t, repo, "config/notes.md", "# unrelated documentation\nplain prose only\n")
+	write(t, repo, "svc/main.go", "package svc\nfunc NewServiceConfig() {}\n")
+
+	response, err := SearchRepository(t.Context(), repo, "test", "NewServiceConfig", SearchOptions{
+		Worktree: true,
+		Profile:  ProfileSyntaxOnly,
+		TopK:     10,
+	})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if err := response.Validate(); err != nil {
+		t.Fatalf("response validation failed: %v (results=%#v)", err, response.Results)
+	}
+	if len(response.Results) == 0 || response.Results[0].SymbolName != "NewServiceConfig" {
+		t.Fatalf("expected symbol result first: %#v", response.Results)
+	}
+	for _, result := range response.Results {
+		if result.FilePath == "config/notes.md" || result.FilePath == "" {
+			t.Fatalf("weak fragment-only path match produced a candidate: %#v", response.Results)
+		}
+	}
+}
+
+func TestSearchRepositoryKeepsFullTermPathOnlyCandidates(t *testing.T) {
+	repo := t.TempDir()
+	// "authentication" matches the path as a full-weight query term, so the
+	// path-only fallback candidate must survive even though the body has no
+	// query tokens.
+	write(t, repo, "docs/authentication.md", "# overview\nplain prose only\n")
+	write(t, repo, "svc/main.go", "package svc\nfunc Unrelated() {}\n")
+
+	response, err := SearchRepository(t.Context(), repo, "test", "authentication", SearchOptions{
+		Worktree: true,
+		Profile:  ProfileSyntaxOnly,
+		TopK:     10,
+	})
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	found := false
+	for _, result := range response.Results {
+		if result.FilePath == "docs/authentication.md" {
+			found = true
+			if !containsString(result.Signals, "path") {
+				t.Fatalf("path-only candidate lost its path signal: %#v", result)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("full-term path-only candidate was dropped: %#v", response.Results)
+	}
+}
+
 func TestSearchRepositoryKeepsUntrackedFiles(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")

--- a/internal/sem/search_test.go
+++ b/internal/sem/search_test.go
@@ -1,9 +1,12 @@
 package sem
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -321,6 +324,25 @@ func ValidateToken(token string) bool { return token != "" }
 	}
 }
 
+func TestWriteSearchSnapshotReplacesExistingEntry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "snapshot.json.gz")
+	first := cachedSearchSnapshot{CacheVersion: searchSnapshotCacheVersion, Tree: "first"}
+	second := cachedSearchSnapshot{CacheVersion: searchSnapshotCacheVersion, Tree: "second"}
+	if err := writeSearchSnapshot(path, first); err != nil {
+		t.Fatalf("write first snapshot: %v", err)
+	}
+	if err := writeSearchSnapshot(path, second); err != nil {
+		t.Fatalf("replace snapshot: %v", err)
+	}
+	got, err := readSearchSnapshot(path)
+	if err != nil {
+		t.Fatalf("read replaced snapshot: %v", err)
+	}
+	if got.Tree != second.Tree {
+		t.Fatalf("cached tree = %q, want %q", got.Tree, second.Tree)
+	}
+}
+
 func TestSearchRepositorySelectivelyIndexesLargeRepositories(t *testing.T) {
 	repo := t.TempDir()
 	for index := 0; index < 20; index++ {
@@ -465,6 +487,28 @@ func TestSearchGitPreselectionThresholdTargetsLargeWorktrees(t *testing.T) {
 	}
 }
 
+func TestScoreSearchPathsStopsDispatchAfterCancellation(t *testing.T) {
+	paths := make([]string, 10_000)
+	for index := range paths {
+		paths[index] = fmt.Sprintf("src/file_%05d.go", index)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	var calls atomic.Int32
+	files := scoreSearchPaths(ctx, paths, 8, func(path string) (searchFileCandidate, bool) {
+		if calls.Add(1) == 1 {
+			cancel()
+		}
+		return searchFileCandidate{path: path, score: 1}, true
+	})
+	if got := calls.Load(); got > 8 {
+		t.Fatalf("canceled dispatch scored %d paths, want at most one in-flight path per worker", got)
+	}
+	if len(files) > 8 {
+		t.Fatalf("canceled dispatch returned %d files, want at most one per worker", len(files))
+	}
+}
+
 func TestSearchTermMatcherIsCaseInsensitiveAndFindsOverlaps(t *testing.T) {
 	terms := []string{"list", "listitem", "secondaryaction", "missing"}
 	matched := newSearchTermMatcher(terms).match("export const ListItemSecondaryAction = true")
@@ -593,6 +637,44 @@ func TestSearchResultContextBudgetPreservesDiverseFocusedResults(t *testing.T) {
 		if result.FocusLine < result.SnippetStartLine || result.FocusLine > result.SnippetEndLine {
 			t.Fatalf("focus line fell outside compacted snippet: %#v", result)
 		}
+	}
+}
+
+func TestCompactSearchResultKeepsLargestFocusedWindowThatFits(t *testing.T) {
+	lines := []string{
+		"first context line with enough detail to consume bytes",
+		"second context line with enough detail to consume bytes",
+		"focus configuration handler with enough detail to consume bytes",
+		"fourth context line with enough detail to consume bytes",
+		"fifth context line with enough detail to consume bytes",
+	}
+	result := SearchResult{
+		Rank:             1,
+		FilePath:         "src/configuration.go",
+		StartLine:        1,
+		EndLine:          len(lines),
+		FocusLine:        3,
+		SnippetStartLine: 1,
+		SnippetEndLine:   len(lines),
+		Signature:        "func HandleConfiguration() error",
+		Signals:          []string{"body"},
+		Snippet:          strings.Join(lines, "\n"),
+	}
+	threeLine := result
+	threeLine.SnippetStartLine = 2
+	threeLine.SnippetEndLine = 4
+	threeLine.Snippet = strings.Join(lines[1:4], "\n")
+	budget := serializedSearchResultBytes(threeLine)
+	if serializedSearchResultBytes(result) <= budget {
+		t.Fatal("test fixture full snippet unexpectedly fits compacted budget")
+	}
+
+	got, size := compactSearchResultToBytes(result, buildSearchQuery("configuration handler"), budget)
+	if size > budget {
+		t.Fatalf("compacted size = %d, budget = %d", size, budget)
+	}
+	if got.SnippetStartLine != 2 || got.SnippetEndLine != 4 || got.Snippet != threeLine.Snippet {
+		t.Fatalf("compacted snippet = lines %d-%d %q, want balanced lines 2-4", got.SnippetStartLine, got.SnippetEndLine, got.Snippet)
 	}
 }
 

--- a/internal/sem/search_test.go
+++ b/internal/sem/search_test.go
@@ -209,6 +209,82 @@ func TestSearchRepositoryRejectsStopWordsOnly(t *testing.T) {
 	}
 }
 
+func TestSearchRepositoryPreservesHeadProvenanceWhenPreselectionIsEmpty(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Sem Test")
+	git(t, repo, "config", "user.email", "sem@example.com")
+	write(t, repo, "alpha.go", "package source\nfunc Alpha() {}\n")
+	write(t, repo, "beta.go", "package source\nfunc Beta() {}\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+
+	response, err := SearchRepository(t.Context(), repo, "test", "unmatched-provenance-query", SearchOptions{
+		Profile:         ProfileSyntaxOnly,
+		MaxIndexedFiles: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Results) != 0 || response.Stats.FilesIndexed != 0 {
+		t.Fatalf("unexpected results: results=%#v stats=%#v", response.Results, response.Stats)
+	}
+	if response.Commit != rev(t, repo, "HEAD") || response.Tree != rev(t, repo, "HEAD^{tree}") {
+		t.Fatalf("provenance does not identify HEAD: commit=%q tree=%q", response.Commit, response.Tree)
+	}
+	if response.Warnings == nil || len(response.Warnings) != 0 {
+		t.Fatalf("warnings = %#v", response.Warnings)
+	}
+}
+
+func TestSearchRepositoryPreservesSourceWarningsWhenPreselectionIsEmpty(t *testing.T) {
+	t.Run("worktree", func(t *testing.T) {
+		repo := t.TempDir()
+		git(t, repo, "init")
+		git(t, repo, "config", "user.name", "Entire Sem Test")
+		git(t, repo, "config", "user.email", "sem@example.com")
+		write(t, repo, "alpha.go", "package source\nfunc Alpha() {}\n")
+		write(t, repo, "beta.go", "package source\nfunc Beta() {}\n")
+		git(t, repo, "add", ".")
+		git(t, repo, "commit", "-m", "initial")
+
+		response, err := SearchRepository(t.Context(), repo, "test", "unmatched-worktree-query", SearchOptions{
+			Worktree:        true,
+			Profile:         ProfileSyntaxOnly,
+			MaxIndexedFiles: 1,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if response.Commit == "" || response.Tree == "" {
+			t.Fatalf("worktree response lost baseline provenance: %#v", response)
+		}
+		if len(response.Warnings) != 1 || response.Warnings[0].Code != "W_WORKTREE_SNAPSHOT" {
+			t.Fatalf("warnings = %#v", response.Warnings)
+		}
+	})
+
+	t.Run("no git head", func(t *testing.T) {
+		repo := t.TempDir()
+		write(t, repo, "alpha.go", "package source\nfunc Alpha() {}\n")
+		write(t, repo, "beta.go", "package source\nfunc Beta() {}\n")
+
+		response, err := SearchRepository(t.Context(), repo, "test", "unmatched-fallback-query", SearchOptions{
+			Profile:         ProfileSyntaxOnly,
+			MaxIndexedFiles: 1,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if response.Commit != "" || response.Tree != "" {
+			t.Fatalf("unexpected git provenance: %#v", response)
+		}
+		if len(response.Warnings) != 1 || response.Warnings[0].Code != "E_NO_GIT_HEAD" {
+			t.Fatalf("warnings = %#v", response.Warnings)
+		}
+	})
+}
+
 func TestSearchRepositoryReusesCommittedIndexCache(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")

--- a/internal/sem/search_test.go
+++ b/internal/sem/search_test.go
@@ -1,0 +1,352 @@
+package sem
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestSearchRepositoryRanksExactSymbol(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, "config/service.go", `package config
+
+type ServiceConfig struct { Name string }
+
+func NewServiceConfig(name string) ServiceConfig {
+	return ServiceConfig{Name: name}
+}
+`)
+	write(t, repo, "docs/example.go", `package docs
+
+// This example discusses constructing a service configuration.
+func Example() {}
+`)
+
+	response, err := SearchRepository(t.Context(), repo, "test", "NewServiceConfig", SearchOptions{
+		Worktree: true,
+		Profile:  ProfileSyntaxOnly,
+		TopK:     5,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Results) == 0 {
+		t.Fatal("search returned no results")
+	}
+	first := response.Results[0]
+	if first.FilePath != "config/service.go" || first.SymbolName != "NewServiceConfig" {
+		t.Fatalf("first result = %#v", first)
+	}
+	if !containsString(first.Signals, "exact-symbol") {
+		t.Fatalf("exact symbol signal missing: %#v", first.Signals)
+	}
+}
+
+func TestSearchRepositoryFindsConceptualBodyText(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, "encoding/serializer.go", `package encoding
+
+// MarshalCompact emits minified serialization output for network transport.
+func MarshalCompact(value any) []byte { return nil }
+
+// MarshalIndented provides pretty printing for human-readable output.
+func MarshalIndented(value any) []byte { return nil }
+`)
+	write(t, repo, "transport/socket.go", `package transport
+
+// Send writes bytes to a socket.
+func Send(value []byte) error { return nil }
+`)
+
+	response, err := SearchRepository(t.Context(), repo, "test", "minified and pretty printing serialization output", SearchOptions{
+		Worktree:          true,
+		Profile:           ProfileSyntaxOnly,
+		TopK:              5,
+		MaxRegionsPerFile: 3,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Results) < 2 {
+		t.Fatalf("results = %#v stats = %#v", response.Results, response.Stats)
+	}
+	seen := map[string]bool{}
+	for _, result := range response.Results {
+		if result.FilePath == "encoding/serializer.go" {
+			seen[result.SymbolName] = true
+		}
+	}
+	if !seen["MarshalCompact"] || !seen["MarshalIndented"] {
+		t.Fatalf("conceptual query did not preserve both relevant regions: %#v", response.Results)
+	}
+}
+
+func TestSearchRepositoryPreservesDistinctRegionsInOneFile(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, "timing/wheel.go", `package timing
+
+// NewTimingWheel creates the production timing wheel.
+func NewTimingWheel(interval int) *Wheel {
+	return newTimingWheelWithClock(interval, systemClock{})
+}
+
+// newTimingWheelWithClock creates the timing wheel with an injected clock.
+func newTimingWheelWithClock(interval int, clock Clock) *Wheel {
+	return &Wheel{}
+}
+
+type Wheel struct{}
+type Clock interface{}
+type systemClock struct{}
+`)
+
+	response, err := SearchRepository(t.Context(), repo, "test", "create timing wheel with injected clock", SearchOptions{
+		Worktree:          true,
+		Profile:           ProfileSyntaxOnly,
+		TopK:              5,
+		MaxRegionsPerFile: 3,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]SearchResult{}
+	for _, result := range response.Results {
+		seen[result.SymbolName] = result
+	}
+	constructor, constructorOK := seen["NewTimingWheel"]
+	helper, helperOK := seen["newTimingWheelWithClock"]
+	if !constructorOK || !helperOK {
+		t.Fatalf("missing distinct same-file regions: %#v", response.Results)
+	}
+	if constructor.StartLine == helper.StartLine {
+		t.Fatalf("regions collapsed to one location: %#v", response.Results)
+	}
+}
+
+func TestSearchRepositoryExpandsIssueConceptsToAPIVocabulary(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, "reader/collection.go", `package reader
+
+// newCollectionReader selects the collection implementation, including EnumSet.
+func newCollectionReader(kind string) *CollectionReader { return &CollectionReader{} }
+
+// readObject parses values from the input stream.
+func (r *CollectionReader) readObject(input []byte) any { return nil }
+
+type CollectionReader struct{}
+`)
+
+	response, err := SearchRepository(t.Context(), repo, "test", "EnumSet deserialization failure", SearchOptions{
+		Worktree:          true,
+		Profile:           ProfileSyntaxOnly,
+		TopK:              10,
+		MaxRegionsPerFile: 3,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seenReader := false
+	for _, result := range response.Results {
+		if result.SymbolName == "readObject" {
+			seenReader = true
+		}
+	}
+	if !seenReader {
+		t.Fatalf("deserialization did not expand to reader API vocabulary: %#v", response.Results)
+	}
+}
+
+func TestSearchRepositoryExpandsSemanticNeighbor(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, "auth/auth.go", `package auth
+
+// Authenticate creates a user session after successful login.
+func Authenticate(raw string) bool {
+	return checkSignature(raw)
+}
+
+func checkSignature(raw string) bool {
+	return len(raw) > 4
+}
+`)
+
+	response, err := SearchRepository(t.Context(), repo, "test", "authenticate user session login", SearchOptions{
+		Worktree: true,
+		Profile:  ProfileFast,
+		TopK:     10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var helper SearchResult
+	for _, result := range response.Results {
+		if result.SymbolName == "checkSignature" {
+			helper = result
+			break
+		}
+	}
+	if helper.SymbolName == "" {
+		t.Fatalf("graph neighbor missing: %#v", response.Results)
+	}
+	foundGraphSignal := false
+	for _, signal := range helper.Signals {
+		if strings.HasPrefix(signal, "graph:") {
+			foundGraphSignal = true
+		}
+	}
+	if !foundGraphSignal {
+		t.Fatalf("helper was not identified through graph expansion: %#v", helper)
+	}
+}
+
+func TestSearchRepositoryRejectsStopWordsOnly(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, "main.go", "package main\n")
+	_, err := SearchRepository(t.Context(), repo, "test", "the and with", SearchOptions{Worktree: true})
+	if err == nil {
+		t.Fatal("expected an error for a stop-word-only query")
+	}
+}
+
+func TestSearchRepositoryReusesCommittedIndexCache(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Sem Test")
+	git(t, repo, "config", "user.email", "sem@example.com")
+	write(t, repo, "auth.go", `package auth
+
+// ValidateToken verifies an authentication token.
+func ValidateToken(token string) bool { return token != "" }
+`)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	options := SearchOptions{
+		Profile:  ProfileFast,
+		TopK:     5,
+		CacheDir: t.TempDir(),
+	}
+	first, err := SearchRepository(t.Context(), repo, "test-version", "validate authentication token", options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Stats.IndexCacheHit {
+		t.Fatal("first search unexpectedly hit the index cache")
+	}
+	second, err := SearchRepository(t.Context(), repo, "test-version", "validate authentication token", options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !second.Stats.IndexCacheHit {
+		t.Fatal("second search did not reuse the committed index cache")
+	}
+	if len(first.Results) == 0 || len(second.Results) == 0 || first.Results[0].SymbolID != second.Results[0].SymbolID {
+		t.Fatalf("cache changed retrieval: first=%#v second=%#v", first.Results, second.Results)
+	}
+}
+
+func TestSearchRepositorySelectivelyIndexesLargeRepositories(t *testing.T) {
+	repo := t.TempDir()
+	for index := 0; index < 20; index++ {
+		write(t, repo, fmt.Sprintf("noise/file_%02d.go", index), fmt.Sprintf("package noise\nfunc Noise%d() int { return %d }\n", index, index))
+	}
+	write(t, repo, "target/needle.go", `package target
+
+// NeedleTarget handles the rare selective-indexing request.
+func NeedleTarget() bool { return true }
+`)
+	response, err := SearchRepository(t.Context(), repo, "test", "NeedleTarget selective indexing", SearchOptions{
+		Worktree:        true,
+		Profile:         ProfileSyntaxOnly,
+		TopK:            5,
+		MaxIndexedFiles: 4,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.Stats.FilesScanned != 21 || response.Stats.FilesIndexed > 4 {
+		t.Fatalf("unexpected selective-index stats: %#v", response.Stats)
+	}
+	if len(response.Results) == 0 || response.Results[0].SymbolName != "NeedleTarget" {
+		t.Fatalf("selective index lost the target: %#v", response.Results)
+	}
+}
+
+func TestSearchTermMatcherIsCaseInsensitiveAndFindsOverlaps(t *testing.T) {
+	terms := []string{"list", "listitem", "secondaryaction", "missing"}
+	matched := newSearchTermMatcher(terms).match("export const ListItemSecondaryAction = true")
+	for _, index := range []int{0, 1, 2} {
+		if !matched[index] {
+			t.Fatalf("term %q was not matched: %#v", terms[index], matched)
+		}
+	}
+	if matched[3] {
+		t.Fatalf("absent term matched: %#v", matched)
+	}
+}
+
+func TestSearchTokenVariantsKeepQualifiedCompoundIdentifiers(t *testing.T) {
+	variants := searchTokenVariants("d.cc.NewServiceConfig")
+	for _, want := range []string{"d.cc.newserviceconfig", "newserviceconfig", "new", "service", "config"} {
+		if !containsString(variants, want) {
+			t.Fatalf("variant %q missing from %#v", want, variants)
+		}
+	}
+}
+
+func TestCodeLikeSearchTokenIgnoresProsePunctuation(t *testing.T) {
+	for _, token := range []string{"documentation.", "Currently,", "spaces."} {
+		if codeLikeSearchToken(token) {
+			t.Fatalf("prose token %q classified as code", token)
+		}
+	}
+	for _, token := range []string{"NewServiceConfig", "resolver_conn_wrapper", "foo/bar.go", "--head", "DOM"} {
+		if !codeLikeSearchToken(token) {
+			t.Fatalf("code token %q was not classified as code", token)
+		}
+	}
+}
+
+func TestCodeLikeSearchWeightDoesNotOverweightShortAcronyms(t *testing.T) {
+	if got := codeLikeSearchWeight("DOM"); got >= 2 {
+		t.Fatalf("short acronym weight = %v", got)
+	}
+	if got := codeLikeSearchWeight("NewServiceConfig"); got <= 2 {
+		t.Fatalf("compound identifier weight = %v", got)
+	}
+}
+
+func TestDiverseSelectionDoesNotSpendBudgetOnClones(t *testing.T) {
+	candidates := []searchCandidate{
+		{score: 10, result: SearchResult{FilePath: "bench/a/item.go", StartLine: 1, EndLine: 2, SymbolName: "same"}},
+		{score: 9.9, result: SearchResult{FilePath: "bench/b/item.go", StartLine: 1, EndLine: 2, SymbolName: "same"}},
+		{score: 8, result: SearchResult{FilePath: "src/implementation.go", StartLine: 1, EndLine: 2, SymbolName: "implementation"}},
+	}
+	selected := selectDiverseCandidates(candidates, 2, 3)
+	if len(selected) != 2 || selected[1].result.SymbolName != "implementation" {
+		t.Fatalf("clone consumed diversity budget: %#v", selected)
+	}
+}
+
+func TestSearchPathPriorPrefersProductCodeUnlessWorkflowRequested(t *testing.T) {
+	issue := buildSearchQuery("pretty print DOM with documentation")
+	if source, workflow := searchPathPrior(issue, "include/dom/serialization.h"), searchPathPrior(issue, ".github/workflows/documentation.yml"); source <= workflow {
+		t.Fatalf("source prior %v did not exceed workflow prior %v", source, workflow)
+	}
+	workflowIssue := buildSearchQuery("fix CI workflow pipeline")
+	if got := searchPathPrior(workflowIssue, ".github/workflows/test.yml"); got < 0 {
+		t.Fatalf("explicit workflow query was penalized: %v", got)
+	}
+	testIssue := buildSearchQuery("add regression test for parser")
+	if got := searchPathPrior(testIssue, "tests/parser_test.go"); got < 0 {
+		t.Fatalf("explicit test query was penalized: %v", got)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sem/search_test.go
+++ b/internal/sem/search_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestSearchRepositoryRanksExactSymbol(t *testing.T) {
@@ -493,6 +495,70 @@ func TestSearchRepositoryKeepsUntrackedFiles(t *testing.T) {
 	}
 }
 
+func TestSearchRepositoryGitPreselectionKeepsFallbackTiers(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Sem Test")
+	git(t, repo, "config", "user.email", "sem@example.com")
+	write(t, repo, "noise/selected.go", "package noise\n// sentinel alphaone\nfunc SelectedNoise() {}\n")
+	write(t, repo, "targets/morph.go", "package targets\n// configure\nfunc MorphTarget() {}\n")
+	write(t, repo, "targets/fragment.go", "package targets\n// profile\nfunc FragmentTarget() {}\n")
+	write(t, repo, "targets/direct.go", "package targets\n// tenthdirect\nfunc DirectTarget() {}\n")
+	fillerDir := filepath.Join(repo, "filler")
+	if err := os.MkdirAll(fillerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for index := 0; index < minGitGrepPreselectionFiles-4; index++ {
+		path := filepath.Join(fillerDir, fmt.Sprintf("file_%05d.go", index))
+		if err := os.WriteFile(path, []byte("package filler\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "large tracked worktree")
+
+	tests := []struct {
+		name       string
+		query      string
+		targetPath string
+	}{
+		{name: "morphology", query: "configuring sentinel", targetPath: "targets/morph.go"},
+		{name: "code fragment", query: "RenderProfileButton sentinel", targetPath: "targets/fragment.go"},
+		{
+			name:       "saturated direct term",
+			query:      "AlphaOne BetaTwo GammaThree DeltaFour EpsilonFive ZetaSix EtaSeven ThetaEight ninthdirect tenthdirect",
+			targetPath: "targets/direct.go",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response, err := SearchRepository(t.Context(), repo, "test", test.query, SearchOptions{
+				Worktree:        true,
+				Profile:         ProfileSyntaxOnly,
+				TopK:            10,
+				MaxIndexedFiles: 2,
+				DisableCache:    true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if response.Stats.FilesScanned != minGitGrepPreselectionFiles {
+				t.Fatalf("files scanned = %d, want %d", response.Stats.FilesScanned, minGitGrepPreselectionFiles)
+			}
+			if response.Stats.FilesContentRead <= 0 || response.Stats.FilesContentRead > 8 {
+				t.Fatalf("git preselection read %d files, want 1..8", response.Stats.FilesContentRead)
+			}
+			found := false
+			for _, result := range response.Results {
+				found = found || result.FilePath == test.targetPath
+			}
+			if !found {
+				t.Fatalf("git preselection lost %s for query %q: %#v", test.targetPath, test.query, response.Results)
+			}
+		})
+	}
+}
+
 func TestSearchGitPreselectionThresholdTargetsLargeWorktrees(t *testing.T) {
 	if shouldUseGitGrepPreselection(true, minGitGrepPreselectionFiles-1) {
 		t.Fatal("small worktree selected git-grep accelerator")
@@ -546,9 +612,47 @@ func TestSearchPreselectionPatternsPreferCodeShapedTerms(t *testing.T) {
 	if !containsString(patterns, "renderprofilebutton") || !containsString(patterns, "trailingaction") {
 		t.Fatalf("preselection patterns = %#v", patterns)
 	}
-	for _, generic := range []string{"render", "profile", "button", "trailing", "action"} {
-		if containsString(patterns, generic) {
-			t.Fatalf("compound identifier fragment %q entered preselection: %#v", generic, patterns)
+	fragmentCount := 0
+	for _, fragment := range []string{"render", "profile", "button", "trailing", "action"} {
+		if containsString(patterns, fragment) {
+			fragmentCount++
+		}
+	}
+	if fragmentCount == 0 || fragmentCount > 2 {
+		t.Fatalf("bounded compound-fragment fallback count = %d, patterns = %#v", fragmentCount, patterns)
+	}
+	if len(patterns) > 12 {
+		t.Fatalf("preselection pattern count = %d", len(patterns))
+	}
+}
+
+func TestSearchPreselectionPatternsReserveMorphologicalFallbacks(t *testing.T) {
+	patterns := searchPreselectionPatterns(buildSearchQuery("configuring serializer behavior"))
+	if !containsString(patterns, "configuring") {
+		t.Fatalf("direct query term missing from preselection: %#v", patterns)
+	}
+	if !containsString(patterns, "configur") && !containsString(patterns, "configure") {
+		t.Fatalf("morphological fallback missing from preselection: %#v", patterns)
+	}
+	if len(patterns) > 12 {
+		t.Fatalf("preselection pattern count = %d", len(patterns))
+	}
+}
+
+func TestSearchPreselectionPatternsPreserveDirectTermsAtCapacity(t *testing.T) {
+	plainTerms := []string{"alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel", "india", "juliet"}
+	plainPatterns := searchPreselectionPatterns(buildSearchQuery(strings.Join(plainTerms, " ")))
+	for _, direct := range plainTerms {
+		if !containsString(plainPatterns, direct) {
+			t.Fatalf("plain query term %q missing from saturated preselection: %#v", direct, plainPatterns)
+		}
+	}
+
+	query := buildSearchQuery("AlphaOne BetaTwo GammaThree DeltaFour EpsilonFive ZetaSix EtaSeven ThetaEight ninthdirect tenthdirect")
+	patterns := searchPreselectionPatterns(query)
+	for _, direct := range []string{"ninthdirect", "tenthdirect"} {
+		if !containsString(patterns, direct) {
+			t.Fatalf("direct query term %q missing from saturated preselection: %#v", direct, patterns)
 		}
 	}
 	if len(patterns) > 12 {
@@ -709,6 +813,26 @@ func TestCompactSearchResultKeepsLargestFocusedWindowThatFits(t *testing.T) {
 	}
 	if got.SnippetStartLine != 2 || got.SnippetEndLine != 4 || got.Snippet != threeLine.Snippet {
 		t.Fatalf("compacted snippet = lines %d-%d %q, want balanced lines 2-4", got.SnippetStartLine, got.SnippetEndLine, got.Snippet)
+	}
+}
+
+func TestTruncateSearchTextNeverExceedsByteBudget(t *testing.T) {
+	query := buildSearchQuery("configuration handler")
+	values := []string{
+		strings.Repeat("å", 20) + " configuration handler " + strings.Repeat("界", 20),
+		"configuration handler " + strings.Repeat("界", 20),
+		strings.Repeat("å", 20) + " configuration handler",
+	}
+	for _, value := range values {
+		for budget := 0; budget <= 64; budget++ {
+			got := truncateSearchText(value, budget, query)
+			if len(got) > budget {
+				t.Fatalf("budget %d produced %d bytes: %q", budget, len(got), got)
+			}
+			if !utf8.ValidString(got) {
+				t.Fatalf("budget %d split UTF-8: %q", budget, got)
+			}
+		}
 	}
 }
 

--- a/internal/sem/search_test.go
+++ b/internal/sem/search_test.go
@@ -46,6 +46,24 @@ func Example() {}
 	}
 }
 
+func TestSearchRepositorySupportsPunctuatedLanguageQuery(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, "native/bridge.cpp", "// C++ bridge implementation\nint bridge() { return 1; }\n")
+	write(t, repo, "docs/unrelated.txt", "plain language documentation\n")
+
+	response, err := SearchRepository(t.Context(), repo, "test", "C++", SearchOptions{
+		Worktree: true,
+		Profile:  ProfileSyntaxOnly,
+		TopK:     5,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Results) == 0 || response.Results[0].FilePath != "native/bridge.cpp" {
+		t.Fatalf("C++ search results = %#v", response.Results)
+	}
+}
+
 func TestSearchRepositoryFindsConceptualBodyText(t *testing.T) {
 	repo := t.TempDir()
 	write(t, repo, "encoding/serializer.go", `package encoding
@@ -557,13 +575,29 @@ func TestSearchTokenVariantsKeepQualifiedCompoundIdentifiers(t *testing.T) {
 	}
 }
 
+func TestSearchQueryPreservesPunctuatedLanguageNames(t *testing.T) {
+	for query, want := range map[string]string{"C++": "c++", "C#": "c#", "F#": "f#"} {
+		t.Run(query, func(t *testing.T) {
+			got := buildSearchQuery(query)
+			if !got.termSet[want] {
+				t.Fatalf("query %q terms = %#v, want %q", query, got.terms, want)
+			}
+		})
+	}
+	for _, query := range []string{"++", "#", ":-"} {
+		if got := buildSearchQuery(query); len(got.terms) != 0 {
+			t.Fatalf("punctuation-only query %q produced terms %#v", query, got.terms)
+		}
+	}
+}
+
 func TestCodeLikeSearchTokenIgnoresProsePunctuation(t *testing.T) {
 	for _, token := range []string{"documentation.", "Currently,", "spaces."} {
 		if codeLikeSearchToken(token) {
 			t.Fatalf("prose token %q classified as code", token)
 		}
 	}
-	for _, token := range []string{"NewServiceConfig", "resolver_conn_wrapper", "foo/bar.go", "--head", "DOM"} {
+	for _, token := range []string{"NewServiceConfig", "resolver_conn_wrapper", "foo/bar.go", "--head", "DOM", "C++", "C#"} {
 		if !codeLikeSearchToken(token) {
 			t.Fatalf("code token %q was not classified as code", token)
 		}


### PR DESCRIPTION
## Summary

- add a native query-scoped hybrid source-search command using lexical evidence, syntax regions, and graph-neighbor expansion
- bound selected files and serialized context, diversify overlapping candidates, and accelerate very large worktrees with Git-assisted narrowing
- retain provenance for empty-result searches and reject invalid weak path-only candidates without removing legitimate path matches

## Validation

- `GOMAXPROCS=4 go test -count=1 -p 4 ./...`
- `git diff --check origin/main...HEAD`
- independent local Copilot review: no actionable findings at the current head

## Draft status

This remains draft until one hosted review cycle and a permanently non-confirmatory, repository-disjoint development no-regression pilot are complete. No confirmatory benchmark result or superiority claim is included in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New search/indexing path touches large-repo performance and cache correctness, but stays local-only with extensive tests and validation on empty/weak candidates.
> 
> **Overview**
> Adds **`entire sem search`**, a local-only command that ranks source regions for natural-language or issue-style queries and returns agent-ready snippets (JSON, NDJSON, or text).
> 
> The pipeline **preselects** query-relevant files (lexical scoring, optional **`git grep`** on large worktrees, parallel worktree scans), then **parses only a bounded set** (default 96) via a new **`OnlyFiles`** snapshot option. Ranking blends BM25-style body/path/symbol signals, **diversity** across files and overlapping regions, optional **graph neighbor** expansion (`--profile fast`), and a default **16 KiB** serialized context budget.
> 
> **Committed-tree** searches can reuse a **tree-keyed gzip index** under the plugin data dir; **worktree** mode skips that cache. Capabilities advertise **`hybrid_source_search`**. README and CLI help document flags (`--head`, `--max-indexed-files`, `--no-cache`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7651779199f09745afe585c798aecd0717ecb09b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->