### PR TITLE
Restructure README, document agent usage, and add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,82 @@
+# Agent Instructions
+
+This repository is **Entire Graph** (`entire-graph`), an Entire CLI plugin that
+provides entity-level checkpoint context and a local-only semantic provider.
+The binary is invoked through Entire as `entire graph <command>`.
+
+## Naming
+
+- Product name: **Entire Graph**. Binary and module name: `entire-graph`
+  (module `github.com/entireio/entire-graph`).
+- The plugin manifest (`entire-plugin.yml`) registers the subcommand name
+  `graph`, so users type `entire graph ...`.
+- The project was previously named `entire-sem`; do not reintroduce the old
+  name. References to **Entire Brain** (`entire-brain`) are intentional — that
+  is the separate downstream consumer that owns persistence, indexing, and
+  query, not an old name for this project.
+
+## Build, Test, Lint
+
+Tasks are defined in `mise.toml`:
+
+```sh
+mise run build     # go build -o entire-graph ./cmd/entire-graph
+mise run test      # go test ./...
+mise run test:ci   # go test -race ./...
+mise run fmt       # gofmt -s -w .
+mise run vet       # go vet ./...
+mise run check     # fmt + vet + race tests + build
+```
+
+CI (`.github/workflows/test.yml`) runs vet, gofmt checks, build, and tests on
+Linux, macOS, and Windows with Go 1.24. Building requires CGO because
+tree-sitter grammars are native.
+
+## Using the plugin from an agent session
+
+- `entire graph search --repo . --query "..."` — ranked source regions with
+  bounded snippets (16 KiB serialized context budget by default). Reads the
+  working tree by default so dirty edits are visible; `--head` switches to
+  committed-tree semantics.
+- `entire graph commit HEAD --json` / `entire graph diff --base A --head B --json` —
+  entity-level semantic diff for judging whether a change is safe to keep.
+- `entire graph checkpoint <id> --json` — resolves the commit carrying an
+  `Entire-Checkpoint: <id>` trailer and diffs it against its first parent.
+- `entire graph snapshot|symbols|edges --repo . --format ndjson` — streamed
+  machine-readable graph records (schema 1.x, frozen GA contract; see
+  `docs/adr/0001-ga-schema-contract.md`).
+- `entire graph capabilities --json` / `entire graph doctor --json` — feature
+  detection and environment verification. All commands are local-only:
+  no network egress, no hosted model calls, no telemetry.
+
+This repository also configures agent harnesses directly: `.claude/settings.json`
+and `.codex/` wire Entire session hooks into Claude Code and Codex, and both
+define an `entire-search` subagent for checkpoint history search via
+`entire search --json`.
+
+## Repository layout
+
+- `cmd/entire-graph/` — thin main; all logic lives in `internal/`.
+- `internal/cli/` — hand-rolled command dispatch and flag parsing (no CLI
+  framework by design). Keep new commands consistent with this style.
+- `internal/sem/` — tree-sitter parsing, provider snapshots, semantic diff,
+  and hybrid search. This is the only package that should know about grammars.
+- `internal/gitutil/` — git subprocess wrappers (no go-git; NUL-delimited
+  output parsing throughout).
+- `internal/bench/`, `cmd/graph-bench/`, `bench/` — pinned-corpus benchmark
+  harness with throughput and RSS guardrails.
+- `docs/` — provider requirements, v2 roadmap, language support matrix,
+  benchmarks, and the GA schema ADR.
+
+## Contract rules that agents must not break
+
+- Schema `1.x` is a frozen GA contract: minor versions are additive-only;
+  breaking wire-format changes require a major bump (`docs/adr/0001-ga-schema-contract.md`).
+- The provider is no-egress: never add code that fetches remote sources,
+  calls hosted APIs, uploads telemetry, or downloads grammars at runtime.
+- `compound-v1` symbol IDs must remain stable across ordinary body and
+  signature edits.
+- Unsupported or unparseable files must surface as machine-readable partial
+  failures, never silent drops.
+- Inventory-only languages must not be presented as semantically parsed
+  (`docs/language-support.md`).

--- a/README.md
+++ b/README.md
@@ -297,14 +297,19 @@ range, signature, body hash, language, and container ID when the symbol is neste
 External endpoint records describe relation targets such as imported modules,
 routes, and tool handlers.
 
