### PR TITLE
fix(gitutil): stop misclassifying git errors as file-absent

### DIFF
--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"sort"
 	"strconv"
@@ -121,7 +120,11 @@ func GrepIndexMatches(ctx context.Context, repo string, patterns []string, maxPe
 		return []GrepMatch{}, nil
 	}
 	args = append(args, "--")
-	cmd := newCmd(ctx, repo, "git", args...)
+	// Preserve the caller's locale here. Unlike the other git commands in this
+	// package, `git grep -i` uses LC_CTYPE for non-ASCII case folding; forcing
+	// the C locale would make Unicode matches disappear.
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = repo
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -291,11 +294,13 @@ func ShowFile(ctx context.Context, repo, rev, path string) (string, bool, error)
 	// the argv (which includes rev+":"+path). Matching the full error text made
 	// any real failure on a path containing a marker substring (e.g. "Path" in
 	// src/PathHelper.go) look like a missing file, swallowing the error.
-	out, stderr, err := runWithStderr(ctx, repo, "git", "show", rev+":"+path)
+	// Peel the revision to a tree before resolving the path. Without the type
+	// constraint, a missing full object ID or a blob object can produce the
+	// same path-looking diagnostic as a genuinely absent file.
+	objectSpec := rev + "^{tree}:" + path
+	out, stderr, err := runWithStderr(ctx, repo, "git", "show", objectSpec)
 	if err != nil {
-		if strings.Contains(stderr, "exists on disk, but not in") ||
-			strings.Contains(stderr, "does not exist") ||
-			strings.Contains(stderr, "not found") {
+		if isMissingPathDiagnostic(stderr) {
 			return "", false, nil
 		}
 		msg := stderr
@@ -305,6 +310,15 @@ func ShowFile(ctx context.Context, repo, rev, path string) (string, bool, error)
 		return "", false, fmt.Errorf("git show %s:%s: %s", rev, path, msg)
 	}
 	return out, true, nil
+}
+
+func isMissingPathDiagnostic(stderr string) bool {
+	// ShowFile runs git under the C locale, so only classify Git's specific
+	// missing-path diagnostics. Broad substring checks can match a bad revision
+	// or an unrelated error merely because an argv value contains the phrase.
+	return strings.HasPrefix(stderr, "fatal: path '") &&
+		(strings.Contains(stderr, "' does not exist in '") ||
+			strings.Contains(stderr, "' exists on disk, but not in '"))
 }
 
 // BatchFileReader reads blobs from one revision through a persistent
@@ -451,7 +465,9 @@ func run(ctx context.Context, dir, name string, args ...string) (string, error) 
 	return stdout, nil
 }
 
-// newCmd builds the exec.Cmd every subprocess in this package runs through.
+// newCmd builds the exec.Cmd used by subprocesses whose diagnostics must be
+// stable. GrepIndexMatches intentionally preserves the caller's locale because
+// git grep uses LC_CTYPE for case folding.
 // It pins the subprocess locale to C (LC_ALL=C overrides LANG and any LC_*;
 // LANG=C is set as a belt-and-braces default) so git's stderr messages are
 // always the English ones our error classification matches — e.g. ShowFile's
@@ -459,7 +475,9 @@ func run(ctx context.Context, dir, name string, args ...string) (string, error) 
 func newCmd(ctx context.Context, dir, name string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "LC_ALL=C", "LANG=C")
