### PR TITLE
fix(sem): extract TypeScript bodyless declarations (overloads, ambients)

### DIFF
--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -13,6 +13,15 @@ const (
 	// interactive user does not have to add flags to every call. Its value is a comma-separated list
 	// of `container-map`, `signature-types`, `type-card`, or `all`. See searchReferenceBlocks.
 	envReferenceBlocks = "ENTIRE_GRAPH_REFERENCE_BLOCKS"
+	// envPresearch names a file holding the payload for this session, computed BEFORE the agent
+	// started. When it is set, `search` echoes those bytes instead of querying — see
+	// echoPresearchPayload for the measurement that motivates it.
+	//
+	// envPresearchAlias is the same knob under the prefix the benchmark harness already uses for
+	// every one of its search knobs (EG_TOPK, EG_DEEP, EG_MAXBYTES, EG_PROFILE), so the harness can
+	// set it beside them; the ENTIRE_GRAPH_ name is the one this repo documents, and it wins.
+	envPresearch      = "ENTIRE_GRAPH_PRESEARCH"
+	envPresearchAlias = "EG_PRESEARCH"
 )
 
 // cacheDirName is this provider's directory inside the platform's per-user cache
@@ -58,14 +67,22 @@ type EntireEnv struct {
 	PluginDataDir string
 	// ReferenceBlocks is the session-wide default for the off-by-default search reference blocks.
 	ReferenceBlocks string
+	// PresearchPath is the file holding this session's pre-computed search payload, or "" when the
+	// caller has not pre-delivered one. See envPresearch.
+	PresearchPath string
 }
 
 func EnvFromOS() EntireEnv {
+	presearch := os.Getenv(envPresearch)
+	if presearch == "" {
+		presearch = os.Getenv(envPresearchAlias)
+	}
 	return EntireEnv{
 		CLIVersion:      os.Getenv(envCLIVersion),
 		RepoRoot:        os.Getenv(envRepoRoot),
 		PluginDataDir:   os.Getenv(envPluginDataDir),
 		ReferenceBlocks: os.Getenv(envReferenceBlocks),
+		PresearchPath:   presearch,
 	}
 }
 

--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -22,6 +22,13 @@ const (
 	// set it beside them; the ENTIRE_GRAPH_ name is the one this repo documents, and it wins.
 	envPresearch      = "ENTIRE_GRAPH_PRESEARCH"
 	envPresearchAlias = "EG_PRESEARCH"
+	// envSearchSession names the file that carries ONE task's search state between calls. The CLI is
+	// one-shot, so nothing else can tell the second search of a task from the first; setting it is
+	// what turns the search echo on. See searchSession.
+	envSearchSession = "EG_SEARCH_SESSION"
+	// envMaxSearches is how many searches of that session actually run a query (default 1, `0`
+	// disables the echo). See searchSession for the measurement.
+	envMaxSearches = "EG_MAX_SEARCHES"
 )
 
 // cacheDirName is this provider's directory inside the platform's per-user cache