-Current relation records are:
+Schema 1.1 defines 30 relation types. Structural: `DEFINES`, `CONTAINS`,
+`IMPORTS`. Calls and construction: `CALLS`, `CONSTRUCTS`, `ASYNC_CALLS`.
+Types and inheritance: `EXTENDS`, `INHERITS`, `IMPLEMENTS`, `OVERRIDES`,
+`USES_TYPE`, `PARAM_TYPE`, `RETURNS_TYPE`. Fields: `READS_FIELD`,
+`WRITES_FIELD`, `ACCESSES`. Boundaries: `HANDLES_ROUTE`, `HANDLES_GRPC`,
+`HANDLES_GRAPHQL`, `HANDLES_TRPC`, `HTTP_CALLS`, `EMITS`, `LISTENS_ON`,
+`HANDLES_TOOL`. Configuration and analysis: `CONFIGURES`, `SIMILAR_TO`,
+`TESTS`, `RESOURCE_DEPENDS_ON`, `DATA_FLOWS`, `FILE_CHANGES_WITH`.
 
-- `DEFINES`
-- `CONTAINS`
-- `IMPORTS`
-- `CALLS`
-- `HANDLES_ROUTE`
-- `HANDLES_TOOL`
+Indexing profiles emit subsets: `syntax-only` emits `DEFINES` and `CONTAINS`,
+`fast` adds imports, shallow calls, and boundary relations, and `full` emits
+every relation type with evidence fields. `capabilities --json` reports the
+supported relation types per language.
 
 Unsupported but detected source files are reported as machine-readable partial
 failures instead of disappearing silently. Supported files with tree-sitter syntax

--- a/README.md
+++ b/README.md
@@ -5,6 +5,29 @@
 Entire already knows a checkpoint touched `auth.py` or `.github/workflows/ci.yml`.
 This plugin answers the next question: which semantic entities changed inside that file?
 
+## What Entire Graph Adds to Entire
+
+- **Entity-level checkpoint context.** `commit`, `checkpoint`, and `diff` report
+  added, removed, renamed, and signature- or body-changed entities with heuristic
+  dependent counts, so a checkpoint can be judged without reading the full diff.
+- **A local-only semantic provider.** `snapshot`, `symbols`, and `edges` stream
+  NDJSON graph records under a frozen schema 1.x contract for downstream
+  consumers such as Entire Brain — no network, no hosted models, no telemetry.
+- **Tree-sitter parsing across 36 languages**, from Go and TypeScript to
+  Terraform, SQL, and GitHub Actions YAML, with 149 more filetypes tracked as
+  inventory-only and honest partial failures for everything else.
+- **A 30-relation code graph with stable identity.** `compound-v1` symbol IDs
+  survive ordinary edits, and relations cover structure, calls, inheritance,
+  fields, service boundaries, and config dependencies, each tagged with
+  resolution and confidence.
+- **Agent-ready hybrid search.** Lexical scoring fused with graph-neighbor
+  expansion returns diverse source regions from the live working tree, budgeted
+  to 16 KiB for direct use in a model context window.
+- **How it works.** The plugin shells out to git for trees and diffs, parses
+  before/after states with tree-sitter behind `internal/sem`, reconciles renames
+  and moves by similarity, and streams results so memory stays bounded on very
+  large repositories.
+
 This plugin builds a binary named `entire-graph`, which is invoked through Entire as:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ entire graph snapshot --repo . --format ndjson
 entire graph symbols --repo . --format ndjson
 entire graph edges --repo . --format ndjson
 entire graph search --repo . --query "where is service config disabled?"