+	// Cmd.Environ observes Dir and updates PWD accordingly. Starting from
+	// os.Environ would leave child processes with the parent's stale PWD.
+	cmd.Env = append(cmd.Environ(), "LC_ALL=C", "LANG=C")
 	return cmd
 }
 

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -287,15 +287,22 @@ func FileCochanges(ctx context.Context, repo string, maxCommits int) ([]FileCoch
 }
 
 func ShowFile(ctx context.Context, repo, rev, path string) (string, bool, error) {
-	out, err := run(ctx, repo, "git", "show", rev+":"+path)
+	// Classify against git's stderr only, never the wrapped error that echoes
+	// the argv (which includes rev+":"+path). Matching the full error text made
+	// any real failure on a path containing a marker substring (e.g. "Path" in
+	// src/PathHelper.go) look like a missing file, swallowing the error.
+	out, stderr, err := runWithStderr(ctx, repo, "git", "show", rev+":"+path)
 	if err != nil {
-		if strings.Contains(err.Error(), "exists on disk, but not in") ||
-			strings.Contains(err.Error(), "Path") ||
-			strings.Contains(err.Error(), "does not exist") ||
-			strings.Contains(err.Error(), "not found") {
+		if strings.Contains(stderr, "exists on disk, but not in") ||
+			strings.Contains(stderr, "does not exist") ||
+			strings.Contains(stderr, "not found") {
 			return "", false, nil
 		}
-		return "", false, err
+		msg := stderr
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", false, fmt.Errorf("git show %s:%s: %s", rev, path, msg)
 	}
 	return out, true, nil
 }
@@ -434,18 +441,27 @@ func RemoteURLs(ctx context.Context, repo string) ([]string, error) {
 }
 
 func run(ctx context.Context, dir, name string, args ...string) (string, error) {
+	stdout, stderr, err := runWithStderr(ctx, dir, name, args...)
+	if err != nil {
+		msg := stderr
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("%s %s: %s", name, strings.Join(args, " "), msg)
+	}
+	return stdout, nil
+}
+
+// runWithStderr runs a command and returns its stdout and trimmed stderr
+// separately, so callers can classify failures against git's own message
+// without the wrapped error text (which echoes the argv, including paths).
+func runWithStderr(ctx context.Context, dir, name string, args ...string) (string, string, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		msg := strings.TrimSpace(stderr.String())
-		if msg == "" {
-			msg = err.Error()
-		}
-		return "", fmt.Errorf("%s %s: %s", name, strings.Join(args, " "), msg)
-	}
-	return stdout.String(), nil
+	err := cmd.Run()
+	return stdout.String(), strings.TrimSpace(stderr.String()), err
 }

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"sort"
 	"strconv"
@@ -120,8 +121,7 @@ func GrepIndexMatches(ctx context.Context, repo string, patterns []string, maxPe
 		return []GrepMatch{}, nil
 	}
 	args = append(args, "--")
-	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Dir = repo
+	cmd := newCmd(ctx, repo, "git", args...)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -321,8 +321,7 @@ type BatchFileReader struct {
 }
 
 func NewBatchFileReader(ctx context.Context, repo, rev string) (*BatchFileReader, error) {
-	cmd := exec.CommandContext(ctx, "git", "cat-file", "--batch")
-	cmd.Dir = repo
+	cmd := newCmd(ctx, repo, "git", "cat-file", "--batch")
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, err
@@ -452,12 +451,23 @@ func run(ctx context.Context, dir, name string, args ...string) (string, error) 
 	return stdout, nil
 }
 
+// newCmd builds the exec.Cmd every subprocess in this package runs through.
+// It pins the subprocess locale to C (LC_ALL=C overrides LANG and any LC_*;
+// LANG=C is set as a belt-and-braces default) so git's stderr messages are
+// always the English ones our error classification matches — e.g. ShowFile's
+// absent-file detection would otherwise break under a non-English git locale.
+func newCmd(ctx context.Context, dir, name string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "LC_ALL=C", "LANG=C")
+	return cmd
+}
+
 // runWithStderr runs a command and returns its stdout and trimmed stderr
 // separately, so callers can classify failures against git's own message
 // without the wrapped error text (which echoes the argv, including paths).
 func runWithStderr(ctx context.Context, dir, name string, args ...string) (string, string, error) {
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Dir = dir
+	cmd := newCmd(ctx, dir, name, args...)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -83,6 +83,51 @@ func TestGrepIndexMatchesUsesFixedStringsAndUnstagedContent(t *testing.T) {
 	}
 }
 
