### PR TITLE
feat(cli): report semantic diff progress

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -93,10 +93,10 @@ func printHelp(out io.Writer) {
 	fmt.Fprintln(out, `entire-graph adds entity-level context to Entire checkpoints.
 
 Usage:
-  entire graph commit [rev] [--json] [--repo path]
+  entire graph commit [rev] [--json] [--progress] [--repo path]
   entire graph checkpoint <checkpoint-id> [--json] [--repo path]
-  entire graph diff --base <rev> --head <rev> [--json] [--repo path] [-- path...]
-  entire graph analyze [--base <rev>] [--head <rev>] [--json] [--repo path] [-- path...]
+  entire graph diff --base <rev> --head <rev> [--json] [--progress] [--repo path] [-- path...]
+  entire graph analyze [--base <rev>] [--head <rev>] [--json] [--progress] [--repo path] [-- path...]
   entire graph doctor [--json]
   entire graph version [--json]
   entire graph capabilities --json
@@ -105,7 +105,11 @@ Usage:
   entire graph edges --repo . --format ndjson [--worktree] [--progress] [--ignore-file path] [--include-file path]
   entire graph index --repo . [--profile syntax-only|fast|full] [--cache-dir path] [--format json] [--head] [--ignore-file path] [--include-file path]
   entire graph search --query "issue or concept" --repo . [--format json|ndjson|text|agent] [--top-k 20] [--max-context-bytes 16384] [--head] [--profile syntax-only|fast|full] [--max-indexed-files n|--index-all-files] [--cache-dir path|--no-cache]
-  entire graph neighbors --symbol NAME --repo . [--file path] [--relation CALLS] [--direction both|in|out] [--depth 1|2] [--limit 20] [--format json|text|agent] [--max-context-bytes 16384] [--head] [--cache-dir path|--no-cache] [--internal-only] [--exclude-tests]`)
+  entire graph neighbors --symbol NAME --repo . [--file path] [--relation CALLS] [--direction both|in|out] [--depth 1|2] [--limit 20] [--format json|text|agent] [--max-context-bytes 16384] [--head] [--cache-dir path|--no-cache] [--internal-only] [--exclude-tests]
+
+Notes:
+  --include-file contains gitignore-style rules that re-include ignored paths; it is not an allowlist.
+  Streaming NDJSON writes aggregate stats and completeness in the trailing summary record.`)
 }
 
 func runDoctor(ctx context.Context, opts Options, args []string) error {
@@ -374,8 +378,9 @@ func includeRecord(mode string, record any) bool {
 }
 
 type commonFlags struct {
-	Repo string
-	JSON bool
+	Repo     string
+	JSON     bool
+	Progress bool
 }
 
 type providerFlags struct {
@@ -534,6 +539,8 @@ func parseCommonFlags(args []string) (commonFlags, []string, error) {
 		switch arg {
 		case "--json":
 			flags.JSON = true
+		case "--progress":
+			flags.Progress = true
 		case "--repo":
 			i++
 			if i >= len(args) {
@@ -570,13 +577,16 @@ func runCommit(ctx context.Context, opts Options, args []string) error {
 	if err != nil {
 		return err
 	}
-	return analyzeAndPrint(ctx, opts.Stdout, repo, base, rev, nil, flags.JSON)
+	return analyzeAndPrint(ctx, opts, repo, base, rev, nil, flags.JSON, flags.Progress)
 }
 
 func runCheckpoint(ctx context.Context, opts Options, args []string) error {
 	flags, rest, err := parseCommonFlags(args)
 	if err != nil {
 		return err
+	}
+	if flags.Progress {
+		return errors.New("checkpoint does not support --progress")
 	}
 	if len(rest) != 1 {
 		return errors.New("checkpoint requires exactly one checkpoint ID")
@@ -628,7 +638,7 @@ func runDiff(ctx context.Context, opts Options, args []string) error {
 	if err != nil {
 		return err
 	}
-	return analyzeAndPrint(ctx, opts.Stdout, repo, base, head, paths, flags.JSON)
+	return analyzeAndPrint(ctx, opts, repo, base, head, paths, flags.JSON, flags.Progress)
 }
 
 func resolveRepo(ctx context.Context, env EntireEnv, explicit string) (string, error) {
@@ -641,12 +651,23 @@ func resolveRepo(ctx context.Context, env EntireEnv, explicit string) (string, e
 	return gitutil.RepoRoot(ctx, ".")
 }
 
-func analyzeAndPrint(ctx context.Context, out io.Writer, repo, base, head string, paths []string, asJSON bool) error {
-	result, err := sem.AnalyzeGitRange(ctx, repo, base, head, paths)
+func analyzeAndPrint(ctx context.Context, opts Options, repo, base, head string, paths []string, asJSON, progress bool) error {
+	analyzeOptions := sem.AnalyzeOptions{}
+	if progress {
+		analyzeOptions.Progress = func(event sem.AnalyzeProgressEvent) {
+			fmt.Fprintf(opts.Stderr, "graph diff progress phase=%s files=%d/%d elapsed=%s\n",
+				event.Phase,
+				event.FilesDone,
+				event.FilesTotal,
+				event.Elapsed.Round(time.Millisecond),
+			)
+		}
+	}
+	result, err := sem.AnalyzeGitRangeWithOptions(ctx, repo, base, head, paths, analyzeOptions)
 	if err != nil {
 		return err
 	}
-	return printResult(out, result, asJSON)
+	return printResult(opts.Stdout, result, asJSON)
 }
 
 func printResult(out io.Writer, result sem.Result, asJSON bool) error {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -435,6 +435,37 @@ func TestHelpDocumentsNeighborAgentContextCap(t *testing.T) {
 	}
 }
 
+func TestDiffProgressReportsToStderr(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	write(t, repo, "auth.py", "def validate_token(token):\n    return bool(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	write(t, repo, "auth.py", "def validate_token(token, issuer=None):\n    return bool(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "change")
+
+	var stdout, stderr bytes.Buffer
+	err := Run(t.Context(), Options{
+		Env:    EntireEnv{RepoRoot: repo},
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}, []string{"diff", "--base", "HEAD~1", "--head", "HEAD", "--progress"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"phase=discover", "phase=parse", "phase=reconcile", "phase=dependents", "phase=complete"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("progress output missing %q:\n%s", want, stderr.String())
+		}
+	}
+	if strings.Contains(stdout.String(), "graph diff progress") {
+		t.Fatalf("progress leaked to stdout:\n%s", stdout.String())
+	}
+}
+
 func TestNeighborsAgentFormatReturnsBoundedCallGraphAndPaths(t *testing.T) {
 	repo := t.TempDir()
 	write(t, repo, "calls.go", `package calls

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -5,19 +5,55 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"time"
 
 	"github.com/entireio/entire-graph/internal/gitutil"
 )
 
 func AnalyzeGitRange(ctx context.Context, repo, base, head string, paths []string) (Result, error) {
+	return AnalyzeGitRangeWithOptions(ctx, repo, base, head, paths, AnalyzeOptions{})
+}
+
+// AnalyzeOptions configures optional semantic diff behavior.
+type AnalyzeOptions struct {
+	Progress func(AnalyzeProgressEvent)
+}
+
+// AnalyzeProgressEvent reports coarse progress for a semantic diff.
+type AnalyzeProgressEvent struct {
+	Phase      string
+	FilesDone  int
+	FilesTotal int
+	Elapsed    time.Duration
+}
+
+// AnalyzeGitRangeWithOptions analyzes a Git range with optional progress reporting.
+func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, paths []string, options AnalyzeOptions) (Result, error) {
+	started := time.Now()
+	emitProgress := func(phase string, filesDone, filesTotal int) {
+		if options.Progress != nil {
+			options.Progress(AnalyzeProgressEvent{
+				Phase:      phase,
+				FilesDone:  filesDone,
+				FilesTotal: filesTotal,
+				Elapsed:    time.Since(started),
+			})
+		}
+	}
+
+	emitProgress("discover", 0, 0)
 	changed, err := gitutil.ChangedFiles(ctx, repo, base, head, paths)
 	if err != nil {
 		return Result{}, err
 	}
+	emitProgress("parse", 0, len(changed))
 	parser := TreeSitterParser{}
 	result := Result{Base: base, Head: head}
 	var deltas []*fileDelta
-	for _, file := range changed {
+	for i, file := range changed {
+		if i > 0 && i%100 == 0 {
+			emitProgress("parse", i, len(changed))
+		}
 		path := file.Path
 		oldPath := file.OldPath
 		if oldPath == "" {
@@ -102,7 +138,9 @@ func AnalyzeGitRange(ctx context.Context, repo, base, head string, paths []strin
 			added:    added,
 		})
 	}
+	emitProgress("parse", len(changed), len(changed))
 
+	emitProgress("reconcile", len(changed), len(changed))
 	result.Warnings = append(result.Warnings, reconcileMoves(deltas)...)
 
 	for _, delta := range deltas {
@@ -126,9 +164,12 @@ func AnalyzeGitRange(ctx context.Context, repo, base, head string, paths []strin
 		})
 	}
 
-	if err := addDependentCounts(ctx, repo, head, &result); err != nil {
+	if err := addDependentCountsWithProgress(ctx, repo, head, &result, func(done, total int) {
+		emitProgress("dependents", done, total)
+	}); err != nil {
 		return Result{}, err
 	}
+	emitProgress("complete", len(changed), len(changed))
 	return result, nil
 }
 

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -96,6 +96,47 @@ func TestAnalyzeGitRangeSurfacesModuleScopeChange(t *testing.T) {
 	}
 }
 