-entire graph snapshot --repo . --format ndjson --worktree --ignore-file .brainignore
+entire graph snapshot --repo . --format ndjson --worktree --ignore-file .graphignore
 entire graph snapshot --repo . --format ndjson --worktree --include-file .graphinclude
 ```
 
@@ -26,40 +26,52 @@ entire graph snapshot --repo . --format ndjson --worktree --include-file .graphi
 This plugin implements the semantic checkpoint context proposed in
 [entireio/cli#589](https://github.com/entireio/cli/issues/589).
 
-The plugin uses a tree-sitter-backed parser for:
+The plugin uses a tree-sitter-backed parser for 36 semantic languages:
 
-- Bash
-- C / C++
-- C#
+- Bash and Zsh
+- C / C++ and Objective-C
+- C# and F#
+- Clojure / ClojureScript
 - CUE
-- Elixir
+- Dart
+- Elixir and Erlang
 - Go
 - Groovy
+- Haskell
 - HCL / Terraform
 - Java
 - JavaScript / TypeScript
+- Julia
 - Kotlin
 - Lua
 - OCaml
+- Perl
 - PHP
 - Protocol Buffers
 - Python
+- R
 - Ruby
 - Rust
 - Scala
 - SQL
 - Swift
+- Zig
 - YAML, including GitHub Actions workflow sections and jobs
+
+Another 149 filetypes are recognized as inventory-only (stable file records
+without semantic claims). See [docs/language-support.md](docs/language-support.md)
+for the full two-tier matrix.
 
 The parser is isolated behind `internal/sem`, so the command surface can stay stable
 while the semantic model gets richer.
 
-This branch also adds a local-only semantic provider contract for tools that need
-machine-readable repository snapshots. Provider commands emit JSON or NDJSON records
-for capabilities, files, symbols, and relations without fetching remote code, calling
-hosted model APIs, uploading telemetry, or downloading grammars at runtime.
+The plugin also implements a local-only semantic provider contract for tools that
+need machine-readable repository snapshots. Provider commands emit JSON or NDJSON
+records for capabilities, files, symbols, and relations without fetching remote
+code, calling hosted model APIs, uploading telemetry, or downloading grammars at
+runtime.
 
-## Install
+## Getting Started
 
 Requirements:
 
@@ -67,14 +79,26 @@ Requirements:
 - Git
 - Go toolchain with CGO support (tree-sitter uses native parser bindings)
 
-Install the current plugin binary from the default branch, then copy it into
-Entire's managed plugin directory:
+1. Install the plugin binary from the default branch and register it with
+   Entire's managed plugin directory:
 
-```sh
-go install github.com/entireio/entire-graph/cmd/entire-graph@main
-entire plugin install "$(go env GOPATH)/bin/entire-graph" --force
-entire graph version
-```
+   ```sh
+   go install github.com/entireio/entire-graph/cmd/entire-graph@main
+   entire plugin install "$(go env GOPATH)/bin/entire-graph" --force
+   ```
+
+2. Verify the install and the local-only environment:
+
+   ```sh
+   entire graph version
+   entire graph doctor --json
+   ```
+
+3. Run your first semantic diff from any git repository:
+
+   ```sh
+   entire graph commit HEAD
+   ```
 
 If `$(go env GOPATH)/bin` is already on your `PATH`, Entire can also discover
 the binary directly after `go install`.
@@ -193,6 +217,57 @@ Run without installing through Entire:
 ```sh
 ENTIRE_REPO_ROOT=/path/to/repo ./entire-graph diff --base HEAD~1 --head HEAD
 ```
+
+## Agent Usage
+
+Entire Graph is built to be called by coding agents, not just humans. Every
+command is local-only and no-egress, so agents can run it freely inside
+sandboxed sessions without leaking source. Typical agent workflows:
+
+- **Find where to work.** Before editing, retrieve ranked code regions for a
+  task description:
+
+  ```sh
+  entire graph search --repo . --query "retry logic for webhook delivery" --format json
+  ```
+
+  Search reads the working tree by default, so an agent sees its own dirty
+  edits. Output is budgeted to 16 KiB of serialized snippets by default,
+  sized for direct inclusion in a model context window. Use `--top-k` and
+  `--max-context-bytes` to tune the budget.
+
+- **Judge a checkpoint.** After a change, summarize what actually changed at
+  the entity level to decide whether to keep, revert, or continue:
+
+  ```sh
+  entire graph commit HEAD --json
+  entire graph checkpoint <checkpoint-id> --json
+  ```
+
+  Signature changes with high dependent counts are a strong signal to run
+  tests before proceeding.
+
+- **Build a code graph.** Ingest machine-readable symbols and relations into
+  agent memory or a downstream store such as Entire Brain:
+
+  ```sh
+  entire graph snapshot --repo . --format ndjson
+  ```
+
+  Records carry stable `compound-v1` IDs, so entities can be tracked across
+  sessions and ordinary edits.
+
+- **Detect capabilities first.** Agents should feature-detect instead of
+  assuming: `entire graph capabilities --json` lists semantic versus
+  inventory-only languages and supported relation types, and
+  `entire graph doctor --json` verifies the environment, including
+  `no_egress=true`.
+
+Inside Entire sessions, the Entire CLI sets `ENTIRE_REPO_ROOT` and
+`ENTIRE_PLUGIN_DATA_DIR` automatically; committed-tree searches then reuse a
+tree-keyed compressed index across invocations. Outside Entire, pass `--repo`
+explicitly. See [AGENTS.md](AGENTS.md) for agent instructions specific to
+working on this repository.
 
 ## Provider Contract
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,33 @@
 # Entire Graph
 
-`entire-graph` is an Entire CLI plugin for entity-level checkpoint context.
+`entire-graph` is an Entire CLI plugin that gives Entire sessions entity-level
+checkpoint context and a local semantic code graph.
 
 Entire already knows a checkpoint touched `auth.py` or `.github/workflows/ci.yml`.
-This plugin answers the next question: which semantic entities changed inside that file?
+This plugin answers the next question: which semantic entities changed inside
+that file? It also serves ranked source context for a task and streams a
+machine-readable graph of symbols and relations, all without network access.
 
-## What Entire Graph Adds to Entire
+The plugin builds a binary named `entire-graph`, which is invoked through
+Entire as:
+
+```sh
+entire graph commit HEAD
+entire graph checkpoint abc123def456
+entire graph diff --base HEAD~1 --head HEAD
+entire graph search --repo . --query "where is service config disabled?"
+entire graph snapshot --repo . --format ndjson
+entire graph capabilities --json
+```
+
+## What It Adds to Entire
 
 - **Entity-level checkpoint context.** `commit`, `checkpoint`, and `diff` report
   added, removed, renamed, and signature- or body-changed entities with heuristic
   dependent counts, so a checkpoint can be judged without reading the full diff.
 - **A local-only semantic provider.** `snapshot`, `symbols`, and `edges` stream
   NDJSON graph records under a frozen schema 1.x contract for downstream
-  consumers such as Entire Brain — no network, no hosted models, no telemetry.
+  consumers such as Entire Brain: no network, no hosted models, no telemetry.
 - **Tree-sitter parsing across 36 languages**, from Go and TypeScript to
   Terraform, SQL, and GitHub Actions YAML, with 149 more filetypes tracked as
   inventory-only and honest partial failures for everything else.
@@ -28,71 +43,20 @@ This plugin answers the next question: which semantic entities changed inside th
   and moves by similarity, and streams results so memory stays bounded on very
   large repositories.
 
-This plugin builds a binary named `entire-graph`, which is invoked through Entire as:
+## Language Support
 
-```sh
-entire graph commit HEAD
-entire graph checkpoint abc123def456
-entire graph diff --base HEAD~1 --head HEAD
-entire graph analyze --json
-entire graph capabilities --json
-entire graph snapshot --repo . --format ndjson
-entire graph symbols --repo . --format ndjson
-entire graph edges --repo . --format ndjson
-entire graph search --repo . --query "where is service config disabled?"
-entire graph snapshot --repo . --format ndjson --worktree --ignore-file .graphignore
-entire graph snapshot --repo . --format ndjson --worktree --include-file .graphinclude
-```
+Tree-sitter-backed semantic parsing covers 36 languages: Bash, C, C++, C#,
+Clojure/ClojureScript, CUE, Dart, Elixir, Erlang, F#, Go, Groovy, Haskell,
+HCL/Terraform, Java, JavaScript, Julia, Kotlin, Lua, Objective-C, OCaml, Perl,
+PHP, Protocol Buffers, Python, R, Ruby, Rust, Scala, SQL, Swift, TypeScript,
+YAML (including GitHub Actions workflow sections and jobs), Zig, and Zsh.
 
-## Status
-
-This plugin implements the semantic checkpoint context proposed in
-[entireio/cli#589](https://github.com/entireio/cli/issues/589).
-
-The plugin uses a tree-sitter-backed parser for 36 semantic languages:
-
-- Bash and Zsh
-- C / C++ and Objective-C
-- C# and F#
-- Clojure / ClojureScript
-- CUE
-- Dart
-- Elixir and Erlang
-- Go
-- Groovy
-- Haskell
-- HCL / Terraform
-- Java
-- JavaScript / TypeScript
-- Julia
-- Kotlin
-- Lua
-- OCaml
-- Perl
-- PHP
-- Protocol Buffers
-- Python
-- R
-- Ruby
-- Rust
-- Scala
-- SQL
-- Swift
-- Zig
-- YAML, including GitHub Actions workflow sections and jobs
-
-Another 149 filetypes are recognized as inventory-only (stable file records
-without semantic claims). See [docs/language-support.md](docs/language-support.md)
+Another 149 filetypes are recognized as inventory-only: stable file records
+without semantic claims. See [docs/language-support.md](docs/language-support.md)
 for the full two-tier matrix.
 
-The parser is isolated behind `internal/sem`, so the command surface can stay stable
-while the semantic model gets richer.
-
-The plugin also implements a local-only semantic provider contract for tools that
-need machine-readable repository snapshots. Provider commands emit JSON or NDJSON
-records for capabilities, files, symbols, and relations without fetching remote
-code, calling hosted model APIs, uploading telemetry, or downloading grammars at
-runtime.
+The parser is isolated behind `internal/sem`, so the command surface stays
+stable while the semantic model gets richer.
 
 ## Getting Started
 
@@ -142,21 +106,37 @@ entire plugin install ./entire-graph --force
 After either install path, `entire graph ...` works anywhere the Entire CLI can
 find the managed plugin.
 
-For a one-command local source install, run:
-
-```sh
-scripts/install-local.sh
-```
-
-For local release archives with `SHA256SUMS`, run:
-
-```sh
-scripts/release.sh
-```
-
-See [docs/operations.md](docs/operations.md) for target and cgo details.
+For a one-command local source install, run `scripts/install-local.sh`. For
+local release archives with `SHA256SUMS`, run `scripts/release.sh`. See
+[docs/operations.md](docs/operations.md) for target and cgo details.
 
 ## Commands
+
+### Semantic Diff
+
+Compare one commit against its first parent, compare two arbitrary refs, or
+analyze the commit associated with an Entire checkpoint trailer:
+
+```sh
+entire graph commit HEAD
+entire graph diff --base main --head HEAD
+entire graph diff --base main --head HEAD --json
+entire graph checkpoint abc123def456
+```
+
+`analyze` is an alias for `diff`. All four commands print human-readable text
+by default and structured output with `--json`. Example:
+
+```text
+Semantic changes HEAD~1..HEAD
+
+auth.py
+  ~ function validate_token signature changed (14 dependents)
+  + class TokenClaims added
+  - function parse_token removed (0 dependents)
+```
+
+### Search
 
 Search the live working tree for ranked source regions:
 
@@ -183,44 +163,16 @@ tree-keyed compressed index. Direct callers can set `--cache-dir`; `--no-cache`
 disables persistence. Worktree searches do not reuse committed indexes, avoiding
 stale results after edits.
 
-Compare one commit against its first parent:
+### Provider Records
 
-```sh
-entire graph commit HEAD
-```
-
-Compare two arbitrary refs:
-
-```sh
-entire graph diff --base main --head HEAD
-```
-
-Emit JSON:
-
-```sh
-entire graph diff --base main --head HEAD --json
-```
-
-Analyze the commit associated with an Entire checkpoint trailer:
-
-```sh
-entire graph checkpoint abc123def456
-```
-
-Inspect the provider and its environment:
-
-```sh
-entire graph version --json
-entire graph doctor --json
-entire graph capabilities --json
-```
-
-Emit semantic provider records:
+Emit machine-readable graph records:
 
 ```sh
 entire graph snapshot --repo . --format ndjson
 entire graph symbols --repo . --format ndjson
 entire graph edges --repo . --format ndjson
