### PR TITLE
fix(sem): disambiguate same-name overloads in semantic diff

### DIFF
--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -366,21 +366,51 @@ func sortedEntities(byKey map[string]Entity) []Entity {
 
 func sortChanges(changes []EntityChange) {
 	sort.Slice(changes, func(i, j int) bool {
-		left := lineForSort(changes[i])
-		right := lineForSort(changes[j])
-		if left == right {
-			return fmt.Sprintf("%s:%s", changes[i].Kind, changes[i].Name) < fmt.Sprintf("%s:%s", changes[j].Kind, changes[j].Name)
+		left, right := changes[i], changes[j]
+		if leftLine, rightLine := lineForSort(left), lineForSort(right); leftLine != rightLine {
+			return leftLine < rightLine
 		}
-		return left < right
+		if left.Kind != right.Kind {
+			return left.Kind < right.Kind
+		}
+		if left.Name != right.Name {
+			return left.Name < right.Name
+		}
+		if left.Type != right.Type {
+			return left.Type < right.Type
+		}
+		if left.OldSignature != right.OldSignature {
+			return left.OldSignature < right.OldSignature
+		}
+		if left.NewSignature != right.NewSignature {
+			return left.NewSignature < right.NewSignature
+		}
+		if left.BeforeStartLine != right.BeforeStartLine {
+			return left.BeforeStartLine < right.BeforeStartLine
+		}
+		if left.AfterStartLine != right.AfterStartLine {
+			return left.AfterStartLine < right.AfterStartLine
+		}
+		if left.OldName != right.OldName {
+			return left.OldName < right.OldName
+		}
+		if left.NewName != right.NewName {
+			return left.NewName < right.NewName
+		}
+		if left.OldPath != right.OldPath {
+			return left.OldPath < right.OldPath
+		}
+		if left.NewPath != right.NewPath {
+			return left.NewPath < right.NewPath
+		}
+		if left.Reconciliation != right.Reconciliation {
+			return left.Reconciliation < right.Reconciliation
+		}
+		if left.Similarity != right.Similarity {
+			return left.Similarity < right.Similarity
+		}
+		return left.DependentsCount < right.DependentsCount
 	})
-}
-
-func key(entity Entity) string {
-	return entity.Kind + ":" + entity.Name
-}
-
-func sigKey(entity Entity) string {
-	return entity.Kind + ":" + entity.Name + ":" + entity.Signature
 }
 
 // keyedEntityMaps assigns each entity an ephemeral key such that entities that
@@ -388,60 +418,200 @@ func sigKey(entity Entity) string {
 // keys are opaque: they are used only inside compareEntities/bestRename and are
 // never persisted or emitted.
 //
-// Matching is two-phase:
+// Matching is evidence-first within each Kind:Name group:
 //
-//  1. Entities that share an exact Kind:Name:Signature across sides pair up
-//     first. True duplicates (an identical Kind:Name:Signature appearing more
-//     than once on one side) are disambiguated by occurrence index in file
-//     order, so the Nth duplicate on each side pairs with the Nth on the
-//     other. Exact pairing makes mid-list overload insertions, removals, and
-//     reorders inert for the untouched overloads instead of cascading phantom
-//     signature_changed events down the list (e.g. removing the first of
-//     three overloads now reports just that one removal).
+//  1. Exact-signature entities pair as content multisets: combined body and
+//     fingerprint evidence first, then body hash, then fingerprint. Members
+//     of an equal-content class are interchangeable, so repeated hashes pair
+//     safely up to the count present on both sides. This keeps an inserted
+//     exact-signature duplicate from shifting every surviving duplicate.
 //
-//  2. The leftovers -- entities whose exact signature has no counterpart on
-//     the other side -- are assigned positional ordinals per Kind:Name in
-//     file order. An in-place signature edit of one overload leaves exactly
-//     one leftover with that name on each side, so the edit still pairs and
-//     surfaces as signature_changed rather than remove+add (issue #35). A
-//     naive always-signature key would regress that case: the rename
-//     reconciler's signature similarity for e.g. F(int) -> F(long) falls well
-//     below renameThreshold.
+//  2. Remaining exact signatures pair by occurrence before leftovers take
+//     unambiguous fingerprint/body anchors across signatures. This prevents
+//     copied or swapped bodies from stealing an unchanged signature, while the
+//     identity anchors preserve the right survivor when one overload is removed
+//     as another changes signature. A final positional fallback still reports
+//     an otherwise-unanchored in-place signature edit as signature_changed
+//     rather than remove+add (issue #35). Multiple residuals without identity
+//     evidence remain inherently ambiguous; their positional pairing is
+//     retained as a compatibility heuristic.
 //
-// The "=" and "~" key prefixes keep phase-1 and phase-2 keys from colliding.
+// Numeric pair keys and side-specific unmatched keys avoid delimiter aliasing
+// with source-language names and signatures.
 func keyedEntityMaps(before, after []Entity) (map[string]Entity, map[string]Entity) {
-	sigCounts := func(entities []Entity) map[string]int {
-		counts := make(map[string]int, len(entities))
-		for _, entity := range entities {
-			counts[sigKey(entity)]++
-		}
-		return counts
+	type groupKey struct {
+		kind string
+		name string
 	}
-	beforeSigs := sigCounts(before)
-	afterSigs := sigCounts(after)
+	type entityGroup struct {
+		before []int
+		after  []int
+	}
 
-	keySide := func(entities []Entity, otherSigs map[string]int) map[string]Entity {
-		out := make(map[string]Entity, len(entities))
-		sigSeen := map[string]int{}
-		leftoverSeen := map[string]int{}
-		for _, entity := range entities {
-			sk := sigKey(entity)
-			occurrence := sigSeen[sk]
-			sigSeen[sk]++
-			if occurrence < otherSigs[sk] {
-				// Phase 1: the other side has a matching Nth occurrence of
-				// this exact Kind:Name:Signature.
-				out[fmt.Sprintf("=%s#%d", sk, occurrence)] = entity
+	groups := map[groupKey]*entityGroup{}
+	groupFor := func(entity Entity) *entityGroup {
+		key := groupKey{kind: entity.Kind, name: entity.Name}
+		group := groups[key]
+		if group == nil {
+			group = &entityGroup{}
+			groups[key] = group
+		}
+		return group
+	}
+	for i, entity := range before {
+		group := groupFor(entity)
+		group.before = append(group.before, i)
+	}
+	for i, entity := range after {
+		group := groupFor(entity)
+		group.after = append(group.after, i)
+	}
+
+	groupKeys := make([]groupKey, 0, len(groups))
+	for key := range groups {
+		groupKeys = append(groupKeys, key)
+	}
+	sort.Slice(groupKeys, func(i, j int) bool {
+		if groupKeys[i].kind != groupKeys[j].kind {
+			return groupKeys[i].kind < groupKeys[j].kind
+		}
+		return groupKeys[i].name < groupKeys[j].name
+	})
+
+	beforeByKey := make(map[string]Entity, len(before))
+	afterByKey := make(map[string]Entity, len(after))
+	beforeMatched := make([]bool, len(before))
+	afterMatched := make([]bool, len(after))
+	pairCount := 0
+
+	pair := func(beforeIndex, afterIndex int) {
+		key := fmt.Sprintf("=%09d", pairCount)
+		pairCount++
+		beforeMatched[beforeIndex] = true
+		afterMatched[afterIndex] = true
+		beforeByKey[key] = before[beforeIndex]
+		afterByKey[key] = after[afterIndex]
+	}
+	type evidenceKey struct {
+		signature   string
+		bodyHash    string
+		fingerprint string
+	}
+	matchClass := func(group *entityGroup, keyFor func(Entity) (evidenceKey, bool)) {
+		afterBuckets := map[evidenceKey][]int{}
+		for _, afterIndex := range group.after {
+			if afterMatched[afterIndex] {
 				continue
 			}
-			// Phase 2: positional ordinal among this side's leftovers.
-			base := key(entity)
-			out[fmt.Sprintf("~%s#%d", base, leftoverSeen[base])] = entity
-			leftoverSeen[base]++
+			key, ok := keyFor(after[afterIndex])
+			if ok {
+				afterBuckets[key] = append(afterBuckets[key], afterIndex)
+			}
 		}
-		return out
+		afterOffsets := map[evidenceKey]int{}
+		for _, beforeIndex := range group.before {
+			if beforeMatched[beforeIndex] {
+				continue
+			}
+			key, ok := keyFor(before[beforeIndex])
+			if !ok {
+				continue
+			}
+			offset := afterOffsets[key]
+			if offset >= len(afterBuckets[key]) {
+				continue
+			}
+			pair(beforeIndex, afterBuckets[key][offset])
+			afterOffsets[key]++
+		}
 	}
-	return keySide(before, afterSigs), keySide(after, beforeSigs)
+	matchUnique := func(group *entityGroup, keyFor func(Entity) (evidenceKey, bool)) {
+		beforeCounts := map[evidenceKey]int{}
+		afterCounts := map[evidenceKey]int{}
+		afterIndexByKey := map[evidenceKey]int{}
+		for _, beforeIndex := range group.before {
+			if beforeMatched[beforeIndex] {
+				continue
+			}
+			if key, ok := keyFor(before[beforeIndex]); ok {
+				beforeCounts[key]++
+			}
+		}
+		for _, afterIndex := range group.after {
+			if afterMatched[afterIndex] {
+				continue
+			}
+			if key, ok := keyFor(after[afterIndex]); ok {
+				afterCounts[key]++
+				afterIndexByKey[key] = afterIndex
+			}
+		}
+		for _, beforeIndex := range group.before {
+			if beforeMatched[beforeIndex] {
+				continue
+			}
+			key, ok := keyFor(before[beforeIndex])
+			if ok && beforeCounts[key] == 1 && afterCounts[key] == 1 {
+				pair(beforeIndex, afterIndexByKey[key])
+			}
+		}
+	}
+	matchRemaining := func(group *entityGroup) {
+		afterRemaining := make([]int, 0, len(group.after))
+		for _, afterIndex := range group.after {
+			if !afterMatched[afterIndex] {
+				afterRemaining = append(afterRemaining, afterIndex)
+			}
+		}
+		afterOffset := 0
+		for _, beforeIndex := range group.before {
+			if beforeMatched[beforeIndex] || afterOffset >= len(afterRemaining) {
+				continue
+			}
+			pair(beforeIndex, afterRemaining[afterOffset])
+			afterOffset++
+		}
+	}
+
+	for _, key := range groupKeys {
+		group := groups[key]
+		matchClass(group, func(entity Entity) (evidenceKey, bool) {
+			ok := entity.BodyHash != "" && entity.Fingerprint != ""
+			return evidenceKey{signature: entity.Signature, bodyHash: entity.BodyHash, fingerprint: entity.Fingerprint}, ok
+		})
+		matchClass(group, func(entity Entity) (evidenceKey, bool) {
+			return evidenceKey{signature: entity.Signature, bodyHash: entity.BodyHash}, entity.BodyHash != ""
+		})
+		matchClass(group, func(entity Entity) (evidenceKey, bool) {
+			return evidenceKey{signature: entity.Signature, fingerprint: entity.Fingerprint}, entity.Fingerprint != ""
+		})
+		matchClass(group, func(entity Entity) (evidenceKey, bool) {
+			return evidenceKey{signature: entity.Signature}, true
+		})
+		matchUnique(group, func(entity Entity) (evidenceKey, bool) {
+			ok := entity.BodyHash != "" && entity.Fingerprint != ""
+			return evidenceKey{bodyHash: entity.BodyHash, fingerprint: entity.Fingerprint}, ok
+		})
+		matchUnique(group, func(entity Entity) (evidenceKey, bool) {
+			return evidenceKey{fingerprint: entity.Fingerprint}, entity.Fingerprint != ""
+		})
+		matchUnique(group, func(entity Entity) (evidenceKey, bool) {
+			return evidenceKey{bodyHash: entity.BodyHash}, entity.BodyHash != ""
+		})
+		matchRemaining(group)
+	}
+
+	for i, entity := range before {
+		if !beforeMatched[i] {
+			beforeByKey[fmt.Sprintf("-before:%09d", i)] = entity
+		}
+	}
+	for i, entity := range after {
+		if !afterMatched[i] {
+			afterByKey[fmt.Sprintf("+after:%09d", i)] = entity
+		}
+	}
+	return beforeByKey, afterByKey
 }
 
 func lineForSort(change EntityChange) int {

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -258,14 +258,8 @@ func Compare(before, after []Entity) []EntityChange {
 // removed and added entities that were not reconciled, sorted deterministically
 // so callers can run a cross-file reconciliation pass over the leftovers.
 func compareEntities(before, after []Entity) (changes []EntityChange, removed, added []Entity) {
-	beforeByKey := map[string]Entity{}
-	afterByKey := map[string]Entity{}
-	for _, entity := range before {
-		beforeByKey[key(entity)] = entity
-	}
-	for _, entity := range after {
-		afterByKey[key(entity)] = entity
-	}
+	beforeByKey := keyedEntities(before)
+	afterByKey := keyedEntities(after)
 
 	deleted := map[string]Entity{}
 	addedByKey := map[string]Entity{}
@@ -384,6 +378,28 @@ func sortChanges(changes []EntityChange) {
 
 func key(entity Entity) string {
 	return entity.Kind + ":" + entity.Name
+}
+
+// keyedEntities maps each entity to a stable key within its parse. Entities that
+// share a Kind:Name (same-name overloads, reachable in languages like C#/Java)
+// are disambiguated by a positional ordinal assigned in file order, so
+// before[Kind:Name#0] pairs with after[Kind:Name#0]. A lone entity is always
+// #0, preserving the pre-ordinal single-entity behavior. Using an ordinal rather
+// than the full signature keeps a signature edit to an overload paired across
+// sides (so it surfaces as signature_changed, not a spurious remove+add).
+//
+// Known limitation: ordinal pairing can misattribute when overloads are
+// reordered or one is inserted/removed mid-list, but that is a strict
+// improvement over last-write-wins dropping all but one same-name overload.
+func keyedEntities(entities []Entity) map[string]Entity {
+	out := make(map[string]Entity, len(entities))
+	counts := map[string]int{}
+	for _, entity := range entities {
+		base := key(entity)
+		out[fmt.Sprintf("%s#%d", base, counts[base])] = entity
+		counts[base]++
+	}
+	return out
 }
 
 func lineForSort(change EntityChange) int {

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -258,8 +258,7 @@ func Compare(before, after []Entity) []EntityChange {
 // removed and added entities that were not reconciled, sorted deterministically
 // so callers can run a cross-file reconciliation pass over the leftovers.
 func compareEntities(before, after []Entity) (changes []EntityChange, removed, added []Entity) {
-	beforeByKey := keyedEntities(before)
-	afterByKey := keyedEntities(after)
+	beforeByKey, afterByKey := keyedEntityMaps(before, after)
 
 	deleted := map[string]Entity{}
 	addedByKey := map[string]Entity{}
@@ -380,26 +379,69 @@ func key(entity Entity) string {
 	return entity.Kind + ":" + entity.Name
 }
 
-// keyedEntities maps each entity to a stable key within its parse. Entities that
-// share a Kind:Name (same-name overloads, reachable in languages like C#/Java)
-// are disambiguated by a positional ordinal assigned in file order, so
-// before[Kind:Name#0] pairs with after[Kind:Name#0]. A lone entity is always
-// #0, preserving the pre-ordinal single-entity behavior. Using an ordinal rather
-// than the full signature keeps a signature edit to an overload paired across
-// sides (so it surfaces as signature_changed, not a spurious remove+add).
+func sigKey(entity Entity) string {
+	return entity.Kind + ":" + entity.Name + ":" + entity.Signature
+}
+
+// keyedEntityMaps assigns each entity an ephemeral key such that entities that
+// should be diffed against each other receive the same key on both sides. The
+// keys are opaque: they are used only inside compareEntities/bestRename and are
+// never persisted or emitted.
 //
-// Known limitation: ordinal pairing can misattribute when overloads are
-// reordered or one is inserted/removed mid-list, but that is a strict
-// improvement over last-write-wins dropping all but one same-name overload.
-func keyedEntities(entities []Entity) map[string]Entity {
-	out := make(map[string]Entity, len(entities))
-	counts := map[string]int{}
-	for _, entity := range entities {
-		base := key(entity)
-		out[fmt.Sprintf("%s#%d", base, counts[base])] = entity
-		counts[base]++
+// Matching is two-phase:
+//
+//  1. Entities that share an exact Kind:Name:Signature across sides pair up
+//     first. True duplicates (an identical Kind:Name:Signature appearing more
+//     than once on one side) are disambiguated by occurrence index in file
+//     order, so the Nth duplicate on each side pairs with the Nth on the
+//     other. Exact pairing makes mid-list overload insertions, removals, and
+//     reorders inert for the untouched overloads instead of cascading phantom
+//     signature_changed events down the list (e.g. removing the first of
+//     three overloads now reports just that one removal).
+//
+//  2. The leftovers -- entities whose exact signature has no counterpart on
+//     the other side -- are assigned positional ordinals per Kind:Name in
+//     file order. An in-place signature edit of one overload leaves exactly
+//     one leftover with that name on each side, so the edit still pairs and
+//     surfaces as signature_changed rather than remove+add (issue #35). A
+//     naive always-signature key would regress that case: the rename
+//     reconciler's signature similarity for e.g. F(int) -> F(long) falls well
+//     below renameThreshold.
+//
+// The "=" and "~" key prefixes keep phase-1 and phase-2 keys from colliding.
+func keyedEntityMaps(before, after []Entity) (map[string]Entity, map[string]Entity) {
+	sigCounts := func(entities []Entity) map[string]int {
+		counts := make(map[string]int, len(entities))
+		for _, entity := range entities {
+			counts[sigKey(entity)]++
+		}
+		return counts
 	}
-	return out
+	beforeSigs := sigCounts(before)
+	afterSigs := sigCounts(after)
+
+	keySide := func(entities []Entity, otherSigs map[string]int) map[string]Entity {
+		out := make(map[string]Entity, len(entities))
+		sigSeen := map[string]int{}
+		leftoverSeen := map[string]int{}
+		for _, entity := range entities {
+			sk := sigKey(entity)
+			occurrence := sigSeen[sk]
+			sigSeen[sk]++
+			if occurrence < otherSigs[sk] {
+				// Phase 1: the other side has a matching Nth occurrence of
+				// this exact Kind:Name:Signature.
+				out[fmt.Sprintf("=%s#%d", sk, occurrence)] = entity
+				continue
+			}
+			// Phase 2: positional ordinal among this side's leftovers.
+			base := key(entity)
+			out[fmt.Sprintf("~%s#%d", base, leftoverSeen[base])] = entity
+			leftoverSeen[base]++
+		}
+		return out
+	}
+	return keySide(before, afterSigs), keySide(after, beforeSigs)
 }
 
 func lineForSort(change EntityChange) int {

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -186,6 +187,66 @@ func TestAnalyzeGitRangeExpandedLanguageSignatureChange(t *testing.T) {
 		}
 	}
 	t.Fatalf("missing Java method signature change in %#v", result.Files)
+}
+
+func TestAnalyzeGitRangeMatchesSurvivingOverloadByFingerprint(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+
+	write(t, repo, "C.java", `class C {
+    int F(int value) {
+        return 1;
+    }
+
+    int F(String value) {
+        return 2;
+    }
+}
+`)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial overloads")
+	base := rev(t, repo, "HEAD")
+
+	write(t, repo, "C.java", `class C {
+    int F(Object value) {
+        return 2;
+    }
+}
+`)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "remove and edit overloads")
+	head := rev(t, repo, "HEAD")
+
+	result, err := AnalyzeGitRange(context.Background(), repo, base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var removedInt, editedString bool
+	for _, file := range result.Files {
+		for _, change := range file.Changes {
+			if change.Kind != "method" || change.Name != "C.F" {
+				continue
+			}
+			switch change.Type {
+			case "removed":
+				if strings.Contains(change.OldSignature, "int") {
+					removedInt = true
+				}
+			case "signature_changed":
+				if strings.Contains(change.OldSignature, "String") && strings.Contains(change.NewSignature, "Object") {
+					editedString = true
+				}
+			case "added":
+				t.Fatalf("surviving overload reported as added: %#v", change)
+			}
+		}
+	}
+	if !removedInt || !editedString {
+		t.Fatalf("missing method changes removedInt=%v editedString=%v in %#v", removedInt, editedString, result.Files)
+	}
 }
 
 func TestAnalyzeGitRangeIncludesGitHubWorkflowYAML(t *testing.T) {
@@ -444,6 +505,192 @@ func TestCompareEntitiesTrueDuplicatesEditOne(t *testing.T) {
 	}
 	if changes[0].Type != "body_changed" || changes[0].Kind != "method" || changes[0].Name != "C.F" {
 		t.Fatalf("change = %#v, want body_changed for method C.F", changes[0])
+	}
+}
+
+func TestCompareEntitiesDuplicateInsertionPreservesExistingBodies(t *testing.T) {
+	// A new exact-signature duplicate inserted before two existing duplicates
+	// must not shift occurrence-index pairing and manufacture body changes for
+	// both survivors. Stable body hashes identify the existing entities; only
+	// the genuinely new h0 entity should remain unmatched.
+	before := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F()", BodyHash: "h1", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F()", BodyHash: "h2", StartLine: 5},
+	}
+	after := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F()", BodyHash: "h0", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F()", BodyHash: "h1", StartLine: 5},
+		{Kind: "method", Name: "C.F", Signature: "F()", BodyHash: "h2", StartLine: 9},
+	}
+
+	changes, removed, added := compareEntities(before, after)
+	if len(changes) != 0 || len(removed) != 0 {
+		t.Fatalf("duplicate insertion caused survivor churn: changes=%#v removed=%#v", changes, removed)
+	}
+	if len(added) != 1 || added[0].BodyHash != "h0" || added[0].StartLine != 1 {
+		t.Fatalf("added = %#v, want only the new h0 duplicate", added)
+	}
+}
+
+func TestCompareEntitiesRepeatedDuplicateInsertionPreservesContentClass(t *testing.T) {
+	// Repeated equal hashes are an equivalence class, not an ambiguity that
+	// should disable matching. Pair the two existing h1 entities as a multiset
+	// and leave only the distinct h0 insertion unmatched.
+	before := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F()", BodyHash: "h1", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F()", BodyHash: "h1", StartLine: 5},
+	}
+	after := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F()", BodyHash: "h0", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F()", BodyHash: "h1", StartLine: 5},
+		{Kind: "method", Name: "C.F", Signature: "F()", BodyHash: "h1", StartLine: 9},
+	}
+
+	changes, removed, added := compareEntities(before, after)
+	if len(changes) != 0 || len(removed) != 0 || len(added) != 1 || added[0].BodyHash != "h0" {
+		t.Fatalf("unexpected duplicate multiset diff: changes=%#v removed=%#v added=%#v", changes, removed, added)
+	}
+}
+
+func TestCompareEntitiesDuplicateReorderUsesBodyBeforeFingerprint(t *testing.T) {
+	// Fingerprints can legitimately collide for exact-signature duplicates
+	// whose bodies normalize alike. An exact body hash is stronger evidence in
+	// this phase and must keep a pure reorder inert.
+	before := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F()", BodyHash: "h1", Fingerprint: "shared", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F()", BodyHash: "h2", Fingerprint: "shared", StartLine: 5},
+	}
+	after := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F()", BodyHash: "h2", Fingerprint: "shared", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F()", BodyHash: "h1", Fingerprint: "shared", StartLine: 5},
+	}
+
+	changes, removed, added := compareEntities(before, after)
+	if len(changes) != 0 || len(removed) != 0 || len(added) != 0 {
+		t.Fatalf("duplicate reorder must be inert: changes=%#v removed=%#v added=%#v", changes, removed, added)
+	}
+}
+
+func TestCompareEntitiesExactSignatureOutranksSharedFingerprint(t *testing.T) {
+	// Cross-signature fingerprint continuity is useful only after exact
+	// signatures are anchored. Shared fingerprints must not turn removal of
+	// F(int) into a phantom F(int)->F(string) signature edit.
+	before := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(int)", Fingerprint: "shared", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(string)", Fingerprint: "shared", StartLine: 5},
+	}
+	after := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(string)", Fingerprint: "shared", StartLine: 1},
+	}
+
+	changes, removed, added := compareEntities(before, after)
+	if len(changes) != 0 || len(added) != 0 {
+		t.Fatalf("exact-signature survivor caused churn: changes=%#v added=%#v", changes, added)
+	}
+	if len(removed) != 1 || removed[0].Signature != "F(int)" {
+		t.Fatalf("removed = %#v, want only F(int)", removed)
+	}
+}
+
+func TestCompareEntitiesExactSignaturesOutrankSwappedBodies(t *testing.T) {
+	// Bodies may be copied or swapped between overloads while both signatures
+	// survive. Cross-signature fingerprint evidence must not steal those exact
+	// signatures and turn two body edits into two phantom signature edits.
+	before := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(int)", BodyHash: "int-body", Fingerprint: "int-body", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(string)", BodyHash: "string-body", Fingerprint: "string-body", StartLine: 5},
+	}
+	after := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(int)", BodyHash: "string-body", Fingerprint: "string-body", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(string)", BodyHash: "int-body", Fingerprint: "int-body", StartLine: 5},
+	}
+
+	changes, removed, added := compareEntities(before, after)
+	if len(removed) != 0 || len(added) != 0 || len(changes) != 2 {
+		t.Fatalf("unexpected swapped-body diff: changes=%#v removed=%#v added=%#v", changes, removed, added)
+	}
+	for _, change := range changes {
+		if change.Type != "body_changed" {
+			t.Fatalf("change = %#v, want body_changed", change)
+		}
+	}
+}
+
+func TestCompareEntitiesRemovalAndSignatureEditMatchByFingerprint(t *testing.T) {
+	// When one overload is removed while another changes signature, positional
+	// leftover pairing chooses the wrong survivor. The unchanged fingerprint
+	// anchors F(string) across its F(object) signature edit, leaving F(int) as
+	// the actual removal even though the edited entity moved to the first line.
+	before := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(int)", BodyHash: "int-body", Fingerprint: "int-fingerprint", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(string)", BodyHash: "old-body", Fingerprint: "survivor", StartLine: 5},
+	}
+	after := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(object)", BodyHash: "new-body", Fingerprint: "survivor", StartLine: 1},
+	}
+
+	changes, removed, added := compareEntities(before, after)
+	if len(added) != 0 {
+		t.Fatalf("unexpected added overloads: %#v", added)
+	}
+	if len(removed) != 1 || removed[0].Signature != "F(int)" {
+		t.Fatalf("removed = %#v, want only F(int)", removed)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("changes = %#v, want one survivor signature change", changes)
+	}
+	change := changes[0]
+	if change.Type != "signature_changed" || change.OldSignature != "F(string)" || change.NewSignature != "F(object)" {
+		t.Fatalf("change = %#v, want signature_changed F(string) -> F(object)", change)
+	}
+	if change.BeforeStartLine != 5 || change.AfterStartLine != 1 {
+		t.Fatalf("change lines = %d -> %d, want 5 -> 1", change.BeforeStartLine, change.AfterStartLine)
+	}
+}
+
+func TestCompareEntitiesReorderedSignatureEditsMatchUniqueFingerprints(t *testing.T) {
+	// Two survivors may both change signature and reorder. Unique fingerprints
+	// must produce a one-to-one match independent of the new file order.
+	before := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(int)", BodyHash: "old-a", Fingerprint: "a", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(string)", BodyHash: "old-b", Fingerprint: "b", StartLine: 5},
+	}
+	after := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(object)", BodyHash: "new-b", Fingerprint: "b", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(long)", BodyHash: "new-a", Fingerprint: "a", StartLine: 5},
+	}
+
+	changes, removed, added := compareEntities(before, after)
+	if len(removed) != 0 || len(added) != 0 || len(changes) != 2 {
+		t.Fatalf("unexpected reordered edit diff: changes=%#v removed=%#v added=%#v", changes, removed, added)
+	}
+	paired := map[string]string{}
+	for _, change := range changes {
+		if change.Type != "signature_changed" {
+			t.Fatalf("change = %#v, want signature_changed", change)
+		}
+		paired[change.OldSignature] = change.NewSignature
+	}
+	if paired["F(int)"] != "F(long)" || paired["F(string)"] != "F(object)" {
+		t.Fatalf("signature pairs = %#v, want int->long and string->object", paired)
+	}
+}
+
+func TestCompareEntitiesSameLineOverloadChangesSortDeterministically(t *testing.T) {
+	before := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(int)", Fingerprint: "a", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(string)", Fingerprint: "b", StartLine: 1},
+	}
+	after := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(long)", Fingerprint: "a", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(object)", Fingerprint: "b", StartLine: 1},
+	}
+
+	for i := 0; i < 100; i++ {
+		changes := Compare(before, after)
+		if len(changes) != 2 || changes[0].OldSignature != "F(int)" || changes[1].OldSignature != "F(string)" {
+			t.Fatalf("iteration %d changes = %#v, want deterministic old-signature order", i, changes)
+		}
 	}
 }
 

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -357,6 +357,91 @@ func TestCompareEntitiesSingleEntityUnchangedBehavior(t *testing.T) {
 	}
 }
 
