### PR TITLE
docs: GOBIN-aware install path + @main

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ completion. 100% local, no network, no model calls, no keys.
 ## Install (one minute)
 
 ```sh
-go install github.com/entireio/entire-graph/cmd/entire-graph@latest
-entire plugin install "$(go env GOPATH)/bin/entire-graph" --force
+go install github.com/entireio/entire-graph/cmd/entire-graph@main
+entire plugin install "$(go env GOBIN | grep . || echo "$(go env GOPATH)/bin")/entire-graph" --force
 ```
 
 Then, in any repo your agents work in:


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/16
<!-- entire-trail-link-end -->

Insider feedback: `entire plugin install "$(go env GOPATH)/bin/..."` failed for users with GOBIN set (binary lands in GOBIN); and `@latest` installs a build predating the snapshot cache. Install line now resolves GOBIN first and pins `@main`.