### PR TITLE
search: separate the complete-body head from the locator head, and pad rank 1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ material. Symbols too large to return whole (>160 lines) keep their focused wind
 **Three blocks each replace a tool call you would otherwise spend a turn on.** They are the default
 payload's reason to exist, and they are instructions rather than background reading.
 
-- **SAME-CONCEPT LITERALS** (`literal_cluster` in JSON, `stats.literal_cluster_bytes`) is `grep`
+- **SAME-CONCEPT LITERAL** (`literal_cluster` in JSON, `stats.literal_cluster_bytes`) is `grep`
   folded into `search`. When the top hit contains one distinctive literal that names the queried
   concept — an enum constant's value, an option string, a compound identifier — the block lists every
   occurrence of it in the repository, each annotated with its enclosing symbol and one of three
@@ -176,7 +176,7 @@ prove it, sweep the concept, check the contract, check the names, check the neig
 
 ```text
 LOW CONFIDENCE  ->  CLOSED SET  ->  [CONTAINER MAP]  ->  candidate fix sites  ->  COVERING TEST
-                ->  VERIFY  ->  SAME-CONCEPT LITERALS  ->  [TYPES IN THIS SIGNATURE]
+                ->  VERIFY  ->  SAME-CONCEPT LITERAL  ->  [TYPES IN THIS SIGNATURE]
                 ->  [DECLARATIONS]  ->  RELATED SITES  ->  DOCS & FIXTURES
 ```
 
@@ -422,7 +422,7 @@ Then go straight to the top hit and edit from the body it printed — do not re-
 confirm what you were just shown, and do not re-search to 'make sure'. Reach the edit in as FEW
 turns as you can: every turn re-reads your whole context, and that replay is what this task costs.
 The result also hands you three things that each replace a round-trip you would otherwise spend:
-  SAME-CONCEPT LITERALS - every place this concept is spelled out, each tagged EDIT / CONSUMER /
+  SAME-CONCEPT LITERAL - every place this concept is spelled out, each tagged EDIT / CONSUMER /
       DOC. This IS your sweep: fix the EDIT sites, ignore the CONSUMER ones. Do not grep for them.
   VERIFY - the narrowest command that exercises the file you are changing. Run it ONCE when your
       edits are in. Read the error, fix exactly what it names, re-run at most once. Never hunt a
@@ -506,7 +506,7 @@ controls and caveats: the graphmark repo, `agentic-swebench/REPRODUCE.md` +
 4. **Never read a whole file to explore.** If you must read, read the line range around the symbol. To understand a type/class, query it — don't open its file.
 5. **Impact = one targeted query.** For "what breaks if I change X", use `neighbors --symbol X --relation CALLS --direction in` — not a whole-graph `snapshot`/`edges` dump, and not a repo-wide grep.
 6. **Minimise turns — in discovery, not in verification.** Token cost is roughly turns × context, so prefer one precise query over three broad ones and stop *discovery* once you can defend the edit with a focused hypothesis. Turn economy applies to finding code; it is not a licence to skip the check that your edit builds.
-7. **Complete the fix.** A fix is often not one edit in one place. The **SAME-CONCEPT LITERALS** block is your repo-wide sweep — fix its `EDIT` sites, ignore its `CONSUMER` sites, and do not grep for either; its header states the repository's own totals, so when the block is there you have seen the whole set. For structural neighbours (callers, siblings, near-duplicates) the RELATED SITES block is already in the payload; one `impact --symbol X` covers anything it missed. Measured: single-edit patches were 22 of 31 paired losses (baseline 8/31).
+7. **Complete the fix.** A fix is often not one edit in one place. The **SAME-CONCEPT LITERAL** block is your repo-wide sweep — fix its `EDIT` sites, ignore its `CONSUMER` sites, and do not grep for either; its header states the repository's own totals, so when the block is there you have seen the whole set. For structural neighbours (callers, siblings, near-duplicates) the RELATED SITES block is already in the payload; one `impact --symbol X` covers anything it missed. Measured: single-edit patches were 22 of 31 paired losses (baseline 8/31).
 8. **Verify once — always, with the command you were given.** Run the **VERIFY** line the search printed; when there was none, compile what you touched or run the nearest existing test, at the narrowest scope that would still catch a syntax, type, name, or arity error. Measured: the clamped agent ran zero builds/tests on 22 of 31 paired losses, two of which could not compile. One verification turn is far cheaper than a wrong patch. Measured separately: test/build accounts for 3.79 turns per session, much of it spent finding the right invocation rather than running it — which is what the VERIFY block removes.
 8b. **Adding a variant? Read the CLOSED-SET WARNING first.** When it reports a switch/match site as `checked at runtime`, add the missing arm before you finish: that failure is a runtime throw, not a compile error, so verification will not catch it either. The block only appears when the compiler would not catch it.
 9. **Verify, don't chase.** Verification is bounded: run it, read the error, fix exactly what the error names, re-run — a couple of iterations, not fifty. Do not enter an edit→test→edit loop hunting a green suite, and do not "fix" failures that predate your change.

