### PR TITLE
fix(sem): honor nested .gitignore in the vendored-directory heuristic; feat(cli): default cache dir + GRAPH_REPORT.md

### DIFF
--- a/docs/BRAIN-VS-GRAPH.md
+++ b/docs/BRAIN-VS-GRAPH.md
@@ -1,0 +1,69 @@
+# Brain vs. graph — what entire-graph deliberately does not do
+
+entire-graph is a **provider**: it turns a git tree into a deterministic, typed, no-egress
+snapshot and answers ranked queries over it. Entire Brain is the **consumer**: it ingests that
+snapshot alongside durable facts, sessions and checkpoints, and is where knowledge that is not
+derivable from one tree lives.
+
+The line is not organizational, it is a property of the artifact. Anything that is a pure function
+of one repository at one revision belongs here, because it must stay deterministic and reproducible
+from the tree alone. Anything that accumulates state across repositories, across time, or across
+users belongs to Brain, because the moment this provider holds that state, "the same commit yields
+the same graph" stops being true and every downstream claim built on it weakens.
+
+This file exists so the items below are not re-litigated each time a competitor ships one.
+
+## The verdicts
+
+### MCP server surface — **Brain's job**
+An MCP server is a stateful, long-lived process with a session, an auth story, and an audience
+(which host, which tools exposed, which redaction). None of that is a function of a git tree, and
+all of it is what Brain already is. The provider stays a one-shot, no-egress binary whose output is
+a stable NDJSON contract; whoever wants MCP wraps that contract. Note the honest cost: until Brain
+ships, every graph call an agent makes is a shell-out plus a permission prompt, and a competitor's
+native tool call is cheaper per invocation. That is a real gap in **invocation economics** — it is
+just not a gap this repository should close by growing a server.
+
+### Multi-repo / cross-project graph — **Brain's job**
+`repoKey` is per-repository and every command takes one `--repo` on purpose: the cache key is the
+git **tree hash**, and there is no such thing as a tree hash for "nine repositories as of roughly
+now". A merged cross-project graph is inherently a stateful, continuously-reconciled store — which
+is Brain's shape, not a provider's. The provider's contribution is that its snapshots are cheap to
+ingest and its symbol IDs are stable, so N of them can be merged upstream.
+
+### save-result / reflect feedback loop — **Brain's job**
+A feedback loop is memory: outcomes recorded per user over time, decayed, corroborated, and fed
+back as a ranking overlay. Landing that here would make search results depend on who ran it and
+what they clicked last week — the exact opposite of the determinism the schema contract and every
+benchmark claim rest on. Brain is the correct home precisely because it is allowed to be stateful.
+If a learned overlay ever influences provider ranking, it must arrive as an explicit input to a
+query, never as hidden local state.
+
+### Human dashboards beyond a markdown report — **neither / not worth it**
+`index --report GRAPH_REPORT.md` is now in the provider, and it is the right amount: a
+deterministic, diffable, committable projection of a snapshot the tool already has in memory, which
+lets a human judge the tool in thirty seconds. An interactive HTML force-graph is not that. It is a
+UI product with its own rendering and performance envelope, it is unusable at the node counts this
+graph reaches on a real monorepo, and Brain's web surfaces are where an Entire user is already
+looking at their code. Building one here would be the most visible and least useful thing in this
+document.
+
+### Per-file incremental invalidation — **graph's job, not done yet**
+Tree-hash keying means a one-character commit pays a full rebuild. That is a provider concern
+(cache correctness, no state beyond the tree) and it is the highest-value unbuilt item on this
+side of the line. It is unbuilt, not declined.
+
+### Watch mode / daemon — **neither / not worth it**
+Explicitly declined, and the reasoning holds: re-running `index` *is* the refresh, a changed tree
+misses the cache by construction, and a daemon adds a stateful moving part to a tool whose main
+claim is that it has none.
+
+### Named per-host installers — **graph's job, not done yet**
+`init-agents` writing `AGENTS.md`/`CLAUDE.md` already covers the instruction-file hosts implicitly.
+Per-host installers are cheap, additive, and a real distribution win; they are simply not
+architecture, so they queue behind product behavior.
+
+## One-line test for anything new
+
+Would this make two runs on the same tree differ, or require state that outlives one command? If
+yes, it is Brain's. If no, it is arguably ours — and then the only question is priority.

--- a/docs/DETAILS.md
+++ b/docs/DETAILS.md
@@ -125,7 +125,7 @@ entire-graph has **no watch mode, no daemon, and no file-watcher**, and it needs
 There are two modes, and neither can go stale on you:
 
 - **Working tree (default).** Every `search`, `neighbors`, and `snapshot` re-reads your live files, so results always include your uncommitted edits. Nothing to refresh — just run the command again.
-- **Committed tree (`--head`).** Results are cached by the git **tree hash** (under `ENTIRE_PLUGIN_DATA_DIR`, or an explicit `--cache-dir`). Make a new commit and the tree hash changes, so the cache **automatically misses and rebuilds** — you can never read a committed-tree answer that is stale for that commit. `--no-cache` disables the cache entirely.
+- **Committed tree (`--head`).** Results are cached by the git **tree hash**. The cache directory defaults to the platform's per-user cache directory (`~/Library/Caches/entire-graph` on macOS, `$XDG_CACHE_HOME/entire-graph` or `~/.cache/entire-graph` elsewhere); `--cache-dir` and `ENTIRE_PLUGIN_DATA_DIR` override it, in that order. Make a new commit and the tree hash changes, so the cache **automatically misses and rebuilds** — you can never read a committed-tree answer that is stale for that commit. `--no-cache` disables the cache entirely. Caching only ever changes latency, never results: measured on this repository, a cold `--head --profile full` search is 9.2s wall and the same query warm is 1.0s, with output byte-identical to `--no-cache`.
 
 To warm the cache for a large repo before a latency-sensitive session, prebuild it once:
 
