### PR TITLE
fix(sem): surface parse failures in diff instead of phantom removals

### DIFF
--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -42,10 +42,24 @@ func AnalyzeGitRange(ctx context.Context, repo, base, head string, paths []strin
 			}
 		}
 
-		beforeEntities, language := parser.Parse(oldPath, before)
-		afterEntities, afterLanguage := parser.Parse(path, after)
+		beforeEntities, language, beforeStatus := parser.ParseWithStatus(oldPath, before)
+		afterEntities, afterLanguage, afterStatus := parser.ParseWithStatus(path, after)
 		if language == "" {
 			language = afterLanguage
+		}
+		// A file that fails to parse on either side yields zero entities with no
+		// signal, which would otherwise make compareEntities report every entity
+		// as phantom removed/added. Surface it as a machine-readable partial
+		// failure and skip the delta instead. Only ParseError suppresses the
+		// delta — a validly-emptied file (ParseError false, zero entities) must
+		// still report its real removed changes.
+		if beforeStatus.ParseError || afterStatus.ParseError {
+			status := afterStatus
+			if !status.ParseError {
+				status = beforeStatus
+			}
+			result.Warnings = append(result.Warnings, parseFailureWarning(path, status))
+			continue
 		}
 		if !beforeOK {
 			beforeEntities = nil
@@ -69,7 +83,7 @@ func AnalyzeGitRange(ctx context.Context, repo, base, head string, paths []strin
 		})
 	}
 