--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -66,7 +66,7 @@ verification turn costs one turn; a patch that does not compile costs everything
 One search returns three more blocks, and each one exists because it removes a round-trip that was
 measured out of real sessions. Use them as instructions, not as background reading.
 
-**SAME-CONCEPT LITERALS** — every place in the repository where the one distinctive literal that
+**SAME-CONCEPT LITERAL** — every place in the repository where the one distinctive literal that
 names this concept is spelled out, each tagged ` + "`EDIT`" + `, ` + "`CONSUMER`" + ` or ` + "`DOC`" + `, with the header stating
 the repository-wide totals. **This IS your sweep.** Fix the ` + "`EDIT`" + ` sites — they declare or register
 the concept. Ignore the ` + "`CONSUMER`" + ` ones — they only pass the string, so they need no change. ` + "`DOC`" + ` is
@@ -139,7 +139,7 @@ The output is grouped, and the groups mean different things:
    gave you, or — when it gave none — build/compile what you touched or run the nearest existing
    test. Pick the narrowest command that would still catch a syntax, type, name, or arity error
    (one package, one file, one test — not the whole suite).
-6b. The SAME-CONCEPT LITERALS block IS your repo-wide sweep: fix its ` + "`EDIT`" + ` sites, ignore its
+6b. The SAME-CONCEPT LITERAL block IS your repo-wide sweep: fix its ` + "`EDIT`" + ` sites, ignore its
    ` + "`CONSUMER`" + ` sites, and do not grep for either. Its header states the repository's own totals.
 6c. Adding a variant to an enum / sealed set / union / const group? If the CLOSED-SET WARNING says
    ` + "`checked at runtime`" + `, add the missing switch arm before you finish. That failure is a runtime

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"github.com/entireio/entire-graph/internal/sem"
 	"os"
 	"path/filepath"
 	"strings"