@@ -289,7 +289,7 @@ Savings scale with symbol connectivity: single-digit for narrow symbols, 280x+ f
 - **Semantic diff:** about 0.1s for a typical `HEAD~1..HEAD` on redis.
 - **Full-graph build:** linear in repository size; 23K relations in 1.5s up to 2.27M relations in 25.6s across the repos above.
 - **Streaming output:** `snapshot` emits records as it parses, so memory stays bounded on very large repositories.
-- **Cached committed-tree search:** reuses a tree-keyed compressed index across invocations when `ENTIRE_PLUGIN_DATA_DIR` is set, so repeated queries on an unchanged tree skip re-parsing. A complete prepared index derives the exact query-selected view, so relation expansion cannot escape that file set.
+- **Cached committed-tree search:** reuses a tree-keyed compressed index across invocations, in the platform's per-user cache directory unless `--cache-dir`/`ENTIRE_PLUGIN_DATA_DIR` redirect it, so repeated queries on an unchanged tree skip re-parsing. The working tree is never cached. A complete prepared index derives the exact query-selected view, so relation expansion cannot escape that file set.
 - **Explicit preindex:** `index --head` builds and verifies that query-independent artifact before latency-sensitive work; cached `search` and `neighbors` calls then report the hit directly.
 
 Absolute numbers are environment-sensitive (measured on Apple Silicon). Read them as relative signals and reproduce locally with the harness.

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -1,6 +1,9 @@
 package cli
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+)
 
 const (
 	envCLIVersion    = "ENTIRE_CLI_VERSION"
@@ -11,6 +14,41 @@ const (
 	// of `container-map`, `signature-types`, `type-card`, or `all`. See searchReferenceBlocks.
 	envReferenceBlocks = "ENTIRE_GRAPH_REFERENCE_BLOCKS"
 )
+
+// cacheDirName is this provider's directory inside the platform's per-user cache
+// root. It is namespaced by product, not by repository: the cache is keyed on the
+// git tree hash, so one directory holds every repository's entries without them
+// colliding.
+const cacheDirName = "entire-graph"
+
+// resolveCacheDir decides where the tree-hash record cache lives. An explicit
+// --cache-dir wins, then the data directory Entire hands a plugin
+// (ENTIRE_PLUGIN_DATA_DIR), and otherwise the platform's per-user cache
+// directory — `os.UserCacheDir` is the convention: XDG_CACHE_HOME (or
+// ~/.cache) on Unix, ~/Library/Caches on macOS, %LocalAppData% on Windows.
+//
+// That last step is the point. Committed-tree caching was implemented but
+// inert for anyone who had not exported ENTIRE_PLUGIN_DATA_DIR by hand, so the
+// documented "same tree hits" path never hit and every `--head` query re-parsed
+// the repository from scratch. Only WHERE the cache lands is decided here.
+// Nothing else moves: the working tree is still never cached, the git tree hash
+// is still the only thing that decides a hit, and --no-cache still disables the
+// cache outright — so results are identical with or without a cache directory.
+// A platform with no resolvable cache root falls back to the previous
+// behaviour of not caching at all.
+func resolveCacheDir(flagValue, pluginDataDir string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	if pluginDataDir != "" {
+		return pluginDataDir
+	}
+	base, err := os.UserCacheDir()
+	if err != nil || base == "" {
+		return ""
+	}
+	return filepath.Join(base, cacheDirName)
+}
 
 // EntireEnv captures environment variables supplied by Entire when it dispatches
 // an external plugin command.

--- a/internal/cli/impact.go
+++ b/internal/cli/impact.go
@@ -124,10 +124,7 @@ func runImpact(ctx context.Context, opts Options, args []string) error {
 	if err != nil {
 		return err
 	}
-	cacheDir := flags.CacheDir
-	if cacheDir == "" {
-		cacheDir = opts.Env.PluginDataDir
-	}
+	cacheDir := resolveCacheDir(flags.CacheDir, opts.Env.PluginDataDir)
 	totalStarted := time.Now()
 	indexStarted := totalStarted
 	snapshot, cacheHit, err := sem.LoadOrBuildProviderSnapshot(ctx, repo, opts.Version, sem.ProviderSnapshotOptions{

--- a/internal/cli/index.go
+++ b/internal/cli/index.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -18,6 +19,11 @@ type indexFlags struct {
 	Format       string
 	IgnoreFiles  []string
 	IncludeFiles []string
+	// Report is where to write the human-readable GRAPH_REPORT.md rendering of the
+	// snapshot this run built or loaded. Empty writes no report. It rides on index
+	// rather than on a command of its own because index is already the command that
+	// materializes a whole committed-tree snapshot for a human to act on.
+	Report string
 }
 
 type indexResponse struct {
@@ -55,12 +61,9 @@ func runIndex(ctx context.Context, opts Options, args []string) error {
 	if err != nil {
 		return err
 	}
-	cacheDir := flags.CacheDir
+	cacheDir := resolveCacheDir(flags.CacheDir, opts.Env.PluginDataDir)
 	if cacheDir == "" {
-		cacheDir = opts.Env.PluginDataDir
-	}
-	if cacheDir == "" {
-		return errors.New("index requires --cache-dir or ENTIRE_PLUGIN_DATA_DIR")
+		return errors.New("index requires --cache-dir or ENTIRE_PLUGIN_DATA_DIR: this platform has no resolvable per-user cache directory")
 	}
 	started := time.Now()
 	snapshot, cacheHit, err := sem.PreindexProviderSnapshot(ctx, repo, opts.Version, sem.ProviderSnapshotOptions{
@@ -95,6 +98,11 @@ func runIndex(ctx context.Context, opts Options, args []string) error {
 		PartialFailures: partialFailures,
 		Completeness:    snapshot.Header.Completeness,
 	}
+	if flags.Report != "" {
+		if err := os.WriteFile(flags.Report, []byte(renderGraphReport(snapshot)), 0o644); err != nil {
+			return fmt.Errorf("write graph report %q: %w", flags.Report, err)
+		}
+	}
 	encoder := json.NewEncoder(opts.Stdout)
 	encoder.SetEscapeHTML(false)
 	return encoder.Encode(response)
@@ -123,6 +131,12 @@ func parseIndexFlags(args []string) (indexFlags, []string, error) {
 				return flags, nil, err
 			}
 			flags.CacheDir, index = value, next
+		case "--report":
+			value, next, err := searchFlagValue(args, index)
+			if err != nil {
+				return flags, nil, err
+			}
+			flags.Report, index = value, next
 		case "--ignore-file":
 			value, next, err := searchFlagValue(args, index)
 			if err != nil {

--- a/internal/cli/index_test.go
+++ b/internal/cli/index_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/entireio/entire-graph/internal/sem"
@@ -119,7 +121,12 @@ func TestIndexRepeatableIgnoreAndIncludeFilesShareCanonicalCacheKey(t *testing.T
 	}
 }
 
-func TestIndexRequiresDurableCacheAndRejectsWorktree(t *testing.T) {
+// TestIndexDefaultsItsCacheAndRejectsWorktree replaces an expectation the default
+// cache directory made obsolete: `index` with no --cache-dir and no
+// ENTIRE_PLUGIN_DATA_DIR used to be an error, because there was nowhere durable to
+// write. It now falls back to the platform's per-user cache directory, so the only
+// remaining refusal is --worktree, which has no durable tree hash to key on.
+func TestIndexDefaultsItsCacheAndRejectsWorktree(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")
 	git(t, repo, "config", "user.name", "Entire Graph Test")
@@ -128,11 +135,36 @@ func TestIndexRequiresDurableCacheAndRejectsWorktree(t *testing.T) {
 	git(t, repo, "add", ".")
 	git(t, repo, "commit", "-m", "initial")
 
-	if err := Run(t.Context(), Options{Version: "test", Env: EntireEnv{RepoRoot: repo}, Stdout: &bytes.Buffer{}}, []string{"index"}); err == nil {
-		t.Fatal("expected index without a durable cache to fail")
+	// Point the platform cache root at a temp dir so the test writes nothing to the
+	// developer's real cache. (Honoured by os.UserCacheDir everywhere except macOS,
+	// which is why the assertion below only requires that the command succeed.)
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	if err := Run(t.Context(), Options{Version: "test", Env: EntireEnv{RepoRoot: repo}, Stdout: &bytes.Buffer{}}, []string{"index", "--repo", repo, "--format", "json"}); err != nil {
+		t.Fatalf("index with no cache flag or env must default its cache directory: %v", err)
 	}
 	if err := Run(t.Context(), Options{Version: "test", Env: EntireEnv{RepoRoot: repo, PluginDataDir: t.TempDir()}, Stdout: &bytes.Buffer{}}, []string{"index", "--worktree"}); err == nil {
 		t.Fatal("expected --worktree to fail")
+	}
+}
+
+// TestResolveCacheDirDefaultsToPlatformCacheDir pins the precedence that turned
+// committed-tree caching on for anyone who had not exported
+// ENTIRE_PLUGIN_DATA_DIR by hand: explicit flag, then the plugin data dir, then
+// the platform's per-user cache directory.
+func TestResolveCacheDirDefaultsToPlatformCacheDir(t *testing.T) {
+	if got := resolveCacheDir("/flag/dir", "/env/dir"); got != "/flag/dir" {
+		t.Fatalf("--cache-dir must win, got %q", got)
+	}
+	if got := resolveCacheDir("", "/env/dir"); got != "/env/dir" {
+		t.Fatalf("ENTIRE_PLUGIN_DATA_DIR must win over the default, got %q", got)
+	}
+	base, err := os.UserCacheDir()
+	if err != nil {
+		t.Skipf("platform has no per-user cache directory: %v", err)
+	}
+	want := filepath.Join(base, cacheDirName)
+	if got := resolveCacheDir("", ""); got != want {
+		t.Fatalf("resolveCacheDir with nothing set = %q, want the platform cache dir %q", got, want)
 	}
 }
 

--- a/internal/cli/neighbors.go
+++ b/internal/cli/neighbors.go
@@ -139,10 +139,7 @@ func runNeighbors(ctx context.Context, opts Options, args []string) error {
 	if err != nil {
 		return err
 	}
-	cacheDir := flags.CacheDir
-	if cacheDir == "" {
-		cacheDir = opts.Env.PluginDataDir
-	}
+	cacheDir := resolveCacheDir(flags.CacheDir, opts.Env.PluginDataDir)
 	totalStarted := time.Now()
 	indexStarted := totalStarted
 	snapshot, cacheHit, err := sem.LoadOrBuildProviderSnapshot(ctx, repo, opts.Version, sem.ProviderSnapshotOptions{

--- a/internal/cli/report.go
+++ b/internal/cli/report.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/entireio/entire-graph/internal/sem"
+)
+
+// renderGraphReport renders a snapshot as GRAPH_REPORT.md: the thirty-second
+// answer to "what did this tool find in my repository?", for a human deciding
+// whether to keep it. It is a pure projection of the summary a snapshot already
+// carries — no re-parsing, no second pass over source, no network — and every map
+// is sorted before printing, so the same snapshot always renders the same bytes.
+func renderGraphReport(snapshot sem.ProviderSnapshot) string {
+	header := snapshot.Header
+	stats := header.Stats
+	var out strings.Builder
+	out.WriteString("# Graph report\n\n")
+	fmt.Fprintf(&out, "- Repository: `%s`\n- Commit: `%s`\n- Tree: `%s`\n",
+		header.RepoKey, header.Commit, header.Tree)
+	fmt.Fprintf(&out, "- Provider: `%s` %s, schema `%s`, profile `%s`\n",
+		header.Provider, header.ProviderVersion, header.SchemaVersion, header.Profile)
+	fmt.Fprintf(&out, "- Completeness: **%s** (%d of %d files parsed, %d partial failures)\n",
+		stats.CompletenessLevel, stats.ParsedFiles, stats.Files, stats.PartialFailures)
+	fmt.Fprintf(&out, "- Graph: **%d symbols**, **%d relations**\n", stats.Symbols, stats.Relations)
+
+	// Languages carry their fidelity tier, because counting an inventory-only
+	// language as semantic coverage is the misreading this table exists to prevent.
+	out.WriteString("\n## Languages\n\n| Language | Tier | Files | Symbols |\n| --- | --- | --- | --- |\n")
+	names := make([]string, 0, len(header.Completeness.Languages))
+	for name := range header.Completeness.Languages {
+		names = append(names, name)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		left, right := header.Completeness.Languages[names[i]], header.Completeness.Languages[names[j]]
+		if left.Symbols != right.Symbols {
+			return left.Symbols > right.Symbols
+		}
+		return names[i] < names[j]
+	})
+	for _, name := range names {
+		tier := header.LanguageTiers[name]
+		if tier == "" {
+			tier = "unknown"
+		}
+		completeness := header.Completeness.Languages[name]
+		fmt.Fprintf(&out, "| %s | %s | %d | %d |\n", name, tier, completeness.Files, completeness.Symbols)
+	}
+
+	writeCountTable(&out, "Symbol kinds", "Kind", countBy(len(snapshot.Symbols), func(i int) string {
+		return snapshot.Symbols[i].Kind
+	}), 0)
+	writeCountTable(&out, "Relations", "Relation", header.Completeness.Relations, 0)
+	writeCountTable(&out, "Top files by symbol count", "File", countBy(len(snapshot.Symbols), func(i int) string {
+		return snapshot.Symbols[i].FilePath
+	}), 20)
+	writeCountTable(&out, "Warnings", "Code", countBy(len(header.Warnings), func(i int) string {
+		return header.Warnings[i].Code
+	}), 0)
+	writeCountTable(&out, "Partial failures", "Code", countBy(len(header.PartialFailures), func(i int) string {
+		return header.PartialFailures[i].Code
+	}), 0)
+	return out.String()
+}
+
+// countBy tallies one field read from each of n records.
+func countBy(n int, value func(int) string) map[string]int {
+	counts := make(map[string]int)
+	for i := 0; i < n; i++ {
+		if key := value(i); key != "" {
+			counts[key]++
+		}
+	}
+	return counts
+}
+
+// writeCountTable prints one count table, ordered by count descending then key
+// ascending so ties cannot reorder between runs. limit caps the rows (0 = all)
+// and any omitted remainder is stated rather than silently dropped. An empty map
+// prints nothing, so a clean repository has no empty warning sections.
+func writeCountTable(out *strings.Builder, title, keyHeader string, counts map[string]int, limit int) {
+	if len(counts) == 0 {
+		return
+	}
+	keys := make([]string, 0, len(counts))
+	for key := range counts {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if counts[keys[i]] != counts[keys[j]] {
+			return counts[keys[i]] > counts[keys[j]]
+		}
+		return keys[i] < keys[j]
+	})
+	fmt.Fprintf(out, "\n## %s\n\n| %s | Count |\n| --- | --- |\n", title, keyHeader)
+	shown := keys
+	if limit > 0 && len(shown) > limit {
+		shown = shown[:limit]
+	}
+	for _, key := range shown {
+		fmt.Fprintf(out, "| %s | %d |\n", key, counts[key])
+	}
+	if len(shown) < len(keys) {
+		fmt.Fprintf(out, "\n%d more not shown.\n", len(keys)-len(shown))
+	}
+}

--- a/internal/cli/report_test.go
+++ b/internal/cli/report_test.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestIndexReportIsDeterministicAndSummarizesTheSnapshot covers the one property a
+// generated report has to have to be worth anything: the same tree renders the
+// same bytes, so the file can be committed, diffed, and reviewed. It also pins
+// that the report is a projection of the snapshot's own summary — the counts it
+// prints have to match what the graph found, not a second pass over the source.
+func TestIndexReportIsDeterministicAndSummarizesTheSnapshot(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	write(t, repo, "auth.go", `package auth
+
+func ValidateToken(token string) bool { return Helper(token) }
+
+func Helper(token string) bool { return token != "" }
+`)
+	write(t, repo, "svc.py", "def handler():\n    return True\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+
+	cacheDir := t.TempDir()
+	render := func(name string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), name)
+		if err := Run(t.Context(), Options{
+			Version: "test-version",
+			Env:     EntireEnv{RepoRoot: repo, PluginDataDir: cacheDir},
+			Stdout:  &bytes.Buffer{},
+		}, []string{"index", "--repo", repo, "--format", "json", "--report", path}); err != nil {
+			t.Fatal(err)
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return string(content)
+	}
+
+	first := render("GRAPH_REPORT.md")
+	// The second run is served from the cache written by the first, so this also
+	// pins that a cached snapshot renders identically to a freshly built one.
+	if second := render("GRAPH_REPORT-again.md"); first != second {
+		t.Fatalf("report is not deterministic for one tree:\n--- first ---\n%s\n--- second ---\n%s", first, second)
+	}
+	for _, want := range []string{
+		"# Graph report", "- Completeness: **ok**", "## Languages",
+		"| Go | semantic | 1 | 2 |", "| Python | semantic | 1 | 1 |",
+		"## Symbol kinds", "| function | 3 |", "## Relations", "| CALLS | 1 |",
+		"## Top files by symbol count", "| auth.go | 2 |",
+	} {
+		if !strings.Contains(first, want) {
+			t.Fatalf("report missing %q:\n%s", want, first)
+		}
+	}
+	// Nothing outside the snapshot may reach the file, or two runs of one tree
+	// would diff on someone else's machine.
+	if strings.Contains(first, repo) {
+		t.Fatalf("report leaked an absolute machine path:\n%s", first)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -120,7 +120,7 @@ Usage:
   entire graph snapshot --repo . --format ndjson [--worktree] [--progress] [--ignore-file path] [--include-file path]
   entire graph symbols --repo . --format ndjson [--worktree] [--progress] [--ignore-file path] [--include-file path]
   entire graph edges --repo . --format ndjson [--worktree] [--progress] [--ignore-file path] [--include-file path]
-  entire graph index --repo . [--profile syntax-only|fast|full] [--cache-dir path] [--format json] [--head] [--ignore-file path] [--include-file path]
+  entire graph index --repo . [--profile syntax-only|fast|full] [--cache-dir path] [--format json] [--head] [--report GRAPH_REPORT.md] [--ignore-file path] [--include-file path]
   entire graph search --query "issue or concept" --repo . [--format json|ndjson|text|agent] [--top-k 10] [--deep] [--max-context-bytes 24576] [--head] [--profile syntax-only|fast|full] [--max-indexed-files n|--index-all-files] [--cache-dir path|--no-cache] [--reference-blocks all|container-map,signature-types,type-card]
   entire graph def NAME|<file>:<line> --repo . [--file path] [--line n] [--kind kind] [--members 15] [--format text|json] [--max-context-bytes 4096] [--head] [--profile fast|full] [--cache-dir path|--no-cache]
   entire graph neighbors --symbol NAME|<file>:<line> --repo . [--file path] [--line n] [--kind kind] [--relation CALLS] [--direction both|in|out] [--depth 1|2] [--limit 20] [--format json|text|agent] [--max-context-bytes 16384] [--head] [--cache-dir path|--no-cache] [--internal-only] [--exclude-tests]
@@ -152,6 +152,12 @@ Notes:
   grep/read exploration, bytes each pulled into context, and an ESTIMATED token saving whose
   assumption is printed with the number. --transcript narrows it to ONE session transcript
   (plus that session's subagent transcripts) instead of a whole project directory.
+  index --report writes a human-readable GRAPH_REPORT.md beside the JSON summary: what the
+  graph found in this tree (languages and their tier, symbol kinds, relations, top files,
+  warnings) rendered from the snapshot itself, so the same tree always renders the same bytes.
+  The committed-tree cache defaults to the platform's per-user cache directory (macOS
+  ~/Library/Caches/entire-graph, XDG_CACHE_HOME or ~/.cache elsewhere); --cache-dir and
+  ENTIRE_PLUGIN_DATA_DIR override it and --no-cache disables it. --worktree is never cached.
   --include-file contains gitignore-style rules that re-include ignored paths; it is not an allowlist.
   Streaming NDJSON writes aggregate stats and completeness in the trailing summary record.
   commit/diff/analyze stop cleanly after --max-seconds (default 120; 0 = unlimited) and emit the
@@ -333,10 +339,7 @@ func runProviderRecords(ctx context.Context, opts Options, args []string, mode s
 	// output-affecting options, so a repeat call on an unchanged HEAD skips the
 	// expensive re-index. It is deliberately bypassed for --worktree (the working
 	// tree may differ from HEAD) and, by returning above, for targeted queries.
-	cacheDir := flags.CacheDir
-	if cacheDir == "" {
-		cacheDir = opts.Env.PluginDataDir
-	}
+	cacheDir := resolveCacheDir(flags.CacheDir, opts.Env.PluginDataDir)
 	useCache := !flags.DisableCache && !flags.Worktree && cacheDir != ""
 	var tree string
 	if useCache {

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -121,10 +121,7 @@ func runSearch(ctx context.Context, opts Options, args []string) error {
 	if err != nil {
 		return err
 	}
-	cacheDir := flags.CacheDir
-	if cacheDir == "" {
-		cacheDir = opts.Env.PluginDataDir
-	}
+	cacheDir := resolveCacheDir(flags.CacheDir, opts.Env.PluginDataDir)
 	contextBudget := flags.MaxContextBytes
 	// Agent output has a much smaller wire representation than the public JSON
 	// response. Keep full snippets until that representation is budgeted below.

--- a/internal/sem/ignore.go
+++ b/internal/sem/ignore.go
@@ -349,6 +349,76 @@ func (s *nestedIgnoreStack) MayIncludeDescendant(rel string) bool {
 	return s.base.MayIncludeDescendant(rel)
 }
 
+// ReincludesDescendant answers the vendored-directory heuristic over the whole
+// stack: a negation in any ignore file on the current path — root or nested —
+// declares part of that tree first-party.
+func (s *nestedIgnoreStack) ReincludesDescendant(rel string) bool {
+	if s.base.ReincludesDescendant(rel) {
+		return true
+	}
+	for _, level := range s.levels {
+		if level.matcher.reincludesDescendantUnder(level.dir, rel) {
+			return true
+		}
+	}
+	return false
+}
+
+// maxNestedIgnoreFiles bounds how many per-directory .gitignore files one listing
+// merges. A repository with more ignore files than this is not a repository whose
+// vendored-tree verdict hinges on the last one.
+const maxNestedIgnoreFiles = 512
+
+// nestedIgnoreRules merges the repository's per-directory .gitignore files for a
+// listing that is not a walk — the committed-tree listing and Git's own
+// working-tree listing both arrive as a flat path set, so there is no walk
+// position to hang a stack off.
+//
+// It exists for one question: whether the project's own exclude rules re-include
+// part of a tree the vendored-directory heuristic would otherwise skip. Reading
+// only the root .gitignore answered "no" for every project that keeps those rules
+// where Git expects them — beside the tree — which silently dropped tracked
+// first-party source (`vendor/.gitignore` holding `*` and `!mypkg/` lost
+// `vendor/mypkg/**` from both `--head` and the working tree, while the identical
+// negation at the root kept it).
+type nestedIgnoreRules struct {
+	base   ignoreMatcher
+	levels []nestedIgnoreLevel
+}
+
+func newNestedIgnoreRules(base ignoreMatcher) *nestedIgnoreRules {
+	return &nestedIgnoreRules{base: base}
+}
+
+// addFile registers the parsed content of the .gitignore at repo-relative path
+// file. Content that does not parse, or one file past the cap, is skipped: this
+// is a heuristic's escape hatch, not a correctness boundary.
+func (r *nestedIgnoreRules) addFile(file, content string) {
+	dir := cleanIgnorePath(path.Dir(filepath.ToSlash(file)))
+	if dir == "" || len(r.levels) >= maxNestedIgnoreFiles {
+		return
+	}
+	var matcher ignoreMatcher
+	if err := matcher.loadContent(content, false); err != nil {
+		return
+	}
+	r.levels = append(r.levels, nestedIgnoreLevel{dir: dir, matcher: matcher})
+}
+
+// ReincludesDescendant reports whether the root rules or any nested .gitignore
+// negate a path at or below rel.
+func (r *nestedIgnoreRules) ReincludesDescendant(rel string) bool {
+	if r.base.ReincludesDescendant(rel) {
+		return true
+	}
+	for _, level := range r.levels {
+		if level.matcher.reincludesDescendantUnder(level.dir, rel) {
+			return true
+		}
+	}
+	return false
+}
+
 // pathUnder returns rel expressed relative to dir when dir contains it.
 func pathUnder(dir, rel string) (string, bool) {
 	if dir == "" {
@@ -381,10 +451,20 @@ func (m ignoreMatcher) MayIncludeDescendant(rel string) bool {
 // ignore rules themselves keep the fetched dependencies out. Basename-only
 // negations (e.g. `!.keep`) carry no path and are not treated as a signal.
 func (m ignoreMatcher) ReincludesDescendant(rel string) bool {
+	return m.reincludesDescendantUnder("", rel)
+}
+
+// reincludesDescendantUnder is ReincludesDescendant for an ignore file that lives
+// in dir rather than at the repository root: its patterns are relative to dir, so
+// each literal prefix is resolved against dir before being compared to rel.
+// Basename-only negations carry no path in either position and are skipped in
+// both, exactly as before.
+func (m ignoreMatcher) reincludesDescendantUnder(dir, rel string) bool {
 	rel = cleanIgnorePath(rel)
 	if rel == "" {
 		return false
 	}
+	dir = cleanIgnorePath(dir)
 	for _, rule := range m.rules {
 		if rule.ignore || rule.includeFile || rule.basenameOnly {
 			continue
@@ -392,6 +472,9 @@ func (m ignoreMatcher) ReincludesDescendant(rel string) bool {
 		prefix := literalPatternPrefix(rule.pattern)
 		if prefix == "" {
 			continue
+		}
+		if dir != "" {
+			prefix = dir + "/" + prefix
 		}
 		if prefix == rel || strings.HasPrefix(prefix, rel+"/") {
 			return true

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -9445,7 +9445,7 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 		if err != nil {
 			return openedSource{}, err
 		}
-		paths = filterVendoredPaths(paths, headIgnoreMatcher(ctx, repo, committedRevision))
+		paths = filterVendoredPaths(paths, headVendorIgnoreRules(ctx, repo, committedRevision, paths))
 		paths = filterIgnoredPaths(paths, ignores)
 		paths, warnings := capSourceFiles(paths, options.maxFiles)
 		batch, err := gitutil.NewBatchFileReader(ctx, repo, committedRevision)
@@ -9717,13 +9717,21 @@ func isInstalledDependencyDirName(rel, name string) bool {
 	return false
 }
 
+// vendorIgnoreRules is the one question the vendored-directory heuristic asks of
+// a project's exclude rules: does the project re-include part of this tree, and
+// therefore mean to keep it? Both a root-only matcher and a set of per-directory
+// .gitignore files can answer it.
+type vendorIgnoreRules interface {
+	ReincludesDescendant(rel string) bool
+}
+
 // skipVendoredDir is the single vendored-directory decision for both the
 // working-tree walk and the HEAD-tree listing: skip unambiguous vendored names
 // always, and ambiguous generated-output names only when the directory is not
 // tracked in git (dirTracked). Gitignore negations that re-include a
 // descendant (see ReincludesDescendant) keep the tree walked in either case;
 // the ignore rules themselves then filter its contents.
-func skipVendoredDir(rel, name string, ignores ignoreMatcher, dirTracked func(string) bool) bool {
+func skipVendoredDir(rel, name string, ignores vendorIgnoreRules, dirTracked func(string) bool) bool {
 	untrackedOnly := isAmbiguousVendoredDirName(name) || isInstalledDependencyDirName(rel, name)
 	vendored := isVendoredScanDir(rel, name) || (untrackedOnly && !dirTracked(rel))
 	return vendored && !ignores.ReincludesDescendant(rel)
@@ -9797,6 +9805,10 @@ func worktreeSourceFiles(ctx context.Context, repo string, ignores ignoreMatcher
 			}
 		}
 	}
+	// The vendored-directory heuristic consults the project's own re-inclusion
+	// rules wherever they live, not only at the root, so a tree the project
+	// deliberately keeps under a vendored-looking name is not dropped.
+	vendorRules := worktreeVendorIgnoreRules(repo, ignores, listed)
 	paths := make([]string, 0, len(listed))
 	seen := make(map[string]struct{}, len(listed))
 	for _, entry := range listed {
@@ -9804,7 +9816,7 @@ func worktreeSourceFiles(ctx context.Context, repo string, ignores ignoreMatcher
 		if _, exists := seen[rel]; exists {
 			continue
 		}
-		if vendoredScanPath(rel, ignores, dirTracked) {
+		if vendoredScanPath(rel, vendorRules, dirTracked) {
 			continue
 		}
 		// Explicit ignore/include rules still arbitrate: an include file may have
@@ -9845,11 +9857,13 @@ func walkWorktreeFiles(repo string, ignores ignoreMatcher, dirTracked func(strin
 					return relErr
 				}
 				rel = filepath.ToSlash(relPath)
-				if skipVendoredDir(rel, name, ignores, dirTracked) {
-					return filepath.SkipDir
-				}
 			}
+			// Enter first: this directory's own .gitignore is part of the evidence
+			// for whether the project re-includes something inside it.
 			stack.enter(rel)
+			if rel != "" && skipVendoredDir(rel, name, stack, dirTracked) {
+				return filepath.SkipDir
+			}
 			if rel != "" && stack.Ignored(rel, true) && !stack.MayIncludeDescendant(rel) {
 				return filepath.SkipDir
 			}
@@ -9876,7 +9890,7 @@ func walkWorktreeFiles(repo string, ignores ignoreMatcher, dirTracked func(strin
 	return paths, err
 }
 
-func filterVendoredPaths(paths []string, ignores ignoreMatcher) []string {
+func filterVendoredPaths(paths []string, ignores vendorIgnoreRules) []string {
 	filtered := paths[:0]
 	for _, rel := range paths {
 		if vendoredPath(rel, ignores) {
@@ -9899,6 +9913,59 @@ func filterIgnoredPaths(paths []string, ignores ignoreMatcher) []string {
 	return filtered
 }
 
+// headVendorIgnoreRules parses every .gitignore in the committed tree — the root
+// one and each per-directory one — at the same exact revision used for listing
+// and content reads, so the vendored-directory heuristic can neither observe a
+// newer HEAD nor miss a project's re-inclusion rules because they sit beside the
+// tree they describe, which is where Git expects them. The tracked listing
+// already in hand is reused to find them, so this costs no extra listing.
+func headVendorIgnoreRules(ctx context.Context, repo, committedRevision string, paths []string) *nestedIgnoreRules {
+	rules := newNestedIgnoreRules(headIgnoreMatcher(ctx, repo, committedRevision))
+	for _, entry := range paths {
+		rel := filepath.ToSlash(entry)
+		if path.Base(rel) != ".gitignore" || !strings.Contains(rel, "/") {
+			continue
+		}
+		if len(rules.levels) >= maxNestedIgnoreFiles {
+			break
+		}
+		content, ok, err := gitutil.ShowFile(ctx, repo, committedRevision, rel)
+		if err != nil || !ok || len(content) > maxNestedIgnoreFileBytes {
+			continue
+		}
+		rules.addFile(rel, content)
+	}
+	return rules
+}
+
+// worktreeVendorIgnoreRules is headVendorIgnoreRules for the working tree: the
+// per-directory .gitignore files Git's own listing reports (one inside an
+// excluded tree is not listed, and that tree is excluded anyway) are read from
+// disk and merged over the root rules.
+func worktreeVendorIgnoreRules(repo string, base ignoreMatcher, listed []string) *nestedIgnoreRules {
+	rules := newNestedIgnoreRules(base)
+	for _, entry := range listed {
+		rel := filepath.ToSlash(entry)
+		if path.Base(rel) != ".gitignore" || !strings.Contains(rel, "/") {
+			continue
+		}
+		if len(rules.levels) >= maxNestedIgnoreFiles {
+			break
+		}
+		full := filepath.Join(repo, filepath.FromSlash(rel))
+		info, err := os.Stat(full)
+		if err != nil || !info.Mode().IsRegular() || info.Size() > maxNestedIgnoreFileBytes {
+			continue
+		}
+		content, err := os.ReadFile(full)
+		if err != nil {
+			continue
+		}
+		rules.addFile(rel, string(content))
+	}
+	return rules
+}
+
 // headIgnoreMatcher parses the repository's root .gitignore at the same exact
 // committed revision used for listing and content reads, so the vendored-
 // directory heuristic cannot observe a newer HEAD.
@@ -9918,14 +9985,14 @@ func headIgnoreMatcher(ctx context.Context, repo, committedRevision string) igno
 // tracked by construction, so ambiguous generated-output directory names
 // (build, dist, external, deps) are never vendored here — headTracked reports
 // every directory as tracked; only the unambiguous vendored names are skipped.
-func vendoredPath(rel string, ignores ignoreMatcher) bool {
+func vendoredPath(rel string, ignores vendorIgnoreRules) bool {
 	headTracked := func(string) bool { return true }
 	return vendoredScanPath(rel, ignores, headTracked)
 }
 
 // vendoredScanPath applies the vendored-directory and vendored-file heuristics to
 // a listed path, consulting dirTracked for the ambiguous generated-output names.
-func vendoredScanPath(rel string, ignores ignoreMatcher, dirTracked func(string) bool) bool {
+func vendoredScanPath(rel string, ignores vendorIgnoreRules, dirTracked func(string) bool) bool {
 	rel = filepath.ToSlash(rel)
 	parts := strings.Split(rel, "/")
 	if len(parts) == 0 {

--- a/internal/sem/worktree_listing_test.go
+++ b/internal/sem/worktree_listing_test.go
@@ -210,6 +210,53 @@ func TestWorktreeSnapshotFileCeilingOnVendoredTree(t *testing.T) {
 	assertSnapshotOmitsPathPrefix(t, snapshot, "backend/node_env/")
 }
 
+// TestSnapshotHonorsNestedGitignoreReinclusion is the regression guard for the
+// vendored-directory heuristic's escape hatch. A project that keeps one of its own
+// packages inside a vendored-looking tree says so in the ignore file beside that
+// tree, which is where Git expects it — and the heuristic read only the
+// repository-root .gitignore, so it saw no re-inclusion and silently dropped
+// TRACKED first-party source from both `--head` and the working tree. Moving the
+// identical negation to the root kept the same file, which is what made the
+// root-only read the cause rather than the vendored name.
+//
+// Both directions matter: the re-included package must come back, and the rest of
+// the vendored tree must stay out, or the fix is just a disabled heuristic.
+func TestSnapshotHonorsNestedGitignoreReinclusion(t *testing.T) {
+	repo := t.TempDir()
+	initRepo(t, repo)
+	writeFile(t, repo, "app.py", "def app_entrypoint():\n    return True\n")
+	writeFile(t, repo, "vendor/.gitignore", "*\n!.gitignore\n!mypkg/\n!mypkg/**\n")
+	writeFile(t, repo, "vendor/mypkg/lib.py", "def vendored_first_party():\n    return True\n")
+	writeFile(t, repo, "vendor/other/dep.py", "def real_dependency():\n    return True\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "keep one package inside vendor/")
+
+	for _, worktree := range []bool{false, true} {
+		mode := "head"
+		if worktree {
+			mode = "worktree"
+		}
+		t.Run(mode, func(t *testing.T) {
+			snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{
+				Worktree: worktree,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, name := range []string{"app_entrypoint", "vendored_first_party"} {
+				if !snapshotHasSymbol(snapshot, name) {
+					t.Fatalf("%s snapshot dropped %q re-included by a nested .gitignore: %#v",
+						mode, name, snapshot.Files)
+				}
+			}
+			if snapshotHasSymbol(snapshot, "real_dependency") {
+				t.Fatalf("%s snapshot included the vendored tree the project did not re-include: %#v",
+					mode, snapshot.Files)
+			}
+		})
+	}
+}
+
 // TestWorktreeWalkFallbackHonorsNestedGitignore covers the non-git fallback: a
 // directory Git cannot enumerate is still filtered by the nested ignore files the
 // project wrote.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/25
<!-- entire-trail-link-end -->

Stacked on #66. The low-hanging items from the graphify comparison — the ones that belong in the graph
rather than in the Brain.

- **Nested `.gitignore` is honored in the vendored-directory heuristic.** It previously consulted only
  the root ignore file, so a dependency tree ignored by a nested `.gitignore` was still walked and
  indexed as if it were first-party source.
- **A default cache directory.** The committed-tree index previously cached only when
  `ENTIRE_PLUGIN_DATA_DIR` happened to be set, so the common invocation silently re-parsed every time.
  It now uses the platform per-user cache dir unless `--cache-dir` / `ENTIRE_PLUGIN_DATA_DIR` redirect
  it. The working tree is still never cached.
- **`index --report GRAPH_REPORT.md`** — a human-readable summary of what got indexed (languages, file
  and symbol counts, partial failures), so "did it actually parse my repo" is answerable without
  piping NDJSON through jq.
- **`docs/BRAIN-VS-GRAPH.md`** — where the boundary is: the graph is deterministic, local, per-commit
  structure; the Brain is durable cross-session knowledge built on top. Written so the next feature
  request lands on the right side of the line.

Full suite green, `gofmt`/`vet` clean.

---
Entire trail: https://entire.io/gh/entireio/entire-graph/trails/25
