### PR TITLE
docs: release-readiness — developer-friendly README + official benchmark numbers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,10 +104,12 @@ entire graph version [--json]       # provider name + plugin version
 
 ## The measured-best agent prompt (copy-paste this)
 
-This exact instruction block is what won the graphmark benchmark (23 SWE-bench instances,
-10 languages: **62.1% weighted token savings vs a no-tool agent**, beating codebase-memory-mcp's
-35.8% on every language mean). Give it to any coding agent that has `entire graph` available —
-substitute your search invocation for `<search-cmd>`:
+This exact instruction block is what won the **official SWE-bench Multilingual benchmark** (300
+instances, 9 languages, Haiku): **54.9% weighted token savings vs a no-tool agent** — double
+codebase-memory-mcp's 27.4% — winning 8/9 languages and 216/293 instances, with identical task
+completion. Replicated on Sonnet (3×: 57.7% vs 36.6%) and on open-source models (31–73% via the
+Pi agent). Give it to any coding agent that has `entire graph` available — substitute your search
+invocation for `<search-cmd>`:
 
 ```text
 A precomputed code-search tool is available: <search-cmd> . Use it to LOCATE the fix BEFORE any
@@ -125,8 +127,8 @@ this repo. Apply the minimal fix and STOP the moment you can justify it.
 For bug-fix/locate tasks, run search at `--profile full` (call-graph expansion active) with default
 text output (tiered: full snippet for the top hits, terse locators after). Measured detail that
 matters: chaining `search -> def -> callers` to "explore the tool" was the #1 measured token
-waste — prefer the search-only fast path above. (Benchmark numbers are a single full-board run
-per arm; a 3x replication is in progress — see the graphmark SNAP20 report for caveats.)
+waste — prefer the search-only fast path above. (Full methodology, prompts, fairness controls and
+caveats: the graphmark repo, `agentic-swebench/REPRODUCE.md` + `BEAT-CMM-VERDICT.md`.)
 
 ## Operating doctrine (the token-saving rules)
 

--- a/README.md
+++ b/README.md
@@ -1,297 +1,82 @@
-# 🧠 entire-graph
+# Entire Graph
 
-![License](https://img.shields.io/badge/license-MIT-blue)
-![Languages](https://img.shields.io/badge/languages-36%20semantic%20%2B%20149%20inventory-2ea44f)
-![Graph](https://img.shields.io/badge/graph-30%20relation%20types-8957e5)
-![Local](https://img.shields.io/badge/100%25%20local-no%20egress-brightgreen)
-![Deterministic](https://img.shields.io/badge/deterministic-no%20LLM%20·%20no%20vectors-f59e0b)
-![Accuracy](https://img.shields.io/badge/accuracy-94%25%20on%2021%20repos-success)
-![Plugin](https://img.shields.io/badge/Entire%20CLI-plugin-24292f)
+**This release is for your agents.**
 
-**A deterministic, local-first code graph for coding agents, and the semantic layer behind Entire checkpoints.** entire-graph parses your repository with tree-sitter and answers structural questions — where is this defined, who calls it, what changed at the entity level, what will this break — straight from a persistent knowledge graph of functions, classes, call chains, routes, and cross-service links. No model calls, no embeddings, no network. The same commit always produces the same graph.
+Entire Graph gives coding agents a precomputed, deterministic map of your codebase — every
+function, type, route, and call relationship — so they stop burning your budget on grep-and-read
+exploration and go straight to the fix.
 
-It ships as an **Entire CLI plugin**, invoked as `entire graph ...`, and doubles as a local-only semantic provider that streams a machine-readable graph of symbols and relations for downstream tools such as Entire Brain.
+On the official **SWE-bench Multilingual** benchmark (300 real issues, 9 languages), an agent with
+Entire Graph used **55% fewer tokens** than the same agent without it — roughly **double the
+savings of the next-best code-memory tool** — winning 8 of 9 languages, with identical task
+completion. 100% local, no network, no model calls, no keys.
 
-```sh
-entire graph search   --repo . --query "where is webhook retry handled?"   # 🔍 ranked code for a task
-entire graph snapshot --repo . --format ndjson                             # 🕸️  full symbol + relation graph
-entire graph diff     --base main --head HEAD                               # 🧬 what changed, at the entity level
-entire graph capabilities --json                                           # 🧭 languages + relation types
-```
-
-> 🔬 **Accuracy first.** On a frozen 21-repo multi-language board of fixed-answer semantic tasks (definition lookup, call graph, imports, change-impact) scored on real checkouts, entire-graph scored **265/283 (94%)** versus **191/283 (68%)** for the leading tree-sitter code-memory tool. A wrong edge is worse than a missing one, so the graph is built to be right about symbols and impact, not just fast at emitting them.
->
-> 🔒 **Security and trust.** entire-graph reads your codebase and writes only to Entire's managed plugin directory. All processing happens 100% locally: no network, no telemetry, no API keys, no grammar downloads at runtime. Your code never leaves your machine. `entire graph doctor --json` reports `no_egress=true`.
-
-> **Are you a coding agent (or configuring one)?** The operating instructions — the parts of the graph, the exact commands, and the query-before-grep doctrine — live in **[AGENTS.md](AGENTS.md)** (mirrored in [CLAUDE.md](CLAUDE.md)). This README is for humans installing and running the plugin.
-
----
-
-## 📑 Contents
-
-- [What it is](#-what-it-is)
-- [Install](#-install)
-- [MCP & Entire Brain integration](#-mcp--entire-brain-integration)
-- [Refresh & keeping the graph current](#-refresh--keeping-the-graph-current)
-- [Quick Start](#-quick-start)
-- [Commands](#-commands)
-- [Language support](#️-language-support)
-- [Benchmarks](#-benchmarks)
-- [Performance](#-performance)
-- [Security & local-first](#-security--local-first)
-- [Architecture](#️-architecture)
-- [Current limits](#️-current-limits)
-- [License](#-license)
-
----
-
-## 🎯 What it is
-
-entire-graph builds a **code graph** — nodes for files, packages, functions, classes, methods, types, routes, and resources; **30 relation types** for calls, construction, inheritance, field access, service boundaries, and config/infra dependencies — and answers structural questions from it:
-
-- **Where is this defined?** → symbols
-- **Who calls this / what does it call?** → neighbors, edges
-- **Find the code for this task** → search (hybrid, ranked)
-- **What changed, and what does it put at risk?** → diff / commit / checkpoint
-- **Give me the whole graph** → snapshot
-
-Everything is **deterministic** (pure tree-sitter static analysis — no LLM, no vectors, no similarity thresholds), **git-native** (every result keyed by `(repo, commit, tree)`, so it is content-addressed and cacheable per commit), and **100% local** (no keys, no network, no telemetry). It scales to millions of relations on one machine and releases memory after each build.
-
----
-
-## 🚀 Install
-
-**Prerequisites:** the Entire CLI · Git · a Go toolchain with **CGO enabled** (tree-sitter uses native parser bindings).
-
-```sh
-# 1. Install the plugin binary and register it with Entire's managed plugin dir
-go install github.com/entireio/entire-graph/cmd/entire-graph@main
-entire plugin install "$(go env GOPATH)/bin/entire-graph" --force
-
-# 2. Verify the install and the local-only environment
-entire graph version
-entire graph doctor --json        # includes "no_egress": true
-
-# 3. Run your first semantic diff, from any git repository
-entire graph commit HEAD
-```
-
-Entire plugins are local executables, not a hosted marketplace: `entire graph` works because Entire finds an `entire-graph` binary in its managed plugin directory or on `$PATH`. If `$(go env GOPATH)/bin` is already on your `PATH`, Entire can discover the binary directly after `go install`.
-
-### 🛠️ Install from source
-
-```sh
-git clone https://github.com/entireio/entire-graph.git
-cd entire-graph
-mise run build                        # go build -o entire-graph ./cmd/entire-graph
-entire plugin install ./entire-graph --force
-```
-
-`scripts/install-local.sh` does this in one command (builds, installs, prints `entire graph version`, and fails early if the parent `entire` CLI is not on `PATH`). For release archives with `SHA256SUMS`, run `scripts/release.sh`. See [docs/operations.md](docs/operations.md) for target and cgo details.
-
-### 🔄 Updating (and migrating from `entire-sem`)
-
-This plugin was renamed from `entire-sem` to `entire-graph` after `v0.1.0` — both the binary and the `cmd/` path changed. To update, or to switch over from the old `entire-sem`:
+## Install (one minute)
 
 ```sh
 go install github.com/entireio/entire-graph/cmd/entire-graph@latest
 entire plugin install "$(go env GOPATH)/bin/entire-graph" --force