@@ -70,6 +77,10 @@ type EntireEnv struct {
 	// PresearchPath is the file holding this session's pre-computed search payload, or "" when the
 	// caller has not pre-delivered one. See envPresearch.
 	PresearchPath string
+	// SearchSession is the state file for one task's searches; empty means the echo is off.
+	SearchSession string
+	// MaxSearches is how many of that task's searches run a query; empty means the default of 1.
+	MaxSearches string
 }
 
 func EnvFromOS() EntireEnv {
@@ -83,6 +94,8 @@ func EnvFromOS() EntireEnv {
 		PluginDataDir:   os.Getenv(envPluginDataDir),
 		ReferenceBlocks: os.Getenv(envReferenceBlocks),
 		PresearchPath:   presearch,
+		SearchSession:   os.Getenv(envSearchSession),
+		MaxSearches:     os.Getenv(envMaxSearches),
 	}
 }
 

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -485,6 +485,25 @@ func writeTextSearchResult(out interface{ Write([]byte) (int, error) }, result s
 	if result.Kind != "" {
 		fmt.Fprintf(out, " kind=%s", result.Kind)
 	}
+	// THE LINE THE QUERY ACTUALLY MATCHED, not just the range that contains it.
+	//
+	// FocusLine is computed for every hit and has always been in the JSON. The text payload — which
+	// is what an agent reads — printed only the snippet's range, so a hit on a 27-line method said
+	// "the answer is somewhere in 135-161" and made the reader find the line itself. Asked what one
+	// change to the returned payload would let it finish in the fewest calls, a Sonnet agent that had
+	// just fixed apache/lucene-13170 from this tool named exactly this: its only non-essential call
+	// was a Read of 135-161 to "pin down line 151 specifically before editing", and it wanted the
+	// matched line marked so "the payload doubles as both 'here's the function' and 'here's the
+	// precise line to change'". Re-reading a file the payload already printed is 10.1% of all
+	// post-payload tool calls in the measured Sonnet sessions.
+	//
+	// It goes in the HEADER rather than as an inline `>>> 151:` marker on the snippet line, which is
+	// what the agent literally asked for. Agents copy snippet text verbatim as the `old_string` anchor
+	// of an edit, so decorating a body line would make that anchor fail to match the file and turn a
+	// navigation aid into a broken patch.
+	if result.FocusLine >= start && result.FocusLine <= end && end > start {
+		fmt.Fprintf(out, " focus=%d", result.FocusLine)
+	}
 	// A section entry may carry no source at all — the covering test degrades to a locator when its
 	// byte allowance cannot hold one line of body. Printing the empty string as if it were source
 	// costs two blank lines and reads as a truncation bug.

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -117,6 +118,12 @@ func runSearch(ctx context.Context, opts Options, args []string) error {
 	if strings.TrimSpace(flags.Query) == "" {
 		return errors.New("search requires --query")
 	}
+	// ZERO-TOLL DELIVERY. When the caller has already computed this session's payload and handed it
+	// to the agent inside context the session pays for anyway, this call must cost nothing: echo
+	// those bytes and return, before the profile, the repo, the cache and the index are touched.
+	if path := strings.TrimSpace(opts.Env.PresearchPath); path != "" {
+		return echoPresearchPayload(opts.Stdout, path)
+	}
 	profile, err := parseProfile(flags.Profile)
 	if err != nil {
 		return err
@@ -177,6 +184,47 @@ func runSearch(ctx context.Context, opts Options, args []string) error {
 	default:
 		return fmt.Errorf("search --format must be json, ndjson, text, or agent, got %q", flags.Format)
 	}
+}
+
+// echoPresearchPayload returns a payload that was computed before the agent started, verbatim.
+//
+// The toll this removes is the MESSAGE, not the bytes. Measured over 178 gated benchmark pairs,
+// the number of graph calls a session makes is invariant — 1.00 / 1.03 / 1.00 per session across
+// baseline-exploration bands <10 / 10-19 / >=20 turns — while what the call buys back is not:
+// greps displaced go 1.35 / 2.16 / 3.74 over the same bands, and the cost ratio with it (1.140 CI
+// [1.063,1.224] n=51 / 0.950 n=108 / 0.841 CI [0.704,0.998] n=19). Split by outcome instead of by
+// band, the two cohorts separate cleanly: sessions where the call displaced no grep at all (n=43)
+// cost 1.165 CI [1.073,1.264] and ran +1.21 turns, sessions where it displaced greps (n=135) cost
+// 0.938 CI [0.889,0.990] and ran -2.07 turns. corr(turn delta, log cost ratio) = +0.735 CI
+// [0.661,0.800] pair-level, +0.802 CI [0.662,0.885] repo-level — the strongest correlate in the
+// set. Independently, a regression holding call count fixed still prices a +7.0% CI [1.9,13.2]
+// tax on merely having made the call, and prices one call at 1.61 messages rather than 1.
+//
+// The toll is also unpredictable: no static feature of a payload predicts that its call will turn
+// out to be a no-op (AUC 0.553 top score, 0.560 spread, 0.563 gap, 0.690 entropy, at a 28% base
+// rate). Selective skipping is therefore not implementable — pre-delivery is the only form the
+// fix can take, and it must be universal.
+//
+// Echoing rather than re-querying is what makes the delivery free: a call the agent still makes
+// costs one message and adds zero information, so it cannot re-open the phase the pre-delivery
+// closed. Retrieval is unaffected because the agent's own query adds almost nothing over the
+// issue text the payload was derived from: of 188 pre-edit greps not covered by the payload, 2
+// (1.1%) named a literal that was in the agent's query and not in the issue.
+//
+// A caller that names a payload it cannot produce gets an error, not a live query. Falling back
+// silently would leave the arm measuring whichever mode each session happened to land in — the
+// same reason an unknown --reference-blocks name is an error rather than a no-op.
+//
+// Note for whoever wires the caller: the payload must be computed with the SAME binary, flags and
+// cached graph the session would have used, and the instruction telling the agent to search first
+// has to go with it — the tool cannot be left un-called while that directive stands.
+func echoPresearchPayload(out interface{ Write([]byte) (int, error) }, path string) error {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("%s: %w", envPresearch, err)
+	}
+	_, err = out.Write(payload)
+	return err
 }
 
 // writeNdjsonSearch streams a payload as one record per line: a header, the blocks that are their own

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -124,6 +125,21 @@ func runSearch(ctx context.Context, opts Options, args []string) error {
 	if path := strings.TrimSpace(opts.Env.PresearchPath); path != "" {
 		return echoPresearchPayload(opts.Stdout, path)
 	}
+	// The echo is decided before any work: a replayed payload must not pay for a repo resolution or
+	// an index build either. See searchSession for what the cap is worth and why it is an echo.
+	session, err := newSearchSession(opts.Env, opts.Stderr)
+	if err != nil {
+		return err
+	}
+	if session != nil {
+		if state, ok := session.echo(); ok {
+			if _, err := io.WriteString(opts.Stdout, searchEchoHeader(flags.Query, state.Query)); err != nil {
+				return err
+			}
+			_, err := io.WriteString(opts.Stdout, state.Payload)
+			return err
+		}
+	}
 	profile, err := parseProfile(flags.Profile)
 	if err != nil {
 		return err
@@ -170,19 +186,36 @@ func runSearch(ctx context.Context, opts Options, args []string) error {
 	if err := response.Validate(); err != nil {
 		return err
 	}
-	switch flags.Format {
+	// With a session active the payload is teed, so the echo replays the exact bytes this call
+	// handed the agent — the stored answer is the rendered output, not a re-render of the response.
+	out := opts.Stdout
+	var payload bytes.Buffer
+	if session != nil {
+		out = io.MultiWriter(opts.Stdout, &payload)
+	}
+	if err := writeSearchResponse(out, response, flags.Format, contextBudget); err != nil {
+		return err
+	}
+	if session != nil {
+		session.record(flags.Query, payload.Bytes())
+	}
+	return nil
+}
+
+func writeSearchResponse(out io.Writer, response sem.SearchResponse, format string, contextBudget int) error {
+	switch format {
 	case "json":
-		encoder := json.NewEncoder(opts.Stdout)
+		encoder := json.NewEncoder(out)
 		encoder.SetEscapeHTML(false)
 		return encoder.Encode(response)
 	case "ndjson":
-		return writeNdjsonSearch(opts.Stdout, response)
+		return writeNdjsonSearch(out, response)
 	case "text":
-		return writeTextSearch(opts.Stdout, response)
+		return writeTextSearch(out, response)
 	case "agent":
-		return writeAgentSearch(opts.Stdout, response, contextBudget)
+		return writeAgentSearch(out, response, contextBudget)
 	default:
-		return fmt.Errorf("search --format must be json, ndjson, text, or agent, got %q", flags.Format)
+		return fmt.Errorf("search --format must be json, ndjson, text, or agent, got %q", format)
 	}
 }
 

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -461,6 +461,14 @@ func writeTextSearchResult(out interface{ Write([]byte) (int, error) }, result s
 	// span the snippet does not contain sends the reader to the wrong lines.
 	start, end := searchResultPrintedRange(result)
 	fmt.Fprintf(out, "%d. %s:%d-%d", result.Rank, result.FilePath, start, end)
+	// A merged span says so, and says the one thing that decides whether the reader re-reads the
+	// region anyway: that the range is contiguous and nothing between the hits it absorbed has
+	// been left out. Without that, a wide range reads exactly like a stitched-together excerpt,
+	// which is what an agent opens the file to check — the measured turn-2 behaviour this merge
+	// exists to remove (fluentd-3328: `sed -n '330,470p'` over a superset of what it already had).
+	if len(result.MergedRanks) > 0 {
+		fmt.Fprintf(out, " [contains ranks %s - contiguous, nothing elided]", joinSearchRanks(result.MergedRanks))
+	}
 	// A block that carries no relevance score must not print one. The covering test is not a
 	// ranked answer — it is the statement of what the fix has to achieve — and `score=0.0000`
 	// beside it reads as "worthless" rather than "not applicable".
@@ -538,6 +546,17 @@ func writeTextSearchTypeCard(out interface{ Write([]byte) (int, error) }, card [
 		}
 		fmt.Fprintf(out, "  %s\n", entry.Decl)
 	}
+}
+
+// joinSearchRanks renders the pre-merge ranks a contiguous span absorbed. They are the ranking's
+// own numbers from BEFORE the merge renumbered it, which is what makes a rank that no longer
+// prints on its own account for itself instead of just going missing.
+func joinSearchRanks(ranks []int) string {
+	parts := make([]string, 0, len(ranks))
+	for _, rank := range ranks {
+		parts = append(parts, strconv.Itoa(rank))
+	}
+	return strings.Join(parts, ",")
 }
 
 func joinSearchUseLines(lines []int) string {

--- a/internal/cli/search_presearch_test.go
+++ b/internal/cli/search_presearch_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// presearchPayload is deliberately NOT anything the renderer could produce: if a byte of it is
+// missing, added, or reordered, the call re-queried instead of echoing.
+const presearchPayload = "PRE-DELIVERED PAYLOAD\nsrc/auth.py:1  validate_token\n"
+
+// TestSearchEchoesPreDeliveredPayload pins zero-toll delivery: when the payload was computed before
+// the agent started, `search` returns it byte-for-byte and does no work — not the repo, not the
+// index, not the ranking. The nonexistent-repo case is the proof that no work happens: a live query
+// cannot resolve that repo, so an echo that survives it cannot have run one.
+func TestSearchEchoesPreDeliveredPayload(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, "src/auth.py", "def validate_token(token):\n    return bool(token)\n")
+	path := filepath.Join(t.TempDir(), "presearch.txt")
+	if err := os.WriteFile(path, []byte(presearchPayload), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, testCase := range []struct {
+		name    string
+		envName string
+		repo    string
+	}{
+		{name: "documented name", envName: envPresearch, repo: repo},
+		{name: "harness alias", envName: envPresearchAlias, repo: repo},
+		{name: "repo never resolved", envName: envPresearch, repo: filepath.Join(repo, "absent")},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Setenv(testCase.envName, path)
+			var out bytes.Buffer
+			err := Run(t.Context(), Options{
+				Version: "test",
+				Env:     EnvFromOS(),
+				Stdout:  &out,
+				Stderr:  &out,
+			}, []string{"search", "--repo", testCase.repo, "--query", "validate the token", "--format", "text"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if out.String() != presearchPayload {
+				t.Fatalf("payload is not byte-identical:\n got %q\nwant %q", out.String(), presearchPayload)
+			}
+			// Named separately because it is the failure that matters: the call went to the graph.
+			if strings.Contains(out.String(), "def validate_token") {
+				t.Fatalf("search re-queried the repo instead of echoing:\n%s", out.String())
+			}
+		})
+	}
+
+	// Both names set: the documented one wins, so a harness that leaves the alias behind cannot
+	// silently serve a stale payload.
+	t.Run("documented name wins", func(t *testing.T) {
+		stale := filepath.Join(t.TempDir(), "stale.txt")
+		if err := os.WriteFile(stale, []byte("STALE"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv(envPresearch, path)
+		t.Setenv(envPresearchAlias, stale)
+		var out bytes.Buffer
+		if err := Run(t.Context(), Options{Version: "test", Env: EnvFromOS(), Stdout: &out, Stderr: &out},
+			[]string{"search", "--repo", repo, "--query", "validate the token"}); err != nil {
+			t.Fatal(err)
+		}
+		if out.String() != presearchPayload {
+			t.Fatalf("alias overrode the documented name: %q", out.String())
+		}
+	})
+}
+
+// TestSearchRefusesUnreadablePresearchPayload pins that a payload the caller promised but cannot
+// produce is an error, not a silent live query: a run that half-echoes and half-queries measures
+// neither mode.
+func TestSearchRefusesUnreadablePresearchPayload(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, "src/auth.py", "def validate_token(token):\n    return bool(token)\n")
+	t.Setenv(envPresearch, filepath.Join(t.TempDir(), "never-written.txt"))
+
+	var out bytes.Buffer
+	err := Run(t.Context(), Options{Version: "test", Env: EnvFromOS(), Stdout: &out, Stderr: &out},
+		[]string{"search", "--repo", repo, "--query", "validate the token", "--format", "text"})
+	if err == nil {
+		t.Fatalf("a missing payload fell back to a live query:\n%s", out.String())
+	}
+	if !strings.Contains(err.Error(), envPresearch) {
+		t.Fatalf("error does not name the variable that caused it: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("stdout is not empty after a refused echo:\n%s", out.String())
+	}
+}

--- a/internal/cli/search_session.go
+++ b/internal/cli/search_session.go
@@ -1,0 +1,160 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// The search echo: one real search per task. The second and later search of the same task returns
+// the FIRST search's payload verbatim under a one-line header, instead of running a new query.
+//
+// Why a cap at all. Measured on agentic SWE-bench sessions, as the cost ratio against the same
+// instance solved with no tool at all: sessions that made >=4 graph calls (n=16) cost 1.148 of
+// baseline, sessions that made exactly ONE call (n=70) cost 0.975 — difference +0.173, bootstrap
+// CI [+0.019,+0.324], which excludes zero. The gradient repeats per configuration: 1.00
+// calls/session -> -12.7% (the cheapest Opus cell measured), 1.17 -> -0.7%, 1.63 -> +5.1%, and
+// 4.45 calls/session (76% of its sessions multi-call) -> the worst retrieval of the set.
+//
+// The natural experiment is one instance, facebook__docusaurus-9183, under two configurations.
+// One call: gold file at rank 1, $0.273, 8 turns, 3 edits. Eight calls: gold absent from the top
+// five, $0.940, 20 turns, 6 edits. Note what the re-queries could not tell the agent — scores are
+// not comparable ACROSS queries, so the eighth query's wrong rank-1 (71.3) outscored the first
+// query's correct hit (35.4). Re-asking does not produce a better-judged answer, it produces a
+// differently-scaled one.
+//
+// Why an echo rather than a refusal. The repeat call costs its message either way — the agent has
+// already paid the turn by the time this code runs — so replaying the payload can only remove
+// information, never add a turn. A bare refusal costs the same turn and invites the agent to ask
+// again, which is worse than no cap. For the same reason the header is a single line that names no
+// other subcommand: pointing a capped session at a different verb is how a cap turns into a
+// fan-out.
+//
+// Why 1 is the default, and why it is still a knob. Graph usage is invariant at 1.33-1.70
+// calls/session across six measured configurations, so a cap of 1 clips the tail and leaves the
+// median session untouched. The tail is not uniform across models: 40% of Haiku sessions issue
+// more than one search, at 2.03 calls/session, and if a second query is what rescues a first-call
+// miss there, the cap removes resolves. So the cap ships as EG_MAX_SEARCHES, `0` disables it, and
+// a tier that has not been replayed offline should run uncapped.
+
+// searchSession is one task's search state. It lives in a file because the CLI is one-shot: a
+// process that has already exited cannot count its successors, and nothing else in the environment
+// distinguishes the second search of a task from the first one. EG_SEARCH_SESSION names the file;
+// the caller (an agent harness) is what scopes it to a task.
+type searchSession struct {
+	path  string
+	limit int
+}
+
+// searchSessionState is the whole persisted record: how many searches ran, and the first one's
+// question and answer.
+type searchSessionState struct {
+	Searches int    `json:"searches"`
+	Query    string `json:"query"`
+	Payload  string `json:"payload"`
+}
+
+// newSearchSession returns nil when the echo is off, which is the default for every caller that
+// does not set EG_SEARCH_SESSION — an interactive user's searches are unaffected by this file.
+func newSearchSession(env EntireEnv, warn io.Writer) (*searchSession, error) {
+	limit := 1
+	raw := strings.TrimSpace(env.MaxSearches)
+	if raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil {
+			return nil, fmt.Errorf("%s: want an integer (0 disables the cap), got %q", envMaxSearches, raw)
+		}
+		limit = parsed
+	}
+	if limit <= 0 {
+		return nil, nil
+	}
+	path := strings.TrimSpace(env.SearchSession)
+	if path == "" {
+		// A cap asked for but not enforceable. This warns on stderr and runs the query rather than
+		// failing, because a search verb that returns NOTHING is far more expensive than an
+		// uncapped one — the harness this ships behind has already paid for that once, when an
+		// empty array under `set -u` made its search verb emit nothing on every run of a whole
+		// cell before anyone noticed. Stderr never reaches the agent's payload, so the warning
+		// cannot cost a turn either.
+		if raw != "" && warn != nil {
+			fmt.Fprintf(warn, "%s is set but %s is not: the cap has no session file to count in, so this search runs uncapped\n",
+				envMaxSearches, envSearchSession)
+		}
+		return nil, nil
+	}
+	return &searchSession{path: path, limit: limit}, nil
+}
+
+// echo reports the payload to replay when this task has already spent its searches. Every state
+// error answers "no echo": a missing, truncated, or unreadable session file must degrade to a real
+// search, never to a failed one.
+func (s *searchSession) echo() (searchSessionState, bool) {
+	state, err := s.load()
+	if err != nil || state.Searches < s.limit || state.Payload == "" {
+		return searchSessionState{}, false
+	}
+	return state, true
+}
+
+func (s *searchSession) load() (searchSessionState, error) {
+	var state searchSessionState
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		return searchSessionState{}, err
+	}
+	if err := json.Unmarshal(data, &state); err != nil {
+		return searchSessionState{}, err
+	}
+	return state, nil
+}
+
+// record counts a search that actually ran and keeps the FIRST payload: the echo replays the answer
+// the ranking gave the original question, not the last rephrasing of it. Persisting is best-effort
+// for the same reason echo is — a session file that cannot be written costs the cap, not the search.
+func (s *searchSession) record(query string, payload []byte) {
+	state, _ := s.load()
+	state.Searches++
+	if state.Payload == "" {
+		state.Query = query
+		state.Payload = string(payload)
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return
+	}
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return
+	}
+	// Temp + rename: a crash between the two writes must not leave the next call reading half a
+	// payload, which it would then echo as if it were the whole answer.
+	tmp, err := os.CreateTemp(dir, ".eg-search-session-*")
+	if err != nil {
+		return
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmp.Name())
+		return
+	}
+	if err := os.Rename(tmp.Name(), s.path); err != nil {
+		os.Remove(tmp.Name())
+	}
+}
+
+// searchEchoHeader is the one line that precedes a replayed payload. It names both questions — the
+// one that was not run, and the one the bytes below actually answer, so the agent is not left
+// reading a payload as if it were a reply to the query it just typed. Then it stops: no alternative
+// verb, no invitation to rephrase.
+func searchEchoHeader(asked, answered string) string {
+	return fmt.Sprintf("(one search per task: %q was not run — below is your first search %q, verbatim)\n", asked, answered)
+}

--- a/internal/cli/search_session_test.go
+++ b/internal/cli/search_session_test.go
@@ -1,0 +1,136 @@
+package cli
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// searchInSession runs one `search` the way a capped agent harness does: same repo, same session
+// file, a different question each time.
+func searchInSession(t *testing.T, repo, session, maxSearches, query string) string {
+	t.Helper()
+	var out bytes.Buffer
+	err := Run(t.Context(), Options{
+		Version: "0.1.0",
+		Env:     EntireEnv{RepoRoot: repo, SearchSession: session, MaxSearches: maxSearches},
+		Stdout:  &out,
+	}, []string{
+		"search", "--repo", repo, "--query", query, "--format", "text",
+		"--profile", "syntax-only", "--worktree", "--top-k", "1",
+	})
+	if err != nil {
+		t.Fatalf("search %q: %v", query, err)
+	}
+	return out.String()
+}
+
+// The second search of a task must replay the first one's payload, not run a new query. The
+// measurement behind the cap is in search_session.go: >=4-call sessions cost 1.148 of the no-tool
+// baseline against 0.975 for one-call sessions, +0.173 with a bootstrap CI of [+0.019,+0.324].
+func TestSearchEchoesFirstPayloadOnRepeatSearch(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	write(t, repo, "alpha.py", "def alpha_widget():\n    return True\n")
+	write(t, repo, "beta.py", "def beta_gadget():\n    return False\n")
+	session := filepath.Join(t.TempDir(), "session.json")
+
+	first := searchInSession(t, repo, session, "", "alpha_widget")
+	if !strings.Contains(first, "alpha.py") {
+		t.Fatalf("first search did not answer its own question: %q", first)
+	}
+
+	second := searchInSession(t, repo, session, "", "beta_gadget")
+	header, replayed, ok := strings.Cut(second, "\n")
+	if !ok {
+		t.Fatalf("echo is not header + payload: %q", second)
+	}
+	// Verbatim: the echo must hand back the exact bytes of the first payload, so a session that
+	// re-asks is left in precisely the state its first search put it in.
+	if replayed != first {
+		t.Fatalf("echoed payload is not the first payload verbatim:\n got: %q\nwant: %q", replayed, first)
+	}
+	// The point of the cap: the second query never ran.
+	if strings.Contains(replayed, "beta.py") {
+		t.Fatalf("second query was executed: %q", replayed)
+	}
+	// One line that names both questions: the one that was skipped, and the one the bytes below
+	// answer — an echo read as a reply to the query just typed is worse than no echo.
+	if !strings.Contains(header, "beta_gadget") || !strings.Contains(header, "not run") {
+		t.Fatalf("header does not say the query was skipped: %q", header)
+	}
+	if !strings.Contains(header, "alpha_widget") {
+		t.Fatalf("header does not say which question the payload answers: %q", header)
+	}
+	// One line, and no other subcommand named in it. A refusal that points somewhere else is how a
+	// capped session turns into a fan-out, which is the behaviour the cap exists to remove.
+	for _, verb := range []string{"neighbors", "impact", "symbols", "edges", "grep", "def "} {
+		if strings.Contains(header, verb) {
+			t.Fatalf("echo header advertises %q: %q", verb, header)
+		}
+	}
+}
+
+// The cap is a knob, not a constant: 40% of Haiku sessions issue more than one search (2.03
+// calls/session), and if the second query is what rescues a first-call miss there, capping costs
+// resolves. `EG_MAX_SEARCHES=0` and "no session file at all" must both run every query.
+func TestSearchWithoutCapRunsEveryQuery(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	write(t, repo, "alpha.py", "def alpha_widget():\n    return True\n")
+	write(t, repo, "beta.py", "def beta_gadget():\n    return False\n")
+
+	for _, tc := range []struct{ name, session, maxSearches string }{
+		{name: "cap disabled", session: filepath.Join(t.TempDir(), "session.json"), maxSearches: "0"},
+		{name: "no session file", session: "", maxSearches: "1"},
+		{name: "unconfigured", session: "", maxSearches: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			searchInSession(t, repo, tc.session, tc.maxSearches, "alpha_widget")
+			second := searchInSession(t, repo, tc.session, tc.maxSearches, "beta_gadget")
+			if !strings.Contains(second, "beta.py") {
+				t.Fatalf("second query did not run: %q", second)
+			}
+			if strings.Contains(second, "not run") {
+				t.Fatalf("uncapped search echoed: %q", second)
+			}
+		})
+	}
+}
+
+// A session file that is missing, truncated, or not JSON must degrade to a real search. The echo is
+// an optimisation; failing the search instead would cost the whole task.
+func TestSearchEchoFailsOpenOnBrokenSessionFile(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	write(t, repo, "alpha.py", "def alpha_widget():\n    return True\n")
+	session := filepath.Join(t.TempDir(), "session.json")
+	write(t, filepath.Dir(session), filepath.Base(session), "{not json")
+
+	got := searchInSession(t, repo, session, "", "alpha_widget")
+	if !strings.Contains(got, "alpha.py") {
+		t.Fatalf("broken session file suppressed the search: %q", got)
+	}
+	// ...and the search it did run becomes the session's first payload.
+	second := searchInSession(t, repo, session, "", "beta_gadget")
+	if !strings.Contains(second, "not run") {
+		t.Fatalf("session did not recover after the broken file: %q", second)
+	}
+}
+
+// An unparseable EG_MAX_SEARCHES is an error, not a silent no-op: a knob that quietly does nothing
+// is how a measurement gets attributed to the wrong build.
+func TestSearchRejectsNonNumericMaxSearches(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	write(t, repo, "alpha.py", "def alpha_widget():\n    return True\n")
+	err := Run(t.Context(), Options{
+		Version: "0.1.0",
+		Env:     EntireEnv{RepoRoot: repo, SearchSession: filepath.Join(t.TempDir(), "s.json"), MaxSearches: "yes"},
+		Stdout:  &bytes.Buffer{},
+	}, []string{"search", "--repo", repo, "--query", "alpha_widget", "--worktree"})
+	if err == nil || !strings.Contains(err.Error(), envMaxSearches) {
+		t.Fatalf("err = %v, want a complaint about %s", err, envMaxSearches)
+	}
+}

--- a/internal/cli/search_span_merge_test.go
+++ b/internal/cli/search_span_merge_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/entireio/entire-graph/internal/sem"
+)
+
+// A merged span is only worth its bytes if the header says the range is contiguous. Measured on
+// fluentd-3328: gold was at rank 1, complete-symbol, and the agent said "Top hit is exact" — then
+// spent turn 2 on `sed -n '200,270p'; sed -n '330,470p'`, 6.9 kB re-reading a superset of ranks
+// 1/2/3, because three disjoint spans of one file look like an excerpt with holes in it.
+func TestSearchTextLabelsAMergedSpanAsContiguous(t *testing.T) {
+	t.Parallel()
+	result := sem.SearchResult{
+		Rank: 1, FilePath: "lib/fluent/plugin/in_tail.rb", Score: 135.8,
+		StartLine: 349, EndLine: 425,
+		SnippetStartLine: 349, SnippetEndLine: 425,
+		FocusLine:   395,
+		Snippet:     "def receive_lines",
+		Signals:     []string{"body", sem.CompleteSymbolSignal, "contiguous-span"},
+		SymbolName:  "receive_lines",
+		MergedRanks: []int{1, 2},
+	}
+	var out bytes.Buffer
+	writeTextSearchResult(&out, result, true)
+	want := "1. lib/fluent/plugin/in_tail.rb:349-425 [contains ranks 1,2 - contiguous, nothing elided] score=135.8000"
+	if !strings.HasPrefix(out.String(), want) {
+		t.Fatalf("merged span header is\n%s\nwant prefix\n%s", out.String(), want)
+	}
+}
+
+// An ordinary hit must be byte-identical to what it was before merging existed: the arm this
+// change is measured against has to differ only where a merge actually happened.
+func TestSearchTextLeavesAnUnmergedHitUnannotated(t *testing.T) {
+	t.Parallel()
+	result := sem.SearchResult{
+		Rank: 2, FilePath: "pylint/lint/expand_modules.py", Score: 46.07,
+		StartLine: 400, EndLine: 500,
+		SnippetStartLine: 474, SnippetEndLine: 478,
+		FocusLine: 474,
+		Snippet:   "def expand_modules(",
+		Signals:   []string{"body"},
+	}
+	var out bytes.Buffer
+	writeTextSearchResult(&out, result, true)
+	if strings.Contains(out.String(), "contains ranks") {
+		t.Fatalf("an unmerged hit was annotated:\n%s", out.String())
+	}
+	want := "2. pylint/lint/expand_modules.py:474-478 score=46.0700"
+	if !strings.HasPrefix(out.String(), want) {
+		t.Fatalf("unmerged header is\n%s\nwant prefix\n%s", out.String(), want)
+	}
+}

--- a/internal/sem/parser.go
+++ b/internal/sem/parser.go
@@ -4378,6 +4378,31 @@ func entityFromNode(node *sitter.Node, src []byte, language, scope string) (Enti
 			name = qualify(scope, name)
 		}
 	case "method_signature", "getter_signature", "setter_signature":
+		// tree-sitter-typescript emits `method_signature` both for an OVERLOAD
+		// declaration inside a class body (`over(a: string): void` immediately
+		// preceding the implementing `method_definition`) and for interface /
+		// type-literal members. A class-body signature is a real declaration of
+		// real code — it is where the parameter types and generics of an
+		// overloaded method live — so it gets its own symbol, exactly like the
+		// `abstract_method_signature` case above. Interface and type-literal
+		// members stay inventory-only: they declare a contract, not a definition,
+		// so emitting them makes every `x.m()` call name-resolvable to a bodyless
+		// interface member. That is not hypothetical — extending this case to
+		// interface_body/object_type members fabricates a CALLS edge in
+		// TestTypeScriptNamespaceCallSkipsParameterReceiverRoots, where a
+		// parameter named `B` shadows a namespace and `B.parse()` then binds to
+		// `Client.parse` instead of resolving to nothing.
+		if language == "TypeScript" {
+			if node.Type() != "method_signature" || !typeScriptClassBodySignature(node) {
+				return Entity{}, false
+			}
+			kind = "method"
+			name = nodeName(node, src)
+			if scope != "" {
+				name = qualify(scope, name)
+			}
+			break
+		}
 		// Dart class members (declaration head; body is a sibling node). Gated to
 		// Dart because `method_signature` also denotes TypeScript interface
 		// members, where extracting them as methods would change TS behavior.
@@ -4397,6 +4422,25 @@ func entityFromNode(node *sitter.Node, src []byte, language, scope string) (Enti
 			name = qualify(scope, name)
 		}
 	case "function_signature":
+		// tree-sitter-typescript emits `function_signature` for every BODYLESS
+		// function declaration: a TypeScript OVERLOAD signature and an ambient
+		// `declare function`. Both are top-level declarations of the module's
+		// public surface, and an overload set is where the parameter types and
+		// generics live — the implementation's own signature is usually the
+		// erased `(source: any, ...)` catch-all. Dropping them made a file like
+		// vue's renderList.ts (five overloads + one implementation) expose a
+		// single symbol covering only the implementation's lines, so the typed
+		// half of the file was invisible to search and no query phrased in terms
+		// of the declared types could retrieve it.
+		if language == "TypeScript" {
+			kind = "function"
+			name = nodeName(node, src)
+			if scope != "" {
+				kind = "method"
+				name = qualify(scope, name)
+			}
+			break
+		}
 		// Dart top-level / local function declaration head. Gated to Dart because
 		// `function_signature` also denotes TypeScript ambient declarations.
 		if language != "Dart" {
@@ -5052,6 +5096,16 @@ func entityFromNode(node *sitter.Node, src []byte, language, scope string) (Enti
 		}
 	}
 	return entity, true
+}
+
+// typeScriptClassBodySignature reports whether a tree-sitter-typescript
+// `method_signature` node is a CLASS member (an overload declaration or an
+// ambient class method) rather than an interface / type-literal member. The
+// grammar reuses one node type for all three; only the class form declares
+// real code, so only it becomes a symbol.
+func typeScriptClassBodySignature(node *sitter.Node) bool {
+	parent := node.Parent()
+	return validNode(parent) && parent.Type() == "class_body"
 }
 
 // dartInnerSignature returns the function/getter/setter signature wrapped by a