@@ -82,7 +83,7 @@ func TestAgentGuideRequiresBoundedVerification(t *testing.T) {
 	// agent uses them, and each with the specific action that removes the round-trip. Their wording
 	// is pinned because it has to stay consistent with the measured harness prompt.
 	for _, want := range []string{
-		"SAME-CONCEPT LITERALS",
+		sem.LiteralClusterBlockName,
 		"This IS your sweep",
 		"Do not grep for any of them",
 		"It is a\ncommand, not a suggestion",

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -45,24 +45,26 @@ const (
 )
 
 type searchFlags struct {
-	Repo              string
-	Query             string
-	Format            string
-	Profile           string
-	Worktree          bool
-	TopK              int
-	ContextLines      int
-	MaxRegionLines    int
-	MaxSnippetLines   int
-	MaxRegionsPerFile int
-	IgnoreFiles       []string
-	IncludeFiles      []string
-	CacheDir          string
-	DisableCache      bool
-	MaxIndexedFiles   int
-	IndexAllFiles     bool
-	MaxContextBytes   int
-	Deep              bool
+	Repo                  string
+	Query                 string
+	Format                string
+	Profile               string
+	Worktree              bool
+	TopK                  int
+	ContextLines          int
+	MaxRegionLines        int
+	MaxSnippetLines       int
+	MaxRegionsPerFile     int
+	IgnoreFiles           []string
+	IncludeFiles          []string
+	CacheDir              string
+	DisableCache          bool
+	MaxIndexedFiles       int
+	IndexAllFiles         bool
+	MaxContextBytes       int
+	BodyHeadRanks         int
+	EnclosureContextLines int
+	Deep                  bool
 	// The reference blocks, off unless asked for. See SearchOptions in internal/sem/search.go for
 	// the session measurement that made OFF the default.
 	ContainerMap   bool
@@ -132,21 +134,23 @@ func runSearch(ctx context.Context, opts Options, args []string) error {
 		flags.MaxContextBytes = 0
 	}
 	response, err := sem.SearchRepository(ctx, repo, opts.Version, flags.Query, sem.SearchOptions{
-		Worktree:          flags.Worktree,
-		IgnoreFiles:       flags.IgnoreFiles,
-		IncludeFiles:      flags.IncludeFiles,
-		Profile:           profile,
-		TopK:              flags.TopK,
-		ContextLines:      flags.ContextLines,
-		MaxRegionLines:    flags.MaxRegionLines,
-		MaxSnippetLines:   flags.MaxSnippetLines,
-		MaxRegionsPerFile: flags.MaxRegionsPerFile,
-		CacheDir:          cacheDir,
-		DisableCache:      flags.DisableCache,
-		MaxIndexedFiles:   flags.MaxIndexedFiles,
-		IndexAllFiles:     flags.IndexAllFiles,
-		MaxContextBytes:   flags.MaxContextBytes,
-		Deep:              flags.Deep,
+		Worktree:              flags.Worktree,
+		IgnoreFiles:           flags.IgnoreFiles,
+		IncludeFiles:          flags.IncludeFiles,
+		Profile:               profile,
+		TopK:                  flags.TopK,
+		ContextLines:          flags.ContextLines,
+		MaxRegionLines:        flags.MaxRegionLines,
+		MaxSnippetLines:       flags.MaxSnippetLines,
+		MaxRegionsPerFile:     flags.MaxRegionsPerFile,
+		CacheDir:              cacheDir,
+		DisableCache:          flags.DisableCache,
+		MaxIndexedFiles:       flags.MaxIndexedFiles,
+		IndexAllFiles:         flags.IndexAllFiles,
+		MaxContextBytes:       flags.MaxContextBytes,
+		BodyHeadRanks:         flags.BodyHeadRanks,
+		EnclosureContextLines: flags.EnclosureContextLines,
+		Deep:                  flags.Deep,
 
 		IncludeContainerMap:   flags.ContainerMap,
 		IncludeSignatureTypes: flags.SignatureTypes,
@@ -1174,6 +1178,18 @@ func parseSearchFlags(args []string) (searchFlags, []string, error) {
 				return flags, nil, err
 			}
 			flags.MaxSnippetLines, i = value, next
+		case "--body-head-ranks":
+			value, next, err := searchPositiveIntFlag(args, i)
+			if err != nil {
+				return flags, nil, err
+			}
+			flags.BodyHeadRanks, i = value, next
+		case "--enclosure-context-lines":
+			value, next, err := searchPositiveIntFlag(args, i)
+			if err != nil {
+				return flags, nil, err
+			}
+			flags.EnclosureContextLines, i = value, next
 		case "--max-regions-per-file":
 			value, next, err := searchPositiveIntFlag(args, i)
 			if err != nil {

--- a/internal/sem/search.go
+++ b/internal/sem/search.go
@@ -65,6 +65,19 @@ type SearchOptions struct {
 	MaxIndexedFiles   int
 	IndexAllFiles     bool
 	MaxContextBytes   int
+	// BodyHeadRanks caps how deep the COMPLETE-BODY upgrade reaches, independently of the
+	// locator head. 0 means the built-in depth (searchEnclosureHeadRanks). It may only narrow
+	// the head, never widen it, so the growth allowance stays sized for the bodies it funds.
+	BodyHeadRanks int
+	// EnclosureContextLines pads the rank-1 complete body with this many source lines on each
+	// side. 0 means no padding (the body's exact symbol bounds).
+	//
+	// Measured on 65 sessions: of the reads that re-open a file whose complete body the payload
+	// ALREADY printed, only 3.8% ask for lines inside that body — 80% ask for lines outside it
+	// (file head 15.6%, within 40 lines 41.4%), median gap 42 lines, median window 50 lines. The
+	// body is the right unit to EDIT and the wrong unit to UNDERSTAND, so a bounded margin buys
+	// back the follow-up read that the unpadded body provokes.
+	EnclosureContextLines int
 	// The three REFERENCE blocks below are OFF by default, and the default is the measurement's
 	// verdict rather than a taste call. Six session-level runs on real agents added the container
 	// map (1119 B), the signature-type block (197 B) and the declaration card (300 B) to the first
@@ -811,10 +824,28 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 	// complete enclosing symbol fits is returned whole — removing the follow-up file read
 	// an agent would otherwise pay a whole turn for — funded, when the budget is tight, by
 	// demoting the tail of the ranking to locators.
-	enclosures := planSearchEnclosures(results, symbolsByID, symbolsByFile, read, defaultSearchEnclosureMaxLines)
+	// How deep the COMPLETE-BODY head reaches is separable from how deep the "never demoted to a
+	// locator" head reaches, and on a capable model they want different depths. Measured on sonnet
+	// (20 instances, config 9): of the files the payload showed, rank 1 was later read 62% of the
+	// time and edited 54%, rank 2 read 27%/edited 20%, but ranks 3/4/5 were read 0%/7%/0% and
+	// edited 11%/7%/0% — while still being charged for 21 complete bodies. Those bytes are replayed
+	// on every later turn and buy nothing on that tier.
+	//
+	// So BodyHeadRanks narrows only the body upgrade. The locator head is deliberately left on
+	// searchEnclosureHeadRanks: a tail locator is the only mention of its file, and the gold file
+	// sits at rank 6-8 on 17% of instances, so shortening the ranking itself loses fix sites (that
+	// is why cutting --top-k to 5 was rejected). Bodies are what cost bytes; locators are not.
+	bodyHeadRanks := searchEnclosureHeadRanks
+	if options.BodyHeadRanks > 0 && options.BodyHeadRanks < bodyHeadRanks {
+		bodyHeadRanks = options.BodyHeadRanks
+	}
+	enclosures := planSearchEnclosures(
+		results, symbolsByID, symbolsByFile, read,
+		defaultSearchEnclosureMaxLines, options.EnclosureContextLines, bodyHeadRanks,
+	)
 	results, completeSymbols, locators := allocateSearchSnippets(
 		results, enclosures, options.MaxContextBytes, searchEnclosureGrowthBytes,
-		searchEnclosureHeadRanks, minInt(searchEnclosureTailSnippetLines, options.MaxSnippetLines),
+		bodyHeadRanks, minInt(searchEnclosureTailSnippetLines, options.MaxSnippetLines),
 	)
 	stats.CompleteSymbols = completeSymbols
 	stats.LocatorSnippets = locators

--- a/internal/sem/search_enclosure.go
+++ b/internal/sem/search_enclosure.go
@@ -124,6 +124,8 @@ func planSearchEnclosures(
 	symbolsByFile map[string][]SymbolRecord,
 	read contentReader,
 	maxLines int,
+	contextLines int,
+	bodyHeadRanks int,
 ) []searchEnclosure {
 	if len(results) == 0 {
 		return nil
@@ -131,10 +133,19 @@ func planSearchEnclosures(
 	if maxLines <= 0 {
 		maxLines = defaultSearchEnclosureMaxLines
 	}
+	if bodyHeadRanks <= 0 {
+		bodyHeadRanks = searchEnclosureHeadRanks
+	}
 	enclosures := make([]searchEnclosure, len(results))
 	fileLines := map[string][]string{}
 	unreadable := map[string]bool{}
 	for index, result := range results {
+		// A rank the allocator can never upgrade needs no enclosure planned for it, and planning
+		// one costs a file read. This is the only place that read happens, so bounding it here
+		// bounds it everywhere.
+		if index >= bodyHeadRanks {
+			continue
+		}
 		symbol, ok := enclosingCallableForResult(result, symbolsByID, symbolsByFile)
 		if !ok {
 			continue
@@ -163,6 +174,21 @@ func planSearchEnclosures(
 		}
 		if result.SnippetStartLine <= start && result.SnippetEndLine >= end {
 			continue
+		}
+		// The margin is rank-1 only and never widens the reported symbol: `symbol` still names the
+		// callable, so a padded body cannot misattribute itself to its neighbours. It is capped by
+		// maxLines like any other body, so a padded body can never exceed the unpadded ceiling.
+		if index == 0 && contextLines > 0 {
+			padStart, padEnd := start-contextLines, end+contextLines
+			if padStart < 1 {
+				padStart = 1
+			}
+			if padEnd > len(lines) {
+				padEnd = len(lines)
+			}
+			if padEnd-padStart+1 <= maxLines {
+				start, end = padStart, padEnd
+			}
 		}
 		enclosures[index] = searchEnclosure{start: start, end: end, lines: lines, symbol: symbol}
 	}

--- a/internal/sem/search_enclosure_test.go
+++ b/internal/sem/search_enclosure_test.go
@@ -124,7 +124,7 @@ func TestPlanSearchEnclosuresResolvesTrueSymbolBounds(t *testing.T) {
 				byFile[record.FilePath] = []SymbolRecord{record}
 			}
 			enclosures := planSearchEnclosures(
-				[]SearchResult{testCase.result}, byID, byFile, reader, testCase.maxLines,
+				[]SearchResult{testCase.result}, byID, byFile, reader, testCase.maxLines, 0, 0,
 			)
 			if len(enclosures) != 1 {
 				t.Fatalf("enclosures = %d, want 1", len(enclosures))
@@ -679,5 +679,96 @@ func TestFitSearchResultsToBudgetPerResultFloor(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestPlanSearchEnclosuresBodyHeadRanksBoundsBodies pins the split between the BODY head and the
+// locator head. Measured on sonnet (config 9, 20 instances): of the files a payload showed, rank 1
+// was later read 62% / edited 54% and rank 2 read 27% / edited 20%, but ranks 3, 4 and 5 were read
+// 0% / 7% / 0% and edited 11% / 7% / 0% — while still being charged for 21 complete bodies whose
+// bytes are replayed on every subsequent turn. Narrowing the body head must therefore stop planning
+// enclosures past the cap, WITHOUT dropping the results themselves: a tail entry is the only mention
+// of its file, and the gold file sits at rank 6-8 on 17% of instances.
+func TestPlanSearchEnclosuresBodyHeadRanksBoundsBodies(t *testing.T) {
+	t.Parallel()
+	lines, symbol := enclosureTestFile(200, 40, 90, "function")
+	reader := enclosureTestReader(lines)
+	byID := map[string]SymbolRecord{symbol.ID: symbol}
+	result := SearchResult{
+		FilePath: "pkg/file.go", StartLine: 60, EndLine: 64, FocusLine: 62,
+		SnippetStartLine: 60, SnippetEndLine: 64, SymbolID: symbol.ID,
+	}
+	results := []SearchResult{result, result, result, result, result}
+
+	enclosures := planSearchEnclosures(results, byID, nil, reader, 0, 0, 2)
+	if len(enclosures) != len(results) {
+		t.Fatalf("enclosures = %d, want %d — narrowing the body head must not drop results",
+			len(enclosures), len(results))
+	}
+	for index, enclosure := range enclosures {
+		if index < 2 {
+			if !enclosure.available() {
+				t.Fatalf("rank %d: want a body inside the head", index+1)
+			}
+			continue
+		}
+		if enclosure.available() {
+			t.Fatalf("rank %d: got a body past bodyHeadRanks=2, want none", index+1)
+		}
+	}
+
+	// 0 means "use the built-in depth", so the default behaviour is unchanged.
+	for index, enclosure := range planSearchEnclosures(results, byID, nil, reader, 0, 0, 0) {
+		if !enclosure.available() {
+			t.Fatalf("rank %d: default depth should still plan a body", index+1)
+		}
+	}
+}
+
+// TestPlanSearchEnclosuresContextLinesPadsRankOneOnly pins the margin. Measured over 65 sessions: of
+// the reads that re-open a file whose complete body the payload ALREADY printed, only 3.8% ask for
+// lines inside that body while 80% ask for lines outside it (median gap 42 lines). The body is the
+// right unit to edit and the wrong unit to understand. The margin is rank-1 only, is capped by
+// maxLines like any other body, and never renames the symbol.
+func TestPlanSearchEnclosuresContextLinesPadsRankOneOnly(t *testing.T) {
+	t.Parallel()
+	lines, symbol := enclosureTestFile(200, 40, 90, "function")
+	reader := enclosureTestReader(lines)
+	byID := map[string]SymbolRecord{symbol.ID: symbol}
+	result := SearchResult{
+		FilePath: "pkg/file.go", StartLine: 60, EndLine: 64, FocusLine: 62,
+		SnippetStartLine: 60, SnippetEndLine: 64, SymbolID: symbol.ID,
+	}
+
+	got := planSearchEnclosures([]SearchResult{result, result}, byID, nil, reader, 0, 10, 0)
+	if got[0].start != 30 || got[0].end != 100 {
+		t.Fatalf("rank 1 = %d-%d, want 30-100 (symbol 40-90 padded by 10)", got[0].start, got[0].end)
+	}
+	if got[0].symbol.Name != symbol.Name {
+		t.Fatalf("padded body renamed the symbol to %q", got[0].symbol.Name)
+	}
+	if got[1].start != 40 || got[1].end != 90 {
+		t.Fatalf("rank 2 = %d-%d, want the unpadded 40-90", got[1].start, got[1].end)
+	}
+
+	// A margin that would push the body past the line cap is refused, not truncated: the cap is
+	// what guarantees a padded body can never cost more than an unpadded one was allowed to.
+	capped := planSearchEnclosures([]SearchResult{result}, byID, nil, reader, 60, 40, 0)
+	if capped[0].start != 40 || capped[0].end != 90 {
+		t.Fatalf("capped = %d-%d, want the unpadded 40-90", capped[0].start, capped[0].end)
+	}
+
+	// The margin clamps at the file edges rather than running off them.
+	edgeLines, edgeSymbol := enclosureTestFile(50, 3, 47, "function")
+	edge := planSearchEnclosures(
+		[]SearchResult{{
+			FilePath: "pkg/file.go", StartLine: 20, EndLine: 24, FocusLine: 22,
+			SnippetStartLine: 20, SnippetEndLine: 24, SymbolID: edgeSymbol.ID,
+		}},
+		map[string]SymbolRecord{edgeSymbol.ID: edgeSymbol}, nil,
+		enclosureTestReader(edgeLines), 0, 25, 0,
+	)
+	if edge[0].start != 1 || edge[0].end != 50 {
+		t.Fatalf("edge = %d-%d, want 1-50 (clamped to the file)", edge[0].start, edge[0].end)
 	}
 }

--- a/internal/sem/search_literals.go
+++ b/internal/sem/search_literals.go
@@ -654,10 +654,18 @@ func searchLiteralClusterCost(cluster *SearchLiteralCluster) int {
 	return maxInt(len(encoded), len(RenderSearchLiteralCluster(cluster)))
 }
 
+// LiteralClusterBlockName is the label the literal-cluster block prints. It is exported because the
+// coding-agent guide TELLS an agent to look for this block by name, and the two spellings drifted:
+// the guide said "SAME-CONCEPT LITERALS" while the payload printed "SAME-CONCEPT LITERAL". Measured
+// cost of that drift: a grep-based audit of 65 agent sessions reported the block firing 0/65 when it
+// actually fired 43/65, because it searched for the documented name rather than the emitted one. One
+// exported constant, asserted by the guide's test, is what keeps them in step.
+const LiteralClusterBlockName = "SAME-CONCEPT LITERAL"
+
 // searchLiteralClusterHeader is the block's label. It states the count so a truncated list can
 // never read as the whole picture.
 func searchLiteralClusterHeader(cluster *SearchLiteralCluster) string {
-	header := fmt.Sprintf("SAME-CONCEPT LITERAL %q — %d in %d file",
+	header := fmt.Sprintf(LiteralClusterBlockName+" %q — %d in %d file",
 		cluster.Literal, cluster.HitsTotal, cluster.FilesTotal)
 	if cluster.FilesTotal != 1 {
 		header += "s"


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/26
<!-- entire-trail-link-end -->

Two new opt-in `SearchOptions` (`0` keeps today's behaviour byte-for-byte, so no shipped payload changes unless a caller asks):

| option | flag | effect |
|---|---|---|
| `BodyHeadRanks` | `--body-head-ranks` | caps how deep the **complete-body** upgrade reaches, independently of the locator head |
| `EnclosureContextLines` | `--enclosure-context-lines` | pads the **rank-1** body with N source lines each side |

## Why — measured, not chosen by taste

**Rank utility** (sonnet, 20 SWE-bench Multilingual instances, matched prompts across arms). Of the files a payload showed, how often the agent later touched them:

| rank | files shown | later Read | later **Edited** |
|---|---|---|---|
| 1 | 24 | **62%** | **54%** |
| 2 | 15 | 27% | 20% |
| 3 | 9 | **0%** | 11% |
| 4 | 15 | 7% | 7% |
| 5 | 13 | **0%** | **0%** |

`searchEnclosureHeadRanks = 5` buys **21 complete bodies at ranks 3–5 that are read 0–7% of the time**, and those bytes are replayed into the model on every later turn.

**Why the two heads must move separately.** The gold file sits at **rank 6–8 on 17% of instances** (5/30, disjoint set), so shortening the *ranking* loses fix sites — cutting `--top-k` to 5 was measured and rejected for exactly that. A tail locator is the only mention of its file and costs ~70 B; a body costs ~1 kB. **Bodies are the expense; locators are the insurance.** `planSearchEnclosures` now also skips ranks the allocator could never upgrade, removing the file read it used to do for them.

**Why pad rank 1.** Over 65 sessions, of the reads that re-open a file whose complete body the payload *already printed*, only **3.8%** ask for lines inside that body — **80% ask for lines outside it** (file head 15.6%, within 40 lines 41.4%), median gap **42 lines**, median requested window **50 lines**. The body is the right unit to *edit* and the wrong unit to *understand*, so the unpadded body provokes the very read it was meant to remove.

The margin is rank-1 only, is capped by `maxLines` like any other body (a padded body can never exceed what an unpadded one was allowed), clamps at file edges, and never renames the symbol.

## Screen — 30 disjoint instances, no model calls, $0

| config | mean bytes | vs as-run | bodies | gold recall | gold has body | top-1 body |
|---|---|---|---|---|---|---|
| as-run (head 5) | 4,310 | — | 3.10 | 22/30 | 14/30 | 25/30 |
| `--body-head-ranks 2` | 2,856 | **−33.7%** | 1.43 | 22/30 | 13/30 | 25/30 |
| ` + --enclosure-context-lines 40` | 4,414 | +2.4% | 1.43 | 22/30 | 13/30 | 25/30 |
| `--body-head-ranks 1 ... 40` | 3,815 | −11.5% | 0.77 | 22/30 | **7/30** | 23/30 |

Dropping the bodies at ranks 3–5 **pays for a 40-line margin on rank 1 almost exactly**: same gold recall, same gold-body coverage, same top-1 coverage, byte-neutral. `--body-head-ranks 1` is **not viable** — it loses 6 gold bodies including at ranks 1 and 2.

Gold recall is identical across every config by construction: results are never dropped, only bodies are.

## Scope and status

This is the mechanism, not a session-level claim. It has **not** yet been run end-to-end against a baseline — the intended next step is a 30-instance sonnet cell, where the falsifier is explicit: if `Read` calls with `offset ≤ 20` and reads adjacent to the rank-1 body do not fall, the margin was not what those reads wanted and should be reverted.

Defaults are unchanged, so nothing here alters current behaviour on its own.

`gofmt`, `go vet ./internal/...` and `go test ./...` are clean. Tests pin: narrowing the body head must not drop results; `0` means the built-in depth; the margin applies to rank 1 only; it is refused rather than truncated when it would exceed the line cap; it clamps at file edges.