### PR TITLE
eg: VERIFY as a hard stop-gate + never-empty verify command (recovers #71's resolution regression)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -424,17 +424,21 @@ turns as you can: every turn re-reads your whole context, and that replay is wha
 The result also hands you three things that each replace a round-trip you would otherwise spend:
   SAME-CONCEPT LITERAL - every place this concept is spelled out, each tagged EDIT / CONSUMER /
       DOC. This IS your sweep: fix the EDIT sites, ignore the CONSUMER ones. Do not grep for them.
-  VERIFY - the narrowest command that exercises the file you are changing. Run it ONCE when your
-      edits are in. Read the error, fix exactly what it names, re-run at most once. Never hunt a
-      green suite, never write a throwaway test script. A patch that does not build fails the
-      whole task.
+  VERIFY - the narrowest command that exercises the file you are changing (when the payload could
+      not name a per-file command it gives the repository's whole-suite command instead). You are
+      NOT done until you have actually RUN this and seen it pass: run it once your edits are in,
+      read the error, fix exactly what it names, re-run at most once. NEVER claim "tests pass"
+      without having run the command — a confident patch that was never executed is the single
+      largest measured cause of a wrong fix. Never hunt a green suite, never write a throwaway test
+      script. A patch that does not build fails the whole task.
   CLOSED-SET WARNING - when you are adding a variant to an enum/sealed set, the switches over it
       that will throw at RUNTIME rather than fail to compile. Add the missing arm before you stop.
 Because the search already named every location — the fix site, the EDIT-tagged literals, the
 related sites — none of your reads or edits depend on each other. Ask for them ALL IN ONE MESSAGE:
 every range you need to see, then every edit you need to make. That is the difference between two
 turns and ten, and turns are the entire cost.
-Then STOP. No further searching, no grep to double-check, no re-reading your own edits.
+Then — and only once VERIFY has actually run and passed — STOP. No further searching, no grep to
+double-check, no re-reading your own edits.
 If the top hit is clearly wrong - a LOW CONFIDENCE marker, or a body that does not match the issue -
 search ONCE more with different words. If that misses too, fall back to the shell in ONE batched
 call rather than staying stuck.
@@ -525,7 +529,7 @@ controls and caveats: the graphmark repo, `agentic-swebench/REPRODUCE.md` +
 5. **Impact = one targeted query.** For "what breaks if I change X", use `neighbors --symbol X --relation CALLS --direction in` — not a whole-graph `snapshot`/`edges` dump, and not a repo-wide grep.
 6. **Minimise turns — in discovery, not in verification.** Token cost is roughly turns × context, so prefer one precise query over three broad ones and stop *discovery* once you can defend the edit with a focused hypothesis. Turn economy applies to finding code; it is not a licence to skip the check that your edit builds.
 7. **Complete the fix.** A fix is often not one edit in one place. The **SAME-CONCEPT LITERAL** block is your repo-wide sweep — fix its `EDIT` sites, ignore its `CONSUMER` sites, and do not grep for either; its header states the repository's own totals, so when the block is there you have seen the whole set. For structural neighbours (callers, siblings, near-duplicates) the RELATED SITES block is already in the payload; one `impact --symbol X` covers anything it missed. Measured: single-edit patches were 22 of 31 paired losses (baseline 8/31).
-8. **Verify once — always, with the command you were given.** Run the **VERIFY** line the search printed; when there was none, compile what you touched or run the nearest existing test, at the narrowest scope that would still catch a syntax, type, name, or arity error. Measured: the clamped agent ran zero builds/tests on 22 of 31 paired losses, two of which could not compile. One verification turn is far cheaper than a wrong patch. Measured separately: test/build accounts for 3.79 turns per session, much of it spent finding the right invocation rather than running it — which is what the VERIFY block removes.
+8. **Verify before you stop — always, with the command you were given.** Running the **VERIFY** line is a *precondition for declaring the task done*, not an optional last step: you have not earned STOP until you have executed it and watched the failing behaviour go green. Run the line the search printed (now always populated — a per-file command when one can be derived, the repository's whole-suite command otherwise); when there was genuinely none, compile what you touched or run the nearest existing test, at the narrowest scope that would still catch a syntax, type, name, or arity error. **Never report that tests pass without having run them** — measured on a 30-instance resolution audit, 2 of 3 regressions vs the prior binary declared success (one literally "All tests pass") having run *zero* tests; the earlier clamp study saw the same shape (zero builds/tests on 22 of 31 paired losses, two of which could not compile). One verification turn is far cheaper than a wrong patch. Measured separately: test/build accounts for 3.79 turns per session, much of it spent finding the right invocation rather than running it — which is what the VERIFY block removes.
 8b. **Adding a variant? Read the CLOSED-SET WARNING first.** When it reports a switch/match site as `checked at runtime`, add the missing arm before you finish: that failure is a runtime throw, not a compile error, so verification will not catch it either. The block only appears when the compiler would not catch it.
 9. **Verify, don't chase.** Verification is bounded: run it, read the error, fix exactly what the error names, re-run — a couple of iterations, not fifty. Do not enter an edit→test→edit loop hunting a green suite, and do not "fix" failures that predate your change.
 10. **Feature-detect before you trust.** If a language might be inventory-only, check `capabilities --json` first — inventory-only files have file records but no semantic relations.

--- a/internal/sem/search_verify.go
+++ b/internal/sem/search_verify.go
@@ -130,6 +130,18 @@ func buildSearchVerifyCommand(
 	}
 	command := deriveSearchVerifyCommand(subject, &evidence)
 	if command == nil {
+		// No narrow command could be derived — most often because the payload found no covering test
+		// (a `test_<name>` minitest file the mirror lookup cannot name, a suite with no per-file
+		// selector). Rather than emit nothing — which, paired with the stop-early doctrine, is what
+		// lets an agent skip verification and ship a confident-but-wrong patch — fall back to the
+		// repository's own WHOLE-SUITE invocation. These are canonical commands (`go test ./...`,
+		// `bundle exec rake test`) that are guaranteed to RUN, so the "silence over a wrong command"
+		// rule still holds: the failure mode it guards against (an error about the invocation, not
+		// the code) cannot happen here. The command is slower and unfiltered, so it is labeled as the
+		// whole suite; a slow-but-real verification beats a whole failed task.
+		command = deriveSearchVerifySuiteCommand(subject, &evidence)
+	}
+	if command == nil {
 		return nil
 	}
 	if searchVerifyCommandCost(command) > searchVerifyCommandMaxBytes {
@@ -321,6 +333,172 @@ var searchVerifyDerivations = []func(string, searchVerifySubject, *searchVerifyE
 	deriveSearchVerifyPytest,
 	deriveSearchVerifyRuby,
 	deriveSearchVerifyMake,
+}
+
+// deriveSearchVerifySuiteCommand is the whole-suite fallback consulted only when no narrow command
+// exists. It walks from the subject's directory towards the root exactly like the narrow derivation
+// and returns the first recognized ecosystem's canonical suite command. Unlike the narrow tier it
+// does NOT require a covering test: its whole point is the case where the payload found none.
+func deriveSearchVerifySuiteCommand(subject searchVerifySubject, evidence *searchVerifyEvidence) *SearchVerifyCommand {
+	dir := path.Dir(subject.sourcePath)
+	if dir == "." || dir == "/" {
+		dir = ""
+	}
+	for depth := 0; depth <= searchVerifyMaxDepth; depth++ {
+		for _, derive := range searchVerifySuiteDerivations {
+			if command := derive(dir, evidence); command != nil {
+				return command
+			}
+		}
+		if dir == "" {
+			break
+		}
+		parent := path.Dir(dir)
+		if parent == "." || parent == "/" || parent == dir {
+			dir = ""
+			continue
+		}
+		dir = parent
+	}
+	return nil
+}
+
+// searchVerifySuiteDerivations mirrors searchVerifyDerivations, language-specific before generic, so
+// a Rust crate with a convenience Makefile still yields `cargo test`, not `make test`.
+var searchVerifySuiteDerivations = []func(string, *searchVerifyEvidence) *SearchVerifyCommand{
+	deriveSearchVerifySuiteCargo,
+	deriveSearchVerifySuiteGo,
+	deriveSearchVerifySuiteMaven,
+	deriveSearchVerifySuiteGradle,
+	deriveSearchVerifySuiteNode,
+	deriveSearchVerifySuiteComposer,
+	deriveSearchVerifySuitePytest,
+	deriveSearchVerifySuiteRuby,
+	deriveSearchVerifySuiteMake,
+}
+
+// searchVerifySuiteCommand builds a whole-suite command, labeling both the target (no covering test
+// was found) and the derivation (whole suite) so the reader knows it is unfiltered and slow.
+func searchVerifySuiteCommand(dir, command, derived string) *SearchVerifyCommand {
+	return &SearchVerifyCommand{
+		Command:     searchVerifyRunIn(dir, command),
+		Targets:     "whole test suite (no covering test identified)",
+		DerivedFrom: derived + " (whole suite)",
+	}
+}
+
+func deriveSearchVerifySuiteCargo(dir string, evidence *searchVerifyEvidence) *SearchVerifyCommand {
+	manifest := searchVerifyJoin(dir, "Cargo.toml")
+	content, ok := evidence.file(manifest)
+	if !ok || (!strings.Contains(content, "[package]") && !strings.Contains(content, "[workspace]")) {
+		return nil
+	}
+	return searchVerifySuiteCommand(dir, "cargo test", manifest)
+}
+
+func deriveSearchVerifySuiteGo(dir string, evidence *searchVerifyEvidence) *SearchVerifyCommand {
+	manifest := searchVerifyJoin(dir, "go.mod")
+	if !evidence.exists(manifest) {
+		return nil
+	}
+	return searchVerifySuiteCommand(dir, "go test ./...", manifest+" module")
+}
+
+func deriveSearchVerifySuiteMaven(dir string, evidence *searchVerifyEvidence) *SearchVerifyCommand {
+	manifest := searchVerifyJoin(dir, "pom.xml")
+	if !evidence.exists(manifest) {
+		return nil
+	}
+	return searchVerifySuiteCommand(dir, "mvn -q test", manifest)
+}
+
+func deriveSearchVerifySuiteGradle(dir string, evidence *searchVerifyEvidence) *SearchVerifyCommand {
+	manifest := ""
+	for _, name := range []string{"build.gradle", "build.gradle.kts"} {
+		if evidence.exists(searchVerifyJoin(dir, name)) {
+			manifest = searchVerifyJoin(dir, name)
+			break
+		}
+	}
+	if manifest == "" || !evidence.exists("gradlew") {
+		return nil
+	}
+	return searchVerifySuiteCommand(dir, "./gradlew test", manifest+" + gradlew")
+}
+
+func deriveSearchVerifySuiteNode(dir string, evidence *searchVerifyEvidence) *SearchVerifyCommand {
+	manifest := searchVerifyJoin(dir, "package.json")
+	content, ok := evidence.file(manifest)
+	if !ok {
+		return nil
+	}
+	var parsed struct {
+		Scripts map[string]string `json:"scripts"`
+	}
+	if err := json.Unmarshal([]byte(content), &parsed); err != nil {
+		return nil
+	}
+	if strings.TrimSpace(parsed.Scripts["test"]) == "" {
+		return nil
+	}
+	return searchVerifySuiteCommand(dir, "npm test", manifest+" scripts.test")
+}
+
+func deriveSearchVerifySuiteComposer(dir string, evidence *searchVerifyEvidence) *SearchVerifyCommand {
+	if !evidence.exists(searchVerifyJoin(dir, "composer.json")) {
+		return nil
+	}
+	for _, name := range []string{"phpunit.xml", "phpunit.xml.dist"} {
+		if evidence.exists(searchVerifyJoin(dir, name)) {
+			return searchVerifySuiteCommand(dir, "vendor/bin/phpunit", searchVerifyJoin(dir, name))
+		}
+	}
+	return nil
+}
+
+func deriveSearchVerifySuitePytest(dir string, evidence *searchVerifyEvidence) *SearchVerifyCommand {
+	for _, name := range searchVerifyPytestConfigs {
+		candidate := searchVerifyJoin(dir, name)
+		content, ok := evidence.file(candidate)
+		if ok && strings.Contains(content, "pytest") {
+			return searchVerifySuiteCommand(dir, "python -m pytest", candidate+" pytest config")
+		}
+	}
+	return nil
+}
+
+// deriveSearchVerifySuiteRuby prefers RSpec when the tree is configured for it (`.rspec`), otherwise
+// falls to `rake test` when the Rakefile names a test task — the same order the narrow Ruby
+// derivation uses, decided by the repository's own layout.
+func deriveSearchVerifySuiteRuby(dir string, evidence *searchVerifyEvidence) *SearchVerifyCommand {
+	hasGemfile := evidence.exists(searchVerifyJoin(dir, "Gemfile"))
+	hasRakefile := evidence.exists(searchVerifyJoin(dir, "Rakefile"))
+	if !hasGemfile && !hasRakefile {
+		return nil
+	}
+	if evidence.exists(searchVerifyJoin(dir, ".rspec")) {
+		return searchVerifySuiteCommand(dir, "bundle exec rspec", searchVerifyJoin(dir, ".rspec"))
+	}
+	if hasRakefile {
+		content, _ := evidence.file(searchVerifyJoin(dir, "Rakefile"))
+		if strings.Contains(content, "test") || strings.Contains(content, "TestTask") {
+			return searchVerifySuiteCommand(dir, "bundle exec rake test", searchVerifyJoin(dir, "Rakefile")+" test task")
+		}
+	}
+	return nil
+}
+
+func deriveSearchVerifySuiteMake(dir string, evidence *searchVerifyEvidence) *SearchVerifyCommand {
+	content, ok := evidence.file(searchVerifyJoin(dir, "Makefile"))
+	if !ok {
+		return nil
+	}
+	for _, target := range []string{"test", "check", "tests"} {
+		if searchMakefileHasTarget(content, target) {
+			return searchVerifySuiteCommand(dir, "make "+target, searchVerifyJoin(dir, "Makefile")+" target "+target)
+		}
+	}
+	return nil
 }
 
 // searchVerifyJoin builds a repository-relative path inside a directory.

--- a/internal/sem/search_verify_test.go
+++ b/internal/sem/search_verify_test.go
@@ -497,3 +497,103 @@ func TestBuildSearchVerifyCommandNeedsACandidateFixSite(t *testing.T) {
 		t.Fatalf("expected silence, got %q", got.Command)
 	}
 }
+
+// TestSearchVerifySuiteFallback covers the whole-suite fallback: when no narrow command can be
+// derived (typically because the payload found no covering test the mirror lookup could name — the
+// faker `test_<name>.rb` minitest case that shipped an EMPTY verify command), the block still emits
+// the repository's own canonical suite command rather than nothing.
+func TestSearchVerifySuiteFallback(t *testing.T) {
+	t.Parallel()
+	for _, testCase := range []struct {
+		name        string
+		files       map[string]string
+		subject     searchVerifySubject
+		wantCommand string
+	}{
+		{
+			name: "ruby minitest repo with no covering test falls back to rake test",
+			files: map[string]string{
+				"Gemfile":                       "source 'https://rubygems.org'\n",
+				"Rakefile":                      "task default: %w[test rubocop]\n",
+				"lib/faker/default/internet.rb": "module Faker\nend\n",
+			},
+			subject:     searchVerifySubject{sourcePath: "lib/faker/default/internet.rb"},
+			wantCommand: "bundle exec rake test",
+		},
+		{
+			name: "ruby rspec repo falls back to bundle exec rspec",
+			files: map[string]string{
+				"Gemfile":      "source 'x'\n",
+				".rspec":       "--require spec_helper\n",
+				"lib/thing.rb": "class Thing; end\n",
+			},
+			subject:     searchVerifySubject{sourcePath: "lib/thing.rb"},
+			wantCommand: "bundle exec rspec",
+		},
+		{
+			name: "node repo with a test script falls back to npm test",
+			files: map[string]string{
+				"package.json": "{\"scripts\":{\"test\":\"jest\"}}",
+				"src/a.js":     "",
+			},
+			subject:     searchVerifySubject{sourcePath: "src/a.js"},
+			wantCommand: "npm test",
+		},
+		{
+			name: "an unrecognized build system stays silent",
+			files: map[string]string{
+				"CMakeLists.txt": "project(x)\n",
+				"src/a.c":        "",
+			},
+			subject:     searchVerifySubject{sourcePath: "src/a.c"},
+			wantCommand: "",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			evidence := searchVerifyTestEvidence(testCase.files)
+			got := deriveSearchVerifySuiteCommand(testCase.subject, &evidence)
+			if testCase.wantCommand == "" {
+				if got != nil {
+					t.Fatalf("expected silence, got %q", got.Command)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected a whole-suite command, got silence")
+			}
+			if got.Command != testCase.wantCommand {
+				t.Fatalf("command = %q, want %q", got.Command, testCase.wantCommand)
+			}
+			if !strings.Contains(got.Targets, "whole test suite") {
+				t.Fatalf("targets must flag the whole suite, got %q", got.Targets)
+			}
+			if searchVerifyCommandCost(got) > searchVerifyCommandMaxBytes {
+				t.Fatalf("cost %d exceeds the cap %d", searchVerifyCommandCost(got), searchVerifyCommandMaxBytes)
+			}
+		})
+	}
+}
+
+// TestBuildSearchVerifyCommandPrefersNarrowOverSuite guards the ordering: a narrow single-file
+// command always wins over the whole-suite fallback when a covering test exists.
+func TestBuildSearchVerifyCommandPrefersNarrowOverSuite(t *testing.T) {
+	t.Parallel()
+	files := map[string]string{
+		"Gemfile":            "source 'x'\n",
+		"Rakefile":           "task default: %w[test]\n",
+		"lib/thing.rb":       "class Thing; end\n",
+		"test/thing_test.rb": "",
+	}
+	results := []SearchResult{
+		{Rank: 1, FilePath: "lib/thing.rb", Section: searchSectionPrimary},
+		{Rank: 2, FilePath: "test/thing_test.rb", Section: searchSectionCoveringTest},
+	}
+	got := buildSearchVerifyCommand(results, searchVerifyTestEvidence(files))
+	if got == nil {
+		t.Fatal("expected a command")
+	}
+	if !strings.Contains(got.Command, "ruby -Itest") {
+		t.Fatalf("expected the narrow single-file command, got %q", got.Command)
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/28
<!-- entire-trail-link-end -->

Stacks on **#71** (`integ/all-2026-07-29`).

## Why
A 30-instance resolution audit (baseline vs cmm vs eg#71 vs prior eg, faithful prompt, official swebench harness) found #71 is the **most token-efficient (+18.8% vs baseline)** but the **lowest resolution (19/30)** — below baseline (21) and the prior eg binary (22). It lost **3 tasks** the prior binary solved (`caddy-4774`, `carbon-2665`, `faker-2705`) and gained none. Token-only scoring would ship this as a win; it's a regression.

## Root cause (from the 3 lost transcripts)
#71 found the right file every time. The terse *"edit straight from the payload / as few turns as possible / then STOP"* doctrine over-rode verification:
- **2 of 3 ran zero tests yet declared success** — caddy literally output "All tests pass" having run none.
- **faker's payload carried a VERIFY header with an empty command** (its minitest file is `test_faker_internet.rb`, a `test_`-prefix the suffix-only mirror lookup can't name), so there was nothing cheap to run and the stop-doctrine won.

## The fix — both changes are to eg itself (the only fair lever)
The prompt is identical across baseline/cmm/eg; only eg's tool payload + shipped doctrine differ. No per-arm benchmark tuning.

**1. Doctrine (`AGENTS.md`).** Running VERIFY is now a **precondition for declaring done**, folded into the STOP rule instead of opposing it. Forbid reporting that tests pass without having run them. The fast path is unchanged (search → edit → verify → stop, one run, no re-reads), so the token edge holds: eg verifies cheaply because the graph hands over the exact command, where baseline spends ~3.79 turns/session finding it.

**2. Retrieval (`internal/sem/search_verify.go`).** A **whole-suite fallback** so VERIFY is never empty. When no narrow per-file command can be derived, emit the repo's canonical suite command (`go test ./...`, `bundle exec rake test`, `cargo test`, `npm test`, `python -m pytest`, Maven/Gradle, PHPUnit, `make test`), clearly labeled *"whole suite (no covering test identified)"*. These are guaranteed to run, so the "silence over a wrong command" principle still holds; narrow commands still win globally (second-pass fallback).

## Verification
- End-to-end: faker now emits `VERIFY: bundle exec rake test`; the old #71 binary emits nothing for the same query.
- New tests: `TestSearchVerifySuiteFallback` (ruby/rspec/node/silence) + `TestBuildSearchVerifyCommandPrefersNarrowOverSuite`.
- Full `internal/sem` suite passes; `go vet` clean.

## Next
Re-run the same 30 instances (all four arms, faithful prompt) and confirm eg resolution recovers toward 22+ while tokens stay near +14–18% vs baseline — with caddy/carbon/faker going green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to agent guidance and optional VERIFY payload derivation in search; behavior is covered by new unit tests with no auth, data, or runtime API impact.
> 
> **Overview**
> Addresses benchmark regressions where agents stopped early and sometimes claimed passing tests without running any, including cases where search emitted an **empty VERIFY** when no per-file test could be named.
> 
> **Agent doctrine (`AGENTS.md`)** now treats running **VERIFY** as a precondition for done: the copy-paste prompt and operating rule 8 require actually executing the printed command (per-file or whole-suite), forbid claiming tests pass without a run, and tie **STOP** to VERIFY having passed.
> 
> **Search VERIFY (`buildSearchVerifyCommand`)** adds a **whole-suite fallback** after narrow derivation fails—walking manifests like the narrow path but emitting canonical suite invocations (`cargo test`, `go test ./...`, `bundle exec rake test`, `npm test`, etc.) labeled as whole suite with no covering test identified. Narrow commands still win when a covering test exists.
> 
> New tests cover suite fallback (Ruby/Node/silence on unknown build systems) and **narrow-over-suite** ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47977e4127d522ba0930678a91fd899b8d0e5bee. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->