+func TestAnalyzeGitRangeReportsProgress(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+
+	write(t, repo, "auth.py", "def validate_token(token):\n    return bool(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	base := rev(t, repo, "HEAD")
+
+	write(t, repo, "auth.py", "def validate_token(token, issuer=None):\n    return bool(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "change")
+	head := rev(t, repo, "HEAD")
+
+	var phases []string
+	_, err := AnalyzeGitRangeWithOptions(t.Context(), repo, base, head, nil, AnalyzeOptions{
+		Progress: func(event AnalyzeProgressEvent) {
+			phases = append(phases, event.Phase)
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"discover", "parse", "reconcile", "dependents", "complete"} {
+		if !containsPhase(phases, want) {
+			t.Fatalf("progress phases %v missing %q", phases, want)
+		}
+	}
+}
+
+func containsPhase(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestAnalyzeGitRangeReconcilesCrossFileMove(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")

--- a/internal/sem/dependents.go
+++ b/internal/sem/dependents.go
@@ -14,12 +14,19 @@ var identifierBoundary = regexp.MustCompile(`[A-Za-z0-9_$]+`)
 type referenceIndex map[string]map[string]struct{}
 
 func addDependentCounts(ctx context.Context, repo, head string, result *Result) error {
+	return addDependentCountsWithProgress(ctx, repo, head, result, nil)
+}
+
+func addDependentCountsWithProgress(ctx context.Context, repo, head string, result *Result, progress func(done, total int)) error {
 	names := changedReferenceNames(*result)
 	if len(names) == 0 {
+		if progress != nil {
+			progress(0, 0)
+		}
 		return nil
 	}
 
-	index, warnings, err := buildReferenceIndex(ctx, repo, head, names)
+	index, warnings, err := buildReferenceIndexWithProgress(ctx, repo, head, names, progress)
 	if err != nil {
 		return err
 	}
@@ -49,6 +56,10 @@ func changedReferenceNames(result Result) map[string]struct{} {
 }
 
 func buildReferenceIndex(ctx context.Context, repo, head string, names map[string]struct{}) (referenceIndex, []ProviderWarning, error) {
+	return buildReferenceIndexWithProgress(ctx, repo, head, names, nil)
+}
+
+func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, names map[string]struct{}, progress func(done, total int)) (referenceIndex, []ProviderWarning, error) {
 	index := referenceIndex{}
 	for name := range names {
 		index[name] = map[string]struct{}{}
@@ -61,9 +72,15 @@ func buildReferenceIndex(ctx context.Context, repo, head string, names map[strin
 	if err != nil {
 		return nil, nil, err
 	}
+	if progress != nil {
+		progress(0, len(files))
+	}
 
 	parser := TreeSitterParser{}
-	for _, path := range files {
+	for i, path := range files {
+		if i > 0 && i%100 == 0 && progress != nil {
+			progress(i, len(files))
+		}
 		if !Supported(path) {
 			continue
 		}
@@ -99,6 +116,9 @@ func buildReferenceIndex(ctx context.Context, repo, head string, names map[strin
 				}
 			}
 		}
+	}
+	if progress != nil {
+		progress(len(files), len(files))
 	}
 
 	return index, warnings, nil


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/12
<!-- entire-trail-link-end -->

## Summary

- add `--progress` to `commit`, `diff`, and `analyze`
- report coarse `discover`, `parse`, `reconcile`, `dependents`, and `complete` progress to stderr
- preserve machine-readable stdout for text and JSON consumers
- clarify that `--include-file` re-includes ignored paths rather than acting as an allowlist
- clarify that streaming NDJSON aggregate metadata is authoritative in the trailing summary record

## Why

While testing Entire Graph against the mise repository, an unrestricted
`main..HEAD` semantic diff produced no output before timing out after 60 seconds.
PR #46 substantially improved common single-commit performance, but a large
range can still spend significant time building dependent counts with no
indication that the process is advancing.

With this change, the same workload reported:

```text
graph diff progress phase=parse files=580/580 elapsed=4.498s
graph diff progress phase=reconcile files=580/580 elapsed=4.498s
graph diff progress phase=dependents files=0/3049 elapsed=7.158s
graph diff progress phase=dependents files=100/3049 elapsed=20.4s
```

Progress is emitted only when requested and always goes to stderr.

The help notes address two assumptions found during the same field test. The
initial zero-valued NDJSON header is intentional under the streaming contract;
the trailing summary is authoritative. Likewise, include files contain
gitignore-style re-inclusion rules and do not restrict parsing to listed paths.

## Validation

- `mise run check`
  - gofmt
  - go vet
  - race-enabled test suite
  - build
- focused `go test ./internal/sem ./internal/cli`
- live `main..HEAD` progress run against mise

*This pull request was generated by an AI coding assistant.*