+func TestGrepIndexMatchesPreservesUnicodeCaseFoldingLocale(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+
+	const path = "src/unicode.go"
+	full := filepath.Join(repo, path)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte("package source\n// wéird\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "add unicode content")
+
+	// Locale names vary across platforms. Find one under which this Git build
+	// supports the Unicode case fold before asserting that GrepIndexMatches
+	// preserves it; the regression forced LC_ALL=C after this probe succeeded.
+	unicodeLocale := ""
+	for _, candidate := range []string{"C.UTF-8", "en_US.UTF-8", "en_US.utf8"} {
+		cmd := exec.Command("git", "grep", "-q", "-i", "-F", "-e", "WÉIRD", "--")
+		cmd.Dir = repo
+		cmd.Env = append(cmd.Environ(), "LC_ALL="+candidate, "LANG="+candidate)
+		if err := cmd.Run(); err == nil {
+			unicodeLocale = candidate
+			break
+		}
+	}
+	if unicodeLocale == "" {
+		t.Skip("installed Git has no available UTF-8 locale with Unicode case folding")
+	}
+	t.Setenv("LC_ALL", unicodeLocale)
+	t.Setenv("LANG", unicodeLocale)
+
+	matches, err := GrepIndexMatches(t.Context(), repo, []string{"WÉIRD"}, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 || matches[0].Path != path || matches[0].Text != "wéird" {
+		t.Fatalf("unicode grep matches = %#v, want one case-folded match in %s", matches, path)
+	}
+}
+
 func TestChangedFilesHandlesNewlinesAndTabsInPaths(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows filenames cannot contain newlines")
@@ -251,6 +296,36 @@ func TestShowFileClassifiesErrorsByStderrNotPath(t *testing.T) {
 		t.Fatalf("ShowFile with bad rev = (ok %v, err nil), want non-nil error", ok)
 	}
 
+	// A syntactically valid but unwritten object ID and an existing blob ID can
+	// both make an untyped `git show REV:PATH` emit a path-looking diagnostic.
+	// Neither is a valid tree revision, so both must remain hard errors.
+	unwrittenCmd := exec.Command("git", "hash-object", "--stdin")
+	unwrittenCmd.Dir = repo
+	unwrittenCmd.Stdin = strings.NewReader("entire-graph pr36 unwritten object\n")
+	unwrittenOut, err := unwrittenCmd.Output()
+	if err != nil {
+		t.Fatalf("git hash-object --stdin: %v", err)
+	}
+	unwrittenOID := strings.TrimSpace(string(unwrittenOut))
+	blobOID := gitOutput(t, repo, "rev-parse", "HEAD:"+path)
+
+	for _, tc := range []struct {
+		name string
+		rev  string
+		path string
+	}{
+		{name: "unwritten full object ID", rev: unwrittenOID, path: path},
+		{name: "blob object", rev: blobOID, path: path},
+		{name: "marker phrase in invalid revision", rev: "not found", path: path},
+		{name: "marker phrase in outside path", rev: "HEAD", path: "../not found"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if out, ok, err := ShowFile(t.Context(), repo, tc.rev, tc.path); err == nil || ok || out != "" {
+				t.Fatalf("ShowFile(%q, %q) = (%q, ok %v, err %v), want (\"\", false, non-nil)", tc.rev, tc.path, out, ok, err)
+			}
+		})
+	}
+
 	// A genuinely missing path at a valid rev is still reported as absent.
 	if out, ok, err := ShowFile(t.Context(), repo, "HEAD", "src/DoesNotExist.go"); err != nil || ok || out != "" {
 		t.Fatalf("ShowFile missing path = (%q, ok %v, err %v), want (\"\", false, nil)", out, ok, err)
@@ -264,12 +339,13 @@ func TestShowFileClassifiesErrorsByStderrNotPath(t *testing.T) {
 
 func TestNewCmdPinsSubprocessLocaleToC(t *testing.T) {
 	// ShowFile classifies file-absent by matching git's English stderr text, so
-	// every git subprocess must run with a pinned C locale. LC_ALL=C must come
-	// after os.Environ() so it overrides any inherited LC_ALL/LANG/LC_MESSAGES.
+	// diagnostic subprocesses run with a pinned C locale. LC_ALL=C must come
+	// after the inherited environment so it overrides LC_ALL/LANG/LC_MESSAGES.
 	t.Setenv("LC_ALL", "fr_FR.UTF-8")
 	t.Setenv("LANG", "fr_FR.UTF-8")
-	cmd := newCmd(context.Background(), t.TempDir(), "git", "version")
-	lcAll, lang := "", ""
+	dir := t.TempDir()
+	cmd := newCmd(context.Background(), dir, "git", "version")
+	lcAll, lang, pwd := "", "", ""
 	for _, kv := range cmd.Env {
 		if v, ok := strings.CutPrefix(kv, "LC_ALL="); ok {
 			lcAll = v
@@ -277,9 +353,15 @@ func TestNewCmdPinsSubprocessLocaleToC(t *testing.T) {
 		if v, ok := strings.CutPrefix(kv, "LANG="); ok {
 			lang = v
 		}
+		if v, ok := strings.CutPrefix(kv, "PWD="); ok {
+			pwd = v
+		}
 	}
 	if lcAll != "C" || lang != "C" {
 		t.Fatalf("effective subprocess locale LC_ALL=%q LANG=%q, want both \"C\"", lcAll, lang)
+	}
+	if runtime.GOOS != "windows" && filepath.Clean(pwd) != filepath.Clean(dir) {
+		t.Fatalf("subprocess PWD=%q, want command directory %q", pwd, dir)
 	}
 }
 

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -223,6 +223,45 @@ func TestBatchFileReaderReadsMultipleFilesFromHead(t *testing.T) {
 	}
 }
 
+func TestShowFileClassifiesErrorsByStderrNotPath(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	git(t, repo, "config", "commit.gpgsign", "false")
+
+	// Path deliberately contains the substring "Path" — the old classifier
+	// treated any error mentioning "Path" as a missing file, and ShowFile's
+	// wrapped error always echoed the argv (which includes the path).
+	const path = "src/PathHelper.go"
+	const content = "package src\n\nfunc Help() {}\n"
+	full := filepath.Join(repo, path)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "add path helper")
+
+	// Regression: a bad rev on a path containing "Path" must surface a real
+	// error, not be swallowed as file-absent.
+	if _, ok, err := ShowFile(t.Context(), repo, "BADREV", path); err == nil {
+		t.Fatalf("ShowFile with bad rev = (ok %v, err nil), want non-nil error", ok)
+	}
+
+	// A genuinely missing path at a valid rev is still reported as absent.
+	if out, ok, err := ShowFile(t.Context(), repo, "HEAD", "src/DoesNotExist.go"); err != nil || ok || out != "" {
+		t.Fatalf("ShowFile missing path = (%q, ok %v, err %v), want (\"\", false, nil)", out, ok, err)
+	}
+
+	// An existing file at HEAD returns its content.
+	if out, ok, err := ShowFile(t.Context(), repo, "HEAD", path); err != nil || !ok || out != content {
+		t.Fatalf("ShowFile existing = (%q, ok %v, err %v), want (%q, true, nil)", out, ok, err, content)
+	}
+}
+
 func git(t *testing.T, repo string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -262,6 +262,27 @@ func TestShowFileClassifiesErrorsByStderrNotPath(t *testing.T) {
 	}
 }
 
+func TestNewCmdPinsSubprocessLocaleToC(t *testing.T) {
+	// ShowFile classifies file-absent by matching git's English stderr text, so
+	// every git subprocess must run with a pinned C locale. LC_ALL=C must come
+	// after os.Environ() so it overrides any inherited LC_ALL/LANG/LC_MESSAGES.
+	t.Setenv("LC_ALL", "fr_FR.UTF-8")
+	t.Setenv("LANG", "fr_FR.UTF-8")
+	cmd := newCmd(context.Background(), t.TempDir(), "git", "version")
+	lcAll, lang := "", ""
+	for _, kv := range cmd.Env {
+		if v, ok := strings.CutPrefix(kv, "LC_ALL="); ok {
+			lcAll = v
+		}
+		if v, ok := strings.CutPrefix(kv, "LANG="); ok {
+			lang = v
+		}
+	}
+	if lcAll != "C" || lang != "C" {
+		t.Fatalf("effective subprocess locale LC_ALL=%q LANG=%q, want both \"C\"", lcAll, lang)
+	}
+}
+
 func git(t *testing.T, repo string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)


### PR DESCRIPTION
## Summary

`ShowFile` in `internal/gitutil/git.go` classified a git failure as *file-absent* (returning `("", false, nil)`) whenever the error text contained `"Path"`, `"does not exist"`, `"not found"`, or `"exists on disk, but not in"`. But `run()` wraps errors as `git show REV:PATH: <stderr>`, so the path (argv) is **always** part of the error string. Any real error — bad rev, IO failure, context cancellation — on a path that happens to contain the substring `"Path"` (e.g. `src/PathHelper.go`) was silently swallowed as a missing file.

## Fix

Classify against git's **stderr only**, never the wrapped error that echoes the argv. Added a `runWithStderr` helper that returns stdout and stderr separately; `run()` now delegates to it and keeps its existing signature, so no other callers change. The redundant `"Path"` clause is gone (git's real capital-P message is already caught by `"exists on disk, but not in"`).

- Genuinely missing paths at a valid rev still return `("", false, nil)`.
- Real failures (including bad rev on a `"Path"` file) now propagate as a non-nil error.

Fixes #31

## Test evidence

Added `TestShowFileClassifiesErrorsByStderrNotPath` (in `internal/gitutil/git_test.go`), which commits `src/PathHelper.go` and asserts:
- `ShowFile(ctx, repo, "BADREV", "src/PathHelper.go")` returns a non-nil error (regression).
- A genuinely missing path at `HEAD` returns `("", false, nil)`.
- An existing file at `HEAD` returns its content, `ok=true`, `nil`.

Verification (all pass):
```
gofmt -s -w . ; gofmt -l internal   # empty
go vet ./...                          # ok
go build ./...                        # ok
go test -race ./internal/gitutil/     # ok
```