-rm -f "$(go env GOPATH)/bin/entire-sem"   # remove the old binary if you had it
 ```
 
-> `…/cmd/entire-graph@latest` needs **v0.2.0 or newer** — `v0.1.0` predates the rename and only ships `cmd/entire-sem`, so `@latest` against it fails with *"module found (v0.1.0), but does not contain package …/cmd/entire-graph"*. If a fresh tag hasn't propagated to the Go module proxy yet, pin it (`@v0.2.0`) or use `@main`. Graph and query behavior is unchanged — only the name.
+Then, in any repo your agents work in:
 
----
+```sh
+entire graph init-agents
+```
 
-## 🔌 MCP & Entire Brain integration
+That's it. `init-agents` drops the operating guide into your project's `AGENTS.md` and `CLAUDE.md`,
+so Claude Code, Codex, Gemini, Cursor, Pi — any agent that reads those files — picks up the
+search-first workflow automatically. No config, no MCP server, no daemon.
 
-**entire-graph is not itself an MCP server, and it exposes no MCP tools.** It is a local CLI plugin and a machine-readable **semantic provider**. There is nothing to configure as an MCP endpoint here, and no daemon to run.
+## What your agents get
 
-MCP access to code intelligence comes from **Entire Brain** (`entire-brain`), a **separate** downstream product. Entire Brain ingests entire-graph's NDJSON output (`snapshot` / `symbols` / `edges`) into its own persistent store and is what exposes MCP tools to agents (`brain_search`, `brain_code`, `brain_impact`, `brain_context`, and so on). So the split is:
-
-| Layer | Role | How you use it |
+| agent workflow | before | with Entire Graph |
 |---|---|---|
-| **entire-graph** (this repo) | Deterministic graph engine + NDJSON provider | `entire graph <command>` on the CLI (see [AGENTS.md](AGENTS.md)) |
-| **Entire Brain** (separate) | Persistence, indexing, query, **MCP server** | MCP tools in your agent, backed by the graph above |
+| **Locate a fix** | grep → open files → grep again (~90% of session tokens) | one `entire graph search` → read a line range → edit |
+| **Impact of a change** | repo-wide grep for callers | `entire graph neighbors --symbol X --relation CALLS --direction in` |
+| **Review a diff** | file-by-file reading | `entire graph diff` — entity-level changes with dependent counts |
 
-If you want MCP-style querying inside an agent, install and configure **Entire Brain** (its own docs) — entire-graph is the graph it builds on. If you just want direct, no-egress graph queries from an agent or the terminal, call `entire graph ...` directly; no MCP layer is required.
+The search understands natural language ("XTRIM trims wrong stream entries"), ranks real
+implementation code above tests and docs, bridges vocabulary gaps through the call graph, and
+returns budgeted output designed to drop straight into an agent's context.
 
----
+Want the exact agent instructions? `entire graph agent-guide` prints them; they also live in
+[AGENTS.md](AGENTS.md), including the copy-paste prompt block that produced the benchmark numbers.
 
-## ♻️ Refresh & keeping the graph current
+## Where it fits in Entire
 
-entire-graph has **no watch mode, no daemon, and no file-watcher**, and it needs none. The graph is **deterministic and content-addressed by `(repo, commit, tree)`**, so "refreshing" is just re-running a query — the result reflects whatever state you point it at.
+Entire Graph is the **semantic layer** of the Entire platform — infrastructure, not another
+workflow to learn:
 
-There are two modes, and neither can go stale on you:
+- **Entire Search / Why / Blame** consume it to answer developer questions with entity-level
+  precision.
+- **Entire Brain** ingests its snapshot stream (`symbols`, `edges`, `snapshot` NDJSON) as the code
+  half of its durable memory.
+- **Checkpoints and Trails** use its `diff`/`commit` analysis to describe what an agent actually
+  changed.
 
-- **Working tree (default).** Every `search`, `neighbors`, and `snapshot` re-reads your live files, so results always include your uncommitted edits. Nothing to refresh — just run the command again.
-- **Committed tree (`--head`).** Results are cached by the git **tree hash** (under `ENTIRE_PLUGIN_DATA_DIR`, or an explicit `--cache-dir`). Make a new commit and the tree hash changes, so the cache **automatically misses and rebuilds** — you can never read a committed-tree answer that is stale for that commit. `--no-cache` disables the cache entirely.
+You (a human) will mostly experience it *through* those surfaces. Your agents call it directly.
 
-To warm the cache for a large repo before a latency-sensitive session, prebuild it once:
+## Numbers, honestly
 
-```sh
-entire graph index --repo . --head --profile full --cache-dir /path/to/cache
-```
-
-Re-running `index` **is** the refresh: same tree → instant cache hit; changed tree → a fresh build. After that, `search` and `neighbors` on the same committed tree report the cache hit directly. This is the whole "keep it current" story — deterministic re-index, no background process.
-
----
-
-## ⚡ Quick Start
-
-```sh
-# What can this graph do here?
-entire graph capabilities --json          # languages (semantic vs inventory-only) + relation types
-entire graph doctor --json                # environment, repo resolution, no_egress=true
-
-# Find the code for a task (ranked, with source and file:line)
-entire graph search --repo . --query "retry logic for webhook delivery" --format text --top-k 8
-
-# See what changed in the last commit, at the entity level
-entire graph commit HEAD
-
-# Stream the whole graph for another tool to ingest
-entire graph snapshot --repo . --format ndjson
-```
-
-Running outside an Entire session? Point the plugin at a repo with `--repo .` (or `ENTIRE_REPO_ROOT=/path/to/repo`).
-
----
-
-## 🧩 Commands
-
-| Command | What it does |
+| measurement | result |
 |---|---|
-| `entire graph search --query "..."` | 🔍 Ranked source regions for a natural-language task |
-| `entire graph neighbors --symbol NAME` | Callers / callees / relations for one symbol (impact) |
-| `entire graph symbols --format ndjson` | Full stream of symbol definitions |
-| `entire graph edges --format ndjson` | Full stream of relations (all 30 types) |
-| `entire graph snapshot --format ndjson` | 🕸️ Full graph: header + files + symbols + relations |
-| `entire graph commit <rev>` | Entity-level semantic diff of a commit vs its first parent |
-| `entire graph diff --base <a> --head <b>` | Semantic diff between two refs (`analyze` is an alias) |
-| `entire graph checkpoint <id>` | Semantic diff for the commit behind an Entire checkpoint trailer |
-| `entire graph index --head` | Prebuild / warm the durable committed-tree cache |
-| `entire graph capabilities --json` | Languages, relation types, features, network requirements |
-| `entire graph doctor --json` | Environment, repo resolution, plugin data dir, `no_egress=true` |
-| `entire graph version [--json]` | Provider name and plugin version |
+| Official SWE-bench Multilingual 300, Haiku | **54.9%** token savings vs no-tool agent (next-best tool: 27.4%) |
+| Sonnet, 23 instances, 3× replicated | **57.7%** vs 36.6% |
+| Open-source models (gpt-oss, Kimi K2.6, DeepSeek V4, GLM-5.2) via the Pi agent | **31–73%** savings vs each model's own baseline |
+| Task completion (patch produced) | parity with baseline in every suite |
 
-Full flags and the agent-facing operating guide are in **[AGENTS.md](AGENTS.md)**. Diff commands print human-readable text by default and structured output with `--json`:
+Methodology, prompts, harness, and every caveat (variance bands, fairness controls, per-model
+configs) are public in the [graphmark](https://github.com/entirehq/graphmark) repo
+(`agentic-swebench/REPRODUCE.md` reproduces everything end to end).
 
-```text
-Semantic changes HEAD~1..HEAD
+## More
 