+func TestCompareEntitiesAddedOverloadReportedAsAdded(t *testing.T) {
+	// Adding a third overload (before has 2, after has 3, appended in file
+	// order) must surface exactly one `added` for the new overload; the two
+	// pre-existing overloads stay paired by ordinal and produce no churn.
+	before := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(int)", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(string)", StartLine: 5},
+	}
+	after := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(int)", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(string)", StartLine: 5},
+		{Kind: "method", Name: "C.F", Signature: "F(bool)", StartLine: 9},
+	}
+
+	changes, removed, added := compareEntities(before, after)
+	if len(changes) != 0 {
+		t.Fatalf("unexpected changes on stable overloads: %#v", changes)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("unexpected removed: %#v", removed)
+	}
+	if len(added) != 1 {
+		t.Fatalf("added = %#v, want exactly one added overload", added)
+	}
+	if added[0].Signature != "F(bool)" {
+		t.Fatalf("added signature = %q, want F(bool)", added[0].Signature)
+	}
+}
+
+func TestCompareEntitiesRemovedOverloadReported(t *testing.T) {
+	// Removing an overload (before has 3, after has 2, the last in file order
+	// dropped) must surface exactly one `removed` for the dropped overload and
+	// must not misattribute the removal to a surviving overload.
+	before := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(int)", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(string)", StartLine: 5},
+		{Kind: "method", Name: "C.F", Signature: "F(bool)", StartLine: 9},
+	}
+	after := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(int)", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(string)", StartLine: 5},
+	}
+
+	changes, removed, added := compareEntities(before, after)
+	if len(changes) != 0 {
+		t.Fatalf("unexpected changes on stable overloads: %#v", changes)
+	}
+	if len(added) != 0 {
+		t.Fatalf("unexpected added: %#v", added)
+	}
+	if len(removed) != 1 {
+		t.Fatalf("removed = %#v, want exactly one removed overload", removed)
+	}
+	if removed[0].Signature != "F(bool)" {
+		t.Fatalf("removed signature = %q, want F(bool)", removed[0].Signature)
+	}
+}
+
+func TestCompareEntitiesTrueDuplicatesEditOne(t *testing.T) {
+	// Two entities with identical Kind:Name:Signature on both sides (true
+	// duplicates). Editing the body of one must surface exactly one
+	// body_changed and no spurious remove/add for the untouched duplicate.
+	// This works precisely because entities are keyed by positional ordinal
+	// rather than signature (which would collide for true duplicates).
+	before := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F()", BodyHash: "h1", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F()", BodyHash: "h1", StartLine: 5},
+	}
+	after := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F()", BodyHash: "h1", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F()", BodyHash: "h2", StartLine: 5},
+	}
+
+	changes, removed, added := compareEntities(before, after)
+	if len(removed) != 0 || len(added) != 0 {
+		t.Fatalf("unexpected remove/add: removed=%#v added=%#v", removed, added)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("changes = %#v, want exactly one body change", changes)
+	}
+	if changes[0].Type != "body_changed" || changes[0].Kind != "method" || changes[0].Name != "C.F" {
+		t.Fatalf("change = %#v, want body_changed for method C.F", changes[0])
+	}
+}
+
 func write(t *testing.T, repo, path, content string) {
 	t.Helper()
 	full := filepath.Join(repo, path)

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -281,6 +281,82 @@ func TestAnalyzeCheckpointResolvesAssociatedCommit(t *testing.T) {
 	}
 }
 
