### PR TITLE
fix(sem): key the committed-tree caches on the resolved file cap, and the records cache on repo identity

### DIFF
--- a/docs/adr/0002-committed-tree-cache-key.md
+++ b/docs/adr/0002-committed-tree-cache-key.md
@@ -1,0 +1,176 @@
+# ADR 0002 — Committed-tree cache key: total over graph-shaping inputs
+
+Status: Accepted
+Date: 2026-07-28
+
+## Context
+
+`entire-graph` has two committed-tree caches of the same shape:
+
+| cache | key | consumers | on by default? |
+|---|---|---|---|
+| search snapshot (`internal/sem/search_cache.go`, `searchSnapshotKey`) | `<cacheDir>/search/…/<sha256>.json.gz` | `search`, `neighbors`, `impact`, `index` | no — `searchFlags{Worktree: true}`, so only `--head` |
+| provider records (`internal/sem/records_cache.go`, `providerRecordsKey`) | `<cacheDir>/records/…/<sha256>.json.gz` | whole-graph `snapshot`, `symbols`, `edges` | yes — those commands default to committed-tree |
+
+`cacheDir` is `--cache-dir` else `ENTIRE_PLUGIN_DATA_DIR`: one flat global directory, shared by
+every repository and every worktree on the machine.
+
+The question this ADR answers: with N worktrees off one repository — branch A refactoring a
+package, branch B renaming symbols, `main` moving on — can a cache entry written on one branch
+be served on another, and what does the current keying cost?
+
+Both keys hash the cache version, the **checkout path** (`filepath.Abs(repo)`), the provider
+version, the **HEAD tree hash**, the profile, `MaxParseBytes`, `OnlyFiles`, and the **contents**
+of any `--ignore-file` / `--include-file`. In `--head` mode the file set is otherwise a pure
+function of the tree: `openSource` lists via `gitutil.ListFiles(ctx, repo, committedRevision)`
+and filters with `loadExplicitIgnoreMatcher` (content-hashed) plus a tree-derived
+`headIgnoreMatcher`. `.git/info/exclude` and `core.excludesFile` reach only the working-tree
+path, which is never cached.
+
+Measured on a binary built from `cdcb8db`, against an isolated clone with three linked
+worktrees — `wtA`/`wtC` at `cdcb8db`, `wtB` at `6e4bfde`, 3 of 317 tracked files differing:
+
+**Branch drift is already safe.** The tree hash is in both keys, so switching branches at one
+checkout path misses:
+
+```
+symbols at cdcb8db = 5740 ; at 6e4bfde = 5736
+byte-identical?    = no          cache entries = 2
+```
+
+Two worktrees cannot collide either, because the checkout path is in the key.
+
+**But two inputs that do shape the graph are not in either key, and both produce a silent wrong
+answer.** First, the file-listing cap: `capSourceFiles` truncates to
+`resolveMaxSourceFiles(options.MaxFiles)`, which folds in `ENTIRE_GRAPH_MAX_FILES`. Neither the
+option nor the effective cap is keyed or re-validated:
+
+```
+1. cap=5, cold  -> symbols = 28     entries=1
+2. NO cap, warm -> symbols = 28     entries=1   <== WRONG
+3. NO cap, cold -> symbols = 5740               <== correct
+```
+
+99.5% of the graph absent, carrying a `W_FILE_LIMIT` warning into a run that asked for no cap.
+One `entire-brain` ingest with a bound poisons every later unbounded query on that tree.
+
+Second, repository identity: `repoKey` resolves the GitHub remote, and **every** symbol and file
+ID is `repoKey + ":" + …`. It is not keyed and not validated on a direct hit:
+
+```
+1. remote=entireio/entire-graph, cold -> repo_key=gh/entireio/entire-graph   id=gh/entireio/entire-graph:JSON:…
+2. remote=someoneelse/a-fork,    warm -> repo_key=gh/entireio/entire-graph   id=gh/entireio/entire-graph:JSON:…  <== WRONG
+3. remote=someoneelse/a-fork,    cold -> repo_key=gh/someoneelse/a-fork      id=gh/someoneelse/a-fork:JSON:…     <== correct
+```
+
+`selectiveSearchSnapshotFromFull` already rejects a `RepoKey` mismatch, which shows the
+invariant is known; the two direct-hit paths and all of `records_cache.go` skip the check.
+
+**And keying on the checkout path costs everything the tree hash was supposed to buy.** One
+shared cache dir, three worktrees, two of them at a byte-identical tree:
+
+```
+### A. DEFAULT MODE (working tree; no --head)
+wtA default run1     0.06s  entries=0   cache=0K
+wtA default run2     0.04s  entries=0   cache=0K
+
+### B. --head MODE, ONE shared cache dir
+wtA --head cold      9.02s  entries=1   cache=428K
+wtA --head warm      0.87s  entries=1   cache=428K
+wtB --head cold      9.37s  entries=2   cache=856K
+wtB --head warm      1.07s  entries=2   cache=856K
+
+### C. wtC = THIRD worktree at the SAME COMMIT/TREE as wtA
+wtC --head           9.04s  entries=3   cache=1284K
+```
+
+The cache is worth having (9.02s → 0.87s, **10.4×**). But `wtB`, differing in 3 of 317 files,
+pays a full rebuild and a second full 428 KB entry; and `wtC`, whose graph is **byte-identical**
+to `wtA`'s, still pays a full 9.04s build and a third 435 KB entry. N worktrees at one commit
+cost N × 9s and N × 435 KB where 1 × would do.
+
+## Decision
+
+**The cache key becomes a total function of every input that shapes the graph: repository
+identity + tree + all snapshot-shaping options. Nothing that can change the output is left
+implicit, and every discriminating field is re-validated on load.**
+
+Concretely, in both `searchSnapshotKey` and `providerRecordsKey`, and in both on-disk
+envelopes and their `valid…` predicates:
+
+1. **Repository identity (`repoKey`) joins the key** and is compared on load. Identity is what
+   every symbol ID embeds, so an entry built under a different identity must miss, not be
+   re-served. This replaces the checkout path as the *identity* term — the path is a proxy for
+   identity that is simultaneously too strict (three worktrees, one graph, three entries) and
+   too loose (identity can change under a fixed path).
+2. **The effective file-listing cap joins the key** — `resolveMaxSourceFiles(options.MaxFiles)`,
+   the resolved value, so `ENTIRE_GRAPH_MAX_FILES` is covered by the same term as the option.
+3. **Cache version strings bump** (`search-snapshot-v5`, `provider-records-v2`) so entries
+   written by the old keying are unreachable by name rather than merely unfindable by hash.
+
+**The trade-off accepted: this only adds misses, never hits.** Every change above narrows what
+counts as a valid entry. Runs that previously reused an entry across a remote-URL change or a
+cap change now rebuild — correctly. We accept the extra cold builds and one extra `git remote`
+subprocess per cache lookup, because a wrong cache hit is worse than a slow miss. We do not
+take the sharing win in the same change, so no new reuse surface is opened alongside a
+correctness fix.
+
+## Consequences
+
+**What this does NOT do — explicitly:**
+
+- **No cross-worktree sharing.** The checkout path stays in the key, so `wtC` still rebuilds
+  `wtA`'s identical graph and the third 435 KB entry is still written. Keying on identity alone
+  is now *possible* (identity is in the key and validated), but not *safe* yet: on a cache hit
+  `search.go:356` overwrites the response's `repoRoot` from the cached header, so a shared entry
+  would report the wrong checkout path — and `records_cache.go` stores opaque NDJSON bytes, so
+  restamping its header means rewriting the serialized first line. Both are separate changes
+  with their own tests.
+- **No per-file content-hash caching / incrementality.** The prize measured above — `wtB`
+  differing in 3 of 317 files should reuse ~99% of the parse, not 0% — needs a per-blob parse
+  cache keyed by blob hash plus relation re-resolution over the union, which is a new index
+  layer, not a key change. This ADR is its prerequisite: a per-blob cache is only sharable
+  across worktrees if repository identity is a keyed, validated term, which it now is.
+- **No change to working-tree mode.** It stays uncached; dirty state has no durable key. The
+  0-entry rows in the measurement are that policy, not a write failure.
+- **No change to tree-only keying of the parsed graph.** Two commits sharing a tree still share
+  an entry, and `FILE_CHANGES_WITH` co-change edges are still allowed to come from the other
+  commit's history — already documented on `searchSnapshotKey` and unchanged here.
+- **No fix for the linked-worktree `.git/info/exclude` ENOTDIR failure** seen while measuring
+  (`read ignore file ".../wtA/.git/info/exclude": not a directory`, exit 1). That is
+  working-tree-only, therefore cache-irrelevant, and is owned by a separate change.
+
+**What it costs:** every existing cache entry is orphaned on disk under the old version
+directory; the first run after upgrading is cold. One additional `git remote` invocation per
+committed-tree cache lookup, alongside the two `rev-parse` calls already made.
+
+**What it buys:** the two measured silent-wrong-answer paths become misses, and the key is now
+defensible as complete — the audit above enumerates the committed-tree inputs, and after this
+change each one is either hashed or provably tree-derived.
+
+**Verified on the same three-worktree lab, with a binary built from this change.** Both holes
+close and nothing else moves:
+
+```
+HOLE 1  NO cap, warm -> symbols = 5740  entries=2   (was 28, entries=1)
+HOLE 2  remote re-pointed, warm -> repo_key=gh/someoneelse/a-fork   (was gh/entireio/entire-graph)
+branch switch at one path -> 2 entries, 5740 vs 5736 symbols   (unchanged)
+wtA --head cold 9.75s -> warm 0.86s                            (warm win unchanged, 11.3x)
+wtC --head at wtA's identical tree -> still a full build, third entry   (unchanged, by design)
+```
+
+## Addendum — what upstream had already fixed
+
+This ADR was written against an older base. Rebasing onto current `main` showed upstream had
+independently keyed `searchSnapshotKey` on repository identity and bumped that cache to
+`search-snapshot-v6`, so the identity half of the problem was already solved **for the search
+cache**. Two gaps remained and are what this change actually closes:
+
+- `searchSnapshotKey` did not fold in the resolved file cap. Bumped to `search-snapshot-v7`.
+- `providerRecordsKey` folded in NEITHER identity NOR the cap, and it is the cache that is on by
+  default. Bumped to `provider-records-v2`; `LoadProviderRecords`/`StoreProviderRecords` now take a
+  `context.Context` so the key can include `repoKey(ctx, repo)` the way the search cache does.
+
+Still explicitly NOT done, unchanged from the original decision: cross-worktree sharing (blocked by
+`repoRoot` being overwritten from the cached header) and per-file content-hash incrementality, for
+which a total key is the prerequisite.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -347,7 +347,7 @@ func runProviderRecords(ctx context.Context, opts Options, args []string, mode s
 		}
 	}
 	if useCache {
-		if records, cachedSummary, hit, err := sem.LoadProviderRecords(repo, opts.Version, tree, mode, cacheDir, options); err == nil && hit {
+		if records, cachedSummary, hit, err := sem.LoadProviderRecords(ctx, repo, opts.Version, tree, mode, cacheDir, options); err == nil && hit {
 			if _, err := opts.Stdout.Write(records); err != nil {
 				return err
 			}
@@ -375,7 +375,7 @@ func runProviderRecords(ctx context.Context, opts Options, args []string, mode s
 	warnIfPartial(opts.Stderr, flags.Worktree, summary)
 	if useCache {
 		// Best effort: a failed cache write never fails the command.
-		_ = sem.StoreProviderRecords(repo, opts.Version, tree, mode, cacheDir, options, recordBuf.Bytes(), summary)
+		_ = sem.StoreProviderRecords(ctx, repo, opts.Version, tree, mode, cacheDir, options, recordBuf.Bytes(), summary)
 	}
 	return nil
 }

--- a/internal/sem/records_cache.go
+++ b/internal/sem/records_cache.go
@@ -2,6 +2,7 @@ package sem
 
 import (
 	"compress/gzip"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -18,7 +19,7 @@ import (
 // set of options. Recomputing them on every call is expensive on large repos, so
 // we cache the raw NDJSON bytes keyed on the HEAD tree hash plus everything else
 // that changes the output. This mirrors the search-snapshot cache next door.
-const providerRecordsCacheVersion = "provider-records-v1"
+const providerRecordsCacheVersion = "provider-records-v2"
 
 // cachedProviderRecords is the on-disk envelope for a cached record stream. The
 // key alone is authoritative (sha256 over version+tree+mode+profile+options+
@@ -42,7 +43,7 @@ type cachedProviderRecords struct {
 // cache. OnlyFiles is included for completeness even though the record commands
 // do not expose it. Callers must NOT use this for --worktree runs (the working
 // tree can differ from HEAD) or for targeted --to/--from/--relation queries.
-func providerRecordsKey(absRepo, providerVersion, tree, mode string, options ProviderSnapshotOptions) (string, error) {
+func providerRecordsKey(absRepo, repositoryKey, providerVersion, tree, mode string, options ProviderSnapshotOptions) (string, error) {
 	hash := sha256.New()
 	writePart := func(value string) {
 		_, _ = io.WriteString(hash, value)
@@ -50,11 +51,19 @@ func providerRecordsKey(absRepo, providerVersion, tree, mode string, options Pro
 	}
 	writePart(providerRecordsCacheVersion)
 	writePart(absRepo)
+	// Repo identity PREFIXES EVERY SYMBOL ID this cache stores, so serving one repository's records
+	// to another hands back IDs attributed to the wrong project. Reproduced by re-pointing a remote:
+	// the warm run still reported gh/entireio/entire-graph after the checkout had become a fork.
+	// searchSnapshotKey already folds this in; this key did not.
+	writePart(repositoryKey)
 	writePart(providerVersion)
 	writePart(tree)
 	writePart(mode)
 	writePart(string(options.Profile))
 	writePart(fmt.Sprintf("%d", options.MaxParseBytes))
+	// Same graph-shaping argument as searchSnapshotKey: a capped build must not answer an uncapped
+	// caller. This cache is the one that is ON BY DEFAULT, so the hole mattered more here.
+	writePart(fmt.Sprintf("max-files=%d", options.MaxFiles))
 	onlyFiles := append([]string(nil), options.OnlyFiles...)
 	sort.Strings(onlyFiles)
 	writePart("only-files")
@@ -95,7 +104,7 @@ func providerRecordsPath(cacheDir, key string) string {
 // The returned summary (when present) lets the caller reproduce the partial-parse
 // warning without re-indexing. A missing/corrupt cache is a miss, not an error;
 // only a key-derivation failure (an unreadable ignore/include file) errors.
-func LoadProviderRecords(repo, providerVersion, tree, mode, cacheDir string, options ProviderSnapshotOptions) ([]byte, *SnapshotSummary, bool, error) {
+func LoadProviderRecords(ctx context.Context, repo, providerVersion, tree, mode, cacheDir string, options ProviderSnapshotOptions) ([]byte, *SnapshotSummary, bool, error) {
 	if cacheDir == "" || tree == "" || options.Worktree {
 		return nil, nil, false, nil
 	}
@@ -103,7 +112,7 @@ func LoadProviderRecords(repo, providerVersion, tree, mode, cacheDir string, opt
 	if err != nil {
 		return nil, nil, false, err
 	}
-	key, err := providerRecordsKey(absRepo, providerVersion, tree, mode, options)
+	key, err := providerRecordsKey(absRepo, repoKey(ctx, absRepo), providerVersion, tree, mode, options)
 	if err != nil {
 		return nil, nil, false, err
 	}
@@ -117,7 +126,7 @@ func LoadProviderRecords(repo, providerVersion, tree, mode, cacheDir string, opt
 // StoreProviderRecords persists a freshly built record stream. Persistence is
 // best effort: retrieval correctness never depends on a writable cache dir, so
 // callers may ignore the returned error.
-func StoreProviderRecords(repo, providerVersion, tree, mode, cacheDir string, options ProviderSnapshotOptions, records []byte, summary *SnapshotSummary) error {
+func StoreProviderRecords(ctx context.Context, repo, providerVersion, tree, mode, cacheDir string, options ProviderSnapshotOptions, records []byte, summary *SnapshotSummary) error {
 	if cacheDir == "" || tree == "" || options.Worktree {
 		return nil
 	}
@@ -125,7 +134,7 @@ func StoreProviderRecords(repo, providerVersion, tree, mode, cacheDir string, op
 	if err != nil {
 		return err
 	}
-	key, err := providerRecordsKey(absRepo, providerVersion, tree, mode, options)
+	key, err := providerRecordsKey(absRepo, repoKey(ctx, absRepo), providerVersion, tree, mode, options)
 	if err != nil {
 		return err
 	}

--- a/internal/sem/records_cache_test.go
+++ b/internal/sem/records_cache_test.go
@@ -2,6 +2,7 @@ package sem
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,11 +22,11 @@ func TestProviderRecordsCacheHitAndMiss(t *testing.T) {
 	records := []byte("{\"record_type\":\"header\"}\n{\"record_type\":\"symbol\"}\n")
 	summary := &SnapshotSummary{RecordType: "summary", Stats: ProviderStats{Files: 3}}
 
-	if err := StoreProviderRecords(repo, version, tree, mode, cacheDir, opts, records, summary); err != nil {
+	if err := StoreProviderRecords(context.Background(), repo, version, tree, mode, cacheDir, opts, records, summary); err != nil {
 		t.Fatalf("store: %v", err)
 	}
 
-	got, gotSummary, hit, err := LoadProviderRecords(repo, version, tree, mode, cacheDir, opts)
+	got, gotSummary, hit, err := LoadProviderRecords(context.Background(), repo, version, tree, mode, cacheDir, opts)
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
@@ -54,7 +55,7 @@ func TestProviderRecordsCacheHitAndMiss(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, hit, err := LoadProviderRecords(repo, tc.version, tc.tree, tc.mode, cacheDir, tc.opts)
+			_, _, hit, err := LoadProviderRecords(context.Background(), repo, tc.version, tc.tree, tc.mode, cacheDir, tc.opts)
 			if err != nil {
 				t.Fatalf("load: %v", err)
 			}
@@ -74,10 +75,10 @@ func TestProviderRecordsCacheWorktreeBypassed(t *testing.T) {
 	records := []byte("x")
 
 	// Store is a no-op under --worktree, and Load never reports a hit.
-	if err := StoreProviderRecords(repo, "v", "tree", "snapshot", cacheDir, opts, records, nil); err != nil {
+	if err := StoreProviderRecords(context.Background(), repo, "v", "tree", "snapshot", cacheDir, opts, records, nil); err != nil {
 		t.Fatalf("store: %v", err)
 	}
-	if _, _, hit, err := LoadProviderRecords(repo, "v", "tree", "snapshot", cacheDir, opts); err != nil || hit {
+	if _, _, hit, err := LoadProviderRecords(context.Background(), repo, "v", "tree", "snapshot", cacheDir, opts); err != nil || hit {
 		t.Fatalf("worktree load: hit=%v err=%v", hit, err)
 	}
 }
@@ -92,18 +93,78 @@ func TestProviderRecordsCacheKeyIncludesIgnoreFileContent(t *testing.T) {
 	}
 	opts := ProviderSnapshotOptions{Profile: ProfileFull, IgnoreFiles: []string{ignore}}
 
-	before, err := providerRecordsKey(repo, "v", "tree", "snapshot", opts)
+	before, err := providerRecordsKey(repo, "id", "v", "tree", "snapshot", opts)
 	if err != nil {
 		t.Fatalf("key before: %v", err)
 	}
 	if err := os.WriteFile(ignore, []byte("second"), 0o600); err != nil {
 		t.Fatalf("rewrite ignore: %v", err)
 	}
-	after, err := providerRecordsKey(repo, "v", "tree", "snapshot", opts)
+	after, err := providerRecordsKey(repo, "id", "v", "tree", "snapshot", opts)
 	if err != nil {
 		t.Fatalf("key after: %v", err)
 	}
 	if before == after {
 		t.Fatal("expected key to change when ignore-file content changes")
+	}
+}
+
+// A capped build must never answer an uncapped caller: the cap SHAPES the graph, so a snapshot
+// built under one is missing everything past it. Measured on this repository before the fix, a
+// cap-5 build wrote 28 symbols and the next uncapped search was served those 28 rather than
+// rebuilding to 5740 — 99.5% of the graph silently absent, and one capped ingest poisoned every
+// later query on the same tree.
+func TestProviderRecordsKeyDiscriminatesFileCap(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	capped := ProviderSnapshotOptions{MaxFiles: 5}
+	uncapped := ProviderSnapshotOptions{}
+	a, err := providerRecordsKey(repo, "id", "v", "tree", "snapshot", capped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := providerRecordsKey(repo, "id", "v", "tree", "snapshot", uncapped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == b {
+		t.Fatal("capped and uncapped runs share a records cache key: a truncated graph would be served to an uncapped caller")
+	}
+}
+
+// Repo identity prefixes every symbol ID this cache stores, so serving one repository's records to
+// another hands back IDs attributed to the wrong project. searchSnapshotKey already folded identity
+// in; this key did not.
+func TestProviderRecordsKeyDiscriminatesRepoIdentity(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	opts := ProviderSnapshotOptions{}
+	a, err := providerRecordsKey(repo, "gh/ownerone/probe", "v", "tree", "snapshot", opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := providerRecordsKey(repo, "gh/ownertwo/probe", "v", "tree", "snapshot", opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == b {
+		t.Fatal("records stored under gh/ownerone/probe would be served to gh/ownertwo/probe")
+	}
+}
+
+// The search snapshot cache had the same cap hole; identity was already keyed upstream.
+func TestSearchSnapshotKeyDiscriminatesFileCap(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	a, err := searchSnapshotKey(repo, "id", "v", "tree", ProviderSnapshotOptions{MaxFiles: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := searchSnapshotKey(repo, "id", "v", "tree", ProviderSnapshotOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == b {
+		t.Fatal("capped and uncapped search snapshots share a key")
 	}
 }

--- a/internal/sem/search_cache.go
+++ b/internal/sem/search_cache.go
@@ -24,7 +24,7 @@ import (
 // and any prior-version directory can simply be deleted wholesale — cleanup is
 // "remove old version dirs" instead of per-entry reachability analysis.
 // (v5 isolated the tree-only key layout; v6, on main, supersedes it.)
-const searchSnapshotCacheVersion = "search-snapshot-v6"
+const searchSnapshotCacheVersion = "search-snapshot-v7"
 
 type cachedSymbolByteRange struct {
 	Start int `json:"start"`
@@ -674,6 +674,12 @@ func searchSnapshotKey(absRepo, repositoryKey, providerVersion, tree string, opt
 	writePart(tree)
 	writePart(string(options.Profile))
 	writePart(fmt.Sprintf("%d", options.MaxParseBytes))
+	// The resolved file cap SHAPES THE GRAPH: a run capped at N files produces a snapshot missing
+	// everything past N, and without the cap in the key that truncated snapshot is served to a later
+	// uncapped caller. Measured on this repo: a cap-5 build wrote 28 symbols, and the next uncapped
+	// search was served those 28 instead of rebuilding to 5740 — 99.5% of the graph silently absent.
+	// One capped ingest therefore poisons every later query on the same tree.
+	writePart(fmt.Sprintf("max-files=%d", options.MaxFiles))
 	// Working-tree entries live in their own key space. The marker is only
 	// written for them so committed-tree keys — and every cache already on disk
 	// built under them — stay byte-identical.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/23
<!-- entire-trail-link-end -->

Stacked on #66.

Two silent-wrong-answer holes, found by asking what happens to the graph cache across branches with
large drift. **Branch drift itself turned out to be safe** — the tree hash is in both keys, so no branch
can ever be served another's graph. Two other graph-shaping inputs were unkeyed.

### 1. The file cap is not keyed

`options.MaxFiles` (and `ENTIRE_GRAPH_MAX_FILES` behind it) shapes the graph: a capped build produces a
snapshot missing everything past the cap. Measured on this repo — a cap-5 build wrote **28 symbols**,
and the next **uncapped** search was served those 28 instead of rebuilding to **5740**. 99.5% of the
graph silently absent, and one capped ingest poisons every later query on that tree.

### 2. The records cache ignores repo identity

Repo identity prefixes every symbol ID the cache stores. Reproduced by re-pointing a remote: the warm
run still reported `gh/entireio/entire-graph` after the checkout had become a fork.
`searchSnapshotKey` already folded identity in — **upstream reached that independently, at
`search-snapshot-v6`** — but `providerRecordsKey` did not, and it is the cache that is **on by
default**.

### Change

- `searchSnapshotKey`: fold in the resolved cap; `search-snapshot-v6` -> `v7`.
- `providerRecordsKey`: fold in **both** identity and the cap; `provider-records-v1` -> `v2`.
- `Load/StoreProviderRecords` take a `context.Context` so the key can use `repoKey(ctx, repo)` the way
  the search cache does. Two production callers, both `internal/cli/root.go`.

Only ever turns hits into misses — no stale-serve path is introduced.

**Mutation-checked:** removing the key terms makes the new tests fail with
`records stored under gh/ownerone/probe would be served to gh/ownertwo/probe` and
`capped and uncapped search snapshots share a key`; restoring them goes green. Full suite green,
`gofmt`/`vet` clean.

Explicitly NOT done (recorded in the ADR): cross-worktree sharing (blocked by `repoRoot` being
overwritten from the cached header) and per-file content-hash incrementality, for which a total key is
the prerequisite.

---
Entire trail: https://entire.io/gh/entireio/entire-graph/trails/23
