### PR TITLE
docs: add updating/migration note (entire-sem → entire-graph)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ entire graph commit HEAD
 
 If `$(go env GOPATH)/bin` is already on your `PATH`, Entire can discover the binary directly after `go install`. Entire plugins are local executables, not a hosted marketplace: `entire graph` works because Entire finds an `entire-graph` binary in its managed plugin directory or on `$PATH`.
 
+### 🔄 Updating (and migrating from `entire-sem`)
+
+This plugin was renamed from `entire-sem` to `entire-graph` after `v0.1.0` — both the binary and the `cmd/` path changed. If you installed the old `entire-sem`, switch over with:
+
+```sh
+go install github.com/entireio/entire-graph/cmd/entire-graph@latest
+entire plugin install "$(go env GOPATH)/bin/entire-graph" --force
+rm -f "$(go env GOPATH)/bin/entire-sem"   # remove the old binary
+```
+
+> `…/cmd/entire-graph@latest` needs **v0.2.0 or newer** — `v0.1.0` predates the rename and only ships `cmd/entire-sem`, so `@latest` against it fails with *"module found (v0.1.0), but does not contain package …/cmd/entire-graph"*. If a fresh tag hasn't propagated to the Go module proxy yet, pin it (`@v0.2.0`) or use `@main`. Graph and query behavior is unchanged — only the name.
+
 ### 🛠️ Install From Source
 
 ```sh


### PR DESCRIPTION
## What
Adds an **Updating / migrating from `entire-sem`** section to the README.

## Why
The plugin was renamed `entire-sem` → `entire-graph` after `v0.1.0` (binary + `cmd/` path). Testers hit:
```
go install github.com/entireio/entire-graph/cmd/entire-graph@latest
go: module github.com/entireio/entire-graph@latest found (v0.1.0), but does not contain package …/cmd/entire-graph
```
because `@latest` resolved to `v0.1.0`, which predates the rename and only ships `cmd/entire-sem`.

## Fix
- Cut **v0.2.0** off `main` (first tag containing `cmd/entire-graph`) — `@latest` now works (verified: `go install …/cmd/entire-graph@latest` installs v0.2.0).
- This PR documents the switch-over (reinstall + drop the old `entire-sem` binary) and the `@latest`-needs-v0.2.0 gotcha, with `@v0.2.0` / `@main` fallbacks for Go-proxy lag right after a tag.

Docs-only.