+func TestCompareEntitiesDisambiguatesSameNameOverloads(t *testing.T) {
+	// Two same-name, same-Kind overloads (reachable in C#/Java) must not
+	// collide in the diff keys. Editing the FIRST overload's signature must be
+	// reported, and the untouched SECOND overload must not become a spurious
+	// remove/add.
+	before := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(int)", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(string)", StartLine: 5},
+	}
+	after := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(long)", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(string)", StartLine: 5},
+	}
+
+	changes, removed, added := compareEntities(before, after)
+	if len(removed) != 0 || len(added) != 0 {
+		t.Fatalf("unexpected remove/add: removed=%#v added=%#v", removed, added)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("changes = %#v, want exactly one signature change for the first overload", changes)
+	}
+	c := changes[0]
+	if c.Type != "signature_changed" || c.Kind != "method" || c.Name != "C.F" {
+		t.Fatalf("change = %#v, want signature_changed for method C.F", c)
+	}
+	if c.OldSignature != "F(int)" || c.NewSignature != "F(long)" {
+		t.Fatalf("change signatures = %q -> %q, want F(int) -> F(long)", c.OldSignature, c.NewSignature)
+	}
+}
+
+func TestCompareEntitiesDetectsSecondOverloadEdit(t *testing.T) {
+	// Control: editing only the SECOND overload is reported, and the first is
+	// left untouched.
+	before := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(int)", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(string)", StartLine: 5},
+	}
+	after := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(int)", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(object)", StartLine: 5},
+	}
+
+	changes, removed, added := compareEntities(before, after)
+	if len(removed) != 0 || len(added) != 0 {
+		t.Fatalf("unexpected remove/add: removed=%#v added=%#v", removed, added)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("changes = %#v, want exactly one signature change for the second overload", changes)
+	}
+	c := changes[0]
+	if c.Type != "signature_changed" || c.OldSignature != "F(string)" || c.NewSignature != "F(object)" {
+		t.Fatalf("change = %#v, want signature_changed F(string) -> F(object)", c)
+	}
+}
+
+func TestCompareEntitiesSingleEntityUnchangedBehavior(t *testing.T) {
+	// Regression: a lone non-overloaded entity keeps its pre-ordinal behavior.
+	before := []Entity{
+		{Kind: "function", Name: "validate", Signature: "validate(token)", StartLine: 1},
+	}
+	after := []Entity{
+		{Kind: "function", Name: "validate", Signature: "validate(token, issuer)", StartLine: 1},
+	}
+
+	changes, removed, added := compareEntities(before, after)
+	if len(removed) != 0 || len(added) != 0 {
+		t.Fatalf("unexpected remove/add: removed=%#v added=%#v", removed, added)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("changes = %#v, want exactly one change", changes)
+	}
+	if changes[0].Type != "signature_changed" || changes[0].Name != "validate" {
+		t.Fatalf("change = %#v, want signature_changed for validate", changes[0])
+	}
+}
+
 func write(t *testing.T, repo, path, content string) {
 	t.Helper()
 	full := filepath.Join(repo, path)

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -282,10 +282,14 @@ func TestAnalyzeCheckpointResolvesAssociatedCommit(t *testing.T) {
 }
 
 func TestCompareEntitiesDisambiguatesSameNameOverloads(t *testing.T) {
-	// Two same-name, same-Kind overloads (reachable in C#/Java) must not
-	// collide in the diff keys. Editing the FIRST overload's signature must be
-	// reported, and the untouched SECOND overload must not become a spurious
-	// remove/add.
+	// Issue #35 repro and regression guard for the phase-2 positional
+	// fallback: two same-name, same-Kind overloads (reachable in C#/Java)
+	// must not collide in the diff keys. Editing the FIRST overload's
+	// signature (F(int) -> F(long)) must be reported as signature_changed,
+	// and the untouched SECOND overload must not become a spurious
+	// remove/add. A naive pure-signature key would regress this to
+	// removed+added because the rename reconciler's signature similarity
+	// (~0.33) is below renameThreshold.
 	before := []Entity{
 		{Kind: "method", Name: "C.F", Signature: "F(int)", StartLine: 1},
 		{Kind: "method", Name: "C.F", Signature: "F(string)", StartLine: 5},
@@ -360,7 +364,7 @@ func TestCompareEntitiesSingleEntityUnchangedBehavior(t *testing.T) {
 func TestCompareEntitiesAddedOverloadReportedAsAdded(t *testing.T) {
 	// Adding a third overload (before has 2, after has 3, appended in file
 	// order) must surface exactly one `added` for the new overload; the two
-	// pre-existing overloads stay paired by ordinal and produce no churn.
+	// pre-existing overloads pair by exact signature and produce no churn.
 	before := []Entity{
 		{Kind: "method", Name: "C.F", Signature: "F(int)", StartLine: 1},
 		{Kind: "method", Name: "C.F", Signature: "F(string)", StartLine: 5},
@@ -419,8 +423,9 @@ func TestCompareEntitiesTrueDuplicatesEditOne(t *testing.T) {
 	// Two entities with identical Kind:Name:Signature on both sides (true
 	// duplicates). Editing the body of one must surface exactly one
 	// body_changed and no spurious remove/add for the untouched duplicate.
-	// This works precisely because entities are keyed by positional ordinal
-	// rather than signature (which would collide for true duplicates).
+	// This works because true duplicates are paired by occurrence index in
+	// file order, so the Nth duplicate on each side pairs with the Nth on
+	// the other (a plain signature key would collide for true duplicates).
 	before := []Entity{
 		{Kind: "method", Name: "C.F", Signature: "F()", BodyHash: "h1", StartLine: 1},
 		{Kind: "method", Name: "C.F", Signature: "F()", BodyHash: "h1", StartLine: 5},
@@ -439,6 +444,87 @@ func TestCompareEntitiesTrueDuplicatesEditOne(t *testing.T) {
 	}
 	if changes[0].Type != "body_changed" || changes[0].Kind != "method" || changes[0].Name != "C.F" {
 		t.Fatalf("change = %#v, want body_changed for method C.F", changes[0])
+	}
+}
+
+func TestCompareEntitiesRemoveFirstOverloadNoCascade(t *testing.T) {
+	// Removing the FIRST of three same-name overloads must report exactly one
+	// `removed F(int)`. Pure positional-ordinal keying used to cascade here:
+	// signature_changed F(int)->F(string), signature_changed
+	// F(string)->F(bool), removed F(bool) -- all phantom. Two-phase matching
+	// pairs the surviving overloads by exact signature first, leaving only
+	// the truly removed one.
+	before := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(int)", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(string)", StartLine: 5},
+		{Kind: "method", Name: "C.F", Signature: "F(bool)", StartLine: 9},
+	}
+	after := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(string)", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(bool)", StartLine: 5},
+	}
+
+	changes, removed, added := compareEntities(before, after)
+	if len(changes) != 0 {
+		t.Fatalf("unexpected changes on surviving overloads: %#v", changes)
+	}
+	if len(added) != 0 {
+		t.Fatalf("unexpected added: %#v", added)
+	}
+	if len(removed) != 1 {
+		t.Fatalf("removed = %#v, want exactly one removed overload", removed)
+	}
+	if removed[0].Signature != "F(int)" {
+		t.Fatalf("removed signature = %q, want F(int)", removed[0].Signature)
+	}
+}
+
+func TestCompareEntitiesMidListInsertOnlyAdded(t *testing.T) {
+	// Inserting an overload in the MIDDLE of the list must surface exactly
+	// one `added F(string)` and leave the surrounding overloads untouched
+	// (no phantom signature_changed on the shifted tail).
+	before := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(int)", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(bool)", StartLine: 5},
+	}
+	after := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(int)", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(string)", StartLine: 5},
+		{Kind: "method", Name: "C.F", Signature: "F(bool)", StartLine: 9},
+	}
+
+	changes, removed, added := compareEntities(before, after)
+	if len(changes) != 0 {
+		t.Fatalf("unexpected changes on stable overloads: %#v", changes)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("unexpected removed: %#v", removed)
+	}
+	if len(added) != 1 {
+		t.Fatalf("added = %#v, want exactly one added overload", added)
+	}
+	if added[0].Signature != "F(string)" {
+		t.Fatalf("added signature = %q, want F(string)", added[0].Signature)
+	}
+}
+
+func TestCompareEntitiesReorderedOverloadsNoChanges(t *testing.T) {
+	// Purely reordering same-name overloads (identical signatures and bodies,
+	// only file positions swapped) must produce no events at all: exact
+	// signature pairing matches each overload to itself regardless of
+	// position.
+	before := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(int)", BodyHash: "hi", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(string)", BodyHash: "hs", StartLine: 5},
+	}
+	after := []Entity{
+		{Kind: "method", Name: "C.F", Signature: "F(string)", BodyHash: "hs", StartLine: 1},
+		{Kind: "method", Name: "C.F", Signature: "F(int)", BodyHash: "hi", StartLine: 5},
+	}
+
+	changes, removed, added := compareEntities(before, after)
+	if len(changes) != 0 || len(removed) != 0 || len(added) != 0 {
+		t.Fatalf("reorder must be inert: changes=%#v removed=%#v added=%#v", changes, removed, added)
 	}
 }
 


