### PR TITLE
perf: 13x faster semantic diff and tree-keyed snapshot cache

### DIFF
--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -126,7 +126,30 @@ func GrepTreeMatches(ctx context.Context, repo, treeish string, patterns []strin
 // least one of the fixed-string patterns. Git emits each path once in
 // NUL-delimited form, avoiding both matched-text fanout and ambiguity from
 // unusual path bytes.
+//
+// It passes -I, so a blob Git itself classifies as binary (a NUL byte early
+// in the content, or a `.gitattributes` binary/-diff marking) is silently
+// excluded from the result even if it contains a matching pattern. That
+// makes this preselection a strict superset of a text-only match, but NOT of
+// every possible match in the tree -- callers that need every matching file
+// regardless of Git's binary heuristic must use GrepTreePathsIncludingBinary.
 func GrepTreePaths(ctx context.Context, repo, treeish string, patterns []string) ([]string, error) {
+	return grepTreePaths(ctx, repo, treeish, patterns, true)
+}
+
+// GrepTreePathsIncludingBinary behaves exactly like GrepTreePaths except it
+// omits -I, so a file Git classifies as binary (an early NUL byte, or a
+// `.gitattributes` binary/-diff marking) is still searched and can appear in
+// the result. Use this when a caller's correctness requires a genuine strict
+// superset of every file that contains a matching pattern, regardless of
+// Git's binary heuristic -- e.g. a prefilter ahead of a parser that reads
+// raw file content directly and does not care whether Git thinks the file is
+// binary.
+func GrepTreePathsIncludingBinary(ctx context.Context, repo, treeish string, patterns []string) ([]string, error) {
+	return grepTreePaths(ctx, repo, treeish, patterns, false)
+}
+
+func grepTreePaths(ctx context.Context, repo, treeish string, patterns []string, textOnly bool) ([]string, error) {
 	if treeish == "" {
 		return nil, errors.New("git grep treeish cannot be empty")
 	}
@@ -136,7 +159,11 @@ func GrepTreePaths(ctx context.Context, repo, treeish string, patterns []string)
 	if len(patterns) == 0 {
 		return []string{}, nil
 	}
-	args := []string{"grep", "-z", "-I", "-i", "-F", "-l"}
+	args := []string{"grep", "-z"}
+	if textOnly {
+		args = append(args, "-I")
+	}
+	args = append(args, "-i", "-F", "-l")
 	patternCount := 0
 	for _, pattern := range patterns {
 		if pattern == "" {

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -179,6 +179,55 @@ func TestGrepTreePathsMatchesTextAPIAndHandlesUnusualPaths(t *testing.T) {
 	}
 }
 
+// TestGrepTreePathsIncludingBinaryFindsFilesGrepTreePathsExcludes pins the
+// only behavioral difference between the two functions: a blob Git itself
+// classifies as binary because of an early embedded NUL byte. GrepTreePaths
+// (which passes -I) must silently exclude it from its result even though it
+// contains a matching pattern; GrepTreePathsIncludingBinary must still find
+// it, and both functions must agree on an ordinary text file.
+func TestGrepTreePathsIncludingBinaryFindsFilesGrepTreePathsExcludes(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+
+	textPath := "src/text.go"
+	binaryPath := "src/binary.go"
+	for path, content := range map[string]string{
+		textPath:   "package source\n// TreeNeedle\n",
+		binaryPath: "package source\n// TreeNeedle\x00 embedded nul\n",
+	} {
+		full := filepath.Join(repo, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	commit := gitOutput(t, repo, "rev-parse", "HEAD")
+
+	textOnly, err := GrepTreePaths(t.Context(), repo, commit, []string{"TreeNeedle"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(textOnly) != 1 || textOnly[0] != textPath {
+		t.Fatalf("GrepTreePaths = %#v, want only %#v (the NUL-containing file must be excluded by -I)", textOnly, []string{textPath})
+	}
+
+	includingBinary, err := GrepTreePathsIncludingBinary(t.Context(), repo, commit, []string{"TreeNeedle"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(includingBinary)
+	want := []string{binaryPath, textPath}
+	if !reflect.DeepEqual(includingBinary, want) {
+		t.Fatalf("GrepTreePathsIncludingBinary = %#v, want %#v", includingBinary, want)
+	}
+}
+
 func TestGrepIndexMatchesPreservesUnicodeCaseFoldingLocale(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")

--- a/internal/sem/dependents.go
+++ b/internal/sem/dependents.go
@@ -2,6 +2,7 @@ package sem
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -18,10 +19,11 @@ func addDependentCounts(ctx context.Context, repo, head string, result *Result) 
 		return nil
 	}
 
-	index, err := buildReferenceIndex(ctx, repo, head, names)
+	index, warnings, err := buildReferenceIndex(ctx, repo, head, names)
 	if err != nil {
 		return err
 	}
+	result.Warnings = append(result.Warnings, warnings...)
 
 	for fileIndex := range result.Files {
 		for changeIndex := range result.Files[fileIndex].Changes {
@@ -46,18 +48,18 @@ func changedReferenceNames(result Result) map[string]struct{} {
 	return out
 }
 
-func buildReferenceIndex(ctx context.Context, repo, head string, names map[string]struct{}) (referenceIndex, error) {
+func buildReferenceIndex(ctx context.Context, repo, head string, names map[string]struct{}) (referenceIndex, []ProviderWarning, error) {
 	index := referenceIndex{}
 	for name := range names {
 		index[name] = map[string]struct{}{}
 	}
 	if len(names) == 0 {
-		return index, nil
+		return index, nil, nil
 	}
 
-	files, err := referenceCandidateFiles(ctx, repo, head, names)
+	files, warnings, err := referenceCandidateFiles(ctx, repo, head, names)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	parser := TreeSitterParser{}
@@ -67,14 +69,17 @@ func buildReferenceIndex(ctx context.Context, repo, head string, names map[strin
 		}
 		content, ok, err := gitutil.ShowFile(ctx, repo, head, path)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if !ok {
 			continue
 		}
-		// Parity with the provider's MaxParseBytes eligibility: never count
-		// dependents inside a file the graph itself refuses to parse.
+		// Parity with the provider's default MaxParseBytes eligibility: never
+		// count dependents inside a file the graph itself refuses to parse.
+		// The analyze path has no option plumbing today, so this is always the
+		// provider's DEFAULT limit, never a caller-supplied override.
 		if len(content) > defaultMaxParseBytes {
+			warnings = append(warnings, dependentsFileTooLargeWarning(path, len(content)))
 			continue
 		}
 
@@ -93,7 +98,35 @@ func buildReferenceIndex(ctx context.Context, repo, head string, names map[strin
 		}
 	}
 
-	return index, nil
+	return index, warnings, nil
+}
+
+// dependentsFileTooLargeWarning mirrors the provider's E_FILE_TOO_LARGE
+// partial failure (provider.go's MaxParseBytes handling), reusing its code
+// and severity, but the effect wording is dependents-specific: the file is
+// skipped as a candidate entirely, so a real reference to a changed name
+// inside it goes uncounted rather than merely losing symbol parsing.
+func dependentsFileTooLargeWarning(path string, size int) ProviderWarning {
+	return ProviderWarning{
+		Code:                 "E_FILE_TOO_LARGE",
+		Severity:             "warning",
+		FilePath:             path,
+		EffectOnCompleteness: "dependent references in this file were not counted because it exceeds max parser input",
+		Detail:               fmt.Sprintf("file is %d bytes, above max parser input %d bytes", size, defaultMaxParseBytes),
+	}
+}
+
+// grepFallbackWarning is surfaced once when the git-grep prefilter itself
+// fails and referenceCandidateFiles falls back to scanning every file in the
+// tree. The fallback keeps dependent counts correct, but it is far slower
+// than the prefiltered path, so callers should know it happened.
+func grepFallbackWarning(err error) ProviderWarning {
+	return ProviderWarning{
+		Code:                 "W_DEPENDENTS_PREFILTER_FAILED",
+		Severity:             "warning",
+		EffectOnCompleteness: "dependents git-grep prefilter failed; fell back to scanning every file in the tree",
+		Detail:               err.Error(),
+	}
 }
 
 // referenceCandidateFiles narrows the head tree to files worth parsing, using
@@ -102,10 +135,16 @@ func buildReferenceIndex(ctx context.Context, repo, head string, names map[strin
 // case-sensitive whole-token check -- a case-sensitive substring is always
 // also a case-insensitive one -- so it can only add extra candidate files,
 // never drop a real dependent; the per-entity containsIdentifier check below
-// still runs unchanged. If the grep call itself fails for any reason, fall
+// still runs unchanged. It uses GrepTreePathsIncludingBinary rather than
+// GrepTreePaths specifically to preserve that superset guarantee for files
+// Git itself classifies as binary (an embedded NUL byte, or a
+// `.gitattributes` binary/-diff marking): a Supported source file flagged
+// binary is still real source that gets parsed below, so the prefilter must
+// not silently drop it. If the grep call itself fails for any reason, fall
 // back to scanning every file in the tree so a git-grep quirk never silently
-// zeroes out dependent counts.
-func referenceCandidateFiles(ctx context.Context, repo, head string, names map[string]struct{}) ([]string, error) {
+// zeroes out dependent counts, and surface exactly one warning noting the
+// prefilter failure so the fallback (much slower) scan is not silent.
+func referenceCandidateFiles(ctx context.Context, repo, head string, names map[string]struct{}) ([]string, []ProviderWarning, error) {
 	patterns := make([]string, 0, len(names))
 	for name := range names {
 		if name != "" {
@@ -113,11 +152,18 @@ func referenceCandidateFiles(ctx context.Context, repo, head string, names map[s
 		}
 	}
 	if len(patterns) > 0 {
-		if matches, err := gitutil.GrepTreePaths(ctx, repo, head, patterns); err == nil {
-			return matches, nil
+		matches, grepErr := gitutil.GrepTreePathsIncludingBinary(ctx, repo, head, patterns)
+		if grepErr == nil {
+			return matches, nil, nil
 		}
+		files, err := gitutil.ListFiles(ctx, repo, head)
+		if err != nil {
+			return nil, nil, err
+		}
+		return files, []ProviderWarning{grepFallbackWarning(grepErr)}, nil
 	}
-	return gitutil.ListFiles(ctx, repo, head)
+	files, err := gitutil.ListFiles(ctx, repo, head)
+	return files, nil, err
 }
 
 func entityBlock(lines []string, entity Entity) string {

--- a/internal/sem/dependents.go
+++ b/internal/sem/dependents.go
@@ -47,17 +47,20 @@ func changedReferenceNames(result Result) map[string]struct{} {
 }
 
 func buildReferenceIndex(ctx context.Context, repo, head string, names map[string]struct{}) (referenceIndex, error) {
-	files, err := gitutil.ListFiles(ctx, repo, head)
+	index := referenceIndex{}
+	for name := range names {
+		index[name] = map[string]struct{}{}
+	}
+	if len(names) == 0 {
+		return index, nil
+	}
+
+	files, err := referenceCandidateFiles(ctx, repo, head, names)
 	if err != nil {
 		return nil, err
 	}
 
 	parser := TreeSitterParser{}
-	index := referenceIndex{}
-	for name := range names {
-		index[name] = map[string]struct{}{}
-	}
-
 	for _, path := range files {
 		if !Supported(path) {
 			continue
@@ -67,6 +70,11 @@ func buildReferenceIndex(ctx context.Context, repo, head string, names map[strin
 			return nil, err
 		}
 		if !ok {
+			continue
+		}
+		// Parity with the provider's MaxParseBytes eligibility: never count
+		// dependents inside a file the graph itself refuses to parse.
+		if len(content) > defaultMaxParseBytes {
 			continue
 		}
 
@@ -86,6 +94,30 @@ func buildReferenceIndex(ctx context.Context, repo, head string, names map[strin
 	}
 
 	return index, nil
+}
+
+// referenceCandidateFiles narrows the head tree to files worth parsing, using
+// git grep's fixed-string, case-insensitive substring search as a
+// preselection pass. That test is a strict superset of containsIdentifier's
+// case-sensitive whole-token check -- a case-sensitive substring is always
+// also a case-insensitive one -- so it can only add extra candidate files,
+// never drop a real dependent; the per-entity containsIdentifier check below
+// still runs unchanged. If the grep call itself fails for any reason, fall
+// back to scanning every file in the tree so a git-grep quirk never silently
+// zeroes out dependent counts.
+func referenceCandidateFiles(ctx context.Context, repo, head string, names map[string]struct{}) ([]string, error) {
+	patterns := make([]string, 0, len(names))
+	for name := range names {
+		if name != "" {
+			patterns = append(patterns, name)
+		}
+	}
+	if len(patterns) > 0 {
+		if matches, err := gitutil.GrepTreePaths(ctx, repo, head, patterns); err == nil {
+			return matches, nil
+		}
+	}
+	return gitutil.ListFiles(ctx, repo, head)
 }
 
 func entityBlock(lines []string, entity Entity) string {

--- a/internal/sem/dependents.go
+++ b/internal/sem/dependents.go
@@ -83,7 +83,10 @@ func buildReferenceIndex(ctx context.Context, repo, head string, names map[strin
 			continue
 		}
 
-		entities, _ := parser.Parse(path, content)
+		entities, _, status := parser.ParseWithStatus(path, content)
+		if status.ParseError {
+			warnings = append(warnings, dependentsParseFailureWarning(path, status))
+		}
 		lines := strings.Split(content, "\n")
 		for _, entity := range entities {
 			block := entityBlock(lines, entity)
@@ -113,6 +116,27 @@ func dependentsFileTooLargeWarning(path string, size int) ProviderWarning {
 		FilePath:             path,
 		EffectOnCompleteness: "dependent references in this file were not counted because it exceeds max parser input",
 		Detail:               fmt.Sprintf("file is %d bytes, above max parser input %d bytes", size, defaultMaxParseBytes),
+	}
+}
+
+// dependentsParseFailureWarning mirrors the provider's parse-failure partial
+// failure (provider.go's ParseStatus.ParseError handling, which emits
+// E_PARSE_ERROR or E_PARSE_TIMEOUT depending on ParseStatus.Code), reusing
+// its code, severity, and detail so the wording lines up across both paths.
+// The effect wording is dependents-specific: entities the parser still
+// recovers keep counting exactly as before -- this warning is purely
+// additive observability, not a change to which entities get counted.
+func dependentsParseFailureWarning(path string, status ParseStatus) ProviderWarning {
+	code := status.Code
+	if code == "" {
+		code = "E_PARSE_ERROR"
+	}
+	return ProviderWarning{
+		Code:                 code,
+		Severity:             "warning",
+		FilePath:             path,
+		EffectOnCompleteness: "dependent references in this file may be undercounted because it failed to parse cleanly",
+		Detail:               status.Detail,
 	}
 }
 

--- a/internal/sem/dependents_test.go
+++ b/internal/sem/dependents_test.go
@@ -1,0 +1,212 @@
+package sem
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// newDependentsTestRepo creates a git repo with:
+//   - auth.py defining Foo (capitalized) and foo (lowercase, unrelated).
+//   - caller_one.py and caller_two.py each with a genuine dependent that
+//     calls Foo.
+//   - near_miss.py that only contains "foo" (case differs from "Foo").
+//   - substring.py that only contains "myFooBar" (substring, not a token).
+//
+// It returns the repo path and the head commit.
+func newDependentsTestRepo(t *testing.T) (repo, head string) {
+	t.Helper()
+	repo = t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+
+	write(t, repo, "auth.py", `def Foo(token):
+    return bool(token)
+
+def foo(token):
+    return not bool(token)
+`)
+	write(t, repo, "caller_one.py", `def check(token):
+    return Foo(token)
+`)
+	write(t, repo, "caller_two.py", `def check_again(token):
+    return Foo(token) and Foo(token)
+`)
+	write(t, repo, "near_miss.py", `def uses_lowercase(token):
+    return foo(token)
+`)
+	write(t, repo, "substring.py", `def myFooBar(token):
+    return token
+`)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	head = rev(t, repo, "HEAD")
+	return repo, head
+}
+
+// TestBuildReferenceIndexCaseSensitiveWholeToken pins the pre-grep semantics:
+// a case-sensitive, whole-token match on the entity block. Git's grep
+// preselection is case-insensitive substring matching, a strict superset, but
+// the final containsIdentifier check must still exclude near-miss files.
+func TestBuildReferenceIndexCaseSensitiveWholeToken(t *testing.T) {
+	repo, head := newDependentsTestRepo(t)
+
+	index, err := buildReferenceIndex(context.Background(), repo, head, map[string]struct{}{"Foo": {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dependents := index["Foo"]
+
+	// (c) genuine dependents in multiple files, counted once per entity even
+	// when an entity calls Foo more than once.
+	if _, ok := dependents["caller_one.py#function:check"]; !ok {
+		t.Fatalf("expected caller_one.py check() as a dependent, got %#v", dependents)
+	}
+	if _, ok := dependents["caller_two.py#function:check_again"]; !ok {
+		t.Fatalf("expected caller_two.py check_again() as a dependent, got %#v", dependents)
+	}
+
+	// (d) self-name exclusion: Foo's own definition must not count itself.
+	if _, ok := dependents["auth.py#function:Foo"]; ok {
+		t.Fatalf("Foo must not be counted as its own dependent, got %#v", dependents)
+	}
+
+	// (a) a file matching only case-insensitively (contains "foo" but the
+	// name is "Foo") must contribute 0 dependents.
+	if _, ok := dependents["near_miss.py#function:uses_lowercase"]; ok {
+		t.Fatalf("case-insensitive-only match must not count as a dependent, got %#v", dependents)
+	}
+	if _, ok := dependents["auth.py#function:foo"]; ok {
+		t.Fatalf("lowercase foo definition must not count as a dependent of Foo, got %#v", dependents)
+	}
+
+	// (b) a file matching as a substring only ("myFooBar" vs name "Foo")
+	// must contribute 0 dependents.
+	if _, ok := dependents["substring.py#function:myFooBar"]; ok {
+		t.Fatalf("substring-only match must not count as a dependent, got %#v", dependents)
+	}
+
+	if got, want := len(dependents), 2; got != want {
+		t.Fatalf("dependents count = %d, want %d: %#v", got, want, dependents)
+	}
+}
+
+// TestBuildReferenceIndexEmptyNamesDoesNoWork pins that an empty names map
+// short-circuits before any git call is made -- passing a repo path that
+// does not exist must not surface an error, because buildReferenceIndex
+// should never reach gitutil.
+func TestBuildReferenceIndexEmptyNamesDoesNoWork(t *testing.T) {
+	index, err := buildReferenceIndex(context.Background(), "/nonexistent/repo/path", "HEAD", map[string]struct{}{})
+	if err != nil {
+		t.Fatalf("expected no error for empty names, got %v", err)
+	}
+	if len(index) != 0 {
+		t.Fatalf("expected empty index, got %#v", index)
+	}
+}
+
+// TestAddDependentCountsNoChangesSkipsIndexBuild pins the same short-circuit
+// at the addDependentCounts level: a Result with no entity changes must not
+// attempt to build a reference index at all.
+func TestAddDependentCountsNoChangesSkipsIndexBuild(t *testing.T) {
+	result := &Result{}
+	if err := addDependentCounts(context.Background(), "/nonexistent/repo/path", "HEAD", result); err != nil {
+		t.Fatalf("expected no error when there are no changes, got %v", err)
+	}
+}
+
+// paddedPythonSource builds a syntactically valid Python file of exactly
+// targetSize bytes: a real function that calls calledName, followed by a
+// single padding comment line long enough to reach the target size.
+func paddedPythonSource(funcName, calledName string, targetSize int) string {
+	prefix := "def " + funcName + "(token):\n    return " + calledName + "(token)\n"
+	padNeeded := targetSize - len(prefix) - len("# \n")
+	if padNeeded < 0 {
+		padNeeded = 0
+	}
+	return prefix + "# " + strings.Repeat("x", padNeeded) + "\n"
+}
+
+// TestBuildReferenceIndexSkipsFilesOverMaxParseBytes pins parity with the
+// provider's MaxParseBytes eligibility: a file whose content exceeds
+// defaultMaxParseBytes must contribute 0 dependents, even though it contains
+// a token matching a changed name, while a file just under the limit with a
+// genuine call is still counted.
+func TestBuildReferenceIndexSkipsFilesOverMaxParseBytes(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+
+	overLimit := paddedPythonSource("huge_caller", "Foo", defaultMaxParseBytes+4096)
+	underLimit := paddedPythonSource("under_caller", "Foo", defaultMaxParseBytes-4096)
+	if len(overLimit) <= defaultMaxParseBytes {
+		t.Fatalf("fixture must exceed defaultMaxParseBytes, got %d bytes", len(overLimit))
+	}
+	if len(underLimit) >= defaultMaxParseBytes {
+		t.Fatalf("fixture must stay under defaultMaxParseBytes, got %d bytes", len(underLimit))
+	}
+
+	write(t, repo, "huge.py", overLimit)
+	write(t, repo, "just_under.py", underLimit)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	head := rev(t, repo, "HEAD")
+
+	index, err := buildReferenceIndex(context.Background(), repo, head, map[string]struct{}{"Foo": {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dependents := index["Foo"]
+	if _, ok := dependents["huge.py#function:huge_caller"]; ok {
+		t.Fatalf("file above defaultMaxParseBytes must contribute 0 dependents, got %#v", dependents)
+	}
+	if _, ok := dependents["just_under.py#function:under_caller"]; !ok {
+		t.Fatalf("expected just_under.py under_caller() as a dependent, got %#v", dependents)
+	}
+	if got, want := len(dependents), 1; got != want {
+		t.Fatalf("dependents count = %d, want %d: %#v", got, want, dependents)
+	}
+}
+
+// TestBuildReferenceIndexFallsBackWhenGrepFails pins the fallback: if the git
+// grep preselection call fails for any reason, buildReferenceIndex must
+// still fall back to a full-tree scan rather than silently returning zero
+// dependents. A NUL byte in a pattern makes the underlying git-grep
+// subprocess invocation fail outright (Go's exec layer rejects NUL bytes in
+// arguments), while leaving the unrelated, well-formed pattern's real
+// dependents fully discoverable via the fallback scan.
+func TestBuildReferenceIndexFallsBackWhenGrepFails(t *testing.T) {
+	repo, head := newDependentsTestRepo(t)
+
+	names := map[string]struct{}{
+		"Foo":         {},
+		"poison\x00x": {},
+	}
+
+	index, err := buildReferenceIndex(context.Background(), repo, head, names)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dependents := index["Foo"]
+	if got, want := len(dependents), 2; got != want {
+		t.Fatalf("dependents count after grep failure = %d, want %d: %#v", got, want, dependents)
+	}
+	if _, ok := dependents["caller_one.py#function:check"]; !ok {
+		t.Fatalf("expected caller_one.py check() as a dependent after fallback, got %#v", dependents)
+	}
+	if _, ok := dependents["caller_two.py#function:check_again"]; !ok {
+		t.Fatalf("expected caller_two.py check_again() as a dependent after fallback, got %#v", dependents)
+	}
+
+	if _, ok := index["poison\x00x"]; !ok {
+		t.Fatalf("expected an (empty) entry for the poisoned name, got %#v", index)
+	}
+	if len(index["poison\x00x"]) != 0 {
+		t.Fatalf("poisoned name should have no real dependents, got %#v", index["poison\x00x"])
+	}
+}

--- a/internal/sem/dependents_test.go
+++ b/internal/sem/dependents_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/entireio/entire-graph/internal/gitutil"
 )
 
 // newDependentsTestRepo creates a git repo with:
@@ -52,9 +54,12 @@ def foo(token):
 func TestBuildReferenceIndexCaseSensitiveWholeToken(t *testing.T) {
 	repo, head := newDependentsTestRepo(t)
 
-	index, err := buildReferenceIndex(context.Background(), repo, head, map[string]struct{}{"Foo": {}})
+	index, warnings, err := buildReferenceIndex(context.Background(), repo, head, map[string]struct{}{"Foo": {}})
 	if err != nil {
 		t.Fatal(err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings on a clean grep prefilter, got %#v", warnings)
 	}
 
 	dependents := index["Foo"]
@@ -98,12 +103,15 @@ func TestBuildReferenceIndexCaseSensitiveWholeToken(t *testing.T) {
 // does not exist must not surface an error, because buildReferenceIndex
 // should never reach gitutil.
 func TestBuildReferenceIndexEmptyNamesDoesNoWork(t *testing.T) {
-	index, err := buildReferenceIndex(context.Background(), "/nonexistent/repo/path", "HEAD", map[string]struct{}{})
+	index, warnings, err := buildReferenceIndex(context.Background(), "/nonexistent/repo/path", "HEAD", map[string]struct{}{})
 	if err != nil {
 		t.Fatalf("expected no error for empty names, got %v", err)
 	}
 	if len(index) != 0 {
 		t.Fatalf("expected empty index, got %#v", index)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for empty names, got %#v", warnings)
 	}
 }
 
@@ -155,7 +163,7 @@ func TestBuildReferenceIndexSkipsFilesOverMaxParseBytes(t *testing.T) {
 	git(t, repo, "commit", "-m", "initial")
 	head := rev(t, repo, "HEAD")
 
-	index, err := buildReferenceIndex(context.Background(), repo, head, map[string]struct{}{"Foo": {}})
+	index, warnings, err := buildReferenceIndex(context.Background(), repo, head, map[string]struct{}{"Foo": {}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,6 +177,16 @@ func TestBuildReferenceIndexSkipsFilesOverMaxParseBytes(t *testing.T) {
 	}
 	if got, want := len(dependents), 1; got != want {
 		t.Fatalf("dependents count = %d, want %d: %#v", got, want, dependents)
+	}
+
+	// The skipped oversized candidate must not be silent: a warning mirroring
+	// the provider's E_FILE_TOO_LARGE partial failure names the file and says
+	// its dependent references were not counted.
+	if got, want := len(warnings), 1; got != want {
+		t.Fatalf("warnings count = %d, want %d: %#v", got, want, warnings)
+	}
+	if warnings[0].Code != "E_FILE_TOO_LARGE" || warnings[0].FilePath != "huge.py" {
+		t.Fatalf("expected an E_FILE_TOO_LARGE warning for huge.py, got %#v", warnings[0])
 	}
 }
 
@@ -187,7 +205,7 @@ func TestBuildReferenceIndexFallsBackWhenGrepFails(t *testing.T) {
 		"poison\x00x": {},
 	}
 
-	index, err := buildReferenceIndex(context.Background(), repo, head, names)
+	index, warnings, err := buildReferenceIndex(context.Background(), repo, head, names)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -208,5 +226,57 @@ func TestBuildReferenceIndexFallsBackWhenGrepFails(t *testing.T) {
 	}
 	if len(index["poison\x00x"]) != 0 {
 		t.Fatalf("poisoned name should have no real dependents, got %#v", index["poison\x00x"])
+	}
+
+	// The fallback itself must not be silent: exactly one warning notes the
+	// prefilter failure and includes the underlying error text.
+	if got, want := len(warnings), 1; got != want {
+		t.Fatalf("warnings count = %d, want %d: %#v", got, want, warnings)
+	}
+	if warnings[0].Code != "W_DEPENDENTS_PREFILTER_FAILED" || warnings[0].Detail == "" {
+		t.Fatalf("expected a W_DEPENDENTS_PREFILTER_FAILED warning with error detail, got %#v", warnings[0])
+	}
+}
+
+// TestBuildReferenceIndexIncludesGitBinaryFlaggedFiles pins that the git-grep
+// prefilter used by referenceCandidateFiles is a genuine strict superset of
+// containsIdentifier's check, even for a file git itself classifies as
+// binary. `git grep -I` (binary-aware search) silently excludes such files
+// from its match list -- it does not error, so the grep-failure fallback
+// never triggers -- which would otherwise make a real dependent inside a
+// NUL-containing but perfectly parseable source file vanish without warning.
+func TestBuildReferenceIndexIncludesGitBinaryFlaggedFiles(t *testing.T) {
+	repo, _ := newDependentsTestRepo(t)
+
+	binaryFlaggedSource := "def binary_caller(token):\n    return Foo(token)\n# nul marker: \x00\n"
+	write(t, repo, "binary_caller.py", binaryFlaggedSource)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "add NUL-containing caller")
+	head := rev(t, repo, "HEAD")
+
+	// Confirm the fixture is actually excluded by git's binary-file heuristic
+	// (`-I`) -- otherwise this test would not be exercising the case it claims
+	// to cover.
+	textOnlyMatches, err := gitutil.GrepTreePaths(context.Background(), repo, head, []string{"Foo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range textOnlyMatches {
+		if path == "binary_caller.py" {
+			t.Fatal("fixture was not excluded by git grep -I; test no longer exercises the binary-file case")
+		}
+	}
+
+	index, warnings, err := buildReferenceIndex(context.Background(), repo, head, map[string]struct{}{"Foo": {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings; the binary-flagged file must be found without a prefilter fallback, got %#v", warnings)
+	}
+
+	dependents := index["Foo"]
+	if _, ok := dependents["binary_caller.py#function:binary_caller"]; !ok {
+		t.Fatalf("expected binary_caller.py binary_caller() as a dependent despite the embedded NUL byte, got %#v", dependents)
 	}
 }

--- a/internal/sem/dependents_test.go
+++ b/internal/sem/dependents_test.go
@@ -238,13 +238,70 @@ func TestBuildReferenceIndexFallsBackWhenGrepFails(t *testing.T) {
 	}
 }
 
+// pfBrokenCallsFooTS is a hard tree-sitter parse failure (mirrors
+// analyze_parsefailure_test.go's pfBrokenTS trick: a malformed leading type
+// alias derails the whole parse) that also contains a whole-token match for
+// "Foo", so it doubles as a dependents candidate file.
+const pfBrokenCallsFooTS = "type Broken = <\n\nexport function alpha(){return Foo()}\nexport function beta(){return 2}\n"
+
+// TestBuildReferenceIndexWarnsOnParseFailure pins that a Supported candidate
+// file which fails to parse (ParseWithStatus reports ParseError) surfaces a
+// warning naming the file, mirroring the provider's parse-failure partial
+// failure, instead of silently undercounting dependents with no trace in
+// Result.Warnings. Any entities the parser still recovers keep counting
+// exactly as before -- this is observability only.
+func TestBuildReferenceIndexWarnsOnParseFailure(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+
+	write(t, repo, "broken.ts", pfBrokenCallsFooTS)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	head := rev(t, repo, "HEAD")
+
+	index, warnings, err := buildReferenceIndex(context.Background(), repo, head, map[string]struct{}{"Foo": {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parseWarning *ProviderWarning
+	for i := range warnings {
+		if warnings[i].FilePath == "broken.ts" {
+			parseWarning = &warnings[i]
+		}
+	}
+	if parseWarning == nil {
+		t.Fatalf("expected a parse-failure warning for broken.ts, got %#v", warnings)
+	}
+	if parseWarning.Code != "E_PARSE_ERROR" {
+		t.Fatalf("expected E_PARSE_ERROR code, got %#v", parseWarning)
+	}
+	if parseWarning.Detail == "" {
+		t.Fatalf("expected non-empty detail on the parse-failure warning, got %#v", parseWarning)
+	}
+
+	// Whatever entities the broken parse did or didn't recover, dependent
+	// counting behavior on them is unchanged by this fix: it is purely
+	// additive observability.
+	dependents := index["Foo"]
+	if _, ok := dependents["broken.ts#function:alpha"]; ok {
+		t.Fatalf("alpha must not count as a dependent unless the parser actually recovered it as an entity, got %#v", dependents)
+	}
+}
+
 // TestBuildReferenceIndexIncludesGitBinaryFlaggedFiles pins that the git-grep
 // prefilter used by referenceCandidateFiles is a genuine strict superset of
 // containsIdentifier's check, even for a file git itself classifies as
 // binary. `git grep -I` (binary-aware search) silently excludes such files
 // from its match list -- it does not error, so the grep-failure fallback
 // never triggers -- which would otherwise make a real dependent inside a
-// NUL-containing but perfectly parseable source file vanish without warning.
+// NUL-containing source file vanish without warning. The embedded NUL byte
+// also trips a genuine (soft-recoverable) tree-sitter-python ERROR node, so
+// this fixture now surfaces a parse-failure warning too; the dependent is
+// still found because tree-sitter still recovers the entity around the
+// error, exactly like the pfSoftTS "soft recovery" case elsewhere.
 func TestBuildReferenceIndexIncludesGitBinaryFlaggedFiles(t *testing.T) {
 	repo, _ := newDependentsTestRepo(t)
 
@@ -271,8 +328,11 @@ func TestBuildReferenceIndexIncludesGitBinaryFlaggedFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(warnings) != 0 {
-		t.Fatalf("expected no warnings; the binary-flagged file must be found without a prefilter fallback, got %#v", warnings)
+	if got, want := len(warnings), 1; got != want {
+		t.Fatalf("expected exactly one parse-failure warning for the NUL byte tripping a tree-sitter ERROR node, got %d: %#v", got, warnings)
+	}
+	if warnings[0].Code != "E_PARSE_ERROR" || warnings[0].FilePath != "binary_caller.py" {
+		t.Fatalf("expected an E_PARSE_ERROR warning for binary_caller.py, got %#v", warnings[0])
 	}
 
 	dependents := index["Foo"]

--- a/internal/sem/search.go
+++ b/internal/sem/search.go
@@ -820,6 +820,7 @@ func preselectSearchFiles(
 	// indexing guard, not a retrieval recall cap once the graph is preindexed.
 	// Deeper sparse search retains the exhaustive path until corpus statistics
 	// can be persisted with the preindex.
+	//
 	// Tree identity is what makes the preindexed graph exact for source's
 	// current HEAD; the grep below runs against source.commit directly, so a
 	// same-tree preindex built at a different commit is still an exact match.

--- a/internal/sem/search.go
+++ b/internal/sem/search.go
@@ -285,8 +285,10 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 		// graph. Do not build a cold graph merely to return no results, but do
 		// preserve cached partial failures/completeness and cache-hit provenance.
 		cachedSnapshot, cacheHit := preindexedSnapshot, preindexCacheHit
-		if cacheHit && selection.commit != "" &&
-			(cachedSnapshot.Header.Commit != selection.commit || cachedSnapshot.Header.Tree != selection.tree) {
+		// Tree, not commit, is what determines whether the graph is still valid:
+		// two different commits sharing a tree parse identically, so only a tree
+		// change mid-search is a real race worth rejecting.
+		if cacheHit && selection.commit != "" && cachedSnapshot.Header.Tree != selection.tree {
 			return SearchResponse{}, errors.New("repository HEAD changed during search; retry against a stable commit")
 		}
 		totalLatency := time.Since(searchStarted).Milliseconds()
@@ -357,8 +359,8 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 		}
 		indexLatency += time.Since(indexStarted)
 	}
-	if selection.commit != "" &&
-		(snapshot.Header.Commit != selection.commit || snapshot.Header.Tree != selection.tree) {
+	// See the analogous no-hit guard above: tree identity is what matters here.
+	if selection.commit != "" && snapshot.Header.Tree != selection.tree {
 		return SearchResponse{}, errors.New("repository HEAD changed during search; retry against a stable commit")
 	}
 	queryStarted := time.Now()
@@ -818,8 +820,10 @@ func preselectSearchFiles(
 	// indexing guard, not a retrieval recall cap once the graph is preindexed.
 	// Deeper sparse search retains the exhaustive path until corpus statistics
 	// can be persisted with the preindex.
+	// Tree identity is what makes the preindexed graph exact for source's
+	// current HEAD; the grep below runs against source.commit directly, so a
+	// same-tree preindex built at a different commit is still an exact match.
 	exactFullPreindex := preindexCacheHit &&
-		preindexedSnapshot.Header.Commit == source.commit &&
 		preindexedSnapshot.Header.Tree == source.tree
 	grepPatterns, grepSafe := searchGitGrepPatterns(q.terms)
 	if exactFullPreindex && !options.Worktree && options.TopK <= defaultSearchTopK && grepSafe {

--- a/internal/sem/search_cache.go
+++ b/internal/sem/search_cache.go
@@ -179,7 +179,7 @@ func loadOrBuildSearchSnapshot(
 // the repository's current HEAD tree. Unlike query-time selective indexing,
 // this cache entry is query independent and can be prepared before an agent
 // task begins. Worktree snapshots are deliberately rejected because dirty
-// state cannot be represented by a durable commit-keyed cache safely.
+// state cannot be represented by a durable tree-keyed cache safely.
 func PreindexProviderSnapshot(
 	ctx context.Context,
 	repo, providerVersion string,
@@ -469,7 +469,7 @@ func filterSearchPartialFailures(failures []PartialFailure, allowedFiles map[str
 	return filtered
 }
 
-// LoadOrBuildProviderSnapshot reuses the commit-keyed, option-keyed compressed
+// LoadOrBuildProviderSnapshot reuses the tree-keyed, option-keyed compressed
 // provider snapshot cache shared with search. Worktree snapshots always bypass
 // the cache so dirty edits cannot be hidden by committed-tree state.
 func LoadOrBuildProviderSnapshot(
@@ -487,6 +487,12 @@ func LoadOrBuildProviderSnapshot(
 // entry can reuse it (e.g. --allow-empty commits, amends, rebases that don't
 // touch content). Commit is provenance metadata carried on the cached value
 // and re-stamped to the serving HEAD on load; it never influences the key.
+// This is scoped to the parsed graph itself: a full-profile snapshot also
+// embeds FILE_CHANGES_WITH co-change relations derived by walking recent git
+// history (see fileChangesWithRelations), so a same-tree hit after a rebase
+// can serve co-change edges computed against the prior history. That is
+// accepted because those edges are heuristic and confidence-scored, not
+// exact facts about the tree.
 func searchSnapshotKey(absRepo, providerVersion, tree string, options ProviderSnapshotOptions) (string, error) {
 	hash := sha256.New()
 	writePart := func(value string) {
@@ -532,8 +538,11 @@ func searchSnapshotKey(absRepo, providerVersion, tree string, options ProviderSn
 
 // validCachedSearchSnapshot deliberately does not compare commit: the cache is
 // tree-keyed, so an entry built at a different commit sharing this tree is a
-// valid hit. Callers re-stamp the commit to the serving HEAD via
-// restampCachedSearchSnapshotCommit before returning the snapshot.
+// valid hit. Callers that serve a cached snapshot re-stamp the commit to the
+// serving HEAD via restampCachedSearchSnapshotCommit before returning it;
+// other call sites (e.g. PreindexProviderSnapshot's persisted-entry check)
+// use this function only as a persistence check and never hand the cached
+// value back to a caller, so they have no re-stamping to do.
 func validCachedSearchSnapshot(cache cachedSearchSnapshot, providerVersion, tree string, options ProviderSnapshotOptions) bool {
 	return cache.CacheVersion == searchSnapshotCacheVersion &&
 		cache.ProviderVersion == providerVersion &&
@@ -550,7 +559,11 @@ func validCachedSearchSnapshot(cache cachedSearchSnapshot, providerVersion, tree
 // parsed graph, so a same-tree cache hit from a different (empty, amended,
 // rebased) commit is exactly correct content-wise; commit is provenance
 // metadata layered on top and must reflect the serving HEAD, never the
-// possibly-stale commit recorded when the entry was built.
+// possibly-stale commit recorded when the entry was built. This is not just
+// provenance cosmetics: query time also reads Header.Commit back out as the
+// git treeish for content reads (see openSearchContentReader in search.go),
+// so serving a stale commit here could point those reads at a dangling or
+// wrong revision.
 func restampCachedSearchSnapshotCommit(cache cachedSearchSnapshot, commit string) cachedSearchSnapshot {
 	cache.Commit = commit
 	cache.Snapshot.Header.Commit = commit

--- a/internal/sem/search_cache.go
+++ b/internal/sem/search_cache.go
@@ -77,15 +77,19 @@ func loadCachedCompleteSearchSnapshot(
 	if fullOptions.Profile == "" {
 		fullOptions.Profile = ProfileFull
 	}
-	fullKey, keyErr := searchSnapshotKey(absRepo, providerVersion, commit, tree, fullOptions)
+	fullKey, keyErr := searchSnapshotKey(absRepo, providerVersion, tree, fullOptions)
 	if keyErr != nil {
 		return ProviderSnapshot{}, false, keyErr
 	}
 	fullPath := filepath.Join(cacheDir, "search", searchSnapshotCacheVersion, fullKey+".json.gz")
 	cached, readErr := readSearchSnapshot(fullPath)
-	if readErr != nil || !validCachedSearchSnapshot(cached, providerVersion, commit, tree, fullOptions) {
+	if readErr != nil || !validCachedSearchSnapshot(cached, providerVersion, tree, fullOptions) {
 		return ProviderSnapshot{}, false, nil
 	}
+	// The cache key is tree-only: a hit may have been built for a different
+	// commit that shares this tree. The parsed graph is exactly correct, but
+	// commit provenance must reflect the HEAD we are serving right now.
+	cached = restampCachedSearchSnapshotCommit(cached, commit)
 	return cached.Snapshot, true, nil
 }
 
@@ -112,12 +116,16 @@ func loadOrBuildSearchSnapshot(
 		snapshot, buildErr := BuildProviderSnapshotWithOptions(ctx, repo, providerVersion, options)
 		return snapshot, false, buildErr
 	}
-	key, err := searchSnapshotKey(absRepo, providerVersion, commit, tree, options)
+	key, err := searchSnapshotKey(absRepo, providerVersion, tree, options)
 	if err != nil {
 		return ProviderSnapshot{}, false, err
 	}
 	path := filepath.Join(cacheDir, "search", searchSnapshotCacheVersion, key+".json.gz")
-	if cached, err := readSearchSnapshot(path); err == nil && validCachedSearchSnapshot(cached, providerVersion, commit, tree, options) {
+	if cached, err := readSearchSnapshot(path); err == nil && validCachedSearchSnapshot(cached, providerVersion, tree, options) {
+		// See loadCachedCompleteSearchSnapshot: tree-only keying means this hit
+		// may belong to a different commit that shares the tree. Re-stamp before
+		// handing it back so no caller ever reports a stale commit.
+		cached = restampCachedSearchSnapshotCommit(cached, commit)
 		return cached.Snapshot, true, nil
 	}
 	// A complete committed-tree snapshot is query independent and can serve a
@@ -126,12 +134,13 @@ func loadOrBuildSearchSnapshot(
 	if len(options.OnlyFiles) > 0 {
 		fullOptions := options
 		fullOptions.OnlyFiles = nil
-		fullKey, keyErr := searchSnapshotKey(absRepo, providerVersion, commit, tree, fullOptions)
+		fullKey, keyErr := searchSnapshotKey(absRepo, providerVersion, tree, fullOptions)
 		if keyErr != nil {
 			return ProviderSnapshot{}, false, keyErr
 		}
 		fullPath := filepath.Join(cacheDir, "search", searchSnapshotCacheVersion, fullKey+".json.gz")
-		if cached, readErr := readSearchSnapshot(fullPath); readErr == nil && validCachedSearchSnapshot(cached, providerVersion, commit, tree, fullOptions) {
+		if cached, readErr := readSearchSnapshot(fullPath); readErr == nil && validCachedSearchSnapshot(cached, providerVersion, tree, fullOptions) {
+			cached = restampCachedSearchSnapshotCommit(cached, commit)
 			selective, deriveErr := selectiveSearchSnapshotFromFull(ctx, absRepo, providerVersion, options, cached.Snapshot)
 			if deriveErr == nil {
 				// Persisting the exact selective view makes repeated identical queries
@@ -148,12 +157,17 @@ func loadOrBuildSearchSnapshot(
 	if err != nil {
 		return ProviderSnapshot{}, false, err
 	}
-	if snapshot.Header.Commit != commit || snapshot.Header.Tree != tree {
+	if snapshot.Header.Tree != tree {
 		return ProviderSnapshot{}, false, fmt.Errorf(
 			"repository HEAD changed while building search snapshot: got commit %q tree %q, started at commit %q tree %q",
 			snapshot.Header.Commit, snapshot.Header.Tree, commit, tree,
 		)
 	}
+	// The tree we started at is still what got built even if a same-tree
+	// commit (e.g. an empty commit) landed concurrently. Re-stamp so the
+	// returned snapshot reports the commit this call is serving, not whatever
+	// HEAD happened to be mid-build.
+	snapshot.Header.Commit = commit
 	cache := newCachedSearchSnapshot(providerVersion, commit, tree, options, snapshot)
 	// Cache persistence is best effort. Retrieval correctness never depends on
 	// a writable cache directory.
@@ -195,7 +209,7 @@ func PreindexProviderSnapshot(
 	if err != nil {
 		return ProviderSnapshot{}, false, err
 	}
-	if snapshot.Header.Commit != commit || snapshot.Header.Tree != tree {
+	if snapshot.Header.Tree != tree {
 		return ProviderSnapshot{}, false, fmt.Errorf(
 			"preindex snapshot provenance mismatch: got commit %q tree %q, want commit %q tree %q",
 			snapshot.Header.Commit, snapshot.Header.Tree, commit, tree,
@@ -204,13 +218,13 @@ func PreindexProviderSnapshot(
 	// Query-time caching is deliberately best effort, but an explicit preindex
 	// command promises a durable artifact. Verify that the entry exists and, if
 	// the best-effort write failed, retry while surfacing the persistence error.
-	key, err := searchSnapshotKey(absRepo, providerVersion, commit, tree, options)
+	key, err := searchSnapshotKey(absRepo, providerVersion, tree, options)
 	if err != nil {
 		return ProviderSnapshot{}, false, err
 	}
 	path := filepath.Join(cacheDir, "search", searchSnapshotCacheVersion, key+".json.gz")
 	persisted, readErr := readSearchSnapshot(path)
-	if readErr != nil || !validCachedSearchSnapshot(persisted, providerVersion, commit, tree, options) {
+	if readErr != nil || !validCachedSearchSnapshot(persisted, providerVersion, tree, options) {
 		cache := newCachedSearchSnapshot(providerVersion, commit, tree, options, snapshot)
 		if err := writeSearchSnapshot(path, cache); err != nil {
 			return ProviderSnapshot{}, false, fmt.Errorf("persist preindex snapshot: %w", err)
@@ -277,7 +291,9 @@ func selectiveSearchSnapshotFromFull(
 	if sc.close != nil {
 		defer sc.close()
 	}
-	if sc.commit != full.Header.Commit || sc.tree != full.Header.Tree || sc.key != full.Header.RepoKey {
+	// Tree (not commit) determines whether the cached full snapshot is a valid
+	// derivation source: two different commits sharing a tree parse identically.
+	if sc.tree != full.Header.Tree || sc.key != full.Header.RepoKey {
 		return ProviderSnapshot{}, fmt.Errorf(
 			"cached full snapshot provenance mismatch: got repo %q commit %q tree %q, want repo %q commit %q tree %q",
 			full.Header.RepoKey, full.Header.Commit, full.Header.Tree, sc.key, sc.commit, sc.tree,
@@ -466,7 +482,12 @@ func LoadOrBuildProviderSnapshot(
 	return loadOrBuildSearchSnapshot(ctx, repo, providerVersion, options, cacheDir, disableCache)
 }
 
-func searchSnapshotKey(absRepo, providerVersion, commit, tree string, options ProviderSnapshotOptions) (string, error) {
+// searchSnapshotKey is deliberately tree-only, not commit-keyed: parsing is a
+// pure function of tree content, so any commit whose tree matches an existing
+// entry can reuse it (e.g. --allow-empty commits, amends, rebases that don't
+// touch content). Commit is provenance metadata carried on the cached value
+// and re-stamped to the serving HEAD on load; it never influences the key.
+func searchSnapshotKey(absRepo, providerVersion, tree string, options ProviderSnapshotOptions) (string, error) {
 	hash := sha256.New()
 	writePart := func(value string) {
 		_, _ = io.WriteString(hash, value)
@@ -475,7 +496,6 @@ func searchSnapshotKey(absRepo, providerVersion, commit, tree string, options Pr
 	writePart(searchSnapshotCacheVersion)
 	writePart(absRepo)
 	writePart(providerVersion)
-	writePart(commit)
 	writePart(tree)
 	writePart(string(options.Profile))
 	writePart(fmt.Sprintf("%d", options.MaxParseBytes))
@@ -510,17 +530,31 @@ func searchSnapshotKey(absRepo, providerVersion, commit, tree string, options Pr
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
-func validCachedSearchSnapshot(cache cachedSearchSnapshot, providerVersion, commit, tree string, options ProviderSnapshotOptions) bool {
+// validCachedSearchSnapshot deliberately does not compare commit: the cache is
+// tree-keyed, so an entry built at a different commit sharing this tree is a
+// valid hit. Callers re-stamp the commit to the serving HEAD via
+// restampCachedSearchSnapshotCommit before returning the snapshot.
+func validCachedSearchSnapshot(cache cachedSearchSnapshot, providerVersion, tree string, options ProviderSnapshotOptions) bool {
 	return cache.CacheVersion == searchSnapshotCacheVersion &&
 		cache.ProviderVersion == providerVersion &&
-		cache.Commit == commit &&
 		cache.Tree == tree &&
 		cache.Profile == options.Profile &&
 		cache.MaxParseBytes == options.MaxParseBytes &&
-		cache.Snapshot.Header.Commit == commit &&
 		cache.Snapshot.Header.Tree == tree &&
 		cache.Snapshot.Header.Provider == ProviderName &&
 		cache.Snapshot.Header.Profile == string(options.Profile)
+}
+
+// restampCachedSearchSnapshotCommit rewrites a loaded cache entry's commit
+// provenance to the commit we are actually serving. Tree determines the
+// parsed graph, so a same-tree cache hit from a different (empty, amended,
+// rebased) commit is exactly correct content-wise; commit is provenance
+// metadata layered on top and must reflect the serving HEAD, never the
+// possibly-stale commit recorded when the entry was built.
+func restampCachedSearchSnapshotCommit(cache cachedSearchSnapshot, commit string) cachedSearchSnapshot {
+	cache.Commit = commit
+	cache.Snapshot.Header.Commit = commit
+	return cache
 }
 
 func readSearchSnapshot(path string) (cachedSearchSnapshot, error) {

--- a/internal/sem/search_cache_test.go
+++ b/internal/sem/search_cache_test.go
@@ -649,3 +649,57 @@ func TestSearchSnapshotCacheKeyPreservesIgnoreFileOrder(t *testing.T) {
 		t.Fatalf("reversed-rule snapshot lost control symbol: %#v", second.Symbols)
 	}
 }
+
+// TestOnlyFilesDerivationReStampsCommitAfterSameTreeCommit pins the re-stamp
+// on the OnlyFiles-derivation branch of loadOrBuildSearchSnapshot: a selective
+// snapshot derived from a complete same-tree cache entry built at an older
+// commit must report the commit it is actually serving right now, not the
+// stale commit recorded when the complete entry was written.
+func TestOnlyFilesDerivationReStampsCommitAfterSameTreeCommit(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	write(t, repo, "selected.go", "package sample\nfunc Selected() bool { return true }\n")
+	write(t, repo, "other.go", "package sample\nfunc Other() bool { return false }\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+
+	cacheDir := t.TempDir()
+	full, cacheHit, err := PreindexProviderSnapshot(t.Context(), repo, "test-version", ProviderSnapshotOptions{
+		Profile: ProfileFull,
+	}, cacheDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cacheHit {
+		t.Fatal("first preindex unexpectedly hit cache")
+	}
+
+	git(t, repo, "commit", "--allow-empty", "-m", "same tree")
+	newHead := rev(t, repo, "HEAD")
+	if newHead == full.Header.Commit {
+		t.Fatal("test setup did not advance HEAD to a new commit")
+	}
+
+	selective, cacheHit, err := LoadOrBuildProviderSnapshot(t.Context(), repo, "test-version", ProviderSnapshotOptions{
+		Profile:   ProfileFull,
+		OnlyFiles: []string{"selected.go"},
+	}, cacheDir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cacheHit {
+		t.Fatal("selective build did not derive from the complete same-tree preindex")
+	}
+	if selective.Header.Tree != full.Header.Tree {
+		t.Fatalf("derived selective snapshot tree changed across an empty commit: got %s, want %s",
+			selective.Header.Tree, full.Header.Tree,
+		)
+	}
+	if selective.Header.Commit != newHead {
+		t.Fatalf("derived selective snapshot commit was not re-stamped to serving HEAD: got %s, want %s",
+			selective.Header.Commit, newHead,
+		)
+	}
+}

--- a/internal/sem/search_cache_test.go
+++ b/internal/sem/search_cache_test.go
@@ -201,7 +201,7 @@ func NeedleTarget() bool { return true }
 		Profile:   ProfileSyntaxOnly,
 		OnlyFiles: []string{"target/needle.go"},
 	}
-	selectiveKey, err := searchSnapshotKey(repo, "test-version", preindexed.Header.Commit, preindexed.Header.Tree, selectiveProviderOptions)
+	selectiveKey, err := searchSnapshotKey(repo, "test-version", preindexed.Header.Tree, selectiveProviderOptions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -504,7 +504,7 @@ func TestPreindexProviderSnapshotSurfacesPersistenceFailure(t *testing.T) {
 	}
 }
 
-func TestPreindexProviderSnapshotDoesNotReuseSameTreeAcrossCommits(t *testing.T) {
+func TestPreindexProviderSnapshotReusesSameTreeAcrossCommits(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")
 	git(t, repo, "config", "user.name", "Entire Graph Test")
@@ -528,6 +528,10 @@ func TestPreindexProviderSnapshotDoesNotReuseSameTreeAcrossCommits(t *testing.T)
 		first[profile] = snapshot
 	}
 	git(t, repo, "commit", "--allow-empty", "-m", "same tree")
+	newHead := rev(t, repo, "HEAD")
+	if newHead == first[ProfileFull].Header.Commit {
+		t.Fatal("test setup did not advance HEAD to a new commit")
+	}
 	for _, profile := range []Profile{ProfileFast, ProfileFull} {
 		second, cacheHit, err := PreindexProviderSnapshot(t.Context(), repo, "test", ProviderSnapshotOptions{
 			Profile: profile,
@@ -535,16 +539,57 @@ func TestPreindexProviderSnapshotDoesNotReuseSameTreeAcrossCommits(t *testing.T)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if cacheHit {
-			t.Fatalf("same-tree but different-commit %s snapshot reused cache", profile)
+		if !cacheHit {
+			t.Fatalf("same-tree but different-commit %s snapshot did not reuse cache", profile)
 		}
-		if second.Header.Tree != first[profile].Header.Tree || second.Header.Commit == first[profile].Header.Commit {
-			t.Fatalf("%s snapshot provenance mismatch: first=%s/%s second=%s/%s",
-				profile,
-				first[profile].Header.Commit, first[profile].Header.Tree,
-				second.Header.Commit, second.Header.Tree,
+		if second.Header.Tree != first[profile].Header.Tree {
+			t.Fatalf("%s snapshot tree changed across an empty commit: first=%s second=%s",
+				profile, first[profile].Header.Tree, second.Header.Tree,
 			)
 		}
+		// The parsed graph is reused from the old commit's cache entry, but the
+		// commit we report must be the one we are actually serving right now,
+		// not the stale commit recorded when the cache entry was built.
+		if second.Header.Commit != newHead {
+			t.Fatalf("%s snapshot commit was not re-stamped to serving HEAD: got %s, want %s",
+				profile, second.Header.Commit, newHead,
+			)
+		}
+	}
+}
+
+func TestSearchReusesSameTreeCacheAcrossCommitsAndReportsCurrentHEAD(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	write(t, repo, "auth.go", "package auth\n\nfunc ValidateToken(token string) bool { return token != \"\" }\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+
+	cacheDir := t.TempDir()
+	options := SearchOptions{Profile: ProfileFull, TopK: 5, CacheDir: cacheDir}
+	if _, _, err := PreindexProviderSnapshot(t.Context(), repo, "test-version", ProviderSnapshotOptions{
+		Profile: ProfileFull,
+	}, cacheDir); err != nil {
+		t.Fatal(err)
+	}
+
+	git(t, repo, "commit", "--allow-empty", "-m", "same tree")
+	newHead := rev(t, repo, "HEAD")
+
+	response, err := SearchRepository(t.Context(), repo, "test-version", "ValidateToken", options)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !response.Stats.IndexCacheHit {
+		t.Fatal("search after an empty commit did not reuse the same-tree cache")
+	}
+	if response.Commit != newHead {
+		t.Fatalf("search response commit = %q, want current HEAD %q", response.Commit, newHead)
+	}
+	if len(response.Results) == 0 || response.Results[0].SymbolName != "ValidateToken" {
+		t.Fatalf("search lost target after cache reuse across commits: %#v", response.Results)
 	}
 }
 
@@ -578,11 +623,11 @@ func TestSearchSnapshotCacheKeyPreservesIgnoreFileOrder(t *testing.T) {
 
 	ignoreTarget := includeTarget
 	ignoreTarget.IgnoreFiles = []string{".reinclude-target", ".ignore-target"}
-	includeKey, err := searchSnapshotKey(repo, "test-version", first.Header.Commit, first.Header.Tree, includeTarget)
+	includeKey, err := searchSnapshotKey(repo, "test-version", first.Header.Tree, includeTarget)
 	if err != nil {
 		t.Fatal(err)
 	}
-	ignoreKey, err := searchSnapshotKey(repo, "test-version", first.Header.Commit, first.Header.Tree, ignoreTarget)
+	ignoreKey, err := searchSnapshotKey(repo, "test-version", first.Header.Tree, ignoreTarget)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/4
<!-- entire-trail-link-end -->

## Summary

Two performance fixes for the graph plugin, found while timing `entire graph commit` on this repo (2m14s–3m45s per run):

1. **Dependents scan prefilter + size parity** (`internal/sem/dependents.go`): `buildReferenceIndex` parsed every supported file in the head tree on every semantic diff — including ~215 MB of vendored grammar `parser.c` files that the provider snapshot path refuses to parse (`MaxParseBytes`, 4 MiB). Now: candidate files are prefiltered with `git grep` over the changed names (binary-inclusive, so it's a strict superset of the whole-token match — counts for real identifiers are bit-identical), and files over the provider's default parse cap are skipped with an `E_FILE_TOO_LARGE` warning, matching the graph's own eligibility everywhere else.

   **Measured: `entire graph commit d7204db` 3m17s → 15s (~13x).**

2. **Tree-keyed snapshot cache** (`internal/sem/search_cache.go`): the cache key and validation pinned the commit SHA as well as the tree, so empty commits, amends, and rebases invalidated a byte-identical graph. Now keyed and validated on tree only, with the serving commit re-stamped onto loaded snapshots (`Header.Commit` doubles as the treeish for query-time content reads, so this is load-bearing, not cosmetic). Verified end-to-end: `index --head` → `git commit --allow-empty` → search reports `cache-hit` with the new HEAD.

## Deliberate semantics changes (flagged for review)

- `dependents_count` no longer counts entities in files >4 MiB — parity with the provider, which already excludes them from every other output. Skips are reported as warnings rather than silent.
- Full-profile snapshots embed history-derived `FILE_CHANGES_WITH` co-change relations; a same-tree cache hit after a **rebase** can serve those edges from the prior history. Accepted because they're heuristic and confidence-scored (0.55–0.7); documented in `searchSnapshotKey`'s comment.
- New (additive) `warnings` entries consumers may start seeing from the diff commands: `E_FILE_TOO_LARGE` (oversized file skipped during dependents counting), `W_DEPENDENTS_PREFILTER_FAILED` (grep prefilter failed, full scan used), and `E_PARSE_ERROR`/`E_PARSE_TIMEOUT` (candidate file didn't parse cleanly; previously silent undercount). Nothing removed or renamed.
- Old commit-keyed cache entries become unreachable orphans in the v4 cache dir (no correctness impact; they'll sit until a cleanup pass exists).

## Testing

- TDD throughout: grep-prefilter superset matrix (case/substring/self-exclusion), binary-flagged file inclusion (red→green), oversized-skip + warning, grep-failure fallback + warning, tree-reuse across commits at preindex and search level, OnlyFiles derivation across commits.
- `mise run check` (gofmt, vet, race tests, build) green.
- Four-agent review (code, tests, silent-failures, comments) applied: binary `-I` hole fixed, observability warnings added, stale comments corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CMtDDkQkwEkfeFyk96TeY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tree-keyed caching and commit re-stamping affect search/preindex correctness and content reads; dependents prefilter changes which files are scanned and when counts can be under-reported (with warnings).
> 
> **Overview**
> **Speeds semantic diff and snapshot reuse** by narrowing dependent-reference work and reusing parsed graphs when only the commit SHA changes.
> 
> **Dependents (`dependents.go`)** no longer walks every supported file on HEAD. It preselects candidates with **`git grep`** (binary-inclusive via new **`GrepTreePathsIncludingBinary`**), skips files over the provider’s default **`MaxParseBytes`**, and on grep failure falls back to a full-tree scan with **`W_DEPENDENTS_PREFILTER_FAILED`**. Oversized skips and parse failures surface **`E_FILE_TOO_LARGE`** / parse warnings on **`Result.Warnings`**; whole-token counting semantics are unchanged.
> 
> **Search cache (`search_cache.go`, `search.go`)** keys and validates snapshots on **tree** only (not commit). Loaded entries **re-stamp `Header.Commit`** to the serving HEAD so content reads and API responses stay correct. Race checks during search compare **tree** identity; preindexed grep preselection no longer requires commit equality.
> 
> **Semantics to note:** `dependents_count` excludes files above the parse cap (aligned with the provider). Same-tree cache hits after a rebase may reuse history-derived **`FILE_CHANGES_WITH`** edges from when the entry was built.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95f746d6a4a103fd815fd73259f8f4099946ddfc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
