### PR TITLE
chore(gitutil): follow-up polish from PR #36 review

### DIFF
--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -307,7 +307,7 @@ func ShowFile(ctx context.Context, repo, rev, path string) (string, bool, error)
 		if msg == "" {
 			msg = err.Error()
 		}
-		return "", false, fmt.Errorf("git show %s:%s: %s", rev, path, msg)
+		return "", false, fmt.Errorf("git show %s: %s", objectSpec, msg)
 	}
 	return out, true, nil
 }
@@ -466,12 +466,12 @@ func run(ctx context.Context, dir, name string, args ...string) (string, error) 
 }
 
 // newCmd builds the exec.Cmd used by subprocesses whose diagnostics must be
-// stable. GrepIndexMatches intentionally preserves the caller's locale because
-// git grep uses LC_CTYPE for case folding.
-// It pins the subprocess locale to C (LC_ALL=C overrides LANG and any LC_*;
-// LANG=C is set as a belt-and-braces default) so git's stderr messages are
-// always the English ones our error classification matches — e.g. ShowFile's
-// absent-file detection would otherwise break under a non-English git locale.
+// stable. It pins the subprocess locale to C (LC_ALL=C overrides LANG and any
+// LC_*; LANG=C is set as a belt-and-braces default) so git's stderr messages
+// are always the English ones our error classification matches — e.g.
+// ShowFile's absent-file detection would otherwise break under a non-English
+// git locale. GrepIndexMatches intentionally bypasses this helper and keeps
+// the caller's locale because git grep uses LC_CTYPE for case folding.
 func newCmd(ctx context.Context, dir, name string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/2
<!-- entire-trail-link-end -->

## Summary

Two non-functional nits flagged in the review of #36:

- **Error message reports the command that actually ran.** `ShowFile` runs `git show rev^{tree}:path` but wrapped failures as `git show rev:path: ...`, so the reported command didn't match the stderr it quoted (which mentions `^{tree}`). It now reports the real object spec.
- **`newCmd` doc comment reordered.** The `GrepIndexMatches` exemption sentence interrupted the explanation of what the helper does; the locale-pinning rationale now comes first, the exemption last.

No behavior change: the error path still returns a non-nil error with git's stderr, and absent-file classification is untouched.

## Verification

```
gofmt -l internal                  # empty
go vet ./...                       # ok (tree-sitter C warning only)
go test -race ./internal/gitutil/  # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AS8YV3giRoWagbRFo3ihAX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and error-message formatting only; absent-file classification and git invocation are unchanged.
> 
> **Overview**
> Polish from PR #36 review with **no runtime behavior change**.
> 
> **`ShowFile` error strings** now quote the real `git show` object spec (`rev^{tree}:path`) instead of `rev:path`, so wrapped failures match the command that actually ran and align with git’s stderr.
> 
> The **`newCmd` comment** is reordered: locale-pinning rationale first, with the `GrepIndexMatches` locale exemption moved to the end so the helper’s purpose reads clearly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fca87d0381401ce06a6a7153fdb859f2618812be. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->