### PR DESCRIPTION
## Summary

`compareEntities` (internal/sem/analyze.go) keyed entities by `Kind:Name`, so two same-name, same-`Kind` overloads (reachable in C#/Java — not TypeScript) collided in `beforeByKey`/`afterByKey` under last-write-wins: only the last one in file order survived. As a result, editing the **first** overload's signature vanished from the diff (only the enclosing class showed `body_changed`); editing the second worked only coincidentally.

## Fix

Two-phase matching in `keyedEntityMaps` (which replaces the per-side `keyedEntities`; it takes both entity slices at once since matching needs both sides):

1. **Phase 1 — exact pairing.** Entities that share an exact `Kind:Name:Signature` across sides pair up first. True duplicates (an identical `Kind:Name:Signature` appearing multiple times on one side) are disambiguated by occurrence index in file order, so the Nth duplicate on each side pairs with the Nth on the other. This makes mid-list overload insertions, removals, and reorders inert for the untouched overloads instead of cascading phantom `signature_changed` events down the list.
2. **Phase 2 — positional fallback for leftovers.** Entities whose exact signature has no counterpart on the other side get positional ordinals per `Kind:Name` in file order. An in-place signature edit of one overload leaves exactly one leftover with that name on each side, so it still pairs and surfaces as `signature_changed` rather than remove+add.

Notes:

- We deliberately do **not** use a naive pure-signature key (signature always in the key, no positional fallback): that would regress the primary #35 repro (`F(int)`→`F(long)` with `F(string)` present) back to removed+added, because the rename reconciler's signature similarity (~0.33) is far below the 0.92 threshold.
- Phase-1 and phase-2 keys use distinct prefixes (`=` / `~`) so they can never collide.
- A lone, non-overloaded entity still pairs exactly as before (exact match when unchanged, sole leftover when edited), preserving prior single-entity behavior.
- Removed/added (present on only one side) still work: unmatched keys fall through to the existing deleted/added handling and rename reconciliation, which treat keys as opaque strings — keys are ephemeral and never persisted or emitted.

## Test evidence

Nine direct `compareEntities` regression tests (package `sem`, hand-constructed `[]Entity`, no grammar needed):

- `TestCompareEntitiesDisambiguatesSameNameOverloads` — #35 repro/regression guard: editing the FIRST of two `method C.F` overloads (`F(int)`→`F(long)`, `F(string)` untouched) yields exactly one `signature_changed` for the first overload, with no spurious remove/add of the second.
- `TestCompareEntitiesDetectsSecondOverloadEdit` — control: editing only the SECOND overload is reported correctly.
- `TestCompareEntitiesSingleEntityUnchangedBehavior` — regression: a single non-overloaded entity is still reported as before.
- `TestCompareEntitiesAddedOverloadReportedAsAdded` — tail-appended overload surfaces as exactly one `added`.
- `TestCompareEntitiesRemovedOverloadReported` — tail-removed overload surfaces as exactly one `removed`.
- `TestCompareEntitiesTrueDuplicatesEditOne` — identical `Kind:Name:Signature` duplicates; editing one body yields exactly one `body_changed` (occurrence-index pairing).
- `TestCompareEntitiesRemoveFirstOverloadNoCascade` — removing the FIRST of three overloads yields exactly one `removed F(int)` and no phantom `signature_changed` cascade (previously misattributed under pure-ordinal keying).
- `TestCompareEntitiesMidListInsertOnlyAdded` — mid-list insert yields exactly one `added`, nothing else.
- `TestCompareEntitiesReorderedOverloadsNoChanges` — pure reorder of identical overloads produces no events at all.

Verification (all pass):

```
gofmt -l  # clean for changed files
go vet ./internal/sem/...   # ok
go build ./...              # ok
go test ./internal/sem/...  # ok
go test ./...               # ok
```

Fixes #35