+entire graph snapshot --repo . --format ndjson --worktree --ignore-file .brainignore
+entire graph snapshot --repo . --format ndjson --worktree --include-file .graphinclude
 ```
 
 `snapshot` writes a complete NDJSON stream: one header record followed by file,
@@ -235,7 +187,17 @@ path is absolute. Pass repeatable `--include-file <path>` flags for gitignore-st
 inclusion rules that are applied after `.gitignore` and `--ignore-file`, allowing
 callers to reopen otherwise ignored paths.
 
-Run without installing through Entire:
+### Environment
+
+Inspect the provider and its environment:
+
+```sh
+entire graph version --json
+entire graph doctor --json
+entire graph capabilities --json
+```
+
+### Running Without Entire
 
 ```sh
 ENTIRE_REPO_ROOT=/path/to/repo ./entire-graph diff --base HEAD~1 --head HEAD
@@ -294,8 +256,8 @@ working on this repository.
 
 ## Provider Contract
 
-The provider contract is designed for Entire or other local tools that want a stable
-semantic graph rather than human-oriented diff text.
+The provider contract is designed for Entire or other local tools that want a
+stable semantic graph rather than human-oriented diff text.
 
 - `version --json` returns the provider name and plugin version.
 - `doctor --json` reports Entire environment variables, repository resolution,