-auth.py
-  ~ function validate_token signature changed (14 dependents)
-  + class TokenClaims added
-  - function parse_token removed (0 dependents)
-```
+- [AGENTS.md](AGENTS.md) — the agent operating guide (also: `entire graph agent-guide`)
+- [docs/DETAILS.md](docs/DETAILS.md) — full command reference, architecture, language support,
+  performance and accuracy benchmarks, security model
+- `entire graph help` — command list; `entire graph doctor --json` — environment check
 
----
+## License
 
-## 🗣️ Language support
-
-`capabilities --json` exposes two honest tiers: `semantic_languages` (parser-backed call/type/data-flow analysis) and `inventory_only_languages` (stable file/document records, no semantic claims). Current counts: **185 recognized names, 36 semantic, 149 inventory-only.**
-
-**36 semantic languages:** Bash, C, C#, C++, CUE, Clojure, ClojureScript, Dart, Elixir, Erlang, F#, Go, Groovy, HCL/Terraform, Haskell, Java, JavaScript, Julia, Kotlin, Lua, OCaml, Objective-C, PHP, Perl, Protocol Buffers, Python, R, Ruby, Rust, SQL, Scala, Swift, TypeScript, YAML (including GitHub Actions workflow sections and jobs), Zig, Zsh.
-
-Everything else is reported as an honest partial failure rather than dropped silently. See [docs/language-support.md](docs/language-support.md) for the full two-tier matrix.
-
----
-
-## 📊 Benchmarks
-
-All figures below are measured on real, public repositories, not estimated. Reproduce them with `cmd/graph-bench` (see [docs/benchmarks.md](docs/benchmarks.md)).
-
-### 🎯 Accuracy vs codebase-memory-mcp
-
-Fixed-answer semantic tasks (definition lookup, call graph, imports, change-impact) on real checkouts, scored as correctness counts.
-
-| System | Score | Corpus |
-|---|---|---|
-| **entire-graph** | **265 / 283 (94%)** | 21 repos, multi-language |
-| codebase-memory-mcp | 191 / 283 (68%) | same board |
-
-### ⚡ Throughput (full profile)
-
-| Repo | Language | Files | Symbols | Relations | Build time |
-|---|---|--:|--:|--:|--:|
-| caddyserver/caddy | Go | 214 | 1,857 | 23,681 | 1.5s |
-| redis/redis | C | 633 | 10,312 | 358,082 | 5.5s |
-| laravel/framework | PHP | 2,019 | 23,182 | 1,872,087 | 17.0s |
-| micropython/micropython | C | 3,447 | 18,788 | 2,268,173 | 25.6s |
-
-### 🪶 Peak memory (vs codebase-memory-mcp)
-
-| Repo | entire-graph | codebase-memory-mcp |
-|---|--:|--:|
-| nlohmann/json | **80 MB** | 599 MB |
-| koin | **64 MB** | 285 MB |
-| Dapper | **43 MB** | 225 MB |
-
-Memory is released back to the OS after the build completes.
-
-### 💸 Token efficiency
-
-Answering the five structural questions for a core symbol, graph query vs reading every referencing file (tiktoken `cl100k`):
-
-| Task | entire-graph | file-by-file | Reduction |
-|---|--:|--:|--:|
-| `redisCommand` (redis), 23 referencing files | ~2,300 tokens | ~654,000 tokens | **283x** |
-
-Savings scale with symbol connectivity: single-digit for narrow symbols, 280x+ for core symbols.
-
----
-
-## ⚡ Performance
-
-- **Semantic diff:** about 0.1s for a typical `HEAD~1..HEAD` on redis.
-- **Full-graph build:** linear in repository size; 23K relations in 1.5s up to 2.27M relations in 25.6s across the repos above.
-- **Streaming output:** `snapshot` emits records as it parses, so memory stays bounded on very large repositories.
-- **Cached committed-tree search:** reuses a tree-keyed compressed index across invocations when `ENTIRE_PLUGIN_DATA_DIR` is set, so repeated queries on an unchanged tree skip re-parsing.
-- **Explicit preindex:** `index --head` builds and verifies that query-independent artifact before latency-sensitive work; cached `search` and `neighbors` calls then report the hit directly.
-
-Absolute numbers are environment-sensitive (measured on Apple Silicon). Read them as relative signals and reproduce locally with the harness.
-
----
-
-## 🔒 Security & local-first
-
-- **Zero egress.** No API keys, no network calls, no telemetry, no grammar downloads at runtime. All 36 grammars are vendored and compiled in.
-- **Verifiable.** `entire graph doctor --json` reports `no_egress=true`. Pass `--no-network` to make the no-egress contract explicit to callers.
-- **Writes only to Entire's managed plugin directory.** Your code is read locally and never leaves the machine — safe to point at private repositories.
-- **Reads committed `HEAD` by default** for provider/graph streams; pass `--worktree` to include live edits.
-
----
-
-## 🏗️ Architecture
-
-```text
-cmd/
-  entire-graph/     Plugin entry point (semantic diff, search, provider commands)
-  graph-bench/      Reproducible benchmark driver
-internal/
-  cli/              Hand-rolled command dispatch and flag parsing
-  sem/              Tree-sitter parsing, symbol + relation extraction, rename reconciliation, search
-  gitutil/          Git subprocess wrappers (NUL-delimited output parsing)
-  bench/            Measurement core (throughput, memory, coverage)
-docs/               Language support matrix, benchmarks, operations, provider requirements, ADRs
-scripts/            Local install and checksum-backed release archives
-```
-
-The parser is isolated behind `internal/sem`, so the command surface stays stable while the semantic model gets richer. The wire schema is a frozen `1.x` GA contract (additive-only minors; see `docs/adr/0001-ga-schema-contract.md`).
-
----
-
-## ⚠️ Current limits
-
-- Dependent counts are heuristic, not compiler / type-checker accurate.
-- `CALLS`, `HANDLES_ROUTE`, and `HANDLES_TOOL` relations are heuristic.
-- Rename detection is heuristic.
-- Unsupported languages are reported as partial failures, not parsed semantically.
-- The plugin is invoked as `entire graph ...`; it requires no changes to the main Entire CLI.
-
----
-
-## 📄 License
-
-MIT. The runtime parser dependency is `github.com/smacker/go-tree-sitter` (MIT). Three tree-sitter grammars are vendored as source under their own upstream MIT licenses: Dart (`internal/sem/grammars/dart/`), PostgreSQL (`internal/sem/pgsql/`), and Zsh (`internal/sem/zsh/`). This implementation does not copy or vendor Ataraxy Labs code.
+See [LICENSE](LICENSE).

--- a/docs/DETAILS.md
+++ b/docs/DETAILS.md
@@ -1,0 +1,297 @@
+# 🧠 entire-graph
+
+![License](https://img.shields.io/badge/license-MIT-blue)
+![Languages](https://img.shields.io/badge/languages-36%20semantic%20%2B%20149%20inventory-2ea44f)
+![Graph](https://img.shields.io/badge/graph-30%20relation%20types-8957e5)
+![Local](https://img.shields.io/badge/100%25%20local-no%20egress-brightgreen)
+![Deterministic](https://img.shields.io/badge/deterministic-no%20LLM%20·%20no%20vectors-f59e0b)
+![Accuracy](https://img.shields.io/badge/accuracy-94%25%20on%2021%20repos-success)
+![Plugin](https://img.shields.io/badge/Entire%20CLI-plugin-24292f)
+
+**A deterministic, local-first code graph for coding agents, and the semantic layer behind Entire checkpoints.** entire-graph parses your repository with tree-sitter and answers structural questions — where is this defined, who calls it, what changed at the entity level, what will this break — straight from a persistent knowledge graph of functions, classes, call chains, routes, and cross-service links. No model calls, no embeddings, no network. The same commit always produces the same graph.
+
+It ships as an **Entire CLI plugin**, invoked as `entire graph ...`, and doubles as a local-only semantic provider that streams a machine-readable graph of symbols and relations for downstream tools such as Entire Brain.
+
+```sh
+entire graph search   --repo . --query "where is webhook retry handled?"   # 🔍 ranked code for a task
+entire graph snapshot --repo . --format ndjson                             # 🕸️  full symbol + relation graph
+entire graph diff     --base main --head HEAD                               # 🧬 what changed, at the entity level
+entire graph capabilities --json                                           # 🧭 languages + relation types
+```
+
+> 🔬 **Accuracy first.** On a frozen 21-repo multi-language board of fixed-answer semantic tasks (definition lookup, call graph, imports, change-impact) scored on real checkouts, entire-graph scored **265/283 (94%)** versus **191/283 (68%)** for the leading tree-sitter code-memory tool. A wrong edge is worse than a missing one, so the graph is built to be right about symbols and impact, not just fast at emitting them.
+>
+> 🔒 **Security and trust.** entire-graph reads your codebase and writes only to Entire's managed plugin directory. All processing happens 100% locally: no network, no telemetry, no API keys, no grammar downloads at runtime. Your code never leaves your machine. `entire graph doctor --json` reports `no_egress=true`.
+
+> **Are you a coding agent (or configuring one)?** The operating instructions — the parts of the graph, the exact commands, and the query-before-grep doctrine — live in **[AGENTS.md](AGENTS.md)** (mirrored in [CLAUDE.md](CLAUDE.md)). This README is for humans installing and running the plugin.
+
+---
+
+## 📑 Contents
+
+- [What it is](#-what-it-is)
+- [Install](#-install)
+- [MCP & Entire Brain integration](#-mcp--entire-brain-integration)
+- [Refresh & keeping the graph current](#-refresh--keeping-the-graph-current)
+- [Quick Start](#-quick-start)
+- [Commands](#-commands)
+- [Language support](#️-language-support)
+- [Benchmarks](#-benchmarks)
+- [Performance](#-performance)
+- [Security & local-first](#-security--local-first)
+- [Architecture](#️-architecture)
+- [Current limits](#️-current-limits)
+- [License](#-license)
+
+---
+
+## 🎯 What it is
+
+entire-graph builds a **code graph** — nodes for files, packages, functions, classes, methods, types, routes, and resources; **30 relation types** for calls, construction, inheritance, field access, service boundaries, and config/infra dependencies — and answers structural questions from it:
+
+- **Where is this defined?** → symbols
+- **Who calls this / what does it call?** → neighbors, edges
+- **Find the code for this task** → search (hybrid, ranked)
+- **What changed, and what does it put at risk?** → diff / commit / checkpoint
+- **Give me the whole graph** → snapshot
+
+Everything is **deterministic** (pure tree-sitter static analysis — no LLM, no vectors, no similarity thresholds), **git-native** (every result keyed by `(repo, commit, tree)`, so it is content-addressed and cacheable per commit), and **100% local** (no keys, no network, no telemetry). It scales to millions of relations on one machine and releases memory after each build.
+
+---
+
+## 🚀 Install
+
+**Prerequisites:** the Entire CLI · Git · a Go toolchain with **CGO enabled** (tree-sitter uses native parser bindings).
+
+```sh
+# 1. Install the plugin binary and register it with Entire's managed plugin dir
+go install github.com/entireio/entire-graph/cmd/entire-graph@main
+entire plugin install "$(go env GOPATH)/bin/entire-graph" --force
+
+# 2. Verify the install and the local-only environment
+entire graph version
+entire graph doctor --json        # includes "no_egress": true
+
+# 3. Run your first semantic diff, from any git repository
+entire graph commit HEAD
+```
+
+Entire plugins are local executables, not a hosted marketplace: `entire graph` works because Entire finds an `entire-graph` binary in its managed plugin directory or on `$PATH`. If `$(go env GOPATH)/bin` is already on your `PATH`, Entire can discover the binary directly after `go install`.
+
+### 🛠️ Install from source
+
+```sh
+git clone https://github.com/entireio/entire-graph.git
+cd entire-graph
+mise run build                        # go build -o entire-graph ./cmd/entire-graph
+entire plugin install ./entire-graph --force
+```
+
+`scripts/install-local.sh` does this in one command (builds, installs, prints `entire graph version`, and fails early if the parent `entire` CLI is not on `PATH`). For release archives with `SHA256SUMS`, run `scripts/release.sh`. See [docs/operations.md](docs/operations.md) for target and cgo details.
+
+### 🔄 Updating (and migrating from `entire-sem`)
+
+This plugin was renamed from `entire-sem` to `entire-graph` after `v0.1.0` — both the binary and the `cmd/` path changed. To update, or to switch over from the old `entire-sem`:
+
+```sh
+go install github.com/entireio/entire-graph/cmd/entire-graph@latest
+entire plugin install "$(go env GOPATH)/bin/entire-graph" --force
+rm -f "$(go env GOPATH)/bin/entire-sem"   # remove the old binary if you had it
+```
+
+> `…/cmd/entire-graph@latest` needs **v0.2.0 or newer** — `v0.1.0` predates the rename and only ships `cmd/entire-sem`, so `@latest` against it fails with *"module found (v0.1.0), but does not contain package …/cmd/entire-graph"*. If a fresh tag hasn't propagated to the Go module proxy yet, pin it (`@v0.2.0`) or use `@main`. Graph and query behavior is unchanged — only the name.
+
+---
+
+## 🔌 MCP & Entire Brain integration
+
+**entire-graph is not itself an MCP server, and it exposes no MCP tools.** It is a local CLI plugin and a machine-readable **semantic provider**. There is nothing to configure as an MCP endpoint here, and no daemon to run.
+
+MCP access to code intelligence comes from **Entire Brain** (`entire-brain`), a **separate** downstream product. Entire Brain ingests entire-graph's NDJSON output (`snapshot` / `symbols` / `edges`) into its own persistent store and is what exposes MCP tools to agents (`brain_search`, `brain_code`, `brain_impact`, `brain_context`, and so on). So the split is:
+
+| Layer | Role | How you use it |
+|---|---|---|
+| **entire-graph** (this repo) | Deterministic graph engine + NDJSON provider | `entire graph <command>` on the CLI (see [AGENTS.md](AGENTS.md)) |
+| **Entire Brain** (separate) | Persistence, indexing, query, **MCP server** | MCP tools in your agent, backed by the graph above |
+
+If you want MCP-style querying inside an agent, install and configure **Entire Brain** (its own docs) — entire-graph is the graph it builds on. If you just want direct, no-egress graph queries from an agent or the terminal, call `entire graph ...` directly; no MCP layer is required.
+
+---
+
+## ♻️ Refresh & keeping the graph current
+
+entire-graph has **no watch mode, no daemon, and no file-watcher**, and it needs none. The graph is **deterministic and content-addressed by `(repo, commit, tree)`**, so "refreshing" is just re-running a query — the result reflects whatever state you point it at.
+
+There are two modes, and neither can go stale on you:
+
+- **Working tree (default).** Every `search`, `neighbors`, and `snapshot` re-reads your live files, so results always include your uncommitted edits. Nothing to refresh — just run the command again.
+- **Committed tree (`--head`).** Results are cached by the git **tree hash** (under `ENTIRE_PLUGIN_DATA_DIR`, or an explicit `--cache-dir`). Make a new commit and the tree hash changes, so the cache **automatically misses and rebuilds** — you can never read a committed-tree answer that is stale for that commit. `--no-cache` disables the cache entirely.
+
+To warm the cache for a large repo before a latency-sensitive session, prebuild it once:
+
+```sh
+entire graph index --repo . --head --profile full --cache-dir /path/to/cache
+```
+
+Re-running `index` **is** the refresh: same tree → instant cache hit; changed tree → a fresh build. After that, `search` and `neighbors` on the same committed tree report the cache hit directly. This is the whole "keep it current" story — deterministic re-index, no background process.
+
+---
+
+## ⚡ Quick Start
+
+```sh
+# What can this graph do here?
+entire graph capabilities --json          # languages (semantic vs inventory-only) + relation types
+entire graph doctor --json                # environment, repo resolution, no_egress=true
+
+# Find the code for a task (ranked, with source and file:line)
+entire graph search --repo . --query "retry logic for webhook delivery" --format text --top-k 8
+
+# See what changed in the last commit, at the entity level
+entire graph commit HEAD
+
+# Stream the whole graph for another tool to ingest
+entire graph snapshot --repo . --format ndjson
+```
+
+Running outside an Entire session? Point the plugin at a repo with `--repo .` (or `ENTIRE_REPO_ROOT=/path/to/repo`).
+
+---
+
+## 🧩 Commands
+
+| Command | What it does |
+|---|---|
+| `entire graph search --query "..."` | 🔍 Ranked source regions for a natural-language task |
+| `entire graph neighbors --symbol NAME` | Callers / callees / relations for one symbol (impact) |
+| `entire graph symbols --format ndjson` | Full stream of symbol definitions |
+| `entire graph edges --format ndjson` | Full stream of relations (all 30 types) |
+| `entire graph snapshot --format ndjson` | 🕸️ Full graph: header + files + symbols + relations |
+| `entire graph commit <rev>` | Entity-level semantic diff of a commit vs its first parent |
+| `entire graph diff --base <a> --head <b>` | Semantic diff between two refs (`analyze` is an alias) |
+| `entire graph checkpoint <id>` | Semantic diff for the commit behind an Entire checkpoint trailer |
+| `entire graph index --head` | Prebuild / warm the durable committed-tree cache |
+| `entire graph capabilities --json` | Languages, relation types, features, network requirements |
+| `entire graph doctor --json` | Environment, repo resolution, plugin data dir, `no_egress=true` |
+| `entire graph version [--json]` | Provider name and plugin version |
+
+Full flags and the agent-facing operating guide are in **[AGENTS.md](AGENTS.md)**. Diff commands print human-readable text by default and structured output with `--json`:
+
+```text
+Semantic changes HEAD~1..HEAD
+
+auth.py
+  ~ function validate_token signature changed (14 dependents)
+  + class TokenClaims added
+  - function parse_token removed (0 dependents)
+```
+
+---
+
+## 🗣️ Language support
+
+`capabilities --json` exposes two honest tiers: `semantic_languages` (parser-backed call/type/data-flow analysis) and `inventory_only_languages` (stable file/document records, no semantic claims). Current counts: **185 recognized names, 36 semantic, 149 inventory-only.**
+
+**36 semantic languages:** Bash, C, C#, C++, CUE, Clojure, ClojureScript, Dart, Elixir, Erlang, F#, Go, Groovy, HCL/Terraform, Haskell, Java, JavaScript, Julia, Kotlin, Lua, OCaml, Objective-C, PHP, Perl, Protocol Buffers, Python, R, Ruby, Rust, SQL, Scala, Swift, TypeScript, YAML (including GitHub Actions workflow sections and jobs), Zig, Zsh.
+
+Everything else is reported as an honest partial failure rather than dropped silently. See [docs/language-support.md](docs/language-support.md) for the full two-tier matrix.
+
+---
+
+## 📊 Benchmarks
+
+All figures below are measured on real, public repositories, not estimated. Reproduce them with `cmd/graph-bench` (see [docs/benchmarks.md](docs/benchmarks.md)).
+
+### 🎯 Accuracy vs codebase-memory-mcp
+
+Fixed-answer semantic tasks (definition lookup, call graph, imports, change-impact) on real checkouts, scored as correctness counts.
+
+| System | Score | Corpus |
+|---|---|---|
+| **entire-graph** | **265 / 283 (94%)** | 21 repos, multi-language |
+| codebase-memory-mcp | 191 / 283 (68%) | same board |
+
+### ⚡ Throughput (full profile)
+
+| Repo | Language | Files | Symbols | Relations | Build time |
+|---|---|--:|--:|--:|--:|
+| caddyserver/caddy | Go | 214 | 1,857 | 23,681 | 1.5s |
+| redis/redis | C | 633 | 10,312 | 358,082 | 5.5s |
+| laravel/framework | PHP | 2,019 | 23,182 | 1,872,087 | 17.0s |
+| micropython/micropython | C | 3,447 | 18,788 | 2,268,173 | 25.6s |
+
+### 🪶 Peak memory (vs codebase-memory-mcp)
+
+| Repo | entire-graph | codebase-memory-mcp |
+|---|--:|--:|
+| nlohmann/json | **80 MB** | 599 MB |
+| koin | **64 MB** | 285 MB |
+| Dapper | **43 MB** | 225 MB |
+
+Memory is released back to the OS after the build completes.
+
+### 💸 Token efficiency
+
+Answering the five structural questions for a core symbol, graph query vs reading every referencing file (tiktoken `cl100k`):
+
+| Task | entire-graph | file-by-file | Reduction |
+|---|--:|--:|--:|
+| `redisCommand` (redis), 23 referencing files | ~2,300 tokens | ~654,000 tokens | **283x** |
+
+Savings scale with symbol connectivity: single-digit for narrow symbols, 280x+ for core symbols.
+
+---
+
+## ⚡ Performance
+
+- **Semantic diff:** about 0.1s for a typical `HEAD~1..HEAD` on redis.
+- **Full-graph build:** linear in repository size; 23K relations in 1.5s up to 2.27M relations in 25.6s across the repos above.
+- **Streaming output:** `snapshot` emits records as it parses, so memory stays bounded on very large repositories.
+- **Cached committed-tree search:** reuses a tree-keyed compressed index across invocations when `ENTIRE_PLUGIN_DATA_DIR` is set, so repeated queries on an unchanged tree skip re-parsing.
+- **Explicit preindex:** `index --head` builds and verifies that query-independent artifact before latency-sensitive work; cached `search` and `neighbors` calls then report the hit directly.
+
+Absolute numbers are environment-sensitive (measured on Apple Silicon). Read them as relative signals and reproduce locally with the harness.
+
+---
+
+## 🔒 Security & local-first
+
+- **Zero egress.** No API keys, no network calls, no telemetry, no grammar downloads at runtime. All 36 grammars are vendored and compiled in.
+- **Verifiable.** `entire graph doctor --json` reports `no_egress=true`. Pass `--no-network` to make the no-egress contract explicit to callers.
+- **Writes only to Entire's managed plugin directory.** Your code is read locally and never leaves the machine — safe to point at private repositories.
+- **Reads committed `HEAD` by default** for provider/graph streams; pass `--worktree` to include live edits.
+
+---
+
+## 🏗️ Architecture
+
+```text
+cmd/
+  entire-graph/     Plugin entry point (semantic diff, search, provider commands)
+  graph-bench/      Reproducible benchmark driver
+internal/
+  cli/              Hand-rolled command dispatch and flag parsing
+  sem/              Tree-sitter parsing, symbol + relation extraction, rename reconciliation, search
+  gitutil/          Git subprocess wrappers (NUL-delimited output parsing)
+  bench/            Measurement core (throughput, memory, coverage)
+docs/               Language support matrix, benchmarks, operations, provider requirements, ADRs
+scripts/            Local install and checksum-backed release archives
+```
+
+The parser is isolated behind `internal/sem`, so the command surface stays stable while the semantic model gets richer. The wire schema is a frozen `1.x` GA contract (additive-only minors; see `docs/adr/0001-ga-schema-contract.md`).
+
+---
+
+## ⚠️ Current limits
+
+- Dependent counts are heuristic, not compiler / type-checker accurate.
+- `CALLS`, `HANDLES_ROUTE`, and `HANDLES_TOOL` relations are heuristic.
+- Rename detection is heuristic.
+- Unsupported languages are reported as partial failures, not parsed semantically.
+- The plugin is invoked as `entire graph ...`; it requires no changes to the main Entire CLI.
+
+---
+
+## 📄 License
+
+MIT. The runtime parser dependency is `github.com/smacker/go-tree-sitter` (MIT). Three tree-sitter grammars are vendored as source under their own upstream MIT licenses: Dart (`internal/sem/grammars/dart/`), PostgreSQL (`internal/sem/pgsql/`), and Zsh (`internal/sem/zsh/`). This implementation does not copy or vendor Ataraxy Labs code.

--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -12,10 +12,10 @@ import (
 // graph in a CONSUMING project (not this repo). It ships inside the binary so every install
 // carries the current doctrine; `init-agents` distributes it into a project's AGENTS.md /
 // CLAUDE.md via a small pointer block, and `agent-guide` prints it for any agent or human.
-// The prompt block is the exact instruction set that measured best on the graphmark
-// agentic-swebench benchmark (23 SWE-bench instances / 10 languages, savings vs a no-tool
-// agent; single-run board 62%, 3x-replicated 58% weighted, ahead of alternatives on every
-// language mean — see the graphmark repo for methodology and caveats).
+// The prompt block is the exact instruction set that won the official SWE-bench Multilingual
+// benchmark (300 instances / 9 languages: 54.9% weighted token savings vs a no-tool agent,
+// double the next-best tool's 27.4%, 8/9 languages; Sonnet 3x replication 57.7% vs 36.6% —
+// see the graphmark repo for methodology, prompts, and caveats).
 const agentGuide = `# entire-graph — coding-agent guide (universal)
 
 A deterministic, local code graph is available via ` + "`entire graph`" + ` (functions, classes,


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/15
<!-- entire-trail-link-end -->

Addresses the positioning feedback: README was too long/academic for everyday developers and read as a standalone product rather than platform infrastructure.

**New README** (~85 lines, was 297): leads with **"This release is for your agents"**; one-minute install (`init-agents` = the whole setup); a table of which agent workflows improve; **"Where it fits in Entire"** — Graph as the semantic layer consumed by Search/Why/Blame and feeding Entire Brain, so humans experience it through those surfaces while agents call it directly; an honest numbers table (official SWE-bench Multilingual 300: 54.9% vs 27.4%, plus Sonnet 3× and OSS-model replications) linking to the public graphmark methodology. Nothing deleted — the full reference moved intact to `docs/DETAILS.md`.

**AGENTS.md + embedded `agent-guide`**: the measured-best prompt block now cites the official 300-instance result instead of the interim single-run numbers.

Skill-distribution issue from Slack (repo docs don't reach consuming projects) remains fixed by #56 (`agent-guide` + `init-agents`); follow-up candidate stays: call `init-agents` from `entire enable`/`agent add`.