--- a/internal/sem/parser_typescript_regression_test.go
+++ b/internal/sem/parser_typescript_regression_test.go
@@ -158,3 +158,127 @@ func TestTypeScriptMasksPreserveLength(t *testing.T) {
 		}
 	}
 }
+
+// A TypeScript OVERLOAD SET is several bodyless `function_signature`
+// declarations followed by one implementation. tree-sitter emits a distinct
+// node type for the bodyless form, and it used to be gated to Dart, so an
+// overloaded function collapsed to the single implementation symbol: vue's
+// packages/runtime-core/src/helpers/renderList.ts (five overloads on lines
+// 10-53, implementation on 54) exposed exactly one symbol spanning 54-107, and
+// the declared parameter types and generics — which live only in the overloads
+// — were unindexed. Every declaration must get its own symbol over its own
+// lines, and the spans must not overlap.
+func TestTypeScriptOverloadSignaturesEachEmitSymbol(t *testing.T) {
+	src := "/** v-for string */\n" + // 1
+		"export function renderList(\n" + // 2
+		"  source: string,\n" + // 3
+		"  renderItem: (value: string, index: number) => VNodeChild,\n" + // 4
+		"): VNodeChild[]\n" + // 5
+		"\n" + // 6
+		"/** v-for iterable */\n" + // 7
+		"export function renderList<T>(\n" + // 8
+		"  source: Iterable<T>,\n" + // 9
+		"  renderItem: (value: T, index: number) => VNodeChild,\n" + // 10
+		"): VNodeChild[]\n" + // 11
+		"\n" + // 12
+		"/** implementation */\n" + // 13
+		"export function renderList(\n" + // 14
+		"  source: any,\n" + // 15
+		"  renderItem: (...args: any[]) => VNodeChild,\n" + // 16
+		"): VNodeChild[] {\n" + // 17
+		"  return []\n" + // 18
+		"}\n" // 19
+
+	var got [][2]int
+	for _, entity := range requireNoTSParseError(t, "renderList.ts", src) {
+		if entity.Name != "renderList" {
+			t.Fatalf("unexpected entity %+v", entity)
+		}
+		if entity.Kind != "function" {
+			t.Errorf("kind = %q, want function: %+v", entity.Kind, entity)
+		}
+		got = append(got, [2]int{entity.StartLine, entity.EndLine})
+	}
+	want := [][2]int{{2, 5}, {8, 11}, {14, 19}}
+	if len(got) != len(want) {
+		t.Fatalf("renderList symbols = %d %v, want %d declarations %v", len(got), got, len(want), want)
+	}
+	for i, span := range want {
+		if got[i] != span {
+			t.Errorf("declaration %d span = %v, want %v", i, got[i], span)
+		}
+	}
+	// Overlapping spans would mean a signature was merged into the
+	// implementation instead of standing on its own lines.
+	for i := 1; i < len(got); i++ {
+		if got[i][0] <= got[i-1][1] {
+			t.Errorf("spans overlap: %v then %v", got[i-1], got[i])
+		}
+	}
+
+	// Same file, same qualified name, same kind: the compound-v1 ID scheme must
+	// still hand out one distinct, stable ID per overload, or `def`/`neighbors`
+	// on an overload set collapses back to a single target.
+	// See TestNeighborsExactSymbolIDDisambiguatesSameFileOverloads in
+	// internal/cli for the consumer side of this contract.
+	entities, _, _ := TreeSitterParser{}.ParseWithStatus("renderList.ts", src)
+	ids := map[string]bool{}
+	for _, symbol := range entitySymbols("gh/vuejs/core", "src/renderList.ts", "TypeScript", entities) {
+		if ids[symbol.ID] {
+			t.Errorf("duplicate symbol ID %q across overloads", symbol.ID)
+		}
+		ids[symbol.ID] = true
+	}
+	if len(ids) != len(want) {
+		t.Errorf("distinct overload IDs = %d, want %d", len(ids), len(want))
+	}
+}
+
+// The same bodyless shape covers ambient declarations (`declare function`,
+// including inside `declare namespace`/`.d.ts` files) and overloaded class
+// methods and constructors (`method_signature` in a class_body). Interface and
+// type-literal members share the node type but stay unextracted on purpose:
+// they declare a contract rather than code, and emitting them lets a call bind
+// to a bodyless member (see TestTypeScriptNamespaceCallSkipsParameterReceiverRoots).
+func TestTypeScriptBodylessDeclarationCoverage(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		path string
+		src  string
+		want []string
+	}{{
+		name: "ambient function",
+		path: "globals.d.ts",
+		src:  "declare function amb(a: string): void\ndeclare namespace N {\n  function inner(b: number): void\n}\n",
+		want: []string{"function amb", "function inner"},
+	}, {
+		name: "class method and constructor overloads",
+		path: "worker.ts",
+		src: "class Worker {\n" +
+			"  constructor(a: string)\n" +
+			"  constructor(a: any) {}\n" +
+			"  run(a: string): void\n" +
+			"  run(a: number): void\n" +
+			"  run(a: any): void {}\n" +
+			"}\n",
+		want: []string{
+			"class Worker", "method Worker.constructor", "method Worker.constructor",
+			"method Worker.run", "method Worker.run", "method Worker.run",
+		},
+	}, {
+		name: "interface and type-literal members stay out",
+		path: "contract.ts",
+		src:  "interface Client {\n  parse(): void\n  parse(raw: string): void\n}\ntype Handler = { handle(a: string): void }\n",
+		want: []string{"interface Client", "type Handler"},
+	}} {
+		t.Run(testCase.name, func(t *testing.T) {
+			var got []string
+			for _, entity := range requireNoTSParseError(t, testCase.path, testCase.src) {
+				got = append(got, entity.Kind+" "+entity.Name)
+			}
+			if strings.Join(got, ", ") != strings.Join(testCase.want, ", ") {
+				t.Errorf("entities = [%s], want [%s]", strings.Join(got, ", "), strings.Join(testCase.want, ", "))
+			}
+		})
+	}
+}