-	result.Warnings = reconcileMoves(deltas)
+	result.Warnings = append(result.Warnings, reconcileMoves(deltas)...)
 
 	for _, delta := range deltas {
 		changes := delta.changes
@@ -96,6 +110,28 @@ func AnalyzeGitRange(ctx context.Context, repo, base, head string, paths []strin
 		return Result{}, err
 	}
 	return result, nil
+}
+
+// parseFailureWarning builds the partial-failure warning emitted when a changed
+// file cannot be parsed on one side of the diff. It mirrors the provider path's
+// parseStatus.ParseError → PartialFailure mapping so both surfaces stay
+// consistent (see provider.go).
+func parseFailureWarning(path string, status ParseStatus) ProviderWarning {
+	code := status.Code
+	if code == "" {
+		code = "E_PARSE_ERROR"
+	}
+	effect := "file parsed with syntax errors; semantic facts may be incomplete"
+	if code == "E_PARSE_TIMEOUT" {
+		effect = "file record emitted but symbol parsing skipped because parser time budget was exceeded"
+	}
+	return ProviderWarning{
+		Code:                 code,
+		Severity:             "warning",
+		FilePath:             path,
+		EffectOnCompleteness: effect,
+		Detail:               status.Detail,
+	}
 }
 
 // fileDelta accumulates a file's resolved changes plus the removed/added

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -47,15 +47,19 @@ func AnalyzeGitRange(ctx context.Context, repo, base, head string, paths []strin
 		if language == "" {
 			language = afterLanguage
 		}
-		// A file that fails to parse on either side yields zero entities with no
-		// signal, which would otherwise make compareEntities report every entity
-		// as phantom removed/added. Surface it as a machine-readable partial
-		// failure and skip the delta instead. Only ParseError suppresses the
-		// delta — a validly-emptied file (ParseError false, zero entities) must
-		// still report its real removed changes.
-		if beforeStatus.ParseError || afterStatus.ParseError {
+		// A hard parse failure yields ZERO entities with no signal, which would
+		// otherwise make compareEntities report every entity on that side as a
+		// phantom removed/added. Surface it as a machine-readable partial failure
+		// and skip the delta instead. We gate on zero entities rather than merely
+		// ParseError: tree-sitter also flags recoverable syntax errors
+		// (root.HasError) while still extracting a complete entity set, and those
+		// diffs are correct and must be kept. A validly-emptied file (ParseError
+		// false) is likewise never suppressed, so its real removed changes stand.
+		afterParseFailed := afterStatus.ParseError && len(afterEntities) == 0
+		beforeParseFailed := beforeStatus.ParseError && len(beforeEntities) == 0
+		if afterParseFailed || beforeParseFailed {
 			status := afterStatus
-			if !status.ParseError {
+			if !afterParseFailed {
 				status = beforeStatus
 			}
 			result.Warnings = append(result.Warnings, parseFailureWarning(path, status))

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -47,23 +47,32 @@ func AnalyzeGitRange(ctx context.Context, repo, base, head string, paths []strin
 		if language == "" {
 			language = afterLanguage
 		}
-		// A hard parse failure yields ZERO entities with no signal, which would
-		// otherwise make compareEntities report every entity on that side as a
-		// phantom removed/added. Surface it as a machine-readable partial failure
-		// and skip the delta instead. We gate on zero entities rather than merely
-		// ParseError: tree-sitter also flags recoverable syntax errors
-		// (root.HasError) while still extracting a complete entity set, and those
-		// diffs are correct and must be kept. A validly-emptied file (ParseError
-		// false) is likewise never suppressed, so its real removed changes stand.
+		// A parse failure on either side degrades the diff. A TOTAL failure
+		// (ParseError with ZERO recovered entities) gives compareEntities no
+		// signal at all and would make it report every entity on that side as
+		// a phantom removed/added, so the delta is skipped and a
+		// machine-readable warning is surfaced instead. A PARTIAL recovery
+		// (ParseError with some entities extracted) keeps the diff — the
+		// recovered changes are real — but is still flagged with a warning,
+		// because symbols missing from the recovered set can surface as
+		// phantom removed/added. A validly-emptied file (ParseError false) is
+		// never suppressed or flagged, so its real removed changes stand.
 		afterParseFailed := afterStatus.ParseError && len(afterEntities) == 0
 		beforeParseFailed := beforeStatus.ParseError && len(beforeEntities) == 0
 		if afterParseFailed || beforeParseFailed {
-			status := afterStatus
+			status, warnPath := afterStatus, path
 			if !afterParseFailed {
-				status = beforeStatus
+				status, warnPath = beforeStatus, oldPath
 			}
-			result.Warnings = append(result.Warnings, parseFailureWarning(path, status))
+			result.Warnings = append(result.Warnings, parseFailureWarning(warnPath, status, true))
 			continue
+		}
+		if afterStatus.ParseError || beforeStatus.ParseError {
+			status, warnPath := afterStatus, path
+			if !afterStatus.ParseError {
+				status, warnPath = beforeStatus, oldPath
+			}
+			result.Warnings = append(result.Warnings, parseFailureWarning(warnPath, status, false))
 		}
 		if !beforeOK {
 			beforeEntities = nil
@@ -116,18 +125,26 @@ func AnalyzeGitRange(ctx context.Context, repo, base, head string, paths []strin
 	return result, nil
 }
 
-// parseFailureWarning builds the partial-failure warning emitted when a changed
-// file cannot be parsed on one side of the diff. It mirrors the provider path's
-// parseStatus.ParseError → PartialFailure mapping so both surfaces stay
-// consistent (see provider.go).
-func parseFailureWarning(path string, status ParseStatus) ProviderWarning {
+// parseFailureWarning builds the warning emitted when a changed file fails to
+// parse on one side of the diff. It reuses the provider path's machine-readable
+// codes (parseStatus.ParseError → PartialFailure, see provider.go), and both
+// surfaces warn on any ParseError — but the effect wording is diff-specific:
+// the provider always emits its (possibly partial) output, while the diff path
+// suppresses the file's delta entirely on a total failure (suppressed == true)
+// and keeps a possibly-degraded diff on a partial recovery.
+func parseFailureWarning(path string, status ParseStatus, suppressed bool) ProviderWarning {
 	code := status.Code
 	if code == "" {
 		code = "E_PARSE_ERROR"
 	}
-	effect := "file parsed with syntax errors; semantic facts may be incomplete"
-	if code == "E_PARSE_TIMEOUT" {
-		effect = "file record emitted but symbol parsing skipped because parser time budget was exceeded"
+	var effect string
+	switch {
+	case suppressed && code == "E_PARSE_TIMEOUT":
+		effect = "file diff suppressed; changes omitted because parser time budget was exceeded"
+	case suppressed:
+		effect = "file diff suppressed; changes omitted because the file could not be parsed"
+	default:
+		effect = "file parsed with syntax errors on one side; diff kept but may be incomplete or contain phantom changes"
 	}
 	return ProviderWarning{
 		Code:                 code,

--- a/internal/sem/analyze_parsefailure_test.go
+++ b/internal/sem/analyze_parsefailure_test.go
@@ -1,0 +1,221 @@
+package sem
+
+import (
+	"context"
+	"testing"
+)
+
+// pfValidTS parses to two top-level entities with no parse error.
+const pfValidTS = "export function alpha() {\n    return 1\n}\n\nexport function beta() {\n    return 2\n}\n"
+
+// pfBrokenTS parses to ZERO entities with ParseStatus.ParseError == true
+// (a hard parse failure).
+const pfBrokenTS = "type Broken = <\n\nexport function alpha(){return 1}\nexport function beta(){return 2}\n"
+
+// pfSoftTS is a recoverable syntax error: tree-sitter flags root.HasError but
+// still extracts the `ok` function. This is the "soft recovery with entities"
+// class the fix must NOT suppress (the earlier Kotlin CI failure pattern).
+const pfSoftTS = "export function ok() {\n    return 1\n}\n@@@ !!! broken <<<\n"
+const pfSoftTSChanged = "export function ok() {\n    return 2\n}\n@@@ !!! broken <<<\n"
+
+func pfParseWarning(result Result, path string) *ProviderWarning {
+	for i := range result.Warnings {
+		w := &result.Warnings[i]
+		if w.FilePath == path && (w.Code == "E_PARSE_ERROR" || w.Code == "E_PARSE_TIMEOUT") {
+			return w
+		}
+	}
+	return nil
+}
+
+// Added file (git status "A") that is unparseable: the before side is the empty
+// base, which must not make beforeParseFailed misfire. Only the after-side hard
+// failure should be surfaced, with no phantom "added" entities.
+func TestAnalyzeGitRange_AddedFileUnparseable(t *testing.T) {
+	t.Parallel()
+	repo := buildLinearRepo(t, func(r string) {
+		write(t, r, "seed.txt", "seed\n")
+	}, func(r string) {
+		write(t, r, "svc.ts", pfBrokenTS)
+	})
+	res, err := AnalyzeGitRange(context.Background(), repo.repo, repo.base, repo.head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pfParseWarning(res, "svc.ts") == nil {
+		t.Fatalf("expected parse-failure warning for added unparseable file, got %#v", res.Warnings)
+	}
+	for _, f := range res.Files {
+		for _, c := range f.Changes {
+			if c.Type == "added" && (c.Name == "alpha" || c.Name == "beta") {
+				t.Fatalf("phantom added entity %q on added unparseable file: %#v", c.Name, res.Files)
+			}
+		}
+	}
+}
+
+// Deleted file (git status "D") that was unparseable: only the before-side hard
+// failure should surface, with no phantom "removed" entities.
+func TestAnalyzeGitRange_DeletedFileUnparseable(t *testing.T) {
+	t.Parallel()
+	repo := buildLinearRepo(t, func(r string) {
+		write(t, r, "svc.ts", pfBrokenTS)
+		write(t, r, "seed.txt", "seed\n")
+	}, func(r string) {
+		git(t, r, "rm", "svc.ts")
+	})
+	res, err := AnalyzeGitRange(context.Background(), repo.repo, repo.base, repo.head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pfParseWarning(res, "svc.ts") == nil {
+		t.Fatalf("expected parse-failure warning for deleted unparseable file, got %#v", res.Warnings)
+	}
+	for _, f := range res.Files {
+		for _, c := range f.Changes {
+			if c.Type == "removed" && (c.Name == "alpha" || c.Name == "beta") {
+				t.Fatalf("phantom removed entity %q on deleted unparseable file: %#v", c.Name, res.Files)
+			}
+		}
+	}
+}
+
+// A file unparseable on BOTH sides yields exactly one warning (not two).
+func TestAnalyzeGitRange_BothSidesUnparseable(t *testing.T) {
+	t.Parallel()
+	repo := buildLinearRepo(t, func(r string) {
+		write(t, r, "svc.ts", pfBrokenTS)
+	}, func(r string) {
+		write(t, r, "svc.ts", pfBrokenTS+"\nmore junk <\n")
+	})
+	res, err := AnalyzeGitRange(context.Background(), repo.repo, repo.base, repo.head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for _, w := range res.Warnings {
+		if w.FilePath == "svc.ts" && w.Code == "E_PARSE_ERROR" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one parse-failure warning for both-sides failure, got %d: %#v", count, res.Warnings)
+	}
+}
+
+// A soft syntax error that still extracts entities must NOT be suppressed: its
+// real change (body_changed for `ok`) must surface and no parse-failure warning
+// should be emitted for it.
+func TestAnalyzeGitRange_SoftErrorWithEntitiesNotSuppressed(t *testing.T) {
+	t.Parallel()
+	repo := buildLinearRepo(t, func(r string) {
+		write(t, r, "svc.ts", pfSoftTS)
+	}, func(r string) {
+		write(t, r, "svc.ts", pfSoftTSChanged)
+	})
+	res, err := AnalyzeGitRange(context.Background(), repo.repo, repo.base, repo.head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if w := pfParseWarning(res, "svc.ts"); w != nil {
+		t.Fatalf("soft-error-with-entities must not be suppressed, but got warning: %#v", w)
+	}
+	var sawChange bool
+	for _, f := range res.Files {
+		for _, c := range f.Changes {
+			if c.Name == "ok" && (c.Type == "body_changed" || c.Type == "signature_changed") {
+				sawChange = true
+			}
+		}
+	}
+	if !sawChange {
+		t.Fatalf("expected a real change for `ok` on the soft-error file, got %#v", res.Files)
+	}
+}
+
+// parseFailureWarning maps both error codes (and defaults an empty code) exactly
+// like the provider path, without needing a slow real timeout to exercise the
+// E_PARSE_TIMEOUT branch.
+func TestParseFailureWarning_CodeMapping(t *testing.T) {
+	t.Parallel()
+	e := parseFailureWarning("a.ts", ParseStatus{ParseError: true, Code: "E_PARSE_ERROR", Detail: "d"})
+	if e.Code != "E_PARSE_ERROR" || e.Severity != "warning" || e.FilePath != "a.ts" || e.Detail != "d" {
+		t.Fatalf("error mapping wrong: %#v", e)
+	}
+	if e.EffectOnCompleteness != "file parsed with syntax errors; semantic facts may be incomplete" {
+		t.Fatalf("error effect wrong: %q", e.EffectOnCompleteness)
+	}
+	tmo := parseFailureWarning("b.ts", ParseStatus{ParseError: true, Code: "E_PARSE_TIMEOUT", Detail: "slow"})
+	if tmo.Code != "E_PARSE_TIMEOUT" {
+		t.Fatalf("timeout code wrong: %#v", tmo)
+	}
+	if tmo.EffectOnCompleteness != "file record emitted but symbol parsing skipped because parser time budget was exceeded" {
+		t.Fatalf("timeout effect wrong: %q", tmo.EffectOnCompleteness)
+	}
+	def := parseFailureWarning("c.ts", ParseStatus{ParseError: true})
+	if def.Code != "E_PARSE_ERROR" {
+		t.Fatalf("empty code should default to E_PARSE_ERROR, got %q", def.Code)
+	}
+}
+
+// A parse-failure warning emitted before the reconcileMoves append must survive
+// alongside a move-ambiguity warning produced by the reconcile pass. This guards
+// the `result.Warnings = append(..., reconcileMoves(...)...)` change against a
+// regression back to a clobbering assignment.
+func TestAnalyzeGitRange_ParseFailurePreservedWithReconcileWarning(t *testing.T) {
+	t.Parallel()
+	const fooBody = "export function foo() {\n    const a = 1\n    const b = 2\n    return a + b\n}\n"
+	repo := buildLinearRepo(t, func(r string) {
+		write(t, r, "a.ts", fooBody)
+		write(t, r, "svc.ts", pfValidTS)
+	}, func(r string) {
+		// remove foo from a.ts, add identical foo to b.ts and c.ts (ambiguous
+		// cross-file move), and break svc.ts (hard parse failure).
+		write(t, r, "a.ts", "// emptied\n")
+		write(t, r, "b.ts", fooBody)
+		write(t, r, "c.ts", fooBody)
+		write(t, r, "svc.ts", pfBrokenTS)
+	})
+	res, err := AnalyzeGitRange(context.Background(), repo.repo, repo.base, repo.head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parseFail, moveAmb bool
+	for _, w := range res.Warnings {
+		if w.Code == "E_PARSE_ERROR" && w.FilePath == "svc.ts" {
+			parseFail = true
+		}
+		if w.Code == "W_MOVE_AMBIGUOUS" {
+			moveAmb = true
+		}
+	}
+	if !parseFail {
+		t.Fatalf("parse-failure warning was lost (clobbered by reconcile append): %#v", res.Warnings)
+	}
+	if !moveAmb {
+		t.Fatalf("expected a move-ambiguity warning to also be present: %#v", res.Warnings)
+	}
+}
+
+type linearRepo struct{ repo, base, head string }
+
+// buildLinearRepo creates a two-commit repo: seed applies mutations for the base
+// commit, change applies mutations for the head commit. Each mutation callback
+// receives the repo root and is responsible for writing/removing files; staging
+// and committing are handled here.
+func buildLinearRepo(t *testing.T, seed, change func(repo string)) linearRepo {
+	t.Helper()
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	seed(repo)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "base")
+	base := rev(t, repo, "HEAD")
+	change(repo)
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-m", "head")
+	head := rev(t, repo, "HEAD")
+	return linearRepo{repo: repo, base: base, head: head}
+}

--- a/internal/sem/analyze_parsefailure_test.go
+++ b/internal/sem/analyze_parsefailure_test.go
@@ -3,6 +3,8 @@ package sem
 import (
 	"context"
 	"testing"
+
+	"github.com/entireio/entire-graph/internal/gitutil"
 )
 
 // pfValidTS parses to two top-level entities with no parse error.
@@ -14,7 +16,8 @@ const pfBrokenTS = "type Broken = <\n\nexport function alpha(){return 1}\nexport
 
 // pfSoftTS is a recoverable syntax error: tree-sitter flags root.HasError but
 // still extracts the `ok` function. This is the "soft recovery with entities"
-// class the fix must NOT suppress (the earlier Kotlin CI failure pattern).
+// class the fix must NOT suppress (the earlier Kotlin CI failure pattern) but
+// must still flag with a degraded-diff warning.
 const pfSoftTS = "export function ok() {\n    return 1\n}\n@@@ !!! broken <<<\n"
 const pfSoftTSChanged = "export function ok() {\n    return 2\n}\n@@@ !!! broken <<<\n"
 
@@ -104,9 +107,10 @@ func TestAnalyzeGitRange_BothSidesUnparseable(t *testing.T) {
 }
 
 // A soft syntax error that still extracts entities must NOT be suppressed: its
-// real change (body_changed for `ok`) must surface and no parse-failure warning
-// should be emitted for it.
-func TestAnalyzeGitRange_SoftErrorWithEntitiesNotSuppressed(t *testing.T) {
+// real change (body_changed for `ok`) must surface. But because the recovered
+// entity set may be incomplete, the diff is degraded and a parse warning must
+// accompany it.
+func TestAnalyzeGitRange_SoftErrorWithEntitiesKeptWithWarning(t *testing.T) {
 	t.Parallel()
 	repo := buildLinearRepo(t, func(r string) {
 		write(t, r, "svc.ts", pfSoftTS)
@@ -117,8 +121,12 @@ func TestAnalyzeGitRange_SoftErrorWithEntitiesNotSuppressed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if w := pfParseWarning(res, "svc.ts"); w != nil {
-		t.Fatalf("soft-error-with-entities must not be suppressed, but got warning: %#v", w)
+	w := pfParseWarning(res, "svc.ts")
+	if w == nil {
+		t.Fatalf("soft-error-with-entities must carry a degraded-diff warning, got %#v", res.Warnings)
+	}
+	if w.EffectOnCompleteness != "file parsed with syntax errors on one side; diff kept but may be incomplete or contain phantom changes" {
+		t.Fatalf("degraded-diff effect wrong: %q", w.EffectOnCompleteness)
 	}
 	var sawChange bool
 	for _, f := range res.Files {
@@ -133,26 +141,126 @@ func TestAnalyzeGitRange_SoftErrorWithEntitiesNotSuppressed(t *testing.T) {
 	}
 }
 
-// parseFailureWarning maps both error codes (and defaults an empty code) exactly
-// like the provider path, without needing a slow real timeout to exercise the
+// pfPartialHeadTS keeps alpha (with a changed body relative to pfValidTS) but
+// corrupts beta's declaration so badly that tree-sitter recovers ONLY alpha:
+// ParseError == true with a PARTIAL entity set. This is the reviewer's repro
+// for the phantom-removal-without-warning gap: beta vanishes from the
+// recovered set, so the diff reports it removed even though it may still exist.
+const pfPartialHeadTS = "export function alpha() {\n    return 42\n}\n\nexport function bet@@@ <<<\n"
+
+// The high-severity repro: base has alpha+beta (clean), head keeps alpha but
+// corrupts beta's declaration. Tree-sitter recovers a partial entity set
+// (ParseError=true, entities=[alpha]). The diff must be KEPT (alpha's real
+// body change surfaces) but flagged with a parse warning, because the missing
+// beta shows up as a potentially-phantom removal.
+func TestAnalyzeGitRange_PartialRecoveryKeepsDiffWithWarning(t *testing.T) {
+	t.Parallel()
+	// Guard the fixture: the corruption must actually yield a partial recovery
+	// (ParseError with a non-empty entity set) on this parser, or the test
+	// would silently exercise the wrong branch.
+	entities, _, status := TreeSitterParser{}.ParseWithStatus("svc.ts", pfPartialHeadTS)
+	if !status.ParseError || len(entities) == 0 {
+		t.Fatalf("fixture must parse as partial recovery, got ParseError=%v entities=%#v", status.ParseError, entities)
+	}
+
+	repo := buildLinearRepo(t, func(r string) {
+		write(t, r, "svc.ts", pfValidTS)
+	}, func(r string) {
+		write(t, r, "svc.ts", pfPartialHeadTS)
+	})
+	res, err := AnalyzeGitRange(context.Background(), repo.repo, repo.base, repo.head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := pfParseWarning(res, "svc.ts")
+	if w == nil {
+		t.Fatalf("expected degraded-diff warning for partial recovery, got %#v", res.Warnings)
+	}
+	if w.EffectOnCompleteness != "file parsed with syntax errors on one side; diff kept but may be incomplete or contain phantom changes" {
+		t.Fatalf("degraded-diff effect wrong: %q", w.EffectOnCompleteness)
+	}
+	var sawAlphaChange bool
+	for _, f := range res.Files {
+		for _, c := range f.Changes {
+			if c.Name == "alpha" && (c.Type == "body_changed" || c.Type == "signature_changed") {
+				sawAlphaChange = true
+			}
+		}
+	}
+	if !sawAlphaChange {
+		t.Fatalf("partial-recovery diff must be kept (alpha's real change), got %#v", res.Files)
+	}
+}
+
+// A rename where only the BEFORE side fails to parse must warn about the OLD
+// path — that is where the unparseable blob lives; the new path parses fine.
+func TestAnalyzeGitRange_RenameBeforeSideParseFailureWarnsOldPath(t *testing.T) {
+	t.Parallel()
+	// Head content: the base content minus the broken first line, so git's
+	// rename detection pairs the delete+add and the after side parses cleanly.
+	const renamedTS = "\nexport function alpha(){return 1}\nexport function beta(){return 2}\n"
+	repo := buildLinearRepo(t, func(r string) {
+		write(t, r, "broken.ts", pfBrokenTS)
+		write(t, r, "seed.txt", "seed\n")
+	}, func(r string) {
+		git(t, r, "rm", "broken.ts")
+		write(t, r, "moved.ts", renamedTS)
+	})
+
+	// Guard the fixture: git must actually report a rename, or the test would
+	// exercise the plain delete/add paths instead of the rename path.
+	changed, err := gitutil.ChangedFiles(context.Background(), repo.repo, repo.base, repo.head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawRename bool
+	for _, f := range changed {
+		if f.Status == "R" && f.OldPath == "broken.ts" && f.Path == "moved.ts" {
+			sawRename = true
+		}
+	}
+	if !sawRename {
+		t.Fatalf("fixture must produce a git rename broken.ts -> moved.ts, got %#v", changed)
+	}
+
+	res, err := AnalyzeGitRange(context.Background(), repo.repo, repo.base, repo.head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if w := pfParseWarning(res, "moved.ts"); w != nil {
+		t.Fatalf("warning must not point at the new path (it parses fine): %#v", w)
+	}
+	if pfParseWarning(res, "broken.ts") == nil {
+		t.Fatalf("expected parse-failure warning on old path broken.ts, got %#v", res.Warnings)
+	}
+}
+
+// parseFailureWarning reuses the provider path's error codes (and defaults an
+// empty code) but with diff-specific effect wording that distinguishes a
+// suppressed delta (total failure) from a kept-but-degraded diff (partial
+// recovery), without needing a slow real timeout to exercise the
 // E_PARSE_TIMEOUT branch.
 func TestParseFailureWarning_CodeMapping(t *testing.T) {
 	t.Parallel()
-	e := parseFailureWarning("a.ts", ParseStatus{ParseError: true, Code: "E_PARSE_ERROR", Detail: "d"})
+	e := parseFailureWarning("a.ts", ParseStatus{ParseError: true, Code: "E_PARSE_ERROR", Detail: "d"}, true)
 	if e.Code != "E_PARSE_ERROR" || e.Severity != "warning" || e.FilePath != "a.ts" || e.Detail != "d" {
 		t.Fatalf("error mapping wrong: %#v", e)
 	}
-	if e.EffectOnCompleteness != "file parsed with syntax errors; semantic facts may be incomplete" {
-		t.Fatalf("error effect wrong: %q", e.EffectOnCompleteness)
+	if e.EffectOnCompleteness != "file diff suppressed; changes omitted because the file could not be parsed" {
+		t.Fatalf("suppressed effect wrong: %q", e.EffectOnCompleteness)
 	}
-	tmo := parseFailureWarning("b.ts", ParseStatus{ParseError: true, Code: "E_PARSE_TIMEOUT", Detail: "slow"})
+	tmo := parseFailureWarning("b.ts", ParseStatus{ParseError: true, Code: "E_PARSE_TIMEOUT", Detail: "slow"}, true)
 	if tmo.Code != "E_PARSE_TIMEOUT" {
 		t.Fatalf("timeout code wrong: %#v", tmo)
 	}
-	if tmo.EffectOnCompleteness != "file record emitted but symbol parsing skipped because parser time budget was exceeded" {
-		t.Fatalf("timeout effect wrong: %q", tmo.EffectOnCompleteness)
+	if tmo.EffectOnCompleteness != "file diff suppressed; changes omitted because parser time budget was exceeded" {
+		t.Fatalf("suppressed timeout effect wrong: %q", tmo.EffectOnCompleteness)
 	}
-	def := parseFailureWarning("c.ts", ParseStatus{ParseError: true})
+	deg := parseFailureWarning("d.ts", ParseStatus{ParseError: true, Code: "E_PARSE_ERROR"}, false)
+	if deg.EffectOnCompleteness != "file parsed with syntax errors on one side; diff kept but may be incomplete or contain phantom changes" {
+		t.Fatalf("degraded effect wrong: %q", deg.EffectOnCompleteness)
+	}
+	def := parseFailureWarning("c.ts", ParseStatus{ParseError: true}, true)
 	if def.Code != "E_PARSE_ERROR" {
 		t.Fatalf("empty code should default to E_PARSE_ERROR, got %q", def.Code)
 	}

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -281,6 +281,106 @@ func TestAnalyzeCheckpointResolvesAssociatedCommit(t *testing.T) {
 	}
 }
 
+func TestAnalyzeGitRangeSurfacesParseFailures(t *testing.T) {
+	const validTS = "export function alpha() {\n    return 1\n}\n\nexport function beta() {\n    return 2\n}\n"
+	// Parses to zero entities with ParseStatus.ParseError == true.
+	const brokenTS = "type Broken = <\n\nexport function alpha(){return 1}\nexport function beta(){return 2}\n"
+	// Valid TypeScript with no top-level entities (a genuinely emptied file).
+	const emptiedTS = "// all symbols removed\n"
+
+	changesByType := func(result Result, changeType string) []EntityChange {
+		var out []EntityChange
+		for _, file := range result.Files {
+			for _, change := range file.Changes {
+				if change.Type == changeType {
+					out = append(out, change)
+				}
+			}
+		}
+		return out
+	}
+	parseWarning := func(result Result, path string) *ProviderWarning {
+		for i := range result.Warnings {
+			w := &result.Warnings[i]
+			if w.FilePath == path && (w.Code == "E_PARSE_ERROR" || w.Code == "E_PARSE_TIMEOUT") {
+				return w
+			}
+		}
+		return nil
+	}
+
+	t.Run("head unparseable surfaces warning without phantom removals", func(t *testing.T) {
+		repo, base, head := buildParseFailureRepo(t, "svc.ts", validTS, brokenTS)
+		result, err := AnalyzeGitRange(context.Background(), repo, base, head, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		w := parseWarning(result, "svc.ts")
+		if w == nil {
+			t.Fatalf("expected parse-failure warning for svc.ts, got %#v", result.Warnings)
+		}
+		if w.Code != "E_PARSE_ERROR" || w.Severity != "warning" || w.EffectOnCompleteness == "" {
+			t.Fatalf("unexpected warning shape: %#v", w)
+		}
+		for _, c := range changesByType(result, "removed") {
+			if c.Name == "alpha" || c.Name == "beta" {
+				t.Fatalf("phantom removed change for %q: %#v", c.Name, result.Files)
+			}
+		}
+	})
+
+	t.Run("base unparseable surfaces warning without phantom additions", func(t *testing.T) {
+		repo, base, head := buildParseFailureRepo(t, "svc.ts", brokenTS, validTS)
+		result, err := AnalyzeGitRange(context.Background(), repo, base, head, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if parseWarning(result, "svc.ts") == nil {
+			t.Fatalf("expected parse-failure warning for svc.ts, got %#v", result.Warnings)
+		}
+		for _, c := range changesByType(result, "added") {
+			if c.Name == "alpha" || c.Name == "beta" {
+				t.Fatalf("phantom added change for %q: %#v", c.Name, result.Files)
+			}
+		}
+	})
+
+	t.Run("genuinely emptied file still reports real removals with no warning", func(t *testing.T) {
+		repo, base, head := buildParseFailureRepo(t, "svc.ts", validTS, emptiedTS)
+		result, err := AnalyzeGitRange(context.Background(), repo, base, head, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if w := parseWarning(result, "svc.ts"); w != nil {
+			t.Fatalf("did not expect a parse-failure warning for a validly emptied file: %#v", w)
+		}
+		removed := map[string]bool{}
+		for _, c := range changesByType(result, "removed") {
+			removed[c.Name] = true
+		}
+		if !removed["alpha"] || !removed["beta"] {
+			t.Fatalf("expected real removed changes for alpha and beta, got %#v", result.Files)
+		}
+	})
+}
+
+func buildParseFailureRepo(t *testing.T, file, baseContent, headContent string) (repo, base, head string) {
+	t.Helper()
+	repo = t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	write(t, repo, file, baseContent)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	base = rev(t, repo, "HEAD")
+	write(t, repo, file, headContent)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "change")
+	head = rev(t, repo, "HEAD")
+	return repo, base, head
+}
+
 func write(t *testing.T, repo, path, content string) {
 	t.Helper()
 	full := filepath.Join(repo, path)

--- a/internal/sem/text.go
+++ b/internal/sem/text.go
@@ -12,7 +12,9 @@ func writeText(out io.Writer, result Result) {
 	fmt.Fprintf(out, "%s %s\n\n", styles.title("Semantic changes"), styles.dim(result.Base+".."+result.Head))
 	if len(result.Files) == 0 {
 		fmt.Fprintln(out, styles.dim("No semantic entity changes detected."))
-		return
+		if len(result.Warnings) > 0 {
+			fmt.Fprintln(out)
+		}
 	}
 
 	for _, file := range result.Files {
@@ -29,6 +31,33 @@ func writeText(out io.Writer, result Result) {
 			fmt.Fprintf(out, "  %s\n", styles.describe(change))
 		}
 		fmt.Fprintln(out)
+	}
+
+	writeTextWarnings(out, styles, result.Warnings)
+}
+
+// writeTextWarnings renders result-level warnings (parse failures, ambiguous
+// moves) so a suppressed or degraded diff is visible in the default text
+// output rather than only in --json. It renders even when there are no file
+// changes, since a suppressed parse failure is exactly the case where the diff
+// would otherwise look empty.
+func writeTextWarnings(out io.Writer, styles textStyles, warnings []ProviderWarning) {
+	if len(warnings) == 0 {
+		return
+	}
+	fmt.Fprintln(out, styles.changed("Warnings"))
+	for _, warning := range warnings {
+		fmt.Fprintf(out, "  %s %s", styles.changed("!"), styles.changed(warning.Code))
+		if warning.FilePath != "" {
+			fmt.Fprintf(out, " %s", styles.file(warning.FilePath))
+		}
+		fmt.Fprintln(out)
+		if warning.EffectOnCompleteness != "" {
+			fmt.Fprintf(out, "    %s\n", styles.dim(warning.EffectOnCompleteness))
+		}
+		if warning.Detail != "" {
+			fmt.Fprintf(out, "    %s\n", styles.dim(warning.Detail))
+		}
 	}
 }
 

--- a/internal/sem/text_test.go
+++ b/internal/sem/text_test.go
@@ -46,6 +46,82 @@ func TestNoColorOverridesForcedColor(t *testing.T) {
 	}
 }
 
+// A suppressed parse failure must be visible in the default text output even
+// when there are no file changes at all — otherwise the user sees only
+// "No semantic entity changes detected." and the failure is silent.
+func TestWriteTextRendersWarningsWithoutFileChanges(t *testing.T) {
+	t.Setenv("ENTIRE_GRAPH_FORCE_COLOR", "")
+	t.Setenv("FORCE_COLOR", "")
+	t.Setenv("NO_COLOR", "")
+
+	var out bytes.Buffer
+	WriteText(&out, Result{
+		Base: "HEAD~1",
+		Head: "HEAD",
+		Warnings: []ProviderWarning{{
+			Code:                 "E_PARSE_ERROR",
+			Severity:             "warning",
+			FilePath:             "svc.ts",
+			EffectOnCompleteness: "file diff suppressed; changes omitted because the file could not be parsed",
+			Detail:               "syntax error near line 1",
+		}},
+	})
+	text := out.String()
+	if !strings.Contains(text, "No semantic entity changes detected.") {
+		t.Fatalf("missing empty-diff line:\n%s", text)
+	}
+	for _, want := range []string{
+		"Warnings",
+		"! E_PARSE_ERROR svc.ts",
+		"file diff suppressed; changes omitted because the file could not be parsed",
+		"syntax error near line 1",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("text output missing %q:\n%s", want, text)
+		}
+	}
+}
+
+// Warnings also render after real file changes (the degraded-but-kept diff
+// case), and a warning without a file path or detail renders cleanly.
+func TestWriteTextRendersWarningsAfterFileChanges(t *testing.T) {
+	t.Setenv("ENTIRE_GRAPH_FORCE_COLOR", "")
+	t.Setenv("FORCE_COLOR", "")
+	t.Setenv("NO_COLOR", "")
+
+	result := sampleTextResult()
+	result.Warnings = []ProviderWarning{{
+		Code:                 "W_MOVE_AMBIGUOUS",
+		Severity:             "warning",
+		EffectOnCompleteness: "symbol move could not be reconciled unambiguously; reported as remove/add",
+	}}
+	var out bytes.Buffer
+	WriteText(&out, result)
+	text := out.String()
+	if !strings.Contains(text, "validate_token") {
+		t.Fatalf("file changes missing:\n%s", text)
+	}
+	if !strings.Contains(text, "Warnings") || !strings.Contains(text, "! W_MOVE_AMBIGUOUS\n") {
+		t.Fatalf("warning section missing or malformed:\n%s", text)
+	}
+	if !strings.Contains(text, "symbol move could not be reconciled unambiguously") {
+		t.Fatalf("warning effect missing:\n%s", text)
+	}
+}
+
+// Without warnings the output is unchanged: no Warnings section appears.
+func TestWriteTextOmitsWarningSectionWhenNone(t *testing.T) {
+	t.Setenv("ENTIRE_GRAPH_FORCE_COLOR", "")
+	t.Setenv("FORCE_COLOR", "")
+	t.Setenv("NO_COLOR", "")
+
+	var out bytes.Buffer
+	WriteText(&out, sampleTextResult())
+	if strings.Contains(out.String(), "Warnings") {
+		t.Fatalf("unexpected Warnings section:\n%s", out.String())
+	}
+}
+
 func sampleTextResult() Result {
 	return Result{
 		Base: "HEAD~1",


### PR DESCRIPTION
## Summary

`AnalyzeGitRange` (and therefore `AnalyzeCheckpoint`, which delegates to it) called `parser.Parse`, discarding the `ParseStatus` returned by `ParseWithStatus`. When a changed file failed to parse (`E_PARSE_ERROR` / `E_PARSE_TIMEOUT`), the parser returned zero entities with no signal, so `compareEntities(before, nil)` reported **every** entity as a phantom `removed` change (or `added`, if the base side failed) with nothing appended to `result.Warnings`. This violated the guarantee that unparseable files surface as machine-readable partial failures, never silent drops.

## Fix

- Switch both base and head parsing in `AnalyzeGitRange` to `TreeSitterParser{}.ParseWithStatus`.
- When **either** side reports `ParseError` for a file, append a `ProviderWarning` (reusing the existing `Result.Warnings` channel, no schema change) and skip the delta for that file instead of emitting phantom changes. The warning mirrors the provider path's `parseStatus.ParseError → PartialFailure` mapping in `provider.go` (code, severity, effect-on-completeness wording, detail).
- Distinguish "parse failed" (`ParseError` true) from a legitimately emptied/zero-entity file (`ParseError` false): only the former is suppressed+warned; a validly-emptied file still reports its real `removed` changes.
- `AnalyzeCheckpoint` is covered automatically since it delegates to `AnalyzeGitRange`.

`writeText` already ignores `Warnings` (including the pre-existing move-ambiguity warnings), so text output is unchanged; `--json` serializes them via the existing `warnings` tag.

Fixes #30

## Test evidence

New regression test `TestAnalyzeGitRangeSurfacesParseFailures` (end-to-end via a temp git repo + `AnalyzeGitRange`) covers all three cases:
- base valid / head unparseable -> partial-failure warning, no phantom `removed` for alpha/beta.
- base unparseable / head valid -> warning, no phantom `added`.
- genuinely emptied file (valid, zero entities) -> real `removed` changes, no warning.

Verification (all pass):
- `gofmt -l internal` -> empty
- `go vet ./...`
- `go build ./...`
- `go test ./internal/sem/`
- `go test -race -run TestAnalyzeGitRangeSurfacesParseFailures ./internal/sem/`