@@ -346,25 +308,12 @@ one file are disambiguated with source ranges, so inserted lines above duplicate
 can change those duplicate IDs; move/rename reconciliation is left to semantic diff
 records.
 
-## Example Output
-
-```text
-Semantic changes HEAD~1..HEAD
-
-auth.py
-  ~ function validate_token signature changed (14 dependents)
-  + class TokenClaims added
-  - function parse_token removed (0 dependents)
-```
-
-## Use Case
+## Why This Exists
 
 When an agent changes a repo, you often need to decide if the checkpoint is safe
 to keep, revert, or continue from. File names are not enough. `entire-graph` shows
 the actual code entities, workflow sections, signatures, and renames that changed,
 so you can understand the checkpoint before reading the full diff.
-
-## Why This Exists
 
 Issue [entireio/cli#589](https://github.com/entireio/cli/issues/589) proposes showing
 checkpoint context at the entity level instead of stopping at "this file changed."
@@ -378,6 +327,8 @@ checkpoint context at the entity level instead of stopping at "this file changed
 - report added, removed, renamed, signature-changed, and body-changed entities
 - expose the same parser through local-only provider commands that emit
   JSON/NDJSON snapshot, symbol, and relation records
+
+## Licensing
 
 The implementation does not copy or vendor Ataraxy Labs code. The runtime parser
 dependency is `github.com/smacker/go-tree-sitter`, which is MIT-licensed. This


### PR DESCRIPTION
## Summary

Documentation-only update based on a full review of the codebase after the Entire Graph rename (#24):

- **README restructure**: reorganize into a task-oriented layout: intro, "What It Adds to Entire" summary, language support, getting started, commands grouped by purpose (semantic diff, search, provider records, environment), agent usage, provider contract, rationale, licensing, and current limits. The `.brainignore` ignore-file example is kept as-is.
- **Language list**: update from the stale 22-language list to the current 36 semantic languages, and link `docs/language-support.md` for the two-tier (semantic vs inventory-only) matrix.
- **Getting Started**: numbered quick start (install, verify with `version`/`doctor --json`, run a first semantic diff).
- **Agent Usage**: new README section documenting how coding agents use the plugin: `search` for bounded context retrieval, `commit`/`checkpoint`/`diff --json` for judging checkpoints, `snapshot` NDJSON for graph ingestion, and `capabilities`/`doctor` for feature detection.
- **Relation vocabulary**: the README claimed 6 relation types; schema 1.1 defines 30 (`internal/sem/provider.go`). List them grouped by family and document which subsets the `syntax-only`, `fast`, and `full` profiles emit.
- **Product summary**: six-point "What It Adds to Entire" overview near the top of the README.
- **AGENTS.md**: new agent instructions for this repository: naming rules (no `entire-sem` regressions; Entire Brain is a separate consumer), mise build/test tasks, plugin usage recipes, repo layout, and contract rules that must not be broken (frozen schema 1.x, no-egress, `compound-v1` stability, no silent file drops).

No Go code is touched.

## Testing

- Docs-only change; all claims verified against the code (relation list from `internal/sem/provider.go`, language counts from `docs/language-support.md`, command surface from `internal/cli/root.go`), and cross-checked by building the binary and counting languages/relations from `capabilities --json`.