--- a/internal/sem/search.go
+++ b/internal/sem/search.go
@@ -159,6 +159,12 @@ type SearchResult struct {
 	// a label rather than a filter.
 	Section string `json:"section,omitempty"`
 	Snippet string `json:"snippet"`
+	// MergedRanks lists the PRE-merge ranks whose spans this one result now covers, set when
+	// several near hits in one file were folded into a single contiguous region
+	// (search_span_merge.go). Present only on a merged span, so its absence is the ordinary
+	// case; when it is present the snippet is the verbatim, unelided text of the whole range,
+	// which is the fact that stops a reader spending a turn bridging the gap itself.
+	MergedRanks []int `json:"merged_ranks,omitempty"`
 	// There is deliberately no per-result `Neighbors` list here. "The types this hit is
 	// written in terms of" is answered once, by the signature-type block (search_sigtypes.go),
 	// and "the other places this change lands" by the related-site block
@@ -218,6 +224,10 @@ type SearchStats struct {
 	// them. Together they report how the byte budget was allocated (schema 1.x additive).
 	CompleteSymbols int `json:"complete_symbol_snippets,omitempty"`
 	LocatorSnippets int `json:"locator_snippets,omitempty"`
+	// MergedSpans counts ranked hits collapsed into a contiguous same-file span
+	// (search_span_merge.go). It is reported for the same reason every other allocation
+	// decision is: a payload that shows fewer blocks than the ranking produced must say so.
+	MergedSpans int `json:"merged_spans,omitempty"`
 	// RelatedSites counts entries in the related-site block: the other places the top hit's
 	// change usually has to land (callers, sibling implementations, near-duplicate bodies).
 	// They are funded out of the tail of the ranking, so this count also says how much of the
@@ -890,6 +900,19 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 	// Truncation is measured against the ranking, by rank, so it has to be read off the
 	// allocator's output BEFORE the related-site block renumbers the payload.
 	truncated := countBudgetTruncatedResults(ranked, results)
+	// Two printed bodies of one file with a small hole between them are one region as far as the
+	// reader is concerned, and the hole is what it spends a turn closing: measured over 113 Opus
+	// payloads, 40% carry such a pair, and the tool makes +19.6% MORE Read calls than the no-tool
+	// baseline while total tool calls fall 14.5%. Folding them into one contiguous, explicitly
+	// unelided span runs here — after truncation has been measured against the ranking, so the
+	// counter still describes what the allocator did, and before sectioning, so it can only ever
+	// touch candidate fix sites. See search_span_merge.go for the bounds that keep it from
+	// evicting a hit to pay for a bridge.
+	if merged, spans, absorbed := mergeSameFileSearchSpans(results, read, options.MaxContextBytes); spans > 0 {
+		results = merged
+		stats.MergedSpans = spans
+		stats.CompleteSymbols = maxInt(0, stats.CompleteSymbols-absorbed)
+	}
 	// Sectioning first: it decides which hit anchors the related-site block, because a
 	// docs-and-fixtures hit at rank 1 is not a fix site and its neighbourhood is not the
 	// neighbourhood of the change.

--- a/internal/sem/search_span_merge.go
+++ b/internal/sem/search_span_merge.go
@@ -1,0 +1,316 @@
+package sem
+
+import (
+	"sort"
+	"strings"
+)
+
+// Same-file span merging
+// ======================
+//
+// The ranking is allowed to return several hits from ONE file, and when it does they come back
+// as separate blocks with a hole between them. That hole is what an agent pays to close.
+//
+// Measured across 113 real Opus search payloads: 45 of them (40%) carry at least two ranked hits
+// in the same file whose printed spans are less than 40 lines apart (R30Oeg 12/25, R30OegBEST
+// 12/30, R30OegV9 9/29, C15opeg_r1 12/29). Two independent lenses caught what that costs.
+//
+//   - Read side. Of 53 answered pre-edit Read calls only 41 carry a line range, and of those only
+//     22 (53.7%) overlap the payload snippet at all; the payload covers a mean 18.2% of the
+//     requested span. The nominal 62.0% read coverage is therefore worth ~33% in practice — the
+//     agent is asking for the surrounding region, not for the block it already has.
+//   - Suite level. The tool makes +19.6% MORE Read calls than the no-tool baseline while total
+//     tool calls fall 14.5% (n=55 paired instances). Bodies removed greps and added reads.
+//
+// The call-by-call case is fluentd-3328: gold sat at rank 1 (in_tail.rb:395-425, score 135.8,
+// complete-symbol, and the agent said so — "Top hit is exact"), and the session still cost 1.64x
+// the baseline, because ranks 1/2/3 were three DISJOINT spans of one file (349-360, 395-425,
+// 427-443) and turn 2 was `sed -n '200,270p'; sed -n '330,470p'` — 6.9 kB re-reading a contiguous
+// superset of what the payload already held. pylint-7080 turn 2 is the same shape: `cat
+// pylint/lint/expand_modules.py`, re-fetching rank 2 verbatim.
+//
+// So when two printed bodies of one file are close enough that the reader would bridge them
+// anyway, the gap is filled and the two blocks become ONE span, labelled with the ranks it
+// absorbed and with an explicit "nothing elided" — because the whole reason the agent re-reads is
+// that it cannot tell whether the hole hides something.
+//
+// Three bounds, and each one is load-bearing rather than decorative. Filling gaps ADDS bytes, and
+// under a fixed ceiling added bytes can evict the last ranked hit — which is how a payload that
+// already works (Haiku, -25.0%) would lose recall:
+//
+//  1. searchSpanMergeMaxGapLines caps how far apart two hits may be to be bridged at all.
+//  2. searchSpanMergeMaxSpanLines caps the merged span, so a chain of near hits cannot walk the
+//     length of a file. (On fluentd-3328 this is what keeps 349-425 and 427-443 apart: bridging
+//     all three would be 95 lines.)
+//  3. Every merge is costed against the payload's own byte ceiling BEFORE it is committed, one
+//     merge at a time. A merge that would not fit simply does not happen, so no ranked hit is
+//     ever evicted to pay for one.
+//
+// And the property that makes the change safe to measure against an unmerged arm: merging never
+// REORDERS. A run's survivor is its best-ranked member, survivors keep their relative order, and
+// a merged-away hit is inside the span that replaced it — so the rank at which a file first
+// appears can only stay the same or improve, never worsen.
+const (
+	// searchSpanMergeMaxGapLines is the largest hole between two printed spans of one file that
+	// is worth filling. Sized from what the agents actually asked for: over 128 post-search reads
+	// the median requested window was 50 lines and the median gap from the printed body 42 lines
+	// (the same measurement that sized searchHeadWindowLines), so 40 lines is the distance at
+	// which a reader is already going to pull both blocks in one range read.
+	searchSpanMergeMaxGapLines = 40
+
+	// searchSpanMergeMaxSpanLines caps the merged span. Two complete bodies plus the bridge is a
+	// region an agent reads; half a file is a context dump, and the ranking is not evidence that
+	// everything between hit 1 and hit 5 is relevant.
+	searchSpanMergeMaxSpanLines = 80
+
+	// searchSpanMergedSignal marks a result whose snippet is a contiguous region covering more
+	// than one ranked hit. It is additive to complete-symbol rather than a replacement for it:
+	// the span still contains the whole callable that earned the body, so the "no follow-up read
+	// needed" promise is strictly stronger, and the renderers that key off complete-symbol must
+	// keep printing the block in full.
+	searchSpanMergedSignal = "contiguous-span"
+)
+
+// mergeSameFileSearchSpans folds runs of near same-file results into one contiguous span each.
+//
+// It returns the rewritten ranking, how many spans were merged, and how many complete-symbol
+// results were absorbed (the caller owes that subtraction to stats.CompleteSymbols, which was
+// counted before this pass ran).
+//
+// Only results that already carry complete-symbol take part. That is deliberate and not merely
+// conservative: complete-symbol is the one signal every renderer prints in FULL regardless of
+// depth, so restricting the pass to it guarantees the merged header always describes text the
+// reader is actually given. Merging a tail locator in would print a range whose body is not
+// there — the exact failure ("the payload says 349-443 but shows me two lines") this pass exists
+// to remove — and it would spend head bytes on ranks measured not to be read.
+//
+// budget is the --max-context-bytes ceiling (<= 0 means none). It is checked against the WHOLE
+// prospective ranking, not against the merge's own delta, because the ceiling the response is
+// validated on is a total.
+func mergeSameFileSearchSpans(results []SearchResult, read contentReader, budget int) ([]SearchResult, int, int) {
+	if len(results) < 2 || read == nil {
+		return results, 0, 0
+	}
+	runs := planSameFileSearchSpans(results)
+	if len(runs) == 0 {
+		return results, 0, 0
+	}
+	fileLines := map[string][]string{}
+	unreadable := map[string]bool{}
+	// The working state is expressed in ORIGINAL indexes rather than in a rewritten slice,
+	// because committing a merge renumbers the ranking: a second run identified by pre-merge
+	// rank would then address the wrong result.
+	keep := make([]int, len(results))
+	for index := range keep {
+		keep[index] = index
+	}
+	override := map[int]SearchResult{}
+	merged, absorbed := 0, 0
+	for _, run := range runs {
+		anchor := results[run[0]]
+		lines, cached := fileLines[anchor.FilePath]
+		if !cached {
+			if unreadable[anchor.FilePath] {
+				continue
+			}
+			content, readable := read(anchor.FilePath)
+			if !readable || strings.IndexByte(content, 0) >= 0 {
+				unreadable[anchor.FilePath] = true
+				continue
+			}
+			lines = strings.Split(content, "\n")
+			fileLines[anchor.FilePath] = lines
+		}
+		survivor, span, ok := mergedSearchSpanResult(results, run, lines)
+		if !ok {
+			continue
+		}
+		trialKeep := dropSearchSpanMembers(keep, run, survivor)
+		trialOverride := map[int]SearchResult{survivor: span}
+		for index, result := range override {
+			trialOverride[index] = result
+		}
+		trial := renderSearchSpanRanking(results, trialKeep, trialOverride)
+		// The cost check is the whole safety story for a payload that already fits: a merge that
+		// would push the ranking past its ceiling is dropped, and the run stays rendered exactly
+		// as it was. Runs are considered in rank order, so which merges survive a tight budget is
+		// deterministic and favours the head.
+		if budget > 0 && searchRankingBytes(trial) > budget {
+			continue
+		}
+		keep, override = trialKeep, trialOverride
+		merged++
+		absorbed += len(run) - 1
+	}
+	if merged == 0 {
+		return results, 0, 0
+	}
+	return renderSearchSpanRanking(results, keep, override), merged, absorbed
+}
+
+// planSameFileSearchSpans groups the eligible results into runs that should become one span.
+// Runs are returned as slices of indexes into results, in ascending source order within a file,
+// and the runs themselves are ordered by their best rank so a byte-starved payload merges the
+// head first.
+func planSameFileSearchSpans(results []SearchResult) [][]int {
+	byFile := map[string][]int{}
+	order := []string{}
+	for index, result := range results {
+		if !eligibleForSearchSpanMerge(result) {
+			continue
+		}
+		if _, seen := byFile[result.FilePath]; !seen {
+			order = append(order, result.FilePath)
+		}
+		byFile[result.FilePath] = append(byFile[result.FilePath], index)
+	}
+	var runs [][]int
+	for _, path := range order {
+		indexes := byFile[path]
+		if len(indexes) < 2 {
+			continue
+		}
+		// Source order, not rank order: adjacency is a property of the file, and a run built in
+		// rank order would bridge 349->427 while skipping 395 that lies between them.
+		sort.SliceStable(indexes, func(a, b int) bool {
+			left, right := results[indexes[a]], results[indexes[b]]
+			if left.SnippetStartLine != right.SnippetStartLine {
+				return left.SnippetStartLine < right.SnippetStartLine
+			}
+			return indexes[a] < indexes[b]
+		})
+		run := []int{indexes[0]}
+		runStart, runEnd := results[indexes[0]].SnippetStartLine, results[indexes[0]].SnippetEndLine
+		flush := func() {
+			if len(run) > 1 {
+				runs = append(runs, run)
+			}
+		}
+		for _, index := range indexes[1:] {
+			next := results[index]
+			gap := next.SnippetStartLine - runEnd - 1
+			end := maxInt(runEnd, next.SnippetEndLine)
+			if gap > searchSpanMergeMaxGapLines || end-runStart+1 > searchSpanMergeMaxSpanLines {
+				flush()
+				run = []int{index}
+				runStart, runEnd = next.SnippetStartLine, next.SnippetEndLine
+				continue
+			}
+			run = append(run, index)
+			runEnd = end
+		}
+		flush()
+	}
+	sort.SliceStable(runs, func(a, b int) bool {
+		return bestSearchSpanRank(results, runs[a]) < bestSearchSpanRank(results, runs[b])
+	})
+	return runs
+}
+
+func eligibleForSearchSpanMerge(result SearchResult) bool {
+	// Sectioned entries answer a different question from the ranking (what the fix has to
+	// achieve, where else it lands) and are rendered under their own headers, so folding one
+	// into a candidate fix site would erase the distinction the sections exist to make.
+	if result.Section != "" {
+		return false
+	}
+	if result.SnippetStartLine < 1 || result.SnippetEndLine < result.SnippetStartLine {
+		return false
+	}
+	return hasSearchSignal(result, searchCompleteSymbolSignal)
+}
+
+func bestSearchSpanRank(results []SearchResult, run []int) int {
+	best := results[run[0]].Rank
+	for _, index := range run[1:] {
+		if rank := results[index].Rank; rank < best {
+			best = rank
+		}
+	}
+	return best
+}
+
+// mergedSearchSpanResult builds the single result that replaces a run: the best-ranked member,
+// widened to the run's full span and carrying the verbatim file text of that whole range. It
+// returns the surviving member's index alongside it.
+func mergedSearchSpanResult(results []SearchResult, run []int, lines []string) (int, SearchResult, bool) {
+	survivor := run[0]
+	first := results[run[0]]
+	start, end := first.SnippetStartLine, first.SnippetEndLine
+	regionStart, regionEnd := first.StartLine, first.EndLine
+	ranks := make([]int, 0, len(run))
+	for _, index := range run {
+		member := results[index]
+		if member.Rank < results[survivor].Rank {
+			survivor = index
+		}
+		start = minInt(start, member.SnippetStartLine)
+		end = maxInt(end, member.SnippetEndLine)
+		regionStart = minInt(regionStart, member.StartLine)
+		regionEnd = maxInt(regionEnd, member.EndLine)
+		ranks = append(ranks, member.Rank)
+	}
+	if start < 1 || end > len(lines) || end < start {
+		return 0, SearchResult{}, false
+	}
+	if end-start+1 > searchSpanMergeMaxSpanLines {
+		return 0, SearchResult{}, false
+	}
+	sort.Ints(ranks)
+	span := results[survivor]
+	span.SnippetStartLine, span.SnippetEndLine = start, end
+	span.Snippet = strings.Join(lines[start-1:end], "\n")
+	span.StartLine = maxInt(1, minInt(regionStart, start))
+	span.EndLine = maxInt(regionEnd, end)
+	span.FocusLine = minInt(maxInt(span.FocusLine, span.StartLine), span.EndLine)
+	// The symbol identity stays the survivor's own. The span now holds more than that callable,
+	// which is exactly what MergedRanks and the "nothing elided" label say; renaming it after the
+	// widest thing it touches would report a container as the fix site.
+	span.Signals = appendUnique(append([]string(nil), span.Signals...), searchSpanMergedSignal)
+	span.MergedRanks = ranks
+	return survivor, span, true
+}
+
+// dropSearchSpanMembers removes every member of a run except its survivor, preserving order.
+func dropSearchSpanMembers(keep, run []int, survivor int) []int {
+	dropped := make(map[int]bool, len(run))
+	for _, index := range run {
+		if index != survivor {
+			dropped[index] = true
+		}
+	}
+	trimmed := make([]int, 0, len(keep))
+	for _, index := range keep {
+		if dropped[index] {
+			continue
+		}
+		trimmed = append(trimmed, index)
+	}
+	return trimmed
+}
+
+// renderSearchSpanRanking materializes a working state back into a ranking. Order comes from the
+// ORIGINAL ranking, so the relative order of everything that survives is untouched.
+//
+// Ranks are renumbered to stay 1..N and dense: the response contract is positional (Validate
+// requires Rank == index+1), so a merged-away hit cannot leave a hole. The numbers inside
+// MergedRanks are the PRE-merge ranks the span absorbed, which is what tells the reader it is not
+// missing a hit that simply is not printed separately any more.
+func renderSearchSpanRanking(results []SearchResult, keep []int, override map[int]SearchResult) []SearchResult {
+	ranking := make([]SearchResult, 0, len(keep))
+	for position, index := range keep {
+		result, replaced := override[index]
+		if !replaced {
+			result = results[index]
+		}
+		result.Rank = position + 1
+		ranking = append(ranking, result)
+	}
+	return ranking
+}
+
+// searchRankingBytes is the serialized cost of a ranking, in the same terms as
+// stats.ResultBytes, so the ceiling this pass checks is the ceiling the response is validated on.
+func searchRankingBytes(results []SearchResult) int {
+	return serializedSearchResultBytes(results)
+}

--- a/internal/sem/search_span_merge_test.go
+++ b/internal/sem/search_span_merge_test.go
@@ -1,0 +1,221 @@
+package sem
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// spanMergeFile builds a deterministic file whose Nth line names itself, so an assertion on the
+// merged snippet is an assertion that the range is VERBATIM and unelided rather than stitched.
+func spanMergeFile(path string, lineCount int) contentReader {
+	lines := make([]string, lineCount)
+	for index := range lines {
+		lines[index] = fmt.Sprintf("line %d", index+1)
+	}
+	content := strings.Join(lines, "\n")
+	return func(requested string) (string, bool) {
+		if requested != path {
+			return "", false
+		}
+		return content, true
+	}
+}
+
+func spanMergeBody(rank int, path string, start, end int) SearchResult {
+	return SearchResult{
+		Rank:             rank,
+		Score:            float64(100 - rank),
+		FilePath:         path,
+		StartLine:        start,
+		EndLine:          end,
+		FocusLine:        start,
+		SnippetStartLine: start,
+		SnippetEndLine:   end,
+		SymbolID:         fmt.Sprintf("sym-%d", rank),
+		SymbolName:       fmt.Sprintf("symbol%d", rank),
+		Signals:          []string{"body", searchCompleteSymbolSignal},
+		Snippet:          strings.Repeat("x", 8),
+	}
+}
+
+func wantLineRange(t *testing.T, snippet string, start, end int) {
+	t.Helper()
+	lines := strings.Split(snippet, "\n")
+	if len(lines) != end-start+1 {
+		t.Fatalf("merged span holds %d lines, want %d", len(lines), end-start+1)
+	}
+	for offset, line := range lines {
+		if want := fmt.Sprintf("line %d", start+offset); line != want {
+			t.Fatalf("merged span line %d is %q, want %q (the range must be contiguous and verbatim)", offset, line, want)
+		}
+	}
+}
+
+// Two printed bodies of one file with a small hole between them are one region as far as the
+// reader is concerned. Measured over 113 Opus payloads, 40% carry such a pair, and the agent
+// closes the hole itself: fluentd-3328 had gold at rank 1 (complete-symbol, "Top hit is exact")
+// and still cost 1.64x baseline because turn 2 was `sed -n '330,470p'` over a contiguous superset
+// of ranks 1/2/3. The merge has to deliver the bridge, and has to say nothing was elided.
+func TestMergeSameFileSearchSpansFoldsNearHitsIntoOneContiguousSpan(t *testing.T) {
+	t.Parallel()
+	read := spanMergeFile("in_tail.rb", 500)
+	results := []SearchResult{
+		spanMergeBody(1, "in_tail.rb", 10, 20),
+		spanMergeBody(2, "in_tail.rb", 45, 55),
+		spanMergeBody(3, "other.rb", 5, 9),
+	}
+	merged, spans, absorbed := mergeSameFileSearchSpans(results, read, 0)
+	if spans != 1 || absorbed != 1 {
+		t.Fatalf("merged %d spans absorbing %d hits, want 1 and 1", spans, absorbed)
+	}
+	if len(merged) != 2 {
+		t.Fatalf("ranking holds %d results after the merge, want 2", len(merged))
+	}
+	span := merged[0]
+	if span.SnippetStartLine != 10 || span.SnippetEndLine != 55 {
+		t.Fatalf("merged span is %d-%d, want 10-55", span.SnippetStartLine, span.SnippetEndLine)
+	}
+	wantLineRange(t, span.Snippet, 10, 55)
+	if got := fmt.Sprint(span.MergedRanks); got != "[1 2]" {
+		t.Fatalf("merged span reports ranks %s, want [1 2]", got)
+	}
+	if !hasSearchSignal(span, searchSpanMergedSignal) {
+		t.Fatalf("merged span is missing the %s signal: %v", searchSpanMergedSignal, span.Signals)
+	}
+	// The signal every renderer keys off to print a block in full must survive, or the header
+	// would name a range whose text is not shown.
+	if !hasSearchSignal(span, searchCompleteSymbolSignal) {
+		t.Fatalf("merged span lost %s: %v", searchCompleteSymbolSignal, span.Signals)
+	}
+	// Order is untouched and ranks stay dense, which is the response contract Validate enforces.
+	if merged[1].FilePath != "other.rb" {
+		t.Fatalf("survivor order changed: rank 2 is %s, want other.rb", merged[1].FilePath)
+	}
+	for index, result := range merged {
+		if result.Rank != index+1 {
+			t.Fatalf("rank %d at index %d: the ranking must stay 1..N and dense", result.Rank, index)
+		}
+	}
+	// StartLine <= SnippetStartLine <= SnippetEndLine <= EndLine, the invariant Validate checks.
+	if span.StartLine > span.SnippetStartLine || span.SnippetEndLine > span.EndLine ||
+		span.FocusLine < span.StartLine || span.FocusLine > span.EndLine {
+		t.Fatalf("merged span breaks the region invariant: %+v", span)
+	}
+}
+
+// The bounds are the whole reason this is safe to ship against a payload that already works
+// (Haiku, -25.0%): filling gaps adds bytes, and added bytes under a fixed ceiling evict hits.
+func TestMergeSameFileSearchSpansRespectsItsBounds(t *testing.T) {
+	t.Parallel()
+	read := spanMergeFile("in_tail.rb", 500)
+	cases := []struct {
+		name    string
+		results []SearchResult
+		budget  int
+	}{
+		{
+			name: "a hole wider than the gap cap is not bridged",
+			results: []SearchResult{
+				spanMergeBody(1, "in_tail.rb", 10, 20),
+				spanMergeBody(2, "in_tail.rb", 62, 72),
+			},
+		},
+		{
+			name: "a span longer than the span cap is not emitted",
+			results: []SearchResult{
+				spanMergeBody(1, "in_tail.rb", 10, 20),
+				spanMergeBody(2, "in_tail.rb", 55, 95),
+			},
+		},
+		{
+			name: "a locator is never folded into a body",
+			results: []SearchResult{
+				spanMergeBody(1, "in_tail.rb", 10, 20),
+				func() SearchResult {
+					locator := spanMergeBody(2, "in_tail.rb", 45, 46)
+					locator.Signals = []string{"path"}
+					return locator
+				}(),
+			},
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			merged, spans, absorbed := mergeSameFileSearchSpans(testCase.results, read, testCase.budget)
+			if spans != 0 || absorbed != 0 {
+				t.Fatalf("merged %d spans absorbing %d hits, want none", spans, absorbed)
+			}
+			if len(merged) != len(testCase.results) {
+				t.Fatalf("ranking holds %d results, want %d untouched", len(merged), len(testCase.results))
+			}
+			for index, result := range merged {
+				if len(result.MergedRanks) > 0 {
+					t.Fatalf("result %d was merged: %v", index, result.MergedRanks)
+				}
+			}
+		})
+	}
+}
+
+// The byte ceiling is checked against the WHOLE prospective ranking before a merge is committed,
+// so a bridge can never be paid for by evicting the hit at the end of the payload.
+func TestMergeSameFileSearchSpansFallsBackWhenTheBridgeWouldNotFit(t *testing.T) {
+	t.Parallel()
+	read := spanMergeFile("in_tail.rb", 500)
+	results := []SearchResult{
+		spanMergeBody(1, "in_tail.rb", 10, 20),
+		spanMergeBody(2, "in_tail.rb", 45, 55),
+	}
+	unmergedBytes := serializedSearchResultBytes(results)
+	if _, spans, _ := mergeSameFileSearchSpans(results, read, unmergedBytes); spans != 0 {
+		t.Fatalf("merged under a budget that only fits the unmerged ranking (%d bytes)", unmergedBytes)
+	}
+	merged, spans, _ := mergeSameFileSearchSpans(results, read, 0)
+	if spans != 1 {
+		t.Fatalf("merged %d spans with no ceiling, want 1", spans)
+	}
+	if got := serializedSearchResultBytes(merged); got <= unmergedBytes {
+		t.Fatalf("merged ranking is %d bytes against %d unmerged: the test's budget proves nothing", got, unmergedBytes)
+	}
+}
+
+// Merging must not be able to make a file harder to find than it already was. The rank at which a
+// file first appears is what the outcome is a step function of, so it may improve (its hits are
+// now inside one earlier span) but never worsen.
+func TestMergeSameFileSearchSpansNeverWorsensAFilesRank(t *testing.T) {
+	t.Parallel()
+	read := spanMergeFile("in_tail.rb", 500)
+	results := []SearchResult{
+		spanMergeBody(1, "parser.rb", 10, 20),
+		spanMergeBody(2, "in_tail.rb", 10, 20),
+		spanMergeBody(3, "in_tail.rb", 45, 55),
+		spanMergeBody(4, "gold.rb", 30, 40),
+	}
+	before := firstSpanMergeRankByFile(results)
+	merged, spans, _ := mergeSameFileSearchSpans(results, read, 0)
+	if spans != 1 {
+		t.Fatalf("merged %d spans, want 1", spans)
+	}
+	after := firstSpanMergeRankByFile(merged)
+	for path, rank := range before {
+		got, present := after[path]
+		if !present {
+			t.Fatalf("%s disappeared from the ranking", path)
+		}
+		if got > rank {
+			t.Fatalf("%s moved from rank %d to rank %d", path, rank, got)
+		}
+	}
+}
+
+func firstSpanMergeRankByFile(results []SearchResult) map[string]int {
+	first := map[string]int{}
+	for _, result := range results {
+		if _, seen := first[result.FilePath]; !seen {
+			first[result.FilePath] = result.Rank
+		}
+	}
+	return first
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/33
<!-- entire-trail-link-end -->

## The bug

`entityFromNode` gated both `function_signature` and `method_signature` to Dart, with the comment that TypeScript uses those node types for interface members. That is only half true.

tree-sitter-typescript emits `function_signature` for **every bodyless function declaration** — overload signatures, `declare function`, ambients, `.d.ts` — and `method_signature` for class-body overload declarations as well as interface members. All of them were silently dropped from the graph.

Concretely, vue's `renderList.ts` has five overload signatures plus one implementation. It exposed **1 symbol**, covering only the implementation's lines. Lines 10–53 — the entire typed surface — were unindexed, so no query phrased in terms of the declared parameter types could retrieve the file. After the fix: **6 symbols**.

## The fix

Additive, `+54` lines, no deletions, narrowly gated:

- **`function_signature`** in TypeScript becomes a `function` (or a `method` when scoped). An overload set is where the parameter types and generics live; the implementation's own signature is usually the erased `(source: any, ...)` catch-all.
- **`method_signature`** becomes a `method` **only inside a `class_body`**, via the new `typeScriptClassBodySignature` helper.

Interface and type-literal members deliberately stay inventory-only. They declare a contract, not a definition, and emitting them would make every `x.m()` call name-resolvable to a bodyless interface member. That is not hypothetical — extending this case to `interface_body`/`object_type` members fabricates a CALLS edge in `TestTypeScriptNamespaceCallSkipsParameterReceiverRoots`, where a parameter named `B` shadows a namespace and `B.parse()` then binds to `Client.parse` instead of correctly resolving to nothing.

Dart behaviour is unchanged — the existing Dart paths are reached only when the language is not TypeScript.

## Verification

- Full `internal/sem` suite green (**1976 tests**).
- New regression test `parser_typescript_regression_test.go` (+124 lines) covering overload sets, `declare function`, class-body overloads, and the interface-member exclusion.
- **Attribution check:** symbol output is byte-identical to the pre-fix binary on eight non-TypeScript repositories — django, axum, gson, carbon, bat, caddy, fmt, rubocop. So the change is attributable to TypeScript alone and cannot perturb other languages.

## Scope note

Repo-wide symbol gain is modest (vuejs +1.0%, docusaurus +2.1%) — this is a correctness fix for a whole class of declarations, not a broad indexing win. Its practical effect is concentrated in TypeScript codebases that use overloads and ambient declarations heavily.