### PR TITLE
fix(sem): make static-accessor and java-module-import masks length-preserving

### DIFF
--- a/internal/sem/parser.go
+++ b/internal/sem/parser.go
@@ -614,7 +614,7 @@ func rustTokenTreeStartsWithIf(src []byte, body *sitter.Node) bool {
 }
 
 var (
-	javaModuleImportPattern      = regexp.MustCompile(`^(\s*import\s+)module\s+`)
+	javaModuleImportPattern      = regexp.MustCompile(`^(\s*import\s+)module(\s+)`)
 	javaVarargsAnnotationPattern = regexp.MustCompile(`@[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*\s*\.\.\.`)
 )
 
@@ -622,7 +622,13 @@ func maskJavaUnsupportedSyntax(content string) string {
 	lines := strings.SplitAfter(content, "\n")
 	for i, line := range lines {
 		text, newline := splitLineEnding(line)
-		text = javaModuleImportPattern.ReplaceAllString(text, "${1}       ")
+		// Blank only the `module` contextual keyword (6 chars -> 6 spaces) and
+		// preserve the trailing whitespace group (${2}) verbatim, so the mask is
+		// length-preserving regardless of how much whitespace follows `module`.
+		// A literal replacement (e.g. 7 spaces) shortened multi-space imports and
+		// shifted every following entity's offsets, corrupting names/signatures/
+		// body-hashes (same bug class as the TS static-accessor mask).
+		text = javaModuleImportPattern.ReplaceAllString(text, "${1}      ${2}")
 		text = javaVarargsAnnotationPattern.ReplaceAllStringFunc(text, func(match string) string {
 			return strings.Repeat(" ", len(match)-3) + "..."
 		})

--- a/internal/sem/parser.go
+++ b/internal/sem/parser.go
@@ -392,7 +392,7 @@ func sourceLineAt(src []byte, line int) string {
 var (
 	tsKeywordTypePropertyPattern  = regexp.MustCompile(`^(\s*)in(\??\s*:)`)
 	tsTypeImportPattern           = regexp.MustCompile(`typeof\s+import\(([^)]*)\)`)
-	tsStaticAccessorMethodPattern = regexp.MustCompile(`\bstatic\s+accessor(\s*\()`)
+	tsStaticAccessorMethodPattern = regexp.MustCompile(`(\bstatic\s+accesso)r(\s*\()`)
 )
 
 func maskTypeScriptUnsupportedSyntax(content string) string {
@@ -458,7 +458,7 @@ func maskTypeScriptKeywordTypeProperty(line string) string {
 }
 
 func maskTypeScriptStaticAccessorMethod(line string) string {
-	return tsStaticAccessorMethodPattern.ReplaceAllString(line, "static accessoR${1}")
+	return tsStaticAccessorMethodPattern.ReplaceAllString(line, "${1}R${2}")
 }
 
 // rustItemWrapperMacroHint cheaply detects source that may contain a

--- a/internal/sem/parser.go
+++ b/internal/sem/parser.go
@@ -458,6 +458,11 @@ func maskTypeScriptKeywordTypeProperty(line string) string {
 }
 
 func maskTypeScriptStaticAccessorMethod(line string) string {
+	// Flip only the trailing `r` of `accessor` to `R`, reconstructing the
+	// surrounding whitespace from capture groups, so the replacement is
+	// byte-length-preserving: entity offsets are computed against the masked
+	// source but sliced from the original, so any length drift corrupts every
+	// following entity (same constraint as the Java module-import mask).
 	return tsStaticAccessorMethodPattern.ReplaceAllString(line, "${1}R${2}")
 }
 

--- a/internal/sem/parser_test.go
+++ b/internal/sem/parser_test.go
@@ -577,10 +577,47 @@ func TestMaskTypeScriptStaticAccessorMethodPreservesLength(t *testing.T) {
 		"  static accessor() { return 1; }",
 		"  static  accessor() { return 1; }",
 		"  static   accessor  () { return 1; }",
+		"  static\taccessor() { return 1; }",
+		"  static\t\taccessor () { return 1; }",
+		"  static \t accessor\t() { return 1; }",
 	} {
 		out := maskTypeScriptStaticAccessorMethod(in)
 		if len(out) != len(in) {
 			t.Fatalf("mask changed length: input %q (%d) -> output %q (%d)", in, len(in), out, len(out))
+		}
+	}
+}
+
+func TestMaskTypeScriptStaticAccessorMethodOnlyMasksStaticAccessorCalls(t *testing.T) {
+	t.Parallel()
+	// Must NOT mask: `accessor` as a plain identifier (not preceded by static),
+	// and `static accessor` with no following paren.
+	for _, in := range []string{
+		"  const accessor = 1;",
+		"  accessor();",
+		"  this.accessor(x);",
+		"  static accessor;",
+		"  static accessor = 1;",
+	} {
+		if out := maskTypeScriptStaticAccessorMethod(in); out != in {
+			t.Fatalf("unexpectedly masked non-static-accessor input %q -> %q", in, out)
+		}
+	}
+	// Must mask (r -> R before the paren) exactly once per occurrence.
+	for _, in := range []string{
+		"  static accessor() {}",
+		"  static  accessor () {}",
+		"  static\taccessor() {}",
+	} {
+		out := maskTypeScriptStaticAccessorMethod(in)
+		if out == in {
+			t.Fatalf("expected mask to fire on %q", in)
+		}
+		if len(out) != len(in) {
+			t.Fatalf("mask changed length: %q -> %q", in, out)
+		}
+		if !strings.Contains(out, "accessoR") || strings.Contains(out, "accessor") {
+			t.Fatalf("expected accessor->accessoR in %q", out)
 		}
 	}
 }
@@ -846,6 +883,63 @@ class MultiplicationTests {
 		}
 	}
 	t.Fatalf("missing method entity after masking module import: %#v", entities)
+}
+
+func TestMaskJavaModuleImportPreservesLength(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{
+		"import module java.base;",
+		"import module  java.base;",
+		"import module   java.base;",
+		"\timport\tmodule\t\tjava.base;",
+		"  import module\tjava.base;",
+	} {
+		out := maskJavaUnsupportedSyntax(in)
+		if len(out) != len(in) {
+			t.Fatalf("mask changed length: input %q (%d) -> output %q (%d)", in, len(in), out, len(out))
+		}
+	}
+}
+
+func TestTreeSitterParserJavaModuleImportMaskPreservesFollowingEntity(t *testing.T) {
+	t.Parallel()
+	find := func(entities []Entity, name string) (Entity, bool) {
+		for _, e := range entities {
+			if e.Name == name {
+				return e, true
+			}
+		}
+		return Entity{}, false
+	}
+	oneSpace := "import module java.base;\nclass C {\n  int bar() { return 42; }\n}\n"
+	multiSpace := "import module   java.base;\nclass C {\n  int bar() { return 42; }\n}\n"
+
+	oneEntities, _, oneStatus := TreeSitterParser{}.ParseWithStatus("C.java", oneSpace)
+	if oneStatus.ParseError {
+		t.Fatalf("one-space parse error: %#v", oneStatus)
+	}
+	multiEntities, _, multiStatus := TreeSitterParser{}.ParseWithStatus("C.java", multiSpace)
+	if multiStatus.ParseError {
+		t.Fatalf("multi-space parse error: %#v", multiStatus)
+	}
+
+	oneBar, ok := find(oneEntities, "C.bar")
+	if !ok {
+		t.Fatalf("one-space: missing C.bar entity: %#v", oneEntities)
+	}
+	multiBar, ok := find(multiEntities, "C.bar")
+	if !ok {
+		t.Fatalf("multi-space: missing C.bar entity (mask corrupted following entity): %#v", multiEntities)
+	}
+	if multiBar.Name != oneBar.Name {
+		t.Fatalf("name mismatch: one-space %q vs multi-space %q", oneBar.Name, multiBar.Name)
+	}
+	if multiBar.Signature != oneBar.Signature {
+		t.Fatalf("signature mismatch: one-space %q vs multi-space %q", oneBar.Signature, multiBar.Signature)
+	}
+	if multiBar.BodyHash != oneBar.BodyHash {
+		t.Fatalf("body-hash mismatch: one-space %q vs multi-space %q", oneBar.BodyHash, multiBar.BodyHash)
+	}
 }
 
 func TestTreeSitterParserGroovyMasksQuotedMethodNames(t *testing.T) {

--- a/internal/sem/parser_test.go
+++ b/internal/sem/parser_test.go
@@ -586,6 +586,20 @@ func TestMaskTypeScriptStaticAccessorMethodPreservesLength(t *testing.T) {
 			t.Fatalf("mask changed length: input %q (%d) -> output %q (%d)", in, len(in), out, len(out))
 		}
 	}
+	// CRLF content exercises the full per-line mask path: splitLineEnding
+	// special-cases \r\n, so verify the mask stays length-preserving and keeps
+	// the \r\n endings intact around the masked construct.
+	crlf := "class C {\r\n  static  accessor() { return 1; }\r\n  bar() { return 42; }\r\n}\r\n"
+	out := maskTypeScriptUnsupportedSyntax(crlf)
+	if len(out) != len(crlf) {
+		t.Fatalf("mask changed length of CRLF input: %q (%d) -> %q (%d)", crlf, len(crlf), out, len(out))
+	}
+	if !strings.Contains(out, "accessoR") {
+		t.Fatalf("expected mask to fire on CRLF input: %q", out)
+	}
+	if got, want := strings.Count(out, "\r\n"), strings.Count(crlf, "\r\n"); got != want {
+		t.Fatalf("mask altered CRLF line endings: got %d, want %d in %q", got, want, out)
+	}
 }
 
 func TestMaskTypeScriptStaticAccessorMethodOnlyMasksStaticAccessorCalls(t *testing.T) {
@@ -898,6 +912,20 @@ func TestMaskJavaModuleImportPreservesLength(t *testing.T) {
 		if len(out) != len(in) {
 			t.Fatalf("mask changed length: input %q (%d) -> output %q (%d)", in, len(in), out, len(out))
 		}
+	}
+	// CRLF content exercises the full per-line mask path: splitLineEnding
+	// special-cases \r\n, so verify the mask stays length-preserving and keeps
+	// the \r\n endings intact around the masked construct.
+	crlf := "import module  java.base;\r\nclass C {\r\n  int bar() { return 42; }\r\n}\r\n"
+	out := maskJavaUnsupportedSyntax(crlf)
+	if len(out) != len(crlf) {
+		t.Fatalf("mask changed length of CRLF input: %q (%d) -> %q (%d)", crlf, len(crlf), out, len(out))
+	}
+	if strings.Contains(out, "module") {
+		t.Fatalf("expected mask to blank `module` in CRLF input: %q", out)
+	}
+	if got, want := strings.Count(out, "\r\n"), strings.Count(crlf, "\r\n"); got != want {
+		t.Fatalf("mask altered CRLF line endings: got %d, want %d in %q", got, want, out)
 	}
 }
 

