### PR TITLE
graph: make DATA_FLOWS evidence selection deterministic

### DIFF
--- a/internal/sem/golden_test.go
+++ b/internal/sem/golden_test.go
@@ -31,6 +31,16 @@ func bravo()   {}
 func charlie() {}
 func delta()   {}
 `)
+	// Several parameters forwarded into the same callee: the relation identity is
+	// one DATA_FLOWS edge, but multiple flows compete to supply its evidence.
+	writeFile(t, repo, "flows.go", `package p
+
+func forwardAll(alpha string, bravo string, charlie string) string {
+	return sink(alpha, bravo, charlie)
+}
+
+func sink(a string, b string, c string) string { return a + b + c }
+`)
 	writeFile(t, repo, "Animals.java", `class Animal {
 	String describe() { return "animal"; }
 	String sound() { return "?"; }
@@ -61,13 +71,48 @@ class Dog extends Animal {
 		return buf.String()
 	}
 
-	first, second := capture(), capture()
-	if first != second {
-		t.Fatalf("stream output is not deterministic across runs")
+	// Repeat: a single second run can match by luck when only two orderings
+	// exist, so sample enough runs to make a map-order leak surface.
+	first := capture()
+	for i := 0; i < 8; i++ {
+		if next := capture(); next != first {
+			t.Fatalf("stream output is not deterministic across runs (run %d differs)", i+2)
+		}
 	}
 	// Sanity: the fixture actually produced the relation kinds we want stable.
 	if !strings.Contains(first, `"type":"CALLS"`) || !strings.Contains(first, `"type":"OVERRIDES"`) {
 		t.Fatalf("fixture did not exercise CALLS/OVERRIDES ordering")
+	}
+	if !strings.Contains(first, `"type":"DATA_FLOWS"`) {
+		t.Fatalf("fixture did not exercise DATA_FLOWS evidence ordering")
+	}
+}
+
+// TestReturnFlowCallsOrderIsTotal guards the ordering that decides which flow
+// supplies a DATA_FLOWS relation's evidence. Several parameters forwarded into
+// one callee produce flows that share a name and evidence kind and differ only
+// in detail; the relation dedupe keeps the first, so a comparator that leaves
+// them tied would let Go's map iteration pick the evidence payload.
+func TestReturnFlowCallsOrderIsTotal(t *testing.T) {
+	block := "func handler(alpha string, bravo string, charlie string) string {\n\treturn forward(alpha, bravo, charlie)\n}\n"
+	params := map[string]bool{"alpha": true, "bravo": true, "charlie": true}
+
+	first := returnFlowCalls(block, params)
+	forwards := 0
+	for _, flow := range first {
+		if flow.EvidenceKind == "argument_forward_flow" && flow.Name == "forward" {
+			forwards++
+		}
+	}
+	if forwards < 3 {
+		t.Fatalf("fixture produced %d competing argument forward flows, want 3", forwards)
+	}
+
+	for i := 0; i < 200; i++ {
+		got := returnFlowCalls(block, params)
+		if !reflect.DeepEqual(got, first) {
+			t.Fatalf("returnFlowCalls order varies across calls: run %d got %+v want %+v", i+2, got, first)
+		}
 	}
 }
 

--- a/internal/sem/types.go
+++ b/internal/sem/types.go
@@ -919,11 +919,26 @@ func returnFlowCalls(block string, params map[string]bool) []returnFlowCall {
 	for _, flow := range flows {
 		out = append(out, flow)
 	}
+	// The comparator must be a total order over every field: `flows` is keyed by
+	// name+kind+detail, so several entries can share a name and evidence kind and
+	// differ only in detail (`a -> f()` vs `b -> f()` when both params are
+	// forwarded to the same callee). Ordering only by name and kind would leave
+	// those tied, letting Go's randomized map iteration decide which one survives
+	// the later relation dedupe — the evidence payload would then vary run to run.
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].Name != out[j].Name {
 			return out[i].Name < out[j].Name
 		}
-		return out[i].EvidenceKind < out[j].EvidenceKind
+		if out[i].EvidenceKind != out[j].EvidenceKind {
+			return out[i].EvidenceKind < out[j].EvidenceKind
+		}
+		if out[i].Detail != out[j].Detail {
+			return out[i].Detail < out[j].Detail
+		}
+		if out[i].Direction != out[j].Direction {
+			return out[i].Direction < out[j].Direction
+		}
+		return out[i].Reason < out[j].Reason
 	})
 	return out
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/29
<!-- entire-trail-link-end -->

Stacked on #72 (base: `claude/verify-gate-suite-fallback`).

A user reported that output is not byte-deterministic: two runs over an identical tigerbeetle tree produced different bytes — ~0.14% of records differed, all `DATA_FLOWS` whose `evidence.detail` named an arbitrary one of several forwarded params (`a -> f()` vs `b -> f()`). Relation identity was stable; only the evidence payload varied. This contradicts AGENTS.md's "the same commit always yields the same graph."

## Root cause

The final sort in `returnFlowCalls` (`internal/sem/types.go`) compared only `Name` and `EvidenceKind`, but the `flows` map it drains is keyed by **name + kind + detail**. When a function forwards several params into the same callee, those entries share a name and kind and differ only in `Detail` — so they tied on the comparator, and `sort.Slice` is not stable, leaving Go's randomized map iteration to decide their order.

Downstream, `dedupeRelations` keys on `from_id + to_id + type` alone and keeps the **first** record. One `DATA_FLOWS` edge, several competing flows to supply its evidence → whichever the map yielded first won.

## Fix

Make the comparator a total order (`Detail`, `Direction`, `Reason` as tiebreakers). For `f(a, b)` the evidence now deterministically names `a`.

## Verification

Reproduced on tigerbeetle@`97c7a8e` (49,625 records), then confirmed fixed:

| path | pre-fix | post-fix |
|---|---|---|
| worktree | run1 vs 2/3/4: 57 / 57 / 48 differing lines | 6 runs, one sha256 |
| committed tree (default) | run1 vs 2/3: 46 / 57 differing lines | 4 runs, byte-identical |
| sorted comparison (reporter's method) | 57 differing records, counts equal | — |

Every differing line was `"type":"DATA_FLOWS"` — 114/114 in the classified run, nothing else. By language: 55 Zig, 2 Python. Observed flips:

```
"detail":"} -> build_ci_step()"     vs  "detail":"b -> build_ci_step()"
"detail":"method -> decode()"       vs  "detail":"indent -> decode()"
"detail":"env -> get_string_utf()"  vs  "detail":"addresses_obj -> get_string_utf()"
```

The reported 51 sits in the run-to-run range (46–57); the count varies per run pair with how many ties the map order flips.

Post-fix byte-identical output also confirmed on cli-cli (Go, 80,616 records, 5 runs), vitejs-vite (TS/JS, 45,027 records, 3 runs), and spring-framework (Java, 720,348 records, 3 runs).

Also checked the cached `--head` query path via `impact`, 5 runs with a fresh cache dir each: content is stable pre- and post-fix — only the latency telemetry header (`Index: cache-miss (27080ms) | ...`) varies, which is expected.

## Tests

`TestStreamSnapshotOrderIsDeterministic` missed this because its fixture never forwarded several params into one callee, and it compared only two runs — which can match by luck when few orderings exist. Added the fixture, raised it to nine runs, asserted `DATA_FLOWS` is actually present, and added `TestReturnFlowCallsOrderIsTotal` as a unit-level guard (200 iterations, with a precondition that the fixture really produces competing flows).

Both guards fail on the pre-fix code and pass after. Full suite, `gofmt`, and `go vet` clean on this stacked base.

## Notes

- The dedupe still **discards** the losing flows rather than merging them into the evidence array — now deterministic, but still lossy. Merging would change record shape and volume, so it's out of scope here — tracked in #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized sort-order fix in semantic extraction with targeted regression tests; no auth, I/O, or API contract changes.
> 
> **Overview**
> Fixes **non-deterministic graph output** when several caller parameters are forwarded into the same callee: `DATA_FLOWS` relation identity stayed stable, but **`evidence.detail`** could flip between params across runs.
> 
> In **`returnFlowCalls`** (`internal/sem/types.go`), the final sort after draining the flows map now uses a **total order**—tie-breaking on **`Detail`**, then **`Direction`**, then **`Reason`**—not just `Name` and `EvidenceKind`. Competing `argument_forward_flow` entries that share name/kind but differ in detail (e.g. `alpha -> sink()` vs `bravo -> sink()`) no longer tie; relation dedupe consistently keeps the first flow and thus a stable evidence payload.
> 
> **Tests** in `golden_test.go`: multi-param forwarding fixture for stream determinism, **nine** snapshot runs instead of two, assertion that `DATA_FLOWS` is exercised, plus **`TestReturnFlowCallsOrderIsTotal`** (200 calls to `returnFlowCalls`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 485f09c23875d37d64c1afe5b2f60392fbed2b70. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