--- a/internal/sem/parser_test.go
+++ b/internal/sem/parser_test.go
@@ -571,6 +571,61 @@ func TestTreeSitterParserTypeScriptMasksStaticAccessorMethod(t *testing.T) {
 	t.Fatalf("missing class entity after masking static accessor method: %#v", entities)
 }
 
+func TestMaskTypeScriptStaticAccessorMethodPreservesLength(t *testing.T) {
+	t.Parallel()
+	for _, in := range []string{
+		"  static accessor() { return 1; }",
+		"  static  accessor() { return 1; }",
+		"  static   accessor  () { return 1; }",
+	} {
+		out := maskTypeScriptStaticAccessorMethod(in)
+		if len(out) != len(in) {
+			t.Fatalf("mask changed length: input %q (%d) -> output %q (%d)", in, len(in), out, len(out))
+		}
+	}
+}
+
+func TestTreeSitterParserTypeScriptStaticAccessorMaskPreservesFollowingEntity(t *testing.T) {
+	t.Parallel()
+	find := func(entities []Entity, name string) (Entity, bool) {
+		for _, e := range entities {
+			if e.Name == name {
+				return e, true
+			}
+		}
+		return Entity{}, false
+	}
+	oneSpace := "class C {\n  static accessor() { return 1; }\n  bar() { return 42; }\n}\n"
+	twoSpace := "class C {\n  static  accessor() { return 1; }\n  bar() { return 42; }\n}\n"
+
+	oneEntities, _, oneStatus := TreeSitterParser{}.ParseWithStatus("c.ts", oneSpace)
+	if oneStatus.ParseError {
+		t.Fatalf("one-space parse error: %#v", oneStatus)
+	}
+	twoEntities, _, twoStatus := TreeSitterParser{}.ParseWithStatus("c.ts", twoSpace)
+	if twoStatus.ParseError {
+		t.Fatalf("two-space parse error: %#v", twoStatus)
+	}
+
+	oneBar, ok := find(oneEntities, "C.bar")
+	if !ok {
+		t.Fatalf("one-space: missing C.bar entity: %#v", oneEntities)
+	}
+	twoBar, ok := find(twoEntities, "C.bar")
+	if !ok {
+		t.Fatalf("two-space: missing C.bar entity (mask corrupted following entity): %#v", twoEntities)
+	}
+	if twoBar.Name != oneBar.Name {
+		t.Fatalf("name mismatch: one-space %q vs two-space %q", oneBar.Name, twoBar.Name)
+	}
+	if twoBar.Signature != oneBar.Signature {
+		t.Fatalf("signature mismatch: one-space %q vs two-space %q", oneBar.Signature, twoBar.Signature)
+	}
+	if twoBar.BodyHash != oneBar.BodyHash {
+		t.Fatalf("body-hash mismatch: one-space %q vs two-space %q", oneBar.BodyHash, twoBar.BodyHash)
+	}
+}
+
 func TestTreeSitterParserTypeScriptMasksGenericCallableTypeSignatures(t *testing.T) {
 	_, language, status := TreeSitterParser{}.ParseWithStatus("callable.ts", `export interface TakePattern<State> {
   <Predicate extends AnyListenerPredicate<State>>(


### PR DESCRIPTION
## Summary

Fixes #33.

`internal/sem/parser.go`'s TypeScript static-accessor mask matched one-or-more whitespace (`\s+`) between `static` and `accessor`, but the replacement hardcoded a single space:

```go
tsStaticAccessorMethodPattern = regexp.MustCompile(`\bstatic\s+accessor(\s*\()`)
// replacement: "static accessoR${1}"
```

So `static  accessor(` (two spaces) was rewritten to `static accessoR(` — one byte shorter. The parser parses the masked bytes but extracts entity text from the **original** source using masked-tree offsets, so any length change shifts every subsequent offset and corrupts each following entity's name/signature/body-hash. (Fires only for a static method literally named `accessor`, i.e. `accessor` followed by `(`.)

## Fix

Length-preserving rewrite: capture everything except the final `r` of `accessor` and rewrite only that char to `R`, preserving all matched bytes (and whitespace) verbatim — matching the sibling masks:

```go
tsStaticAccessorMethodPattern = regexp.MustCompile(`(\bstatic\s+accesso)r(\s*\()`)
// replacement: "${1}R${2}"
```

## Test evidence

Added regression tests in `internal/sem/parser_test.go`:

- `TestMaskTypeScriptStaticAccessorMethodPreservesLength` — asserts `len(output) == len(input)` for one-space and multi-space inputs.
- `TestTreeSitterParserTypeScriptStaticAccessorMaskPreservesFollowingEntity` — parses `static  accessor()` (two spaces) followed by `bar()`; asserts the following method is `C.bar` with the same name/signature/body-hash as the one-space variant.

Confirmed both tests **fail before** the fix (the following entity corrupts to `C.ba` / signature offset drift) and **pass after**.

Verification (all pass):

```
gofmt -l internal        # clean
go vet ./...             # ok
go build ./...           # ok
go test ./internal/sem/  # ok
go test -race -run 'TestMaskTypeScriptStaticAccessorMethodPreservesLength|TestTreeSitterParserTypeScriptStaticAccessorMaskPreservesFollowingEntity' ./internal/sem/  # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: second mask of the same class (found during review)

An adversarial review of this fix audited every literal-replacement mask in `parser.go` and found the **same length-changing bug** in `javaModuleImportPattern`:

```go
// pattern ^(\s*import\s+)module\s+  with a fixed 7-space replacement
```

`import module   java.base;` (multiple spaces after `module`, greedy `\s+`) shrank the line and corrupted every downstream entity's offsets (e.g. `class C` → entity `s`, `C.bar` → `s.t b`) — verified empirically via `ParseWithStatus`. Fixed the same way (capture the trailing whitespace, emit a 6-char `module` mask + verbatim whitespace), so it is length-invariant for any whitespace count.

Added tests: `TestMaskJavaModuleImportPreservesLength` and `TestTreeSitterParserJavaModuleImportMaskPreservesFollowingEntity`, plus extended the static-accessor length test with tab/mixed-whitespace inputs and a negative-match test.

Full `go test ./...` passes.

Fixes #41 (the Java `import module` mask, same bug class, found and fixed during this review).