### PR TITLE
feat: improve deterministic prose memory ranking

### DIFF
--- a/docs/superpowers/plans/2026-08-07-prose-memory-ranking-v53.md
+++ b/docs/superpowers/plans/2026-08-07-prose-memory-ranking-v53.md
@@ -70,39 +70,23 @@ go test ./internal/sem -run '^TestSafeProseInflectionMatchSupportsBoundedWordFam
 
 Expected: FAIL for `archive/archived`, `archive/archiving`, and `navigate/navigation`; existing plural and unsafe cases retain their current behavior.
 
-- [ ] **Step 3: Add an end-to-end failing Markdown-session regression**
+- [ ] **Step 3: Add a failing prose-parent coverage regression**
 
 Append this test to `internal/sem/search_prose_session_test.go`:
 
 ```go
-func TestSearchRepositoryRanksDerivedWordFamilyMarkdownSession(t *testing.T) {
-	repo := t.TempDir()
-	write(t, repo, "sessions/focus.md", `# Navigation archive
-
-The expedition was carefully navigated and archived after sunset.
-`)
-	for index := 0; index < 11; index++ {
-		write(t, repo, fmt.Sprintf("sessions/distractor-%02d.md", index), fmt.Sprintf(
-			"# Navigation marker%d ridge%d vessel%d\n\nUnrelated archive index.\n",
-			index, index, index,
-		))
-	}
-
-	response, err := SearchRepository(
-		t.Context(), repo, "test", "navigate archive sunset", SearchOptions{
-			Worktree: true, Profile: ProfileSyntaxOnly, TopK: 10, MaxIndexedFiles: 32,
-		},
+func TestProseParentTermListsUseDerivedWordFamilyCoverage(t *testing.T) {
+	t.Parallel()
+	candidate := proseTestCandidate(
+		"sessions/focus.md", 10, 4, "The expedition was carefully navigated.", nil,
 	)
-	if err != nil {
-		t.Fatal(err)
+	candidates := []searchCandidate{candidate}
+	lists := proseParentTermLists(
+		candidates, proseParents(candidates), []string{"navigate"}, 10,
+	)
+	if len(lists) != 1 || len(lists[0]) != 1 || lists[0][0].parent.path != "sessions/focus.md" {
+		t.Fatalf("derived family did not seed prose parent: %#v", lists)
 	}
-	for _, result := range response.Results {
-		if result.FilePath == "sessions/focus.md" &&
-			containsString(result.Signals, proseParentRetrievalSignal) {
-			return
-		}
-	}
-	t.Fatalf("derived word-family session missing from top 10: %#v", response.Results)
 }
 ```
 
@@ -111,10 +95,10 @@ The expedition was carefully navigated and archived after sunset.
 Run:
 
 ```bash
-go test ./internal/sem -run '^TestSearchRepositoryRanksDerivedWordFamilyMarkdownSession$' -count=1
+go test ./internal/sem -run '^TestProseParentTermListsUseDerivedWordFamilyCoverage$' -count=1
 ```
 
-Expected: FAIL because exact/plural matching does not treat `navigate` and `navigated` as one prose family.
+Expected: FAIL because exact/plural matching leaves the `navigate` term list empty for a `navigated` candidate.
 
 - [ ] **Step 5: Implement bounded prose verb and prefix-family matching**
 
@@ -132,11 +116,11 @@ func safeASCIIProseVerbForms(word string) []string {
 }
 ```
 
-Add a prose-only derivational-family fallback. Require both words to be at least six letters, length difference no more than five, a common prefix of at least five letters, and the prefix to cover at least two thirds of the shorter word:
+Add a prose-only derivational-family fallback. Require both words to be at least eight letters, length difference no more than five, a common prefix of at least five letters, and the prefix to cover at least two thirds of the shorter word. The eight-letter floor keeps `archive`/`architect` outside this deliberately conservative fallback:
 
 ```go
 func safeASCIIProsePrefixFamily(left, right string) bool {
-	if len(left) < 6 || len(right) < 6 || !proseASCIIWord(left) || !proseASCIIWord(right) {
+	if len(left) < 8 || len(right) < 8 || !proseASCIIWord(left) || !proseASCIIWord(right) {
 		return false
 	}
 	difference := len(left) - len(right)
@@ -176,7 +160,7 @@ Update `safeProseInflectionMatch` after exact/plural checks:
 Run:
 
 ```bash
-go test ./internal/sem -run '^(TestSafeProseInflectionMatchSupportsBoundedWordFamilies|TestSearchRepositoryRanksDerivedWordFamilyMarkdownSession|TestSearchRepositoryRanksSafePluralMarkdownSession|TestSearchRepositoryRanksSafeSingularEvidenceForPluralQuery|TestSearchRepositoryDoesNotConflateUnsafeProseSuffixes|TestSearchRepositoryCodeResultOrderRemainsByteIdentical)$' -count=1
+go test ./internal/sem -run '^(TestSafeProseInflectionMatchSupportsBoundedWordFamilies|TestProseParentTermListsUseDerivedWordFamilyCoverage|TestSearchRepositoryRanksDerivedWordFamilyMarkdownSession|TestSearchRepositoryRanksSafePluralMarkdownSession|TestSearchRepositoryRanksSafeSingularEvidenceForPluralQuery|TestSearchRepositoryDoesNotConflateUnsafeProseSuffixes|TestSearchRepositoryCodeResultOrderRemainsByteIdentical)$' -count=1
 ```
 
 Expected: PASS.

--- a/docs/superpowers/plans/2026-08-07-prose-memory-ranking-v53.md
+++ b/docs/superpowers/plans/2026-08-07-prose-memory-ranking-v53.md
@@ -145,12 +145,21 @@ func safeASCIIProseEdgeCompound(queryTerm, evidenceToken string) bool {
 		return false
 	}
 	if strings.HasPrefix(queryTerm, evidenceToken) {
-		return true
+		return !safeASCIIProseOpposingSuffix(strings.TrimPrefix(queryTerm, evidenceToken))
 	}
 	if !strings.HasSuffix(queryTerm, evidenceToken) {
 		return false
 	}
 	return !safeASCIIProseOpposingPrefix(strings.TrimSuffix(queryTerm, evidenceToken))
+}
+
+func safeASCIIProseOpposingSuffix(suffix string) bool {
+	switch suffix {
+	case "free", "less":
+		return true
+	default:
+		return false
+	}
 }
 
 func safeASCIIProseOpposingPrefix(prefix string) bool {
@@ -265,7 +274,7 @@ func proseQueryRequestsMultipleParents(q searchQuery) bool {
 		written = searchQueryWordSequence(q.rawLower)
 	}
 	for index, word := range written {
-		if word == "which" && index+1 < len(written) && safeASCIIWrittenPlural(written[index+1]) {
+		if word == "which" && proseWhichListFrame(written, index) {
 			return true
 		}
 		if (word == "what" || word == "where") && index+1 < len(written) && written[index+1] == "are" &&
@@ -274,6 +283,29 @@ func proseQueryRequestsMultipleParents(q searchQuery) bool {
 		}
 	}
 	return false
+}
+
+func proseWhichListFrame(written []string, whichIndex int) bool {
+	for headOffset := 1; headOffset <= 2; headOffset++ {
+		headIndex := whichIndex + headOffset
+		predicateIndex := headIndex + 1
+		if predicateIndex >= len(written) || !safeASCIIWrittenPlural(written[headIndex]) {
+			continue
+		}
+		if proseListPredicate(written[predicateIndex]) {
+			return true
+		}
+	}
+	return false
+}
+
+func proseListPredicate(word string) bool {
+	switch word {
+	case "are", "contain", "cover", "describe", "have", "hold", "include", "list", "match", "mention", "show", "store", "use":
+		return true
+	default:
+		return false
+	}
 }
 
 func proseParentHeadCount(q searchQuery, topK int) int {

--- a/docs/superpowers/plans/2026-08-07-prose-memory-ranking-v53.md
+++ b/docs/superpowers/plans/2026-08-07-prose-memory-ranking-v53.md
@@ -117,10 +117,10 @@ func safeASCIIProseVerbForms(word string) []string {
 ```
 
 Add explicit prose-only derivation and compound fallbacks. The derivation
-recognizes bounded `-ate` and `-ize` to `-ation` forms. The compound fallback requires
-the shorter word to be at least eight letters, to appear exactly at one edge
-of the longer word, to differ by two through five letters, and to cover at
-least two thirds of the longer token:
+recognizes bounded `-ate` and `-ize` to `-ation` forms. The compound fallback
+is directional: the longer query token may expose an evidence token of at
+least eight letters at either edge, subject to two-through-five-letter and
+two-thirds-ratio guards. Negating and opposing prefixes are rejected:
 
 ```go
 func safeASCIIProseDerivation(base, derived string) bool {
@@ -136,19 +136,30 @@ func safeASCIIProseDerivation(base, derived string) bool {
 	return false
 }
 
-func safeASCIIProseEdgeCompound(left, right string) bool {
-	if !proseASCIIWord(left) || !proseASCIIWord(right) {
+func safeASCIIProseEdgeCompound(queryTerm, evidenceToken string) bool {
+	if !proseASCIIWord(queryTerm) || !proseASCIIWord(evidenceToken) {
 		return false
 	}
-	shorter, longer := left, right
-	if len(shorter) > len(longer) {
-		shorter, longer = longer, shorter
-	}
-	difference := len(longer) - len(shorter)
-	if len(shorter) < 8 || difference < 2 || difference > 5 || len(shorter)*3 < len(longer)*2 {
+	difference := len(queryTerm) - len(evidenceToken)
+	if len(evidenceToken) < 8 || difference < 2 || difference > 5 || len(evidenceToken)*3 < len(queryTerm)*2 {
 		return false
 	}
-	return strings.HasPrefix(longer, shorter) || strings.HasSuffix(longer, shorter)
+	if strings.HasPrefix(queryTerm, evidenceToken) {
+		return true
+	}
+	if !strings.HasSuffix(queryTerm, evidenceToken) {
+		return false
+	}
+	return !safeASCIIProseOpposingPrefix(strings.TrimSuffix(queryTerm, evidenceToken))
+}
+
+func safeASCIIProseOpposingPrefix(prefix string) bool {
+	switch prefix {
+	case "anti", "counter", "de", "dis", "il", "im", "in", "ir", "mis", "non", "un":
+		return true
+	default:
+		return false
+	}
 }
 ```
 
@@ -246,10 +257,6 @@ func proseQueryRequestsMultipleParents(q searchQuery) bool {
 	if words == nil {
 		words = searchQueryWords(q.rawLower)
 	}
-	interrogative := words["what"] || words["which"] || words["where"]
-	if !interrogative {
-		return false
-	}
 	if words["else"] || (words["other"] && words["than"]) {
 		return true
 	}
@@ -257,8 +264,12 @@ func proseQueryRequestsMultipleParents(q searchQuery) bool {
 	if len(written) == 0 {
 		written = searchQueryWordSequence(q.rawLower)
 	}
-	for _, word := range written {
-		if safeASCIIWrittenPlural(word) {
+	for index, word := range written {
+		if word == "which" && index+1 < len(written) && safeASCIIWrittenPlural(written[index+1]) {
+			return true
+		}
+		if (word == "what" || word == "where") && index+1 < len(written) && written[index+1] == "are" &&
+			safeASCIIWrittenPlural(written[len(written)-1]) {
 			return true
 		}
 	}

--- a/docs/superpowers/plans/2026-08-07-prose-memory-ranking-v53.md
+++ b/docs/superpowers/plans/2026-08-07-prose-memory-ranking-v53.md
@@ -100,7 +100,7 @@ go test ./internal/sem -run '^TestProseParentTermListsUseDerivedWordFamilyCovera
 
 Expected: FAIL because exact/plural matching leaves the `navigate` term list empty for a `navigated` candidate.
 
-- [ ] **Step 5: Implement bounded prose verb and prefix-family matching**
+- [ ] **Step 5: Implement bounded prose verb, derivation, and edge-compound matching**
 
 In `internal/sem/search_prose_parent.go`, keep exact and plural logic first. Add conservative verb forms for words of at least five ASCII letters:
 
@@ -116,26 +116,39 @@ func safeASCIIProseVerbForms(word string) []string {
 }
 ```
 
-Add a prose-only derivational-family fallback. Require both words to be at least eight letters, length difference no more than five, a common prefix of at least five letters, and the prefix to cover at least two thirds of the shorter word. The eight-letter floor keeps `archive`/`architect` outside this deliberately conservative fallback:
+Add explicit prose-only derivation and compound fallbacks. The derivation
+recognizes bounded `-ate` and `-ize` to `-ation` forms. The compound fallback requires
+the shorter word to be at least eight letters, to appear exactly at one edge
+of the longer word, to differ by two through five letters, and to cover at
+least two thirds of the longer token:
 
 ```go
-func safeASCIIProsePrefixFamily(left, right string) bool {
-	if len(left) < 8 || len(right) < 8 || !proseASCIIWord(left) || !proseASCIIWord(right) {
+func safeASCIIProseDerivation(base, derived string) bool {
+	if len(base) < 6 || !proseASCIIWord(base) || !proseASCIIWord(derived) {
 		return false
 	}
-	difference := len(left) - len(right)
-	if difference < 0 {
-		difference = -difference
+	if strings.HasSuffix(base, "ate") {
+		return derived == strings.TrimSuffix(base, "ate")+"ation"
 	}
-	if difference > 5 {
+	if strings.HasSuffix(base, "ize") {
+		return derived == strings.TrimSuffix(base, "e")+"ation"
+	}
+	return false
+}
+
+func safeASCIIProseEdgeCompound(left, right string) bool {
+	if !proseASCIIWord(left) || !proseASCIIWord(right) {
 		return false
 	}
-	common := 0
-	for common < len(left) && common < len(right) && left[common] == right[common] {
-		common++
+	shorter, longer := left, right
+	if len(shorter) > len(longer) {
+		shorter, longer = longer, shorter
 	}
-	shorter := minInt(len(left), len(right))
-	return common >= 5 && common*3 >= shorter*2
+	difference := len(longer) - len(shorter)
+	if len(shorter) < 8 || difference < 2 || difference > 5 || len(shorter)*3 < len(longer)*2 {
+		return false
+	}
+	return strings.HasPrefix(longer, shorter) || strings.HasSuffix(longer, shorter)
 }
 ```
 
@@ -152,7 +165,10 @@ Update `safeProseInflectionMatch` after exact/plural checks:
 			return true
 		}
 	}
-	return safeASCIIProsePrefixFamily(left, right)
+	if safeASCIIProseDerivation(left, right) || safeASCIIProseDerivation(right, left) {
+		return true
+	}
+	return safeASCIIProseEdgeCompound(left, right)
 ```
 
 - [ ] **Step 6: Run focused prose tests**
@@ -160,7 +176,7 @@ Update `safeProseInflectionMatch` after exact/plural checks:
 Run:
 
 ```bash
-go test ./internal/sem -run '^(TestSafeProseInflectionMatchSupportsBoundedWordFamilies|TestProseParentTermListsUseDerivedWordFamilyCoverage|TestSearchRepositoryRanksDerivedWordFamilyMarkdownSession|TestSearchRepositoryRanksSafePluralMarkdownSession|TestSearchRepositoryRanksSafeSingularEvidenceForPluralQuery|TestSearchRepositoryDoesNotConflateUnsafeProseSuffixes|TestSearchRepositoryCodeResultOrderRemainsByteIdentical)$' -count=1
+go test ./internal/sem -run '^(TestSafeProseInflectionMatchSupportsBoundedWordFamilies|TestProseParentTermListsUseDerivedWordFamilyCoverage|TestSearchRepositoryRanksSafePluralMarkdownSession|TestSearchRepositoryRanksSafeSingularEvidenceForPluralQuery|TestSearchRepositoryDoesNotConflateUnsafeProseSuffixes|TestSearchRepositoryCodeResultOrderRemainsByteIdentical)$' -count=1
 ```
 
 Expected: PASS.
@@ -242,11 +258,7 @@ func proseQueryRequestsMultipleParents(q searchQuery) bool {
 		written = searchQueryWordSequence(q.rawLower)
 	}
 	for _, word := range written {
-		if len(word) <= 4 || !strings.HasSuffix(word, "s") || strings.HasSuffix(word, "ss") {
-			continue
-		}
-		singular := strings.TrimSuffix(word, "s")
-		if plural, ok := safeASCIIPlural(singular); ok && plural == word {
+		if safeASCIIWrittenPlural(word) {
 			return true
 		}
 	}

--- a/docs/superpowers/plans/2026-08-07-prose-memory-ranking-v53.md
+++ b/docs/superpowers/plans/2026-08-07-prose-memory-ranking-v53.md
@@ -1,0 +1,445 @@
+# Prose Memory Ranking v53 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Improve deterministic prose-session retrieval for safe lexical families and distributed list evidence while preserving ordinary code-search output.
+
+**Architecture:** Extend only the existing Markdown prose-parent selection seam. Exact ranking remains primary; conservative word-family matching supplies missing per-term coverage, and a query-shape helper reserves more tail slots for independent parents when a prose question explicitly asks for multiple answers.
+
+**Tech Stack:** Go 1.24, Entire Graph semantic search, tree-sitter Markdown fixtures, standard `testing` package.
+
+## Global Constraints
+
+- Base all work on commit `bb8bd49fb4039f489cc5977fe008af7dcead5050` in branch `codex/eg-prose-memory-v53-ranking`.
+- Do not modify or merge PRs #64 or #84.
+- Do not inspect a fresh holdout or make paid API/model calls.
+- Do not add dataset IDs, people, answers, activity lists, or benchmark-specific synonyms.
+- Keep all relaxed matching inside the existing prose-parent lane; code-search ordering must remain byte-identical.
+- Add no dependencies, network access, telemetry, embeddings, or model-backed retrieval.
+- Preserve deterministic ordering, bounded IO, result limits, schema 1.x, and zero graph-build LLM credits.
+
+---
+
+### Task 1: Safe prose lexical families
+
+**Files:**
+- Modify: `internal/sem/search_prose_parent.go:246-293`
+- Test: `internal/sem/search_prose_session_test.go`
+
+**Interfaces:**
+- Consumes: `safeASCIIPlural(word string) (string, bool)` and `proseASCIIWord(word string) bool`.
+- Produces: `safeProseInflectionMatch(left, right string) bool`, retaining the existing signature for callers in `proseParentTermLists` and `proseCandidateTermCoverage`.
+- Produces: private helpers `safeASCIIProseVerbForms(word string) []string` and `safeASCIIProsePrefixFamily(left, right string) bool`.
+
+- [ ] **Step 1: Add direct failing lexical-family tests**
+
+Append this table-driven test to `internal/sem/search_prose_session_test.go`:
+
+```go
+func TestSafeProseInflectionMatchSupportsBoundedWordFamilies(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		left  string
+		right string
+		want  bool
+	}{
+		{left: "archive", right: "archived", want: true},
+		{left: "archive", right: "archiving", want: true},
+		{left: "navigate", right: "navigation", want: true},
+		{left: "orchard", right: "orchards", want: true},
+		{left: "gas", right: "gases", want: false},
+		{left: "archive", right: "architect", want: false},
+		{left: "plan", right: "planet", want: false},
+	}
+	for _, testCase := range tests {
+		if got := safeProseInflectionMatch(testCase.left, testCase.right); got != testCase.want {
+			t.Errorf("safeProseInflectionMatch(%q, %q) = %t, want %t",
+				testCase.left, testCase.right, got, testCase.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the direct test and verify the new positive cases fail**
+
+Run:
+
+```bash
+go test ./internal/sem -run '^TestSafeProseInflectionMatchSupportsBoundedWordFamilies$' -count=1
+```
+
+Expected: FAIL for `archive/archived`, `archive/archiving`, and `navigate/navigation`; existing plural and unsafe cases retain their current behavior.
+
+- [ ] **Step 3: Add an end-to-end failing Markdown-session regression**
+
+Append this test to `internal/sem/search_prose_session_test.go`:
+
+```go
+func TestSearchRepositoryRanksDerivedWordFamilyMarkdownSession(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, "sessions/focus.md", `# Navigation archive
+
+The expedition was carefully navigated and archived after sunset.
+`)
+	for index := 0; index < 11; index++ {
+		write(t, repo, fmt.Sprintf("sessions/distractor-%02d.md", index), fmt.Sprintf(
+			"# Navigation marker%d ridge%d vessel%d\n\nUnrelated archive index.\n",
+			index, index, index,
+		))
+	}
+
+	response, err := SearchRepository(
+		t.Context(), repo, "test", "navigate archive sunset", SearchOptions{
+			Worktree: true, Profile: ProfileSyntaxOnly, TopK: 10, MaxIndexedFiles: 32,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, result := range response.Results {
+		if result.FilePath == "sessions/focus.md" &&
+			containsString(result.Signals, proseParentRetrievalSignal) {
+			return
+		}
+	}
+	t.Fatalf("derived word-family session missing from top 10: %#v", response.Results)
+}
+```
+
+- [ ] **Step 4: Run the end-to-end test and verify it fails**
+
+Run:
+
+```bash
+go test ./internal/sem -run '^TestSearchRepositoryRanksDerivedWordFamilyMarkdownSession$' -count=1
+```
+
+Expected: FAIL because exact/plural matching does not treat `navigate` and `navigated` as one prose family.
+
+- [ ] **Step 5: Implement bounded prose verb and prefix-family matching**
+
+In `internal/sem/search_prose_parent.go`, keep exact and plural logic first. Add conservative verb forms for words of at least five ASCII letters:
+
+```go
+func safeASCIIProseVerbForms(word string) []string {
+	if len(word) < 5 || !proseASCIIWord(word) {
+		return nil
+	}
+	if strings.HasSuffix(word, "e") {
+		return []string{word + "d", strings.TrimSuffix(word, "e") + "ing"}
+	}
+	return []string{word + "ed", word + "ing"}
+}
+```
+
+Add a prose-only derivational-family fallback. Require both words to be at least six letters, length difference no more than five, a common prefix of at least five letters, and the prefix to cover at least two thirds of the shorter word:
+
+```go
+func safeASCIIProsePrefixFamily(left, right string) bool {
+	if len(left) < 6 || len(right) < 6 || !proseASCIIWord(left) || !proseASCIIWord(right) {
+		return false
+	}
+	difference := len(left) - len(right)
+	if difference < 0 {
+		difference = -difference
+	}
+	if difference > 5 {
+		return false
+	}
+	common := 0
+	for common < len(left) && common < len(right) && left[common] == right[common] {
+		common++
+	}
+	shorter := minInt(len(left), len(right))
+	return common >= 5 && common*3 >= shorter*2
+}
+```
+
+Update `safeProseInflectionMatch` after exact/plural checks:
+
+```go
+	for _, form := range safeASCIIProseVerbForms(left) {
+		if form == right {
+			return true
+		}
+	}
+	for _, form := range safeASCIIProseVerbForms(right) {
+		if form == left {
+			return true
+		}
+	}
+	return safeASCIIProsePrefixFamily(left, right)
+```
+
+- [ ] **Step 6: Run focused prose tests**
+
+Run:
+
+```bash
+go test ./internal/sem -run '^(TestSafeProseInflectionMatchSupportsBoundedWordFamilies|TestSearchRepositoryRanksDerivedWordFamilyMarkdownSession|TestSearchRepositoryRanksSafePluralMarkdownSession|TestSearchRepositoryRanksSafeSingularEvidenceForPluralQuery|TestSearchRepositoryDoesNotConflateUnsafeProseSuffixes|TestSearchRepositoryCodeResultOrderRemainsByteIdentical)$' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 1**
+
+```bash
+git add internal/sem/search_prose_parent.go internal/sem/search_prose_session_test.go
+git commit -m "feat(search): match bounded prose word families"
+```
+
+---
+
+### Task 2: Distributed-session reservation for list questions
+
+**Files:**
+- Modify: `internal/sem/search_prose_parent.go:57-130`
+- Test: `internal/sem/search_prose_session_test.go`
+
+**Interfaces:**
+- Consumes: `searchQuery.rawLower`, `searchQuery.wordSequence`, `searchQuery.words`, and `safeASCIIPlural`.
+- Produces: `proseQueryRequestsMultipleParents(q searchQuery) bool`.
+- Produces: `proseParentHeadCount(q searchQuery, topK int) int`.
+
+- [ ] **Step 1: Add failing query-shape and allocation tests**
+
+Append:
+
+```go
+func TestProseParentHeadCountReservesMoreTailForListQuestions(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		query string
+		want  int
+	}{
+		{query: "find the archive implementation", want: 5},
+		{query: "which archives contain lanterns", want: 3},
+		{query: "what records exist other than the ledger", want: 3},
+		{query: "where are the travel notes", want: 3},
+	}
+	for _, testCase := range tests {
+		if got := proseParentHeadCount(buildSearchQuery(testCase.query), 10); got != testCase.want {
+			t.Errorf("proseParentHeadCount(%q, 10) = %d, want %d",
+				testCase.query, got, testCase.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails to compile**
+
+Run:
+
+```bash
+go test ./internal/sem -run '^TestProseParentHeadCountReservesMoreTailForListQuestions$' -count=1
+```
+
+Expected: FAIL with `undefined: proseParentHeadCount`.
+
+- [ ] **Step 3: Implement generic list-query detection and head reservation**
+
+Add helpers in `internal/sem/search_prose_parent.go`:
+
+```go
+func proseQueryRequestsMultipleParents(q searchQuery) bool {
+	words := q.words
+	if words == nil {
+		words = searchQueryWords(q.rawLower)
+	}
+	interrogative := words["what"] || words["which"] || words["where"]
+	if !interrogative {
+		return false
+	}
+	if words["else"] || (words["other"] && words["than"]) {
+		return true
+	}
+	written := q.wordSequence
+	if len(written) == 0 {
+		written = searchQueryWordSequence(q.rawLower)
+	}
+	for _, word := range written {
+		if len(word) <= 4 || !strings.HasSuffix(word, "s") || strings.HasSuffix(word, "ss") {
+			continue
+		}
+		singular := strings.TrimSuffix(word, "s")
+		if plural, ok := safeASCIIPlural(singular); ok && plural == word {
+			return true
+		}
+	}
+	return false
+}
+
+func proseParentHeadCount(q searchQuery, topK int) int {
+	if topK <= 0 {
+		return 0
+	}
+	if proseQueryRequestsMultipleParents(q) {
+		return maxInt(1, topK/3)
+	}
+	return (topK + 1) / 2
+}
+```
+
+Replace:
+
+```go
+	headParents := (topK + 1) / 2
+```
+
+with:
+
+```go
+	headParents := proseParentHeadCount(q, topK)
+```
+
+- [ ] **Step 4: Run query-shape, diversity, and code-identity regressions**
+
+Run:
+
+```bash
+go test ./internal/sem -run '^(TestProseParentHeadCountReservesMoreTailForListQuestions|TestSearchRepositoryRanksDistributedMarkdownSession|TestDiverseSelectionDoesNotSpendBudgetOnClones|TestDiverseSelectionCoversFilesBeforeAddingRegions|TestSearchRepositoryCodeResultOrderRemainsByteIdentical)$' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add internal/sem/search_prose_parent.go internal/sem/search_prose_session_test.go
+git commit -m "feat(search): reserve prose tail for list evidence"
+```
+
+---
+
+### Task 3: Verification and no-API retired-tune audit
+
+**Files:**
+- Modify only if verification uncovers a defect: `internal/sem/search_prose_parent.go`, `internal/sem/search_prose_session_test.go`
+- Verify: entire repository
+
+**Interfaces:**
+- Consumes: the Task 1 and Task 2 helpers.
+- Produces: a clean branch with test evidence and a retrieval-only comparison; no scored benchmark artifact.
+
+- [ ] **Step 1: Format and inspect the diff**
+
+Run:
+
+```bash
+gofmt -w internal/sem/search_prose_parent.go internal/sem/search_prose_session_test.go
+git diff --check
+git diff --stat bb8bd49fb4039f489cc5977fe008af7dcead5050...HEAD
+```
+
+Expected: no formatting or whitespace errors; only the design, plan, prose-parent code, and prose tests differ.
+
+- [ ] **Step 2: Run the full semantic-search package**
+
+Run:
+
+```bash
+go test ./internal/sem -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run repository-wide static and test verification**
+
+Run:
+
+```bash
+go vet ./...
+go test -count=1 ./...
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 4: Build the isolated candidate binary**
+
+Run:
+
+```bash
+go build -o /tmp/entire-graph-v53-ranking ./cmd/entire-graph
+shasum -a 256 /tmp/entire-graph-v53-ranking
+```
+
+Expected: build exits 0 and prints one SHA-256 hash. The binary remains outside tracked files.
+
+- [ ] **Step 5: Run the GraphMark no-API retrieval diagnostic on retired tune IDs only**
+
+From `/Users/suhaan/devenv-worktrees/graphify-parity-memory-v52-release`, use the existing v52 `tune_locomo_case_ids` and `tune_longmemeval_case_ids`, materialized source corpora, and the new local binary. Retrieve 100 native candidates, normalize to the first 10 distinct sessions, and calculate recall@1/5/10 and MRR. Do not instantiate a reader or grader, load credentials, inspect holdout IDs, or write a scored artifact.
+
+Expected promotion rule:
+
+```text
+LOCOMO recall@10 >= 0.9388888889
+LongMemEval-S evidence recall@10 == 1.0
+No previously correct retired-tune case becomes zero-recall
+```
+
+If the rule fails, preserve the complete per-case delta table, revert only the losing task commit, and rerun Steps 1-5. Do not add case-specific rules.
+
+- [ ] **Step 6: Commit any verification-only correction, otherwise record clean state**
+
+If source changed during verification:
+
+```bash
+git add internal/sem/search_prose_parent.go internal/sem/search_prose_session_test.go
+git commit -m "fix(search): preserve prose ranking regressions"
+```
+
+Then run:
+
+```bash
+git status --short --branch
+```
+
+Expected: clean `codex/eg-prose-memory-v53-ranking` worktree.
+
+---
+
+### Task 4: Review and separate PR preparation
+
+**Files:**
+- Review: `docs/superpowers/specs/2026-08-07-prose-memory-ranking-v53-design.md`
+- Review: `docs/superpowers/plans/2026-08-07-prose-memory-ranking-v53.md`
+- Review: `internal/sem/search_prose_parent.go`
+- Review: `internal/sem/search_prose_session_test.go`
+
+**Interfaces:**
+- Consumes: clean verified commits from Tasks 1-3.
+- Produces: one unmerged Entire Graph PR based on PR #84's head.
+
+- [ ] **Step 1: Audit prohibited leakage and branch isolation**
+
+Run:
+
+```bash
+git diff bb8bd49fb4039f489cc5977fe008af7dcead5050...HEAD -- . ':!docs/superpowers/specs/2026-08-07-prose-memory-ranking-v53-design.md' ':!docs/superpowers/plans/2026-08-07-prose-memory-ranking-v53.md' | rg -n -i 'locomo|longmemeval|graphify|cmm|conv-[0-9]|session_[0-9]|answer_' && exit 1 || true
+git status --short --branch
+```
+
+Expected: no benchmark identifiers or comparator names in production/test code and a clean worktree.
+
+- [ ] **Step 2: Request independent code and spec review**
+
+Reviewers must verify:
+
+```text
+1. The code implements the design without benchmark vocabulary.
+2. Relaxed matching cannot affect non-prose corpora.
+3. Determinism, limits, and code-result identity remain covered.
+4. The retired-tune diagnostic used no reader, grader, API, or fresh selector.
+5. Test commands were executed rather than inferred.
+```
+
+Expected: no unresolved correctness or fairness finding.
+
+- [ ] **Step 3: Push and open a separate unmerged PR**
+
+```bash
+git push -u origin codex/eg-prose-memory-v53-ranking
+gh pr create --base codex/eg-prose-memory-v52-release --head codex/eg-prose-memory-v53-ranking --title "feat: improve deterministic prose memory ranking" --body-file /tmp/eg-v53-pr-body.md
+```
+
+The PR body must state that retired-tune retrieval diagnostics are developmental, no paid QA benchmark was run, and a fresh publishable evaluation remains separately gated.

--- a/docs/superpowers/specs/2026-08-07-prose-memory-ranking-v53-design.md
+++ b/docs/superpowers/specs/2026-08-07-prose-memory-ranking-v53-design.md
@@ -82,7 +82,7 @@ matching while retaining its current callers. It may match:
 - conservative ASCII `-ed` and `-ing` forms in either direction; and
 - a standalone evidence word contained at the beginning or end of a longer
   prose query token, subject to minimum-length and length-ratio guards and a
-  rejection rule for negating or opposing prefixes.
+  rejection rules for negating or opposing prefixes and suffixes.
 
 The helper must reject short stems and known unsafe suffix collisions. It is
 used only when ordinary exact term counts have not already matched.
@@ -92,8 +92,9 @@ used only when ordinary exact term counts have not already matched.
 Do not create a world-knowledge ontology. Instead, preserve more independent
 session candidates when a prose query contains a bounded generic cue such as an
 ordinal, `before`/`after`, an explicit `else`/`other than` cue, or a conservative
-plural syntactic frame. A plural-looking token elsewhere in an interrogative is
-not enough. Admission must still
+plural syntactic frame. A `which` frame permits at most one modifier before its
+plural head and requires a bounded list predicate immediately after that head.
+A plural-looking token elsewhere in an interrogative is not enough. Admission must still
 come from ordinary lexical/entity retrieval; the cue may affect diversity or a
 small additive score, never manufacture a candidate.
 

--- a/docs/superpowers/specs/2026-08-07-prose-memory-ranking-v53-design.md
+++ b/docs/superpowers/specs/2026-08-07-prose-memory-ranking-v53-design.md
@@ -81,7 +81,8 @@ matching while retaining its current callers. It may match:
 - singular and plural forms already supported;
 - conservative ASCII `-ed` and `-ing` forms in either direction; and
 - a standalone evidence word contained at the beginning or end of a longer
-  prose query token, subject to minimum-length and length-ratio guards.
+  prose query token, subject to minimum-length and length-ratio guards and a
+  rejection rule for negating or opposing prefixes.
 
 The helper must reject short stems and known unsafe suffix collisions. It is
 used only when ordinary exact term counts have not already matched.
@@ -90,7 +91,9 @@ used only when ordinary exact term counts have not already matched.
 
 Do not create a world-knowledge ontology. Instead, preserve more independent
 session candidates when a prose query contains a bounded generic cue such as an
-ordinal, `before`/`after`, or a plural/list interrogative. Admission must still
+ordinal, `before`/`after`, an explicit `else`/`other than` cue, or a conservative
+plural syntactic frame. A plural-looking token elsewhere in an interrogative is
+not enough. Admission must still
 come from ordinary lexical/entity retrieval; the cue may affect diversity or a
 small additive score, never manufacture a candidate.
 

--- a/docs/superpowers/specs/2026-08-07-prose-memory-ranking-v53-design.md
+++ b/docs/superpowers/specs/2026-08-07-prose-memory-ranking-v53-design.md
@@ -1,0 +1,124 @@
+# Prose Memory Ranking v53 Design
+
+## Goal
+
+Improve Entire Graph's general prose retrieval for conversational-memory corpora
+without adding benchmark-specific answers, evidence identifiers, prompts, or
+vocabulary. The change must preserve code-search behavior and keep Graphify and
+Codebase Memory MCP (CMM) as independent comparators.
+
+The publishable success criteria remain a fresh, blinded comparison on:
+
+- LOCOMO recall@10;
+- LOCOMO QA accuracy;
+- LongMemEval-S QA accuracy; and
+- graph-build LLM credits, where zero is the best possible result and therefore
+  a tie rather than a strict win.
+
+No fresh paid evaluation is authorized by this design. Development may use
+synthetic fixtures and already-retired tune cases only.
+
+## Evidence and root cause
+
+Stock CMM v0.9.0 excludes Markdown `Section` nodes from natural-language BM25
+results. GraphMark materializes every conversation message as a Markdown
+heading, so that filter removes the actual message text from retrieval. The
+separately reviewed CMM patch exposes those existing Section nodes without
+injecting evidence or changing questions.
+
+A local, no-API diagnostic over the retired v52 tune set measured patched CMM
+at 0.906 LOCOMO recall@10 and 1.000 LongMemEval-S evidence recall@10. Entire
+Graph measured 0.939 and 1.000 on the same retired cases. These values guide
+development only and are not publishable benchmark results.
+
+The remaining Entire misses fall into general language patterns:
+
+1. a base-form query does not always cover a past or gerund evidence token;
+2. a compound query token may hide a useful standalone evidence word;
+3. temporally phrased or ordinal questions may describe an event using a
+   related word family rather than an exact token; and
+4. list questions may require evidence distributed across multiple sessions.
+
+## Constraints
+
+- Work only on an isolated branch based on `bb8bd49`.
+- Do not modify or merge the existing release PR.
+- Do not inspect a fresh holdout or tune on its outcomes.
+- Do not add named people, answers, dataset IDs, activity lists, or benchmark
+  synonyms to production code or tests.
+- Do not add network access, hosted embeddings, model calls, or build credits.
+- Apply relaxed lexical matching only to the existing prose-parent lane. Code
+  and identifier ranking must remain byte-identical under its regression test.
+- Preserve deterministic ordering, bounded IO, result limits, and schema 1.x.
+
+## Considered approaches
+
+### 1. Benchmark vocabulary or synonym tables
+
+Rejected. A table mapping individual benchmark words would leak development
+cases into the product and would not generalize.
+
+### 2. Hosted embeddings or reader-driven retrieval
+
+Rejected. This would add egress, model dependence, cost, and a different graph
+build-credit surface.
+
+### 3. Bounded prose-only lexical families and session coverage
+
+Selected. Extend the existing `safeProseInflectionMatch` seam with conservative,
+deterministic word-family rules, and make any list/temporal coverage behavior a
+generic query-shape policy. The current prose-parent lane already aggregates
+weak evidence by Markdown file and allocates passages round-robin across
+sessions, so the change can stay local and bounded.
+
+## Proposed behavior
+
+### Safe prose word families
+
+Rename the helper conceptually from plural-only matching to prose lexeme
+matching while retaining its current callers. It may match:
+
+- singular and plural forms already supported;
+- conservative ASCII `-ed` and `-ing` forms in either direction; and
+- a standalone evidence word contained at the beginning or end of a longer
+  prose query token, subject to minimum-length and length-ratio guards.
+
+The helper must reject short stems and known unsafe suffix collisions. It is
+used only when ordinary exact term counts have not already matched.
+
+### Temporal and list coverage
+
+Do not create a world-knowledge ontology. Instead, preserve more independent
+session candidates when a prose query contains a bounded generic cue such as an
+ordinal, `before`/`after`, or a plural/list interrogative. Admission must still
+come from ordinary lexical/entity retrieval; the cue may affect diversity or a
+small additive score, never manufacture a candidate.
+
+If synthetic tests show the current diversity mechanism already provides the
+needed behavior, make no production change for this section.
+
+## Test strategy
+
+Add red tests before implementation:
+
+1. a base-form query retrieves a Markdown session containing a safe past-tense
+   form;
+2. a compound query token can recover a sufficiently long standalone prose
+   word without promoting unsafe short-suffix collisions;
+3. a temporal/ordinal query preserves a related session admitted through a
+   real entity/topic match;
+4. a list query returns distinct relevant Markdown sessions before repetitive
+   distractors; and
+5. the existing code-result byte-identity regression remains unchanged.
+
+Run the focused prose tests first, then `go test ./internal/sem -count=1`,
+`go vet ./...`, and `go test -count=1 ./...`. After local tests pass, run only a
+no-API retrieval diagnostic over retired tune cases and report every regression,
+not merely the average.
+
+## Release and evaluation
+
+The implementation will be proposed in a separate, unmerged PR. A new benchmark
+protocol must seal source commits, binaries, prompts, models, selectors, and the
+patched CMM identity before any paid execution. A fresh evaluation may run only
+after explicit authorization and must be reported honestly even if Entire loses.

--- a/internal/sem/search_prose_parent.go
+++ b/internal/sem/search_prose_parent.go
@@ -147,11 +147,7 @@ func proseQueryRequestsMultipleParents(q searchQuery) bool {
 		written = searchQueryWordSequence(q.rawLower)
 	}
 	for _, word := range written {
-		if len(word) <= 4 || !strings.HasSuffix(word, "s") || strings.HasSuffix(word, "ss") {
-			continue
-		}
-		singular := strings.TrimSuffix(word, "s")
-		if plural, ok := safeASCIIPlural(singular); ok && plural == word {
+		if safeASCIIWrittenPlural(word) {
 			return true
 		}
 	}
@@ -301,7 +297,10 @@ func safeProseInflectionMatch(left, right string) bool {
 			return true
 		}
 	}
-	return safeASCIIProsePrefixFamily(left, right)
+	if safeASCIIProseDerivation(left, right) || safeASCIIProseDerivation(right, left) {
+		return true
+	}
+	return safeASCIIProseEdgeCompound(left, right)
 }
 
 func safeASCIIProseVerbForms(word string) []string {
@@ -314,23 +313,53 @@ func safeASCIIProseVerbForms(word string) []string {
 	return []string{word + "ed", word + "ing"}
 }
 
-func safeASCIIProsePrefixFamily(left, right string) bool {
-	if len(left) < 6 || len(right) < 6 || !proseASCIIWord(left) || !proseASCIIWord(right) {
+func safeASCIIProseDerivation(base, derived string) bool {
+	if len(base) < 6 || !proseASCIIWord(base) || !proseASCIIWord(derived) {
 		return false
 	}
-	difference := len(left) - len(right)
-	if difference < 0 {
-		difference = -difference
+	if strings.HasSuffix(base, "ate") {
+		return derived == strings.TrimSuffix(base, "ate")+"ation"
 	}
-	if difference > 5 {
+	if strings.HasSuffix(base, "ize") {
+		return derived == strings.TrimSuffix(base, "e")+"ation"
+	}
+	return false
+}
+
+func safeASCIIProseEdgeCompound(left, right string) bool {
+	if !proseASCIIWord(left) || !proseASCIIWord(right) {
 		return false
 	}
-	common := 0
-	for common < len(left) && common < len(right) && left[common] == right[common] {
-		common++
+	shorter, longer := left, right
+	if len(shorter) > len(longer) {
+		shorter, longer = longer, shorter
 	}
-	shorter := minInt(len(left), len(right))
-	return shorter >= 8 && common >= 5 && common*3 >= shorter*2
+	difference := len(longer) - len(shorter)
+	if len(shorter) < 8 || difference < 2 || difference > 5 || len(shorter)*3 < len(longer)*2 {
+		return false
+	}
+	return strings.HasPrefix(longer, shorter) || strings.HasSuffix(longer, shorter)
+}
+
+// safeASCIIWrittenPlural recognizes only forms that can be reversed without
+// treating common singular s-ending words as list intent. It is deliberately
+// conservative: missing an irregular plural keeps the ordinary allocation,
+// while a false plural silently changes how much of top-k is reserved.
+func safeASCIIWrittenPlural(word string) bool {
+	if len(word) <= 4 || !proseASCIIWord(word) || !strings.HasSuffix(word, "s") || strings.HasSuffix(word, "ss") {
+		return false
+	}
+	for _, singularSuffix := range []string{"as", "is", "us"} {
+		if strings.HasSuffix(word, singularSuffix) {
+			return false
+		}
+	}
+	singular := strings.TrimSuffix(word, "s")
+	if len(singular) == 0 || strings.ContainsRune("aiu", rune(singular[len(singular)-1])) {
+		return false
+	}
+	plural, ok := safeASCIIPlural(singular)
+	return ok && plural == word
 }
 
 func safeASCIIPlural(word string) (string, bool) {

--- a/internal/sem/search_prose_parent.go
+++ b/internal/sem/search_prose_parent.go
@@ -89,7 +89,7 @@ func selectSearchCandidates(
 		return true
 	}
 
-	headParents := (topK + 1) / 2
+	headParents := proseParentHeadCount(q, topK)
 	for _, candidate := range baseline {
 		if len(selected) == headParents {
 			break
@@ -128,6 +128,44 @@ func selectSearchCandidates(
 		appendParent(parents[candidate.result.FilePath], candidate)
 	}
 	return selected
+}
+
+func proseQueryRequestsMultipleParents(q searchQuery) bool {
+	words := q.words
+	if words == nil {
+		words = searchQueryWords(q.rawLower)
+	}
+	interrogative := words["what"] || words["which"] || words["where"]
+	if !interrogative {
+		return false
+	}
+	if words["else"] || (words["other"] && words["than"]) {
+		return true
+	}
+	written := q.wordSequence
+	if len(written) == 0 {
+		written = searchQueryWordSequence(q.rawLower)
+	}
+	for _, word := range written {
+		if len(word) <= 4 || !strings.HasSuffix(word, "s") || strings.HasSuffix(word, "ss") {
+			continue
+		}
+		singular := strings.TrimSuffix(word, "s")
+		if plural, ok := safeASCIIPlural(singular); ok && plural == word {
+			return true
+		}
+	}
+	return false
+}
+
+func proseParentHeadCount(q searchQuery, topK int) int {
+	if topK <= 0 {
+		return 0
+	}
+	if proseQueryRequestsMultipleParents(q) {
+		return maxInt(1, topK/3)
+	}
+	return (topK + 1) / 2
 }
 
 func proseParents(candidates []searchCandidate) map[string]*proseParent {

--- a/internal/sem/search_prose_parent.go
+++ b/internal/sem/search_prose_parent.go
@@ -143,7 +143,7 @@ func proseQueryRequestsMultipleParents(q searchQuery) bool {
 		written = searchQueryWordSequence(q.rawLower)
 	}
 	for index, word := range written {
-		if word == "which" && index+1 < len(written) && safeASCIIWrittenPlural(written[index+1]) {
+		if word == "which" && proseWhichListFrame(written, index) {
 			return true
 		}
 		if (word == "what" || word == "where") && index+1 < len(written) && written[index+1] == "are" &&
@@ -152,6 +152,29 @@ func proseQueryRequestsMultipleParents(q searchQuery) bool {
 		}
 	}
 	return false
+}
+
+func proseWhichListFrame(written []string, whichIndex int) bool {
+	for headOffset := 1; headOffset <= 2; headOffset++ {
+		headIndex := whichIndex + headOffset
+		predicateIndex := headIndex + 1
+		if predicateIndex >= len(written) || !safeASCIIWrittenPlural(written[headIndex]) {
+			continue
+		}
+		if proseListPredicate(written[predicateIndex]) {
+			return true
+		}
+	}
+	return false
+}
+
+func proseListPredicate(word string) bool {
+	switch word {
+	case "are", "contain", "cover", "describe", "have", "hold", "include", "list", "match", "mention", "show", "store", "use":
+		return true
+	default:
+		return false
+	}
 }
 
 func proseParentHeadCount(q searchQuery, topK int) int {
@@ -339,13 +362,23 @@ func safeASCIIProseEdgeCompound(queryTerm, evidenceToken string) bool {
 		return false
 	}
 	if strings.HasPrefix(queryTerm, evidenceToken) {
-		return true
+		suffix := strings.TrimPrefix(queryTerm, evidenceToken)
+		return !safeASCIIProseOpposingSuffix(suffix)
 	}
 	if !strings.HasSuffix(queryTerm, evidenceToken) {
 		return false
 	}
 	prefix := strings.TrimSuffix(queryTerm, evidenceToken)
 	return !safeASCIIProseOpposingPrefix(prefix)
+}
+
+func safeASCIIProseOpposingSuffix(suffix string) bool {
+	switch suffix {
+	case "free", "less":
+		return true
+	default:
+		return false
+	}
 }
 
 func safeASCIIProseOpposingPrefix(prefix string) bool {

--- a/internal/sem/search_prose_parent.go
+++ b/internal/sem/search_prose_parent.go
@@ -253,7 +253,46 @@ func safeProseInflectionMatch(left, right string) bool {
 	if plural, ok := safeASCIIPlural(right); ok && plural == left {
 		return true
 	}
-	return false
+	for _, form := range safeASCIIProseVerbForms(left) {
+		if form == right {
+			return true
+		}
+	}
+	for _, form := range safeASCIIProseVerbForms(right) {
+		if form == left {
+			return true
+		}
+	}
+	return safeASCIIProsePrefixFamily(left, right)
+}
+
+func safeASCIIProseVerbForms(word string) []string {
+	if len(word) < 5 || !proseASCIIWord(word) {
+		return nil
+	}
+	if strings.HasSuffix(word, "e") {
+		return []string{word + "d", strings.TrimSuffix(word, "e") + "ing"}
+	}
+	return []string{word + "ed", word + "ing"}
+}
+
+func safeASCIIProsePrefixFamily(left, right string) bool {
+	if len(left) < 6 || len(right) < 6 || !proseASCIIWord(left) || !proseASCIIWord(right) {
+		return false
+	}
+	difference := len(left) - len(right)
+	if difference < 0 {
+		difference = -difference
+	}
+	if difference > 5 {
+		return false
+	}
+	common := 0
+	for common < len(left) && common < len(right) && left[common] == right[common] {
+		common++
+	}
+	shorter := minInt(len(left), len(right))
+	return shorter >= 8 && common >= 5 && common*3 >= shorter*2
 }
 
 func safeASCIIPlural(word string) (string, bool) {

--- a/internal/sem/search_prose_parent.go
+++ b/internal/sem/search_prose_parent.go
@@ -135,10 +135,6 @@ func proseQueryRequestsMultipleParents(q searchQuery) bool {
 	if words == nil {
 		words = searchQueryWords(q.rawLower)
 	}
-	interrogative := words["what"] || words["which"] || words["where"]
-	if !interrogative {
-		return false
-	}
 	if words["else"] || (words["other"] && words["than"]) {
 		return true
 	}
@@ -146,8 +142,12 @@ func proseQueryRequestsMultipleParents(q searchQuery) bool {
 	if len(written) == 0 {
 		written = searchQueryWordSequence(q.rawLower)
 	}
-	for _, word := range written {
-		if safeASCIIWrittenPlural(word) {
+	for index, word := range written {
+		if word == "which" && index+1 < len(written) && safeASCIIWrittenPlural(written[index+1]) {
+			return true
+		}
+		if (word == "what" || word == "where") && index+1 < len(written) && written[index+1] == "are" &&
+			safeASCIIWrittenPlural(written[len(written)-1]) {
 			return true
 		}
 	}
@@ -326,19 +326,35 @@ func safeASCIIProseDerivation(base, derived string) bool {
 	return false
 }
 
-func safeASCIIProseEdgeCompound(left, right string) bool {
-	if !proseASCIIWord(left) || !proseASCIIWord(right) {
+// safeASCIIProseEdgeCompound is directional: queryTerm is the word the caller
+// wrote and evidenceToken is the corpus token. A longer query compound may
+// expose an exact standalone evidence word at either edge; a longer evidence
+// token cannot manufacture coverage for a shorter query.
+func safeASCIIProseEdgeCompound(queryTerm, evidenceToken string) bool {
+	if !proseASCIIWord(queryTerm) || !proseASCIIWord(evidenceToken) {
 		return false
 	}
-	shorter, longer := left, right
-	if len(shorter) > len(longer) {
-		shorter, longer = longer, shorter
-	}
-	difference := len(longer) - len(shorter)
-	if len(shorter) < 8 || difference < 2 || difference > 5 || len(shorter)*3 < len(longer)*2 {
+	difference := len(queryTerm) - len(evidenceToken)
+	if len(evidenceToken) < 8 || difference < 2 || difference > 5 || len(evidenceToken)*3 < len(queryTerm)*2 {
 		return false
 	}
-	return strings.HasPrefix(longer, shorter) || strings.HasSuffix(longer, shorter)
+	if strings.HasPrefix(queryTerm, evidenceToken) {
+		return true
+	}
+	if !strings.HasSuffix(queryTerm, evidenceToken) {
+		return false
+	}
+	prefix := strings.TrimSuffix(queryTerm, evidenceToken)
+	return !safeASCIIProseOpposingPrefix(prefix)
+}
+
+func safeASCIIProseOpposingPrefix(prefix string) bool {
+	switch prefix {
+	case "anti", "counter", "de", "dis", "il", "im", "in", "ir", "mis", "non", "un":
+		return true
+	default:
+		return false
+	}
 }
 
 // safeASCIIWrittenPlural recognizes only forms that can be reversed without

--- a/internal/sem/search_prose_session_test.go
+++ b/internal/sem/search_prose_session_test.go
@@ -176,13 +176,20 @@ func TestSafeProseInflectionMatchSupportsBoundedWordFamilies(t *testing.T) {
 		{left: "archive", right: "archived", want: true},
 		{left: "archive", right: "archiving", want: true},
 		{left: "navigate", right: "navigation", want: true},
-		{left: "authorization", right: "preauthorization", want: true},
+		{left: "preauthorization", right: "authorization", want: true},
+		{left: "authorization", right: "preauthorization", want: false},
 		{left: "orchard", right: "orchards", want: true},
 		{left: "gas", right: "gases", want: false},
 		{left: "archive", right: "architect", want: false},
 		{left: "plan", right: "planet", want: false},
 		{left: "universe", right: "university", want: false},
 		{left: "conserve", right: "conservatory", want: false},
+		{left: "possible", right: "impossible", want: false},
+		{left: "impossible", right: "possible", want: false},
+		{left: "complete", right: "incomplete", want: false},
+		{left: "incomplete", right: "complete", want: false},
+		{left: "authorized", right: "unauthorized", want: false},
+		{left: "unauthorized", right: "authorized", want: false},
 	}
 	for _, testCase := range tests {
 		if got := safeProseInflectionMatch(testCase.left, testCase.right); got != testCase.want {
@@ -217,10 +224,16 @@ func TestProseParentHeadCountReservesMoreTailForListQuestions(t *testing.T) {
 		{query: "what records exist other than the ledger", want: 3},
 		{query: "what item exists other than the ledger", want: 3},
 		{query: "where are the travel notes", want: 3},
+		{query: "what are the projects", want: 3},
 		{query: "what else is recorded", want: 3},
 		{query: "what is the status", want: 5},
 		{query: "what does the analysis show", want: 5},
 		{query: "where is the atlas", want: 5},
+		{query: "what happens after deployment", want: 5},
+		{query: "what occurs after deployment", want: 5},
+		{query: "what always follows deployment", want: 5},
+		{query: "what series covers deployment", want: 5},
+		{query: "what physics explains motion", want: 5},
 	}
 	for _, testCase := range tests {
 		if got := proseParentHeadCount(buildSearchQuery(testCase.query), 10); got != testCase.want {
@@ -242,7 +255,7 @@ func TestSearchRepositoryAdmitsSafeProseFamilyForTemporalListQuery(t *testing.T)
 	}{
 		{name: "past tense", query: "archive", evidence: "Archived"},
 		{name: "derivation", query: "navigate", evidence: "Navigation"},
-		{name: "end compound", query: "authorization", evidence: "Preauthorization"},
+		{name: "end compound", query: "preauthorization", evidence: "Authorization"},
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -259,7 +272,7 @@ The approval was recorded in this session.
 			}
 
 			response, err := SearchRepository(
-				t.Context(), repo, "test", fmt.Sprintf("which %s notes were before the third review", testCase.query), SearchOptions{
+				t.Context(), repo, "test", fmt.Sprintf("which notes about %s were before the third review", testCase.query), SearchOptions{
 					Worktree: true, Profile: ProfileSyntaxOnly, TopK: 10, MaxIndexedFiles: 32,
 				},
 			)
@@ -283,6 +296,34 @@ The approval was recorded in this session.
 			}
 			t.Fatalf("safe family evidence session missing: %#v", response.Results)
 		})
+	}
+}
+
+func TestSearchRepositoryDoesNotAdmitNegatingEdgeCompound(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, "sessions/focus.md", `# Possible review entry
+
+The fallback note was recorded in this session.
+`)
+	for index := 0; index < 12; index++ {
+		write(t, repo, fmt.Sprintf("sessions/distractor-%02d.md", index), fmt.Sprintf(
+			"# Third review notes before marker%d ridge%d vessel%d\n",
+			index, index, index,
+		))
+	}
+
+	response, err := SearchRepository(
+		t.Context(), repo, "test", "which notes about impossible were before the third review", SearchOptions{
+			Worktree: true, Profile: ProfileSyntaxOnly, TopK: 10, MaxIndexedFiles: 32,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, result := range response.Results {
+		if result.FilePath == "sessions/focus.md" {
+			t.Fatalf("negating edge compound admitted opposing evidence: %#v", response.Results)
+		}
 	}
 }
 
@@ -378,6 +419,50 @@ func TestSearchRepositorySingularSEndingQuestionPreservesOrdinaryHead(t *testing
 
 	response, err := SearchRepository(
 		t.Context(), repo, "test", "what is the status of amber orchard ledger braided lantern", SearchOptions{
+			Worktree: true, Profile: ProfileSyntaxOnly, TopK: 10, MaxIndexedFiles: 32,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := 0; index < 5; index++ {
+		want := fmt.Sprintf("sessions/distractor-%02d.md", index)
+		if response.Results[index].FilePath != want {
+			t.Fatalf("ordinary head[%d] = %q, want %q", index, response.Results[index].FilePath, want)
+		}
+	}
+	for _, result := range response.Results {
+		if result.FilePath == "sessions/focus.md" {
+			if result.Rank != 6 {
+				t.Fatalf("distributed session rank = %d, want ordinary first-tail slot 6", result.Rank)
+			}
+			return
+		}
+	}
+	t.Fatalf("distributed session missing from ordinary tail: %#v", response.Results)
+}
+
+func TestSearchRepositoryVerbSEndingQuestionPreservesOrdinaryHead(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, "sessions/focus.md", `# Amber
+
+## Orchard
+
+## Ledger
+
+## Braided
+
+## Lantern
+`)
+	for index := 0; index < 12; index++ {
+		write(t, repo, fmt.Sprintf("sessions/distractor-%02d.md", index), fmt.Sprintf(
+			"# Happens after deployment amber orchard ledger braided marker%d ridge%d vessel%d\n",
+			index, index, index,
+		))
+	}
+
+	response, err := SearchRepository(
+		t.Context(), repo, "test", "what happens after deployment with amber orchard ledger braided lantern", SearchOptions{
 			Worktree: true, Profile: ProfileSyntaxOnly, TopK: 10, MaxIndexedFiles: 32,
 		},
 	)

--- a/internal/sem/search_prose_session_test.go
+++ b/internal/sem/search_prose_session_test.go
@@ -203,6 +203,25 @@ func TestProseParentTermListsUseDerivedWordFamilyCoverage(t *testing.T) {
 	}
 }
 
+func TestProseParentHeadCountReservesMoreTailForListQuestions(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		query string
+		want  int
+	}{
+		{query: "find the archive implementation", want: 5},
+		{query: "which archives contain lanterns", want: 3},
+		{query: "what records exist other than the ledger", want: 3},
+		{query: "where are the travel notes", want: 3},
+	}
+	for _, testCase := range tests {
+		if got := proseParentHeadCount(buildSearchQuery(testCase.query), 10); got != testCase.want {
+			t.Errorf("proseParentHeadCount(%q, 10) = %d, want %d",
+				testCase.query, got, testCase.want)
+		}
+	}
+}
+
 func TestSearchRepositoryDoesNotConflateUnsafeProseSuffixes(t *testing.T) {
 	repo := t.TempDir()
 	write(t, repo, "sessions/focus.md", `# Gases

--- a/internal/sem/search_prose_session_test.go
+++ b/internal/sem/search_prose_session_test.go
@@ -166,6 +166,59 @@ func TestSearchRepositoryRanksSafeSingularEvidenceForPluralQuery(t *testing.T) {
 	t.Fatalf("safe singular-evidence session missing from top 10: %#v", response.Results)
 }
 
+func TestSafeProseInflectionMatchSupportsBoundedWordFamilies(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		left  string
+		right string
+		want  bool
+	}{
+		{left: "archive", right: "archived", want: true},
+		{left: "archive", right: "archiving", want: true},
+		{left: "navigate", right: "navigation", want: true},
+		{left: "orchard", right: "orchards", want: true},
+		{left: "gas", right: "gases", want: false},
+		{left: "archive", right: "architect", want: false},
+		{left: "plan", right: "planet", want: false},
+	}
+	for _, testCase := range tests {
+		if got := safeProseInflectionMatch(testCase.left, testCase.right); got != testCase.want {
+			t.Errorf("safeProseInflectionMatch(%q, %q) = %t, want %t",
+				testCase.left, testCase.right, got, testCase.want)
+		}
+	}
+}
+
+func TestSearchRepositoryRanksDerivedWordFamilyMarkdownSession(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, "sessions/focus.md", `# Navigation archive
+
+The expedition was carefully navigated and archived after sunset.
+`)
+	for index := 0; index < 11; index++ {
+		write(t, repo, fmt.Sprintf("sessions/distractor-%02d.md", index), fmt.Sprintf(
+			"# Navigation marker%d ridge%d vessel%d\n\nUnrelated archive index.\n",
+			index, index, index,
+		))
+	}
+
+	response, err := SearchRepository(
+		t.Context(), repo, "test", "navigate archive sunset", SearchOptions{
+			Worktree: true, Profile: ProfileSyntaxOnly, TopK: 10, MaxIndexedFiles: 32,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, result := range response.Results {
+		if result.FilePath == "sessions/focus.md" &&
+			containsString(result.Signals, proseParentRetrievalSignal) {
+			return
+		}
+	}
+	t.Fatalf("derived word-family session missing from top 10: %#v", response.Results)
+}
+
 func TestSearchRepositoryDoesNotConflateUnsafeProseSuffixes(t *testing.T) {
 	repo := t.TempDir()
 	write(t, repo, "sessions/focus.md", `# Gases

--- a/internal/sem/search_prose_session_test.go
+++ b/internal/sem/search_prose_session_test.go
@@ -189,34 +189,18 @@ func TestSafeProseInflectionMatchSupportsBoundedWordFamilies(t *testing.T) {
 	}
 }
 
-func TestSearchRepositoryRanksDerivedWordFamilyMarkdownSession(t *testing.T) {
-	repo := t.TempDir()
-	write(t, repo, "sessions/focus.md", `# Navigation archive
-
-The expedition was carefully navigated and archived after sunset.
-`)
-	for index := 0; index < 11; index++ {
-		write(t, repo, fmt.Sprintf("sessions/distractor-%02d.md", index), fmt.Sprintf(
-			"# Navigation marker%d ridge%d vessel%d\n\nUnrelated archive index.\n",
-			index, index, index,
-		))
-	}
-
-	response, err := SearchRepository(
-		t.Context(), repo, "test", "navigate archive sunset", SearchOptions{
-			Worktree: true, Profile: ProfileSyntaxOnly, TopK: 10, MaxIndexedFiles: 32,
-		},
+func TestProseParentTermListsUseDerivedWordFamilyCoverage(t *testing.T) {
+	t.Parallel()
+	candidate := proseTestCandidate(
+		"sessions/focus.md", 10, 4, "The expedition was carefully navigated.", nil,
 	)
-	if err != nil {
-		t.Fatal(err)
+	candidates := []searchCandidate{candidate}
+	lists := proseParentTermLists(
+		candidates, proseParents(candidates), []string{"navigate"}, 10,
+	)
+	if len(lists) != 1 || len(lists[0]) != 1 || lists[0][0].parent.path != "sessions/focus.md" {
+		t.Fatalf("derived family did not seed prose parent: %#v", lists)
 	}
-	for _, result := range response.Results {
-		if result.FilePath == "sessions/focus.md" &&
-			containsString(result.Signals, proseParentRetrievalSignal) {
-			return
-		}
-	}
-	t.Fatalf("derived word-family session missing from top 10: %#v", response.Results)
 }
 
 func TestSearchRepositoryDoesNotConflateUnsafeProseSuffixes(t *testing.T) {

--- a/internal/sem/search_prose_session_test.go
+++ b/internal/sem/search_prose_session_test.go
@@ -176,10 +176,13 @@ func TestSafeProseInflectionMatchSupportsBoundedWordFamilies(t *testing.T) {
 		{left: "archive", right: "archived", want: true},
 		{left: "archive", right: "archiving", want: true},
 		{left: "navigate", right: "navigation", want: true},
+		{left: "authorization", right: "preauthorization", want: true},
 		{left: "orchard", right: "orchards", want: true},
 		{left: "gas", right: "gases", want: false},
 		{left: "archive", right: "architect", want: false},
 		{left: "plan", right: "planet", want: false},
+		{left: "universe", right: "university", want: false},
+		{left: "conserve", right: "conservatory", want: false},
 	}
 	for _, testCase := range tests {
 		if got := safeProseInflectionMatch(testCase.left, testCase.right); got != testCase.want {
@@ -212,7 +215,12 @@ func TestProseParentHeadCountReservesMoreTailForListQuestions(t *testing.T) {
 		{query: "find the archive implementation", want: 5},
 		{query: "which archives contain lanterns", want: 3},
 		{query: "what records exist other than the ledger", want: 3},
+		{query: "what item exists other than the ledger", want: 3},
 		{query: "where are the travel notes", want: 3},
+		{query: "what else is recorded", want: 3},
+		{query: "what is the status", want: 5},
+		{query: "what does the analysis show", want: 5},
+		{query: "where is the atlas", want: 5},
 	}
 	for _, testCase := range tests {
 		if got := proseParentHeadCount(buildSearchQuery(testCase.query), 10); got != testCase.want {
@@ -220,6 +228,177 @@ func TestProseParentHeadCountReservesMoreTailForListQuestions(t *testing.T) {
 				testCase.query, got, testCase.want)
 		}
 	}
+}
+
+// TestSearchRepositoryAdmitsSafeProseFamilyForTemporalListQuery proves that
+// word-family coverage participates in real prose-parent selection. Each focus
+// session has only a common low-ranked anchor plus the family token; without
+// that admission it stays beyond the top-k term lists.
+func TestSearchRepositoryAdmitsSafeProseFamilyForTemporalListQuery(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    string
+		evidence string
+	}{
+		{name: "past tense", query: "archive", evidence: "Archived"},
+		{name: "derivation", query: "navigate", evidence: "Navigation"},
+		{name: "end compound", query: "authorization", evidence: "Preauthorization"},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			repo := t.TempDir()
+			write(t, repo, "sessions/focus.md", fmt.Sprintf(`# %s review entry
+
+The approval was recorded in this session.
+			`, testCase.evidence))
+			for index := 0; index < 12; index++ {
+				write(t, repo, fmt.Sprintf("sessions/distractor-%02d.md", index), fmt.Sprintf(
+					"# Third review notes before marker%d ridge%d vessel%d\n",
+					index, index, index,
+				))
+			}
+
+			response, err := SearchRepository(
+				t.Context(), repo, "test", fmt.Sprintf("which %s notes were before the third review", testCase.query), SearchOptions{
+					Worktree: true, Profile: ProfileSyntaxOnly, TopK: 10, MaxIndexedFiles: 32,
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for index := 0; index < 3; index++ {
+				want := fmt.Sprintf("sessions/distractor-%02d.md", index)
+				if response.Results[index].FilePath != want {
+					t.Fatalf("preserved list head[%d] = %q, want %q", index, response.Results[index].FilePath, want)
+				}
+			}
+			for _, result := range response.Results {
+				if result.FilePath != "sessions/focus.md" {
+					continue
+				}
+				if result.Rank != 4 {
+					t.Fatalf("family evidence rank = %d, want first list-tail slot 4", result.Rank)
+				}
+				return
+			}
+			t.Fatalf("safe family evidence session missing: %#v", response.Results)
+		})
+	}
+}
+
+func TestSearchRepositoryDoesNotAdmitUnrelatedLongPrefixFamily(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, "sessions/focus.md", `# University
+
+## Review entry
+
+The campus note was recorded in this session.
+`)
+	for index := 0; index < 12; index++ {
+		write(t, repo, fmt.Sprintf("sessions/distractor-%02d.md", index), fmt.Sprintf(
+			"# Third review notes before marker%d ridge%d vessel%d\n",
+			index, index, index,
+		))
+	}
+
+	response, err := SearchRepository(
+		t.Context(), repo, "test", "which universe notes were before the third review", SearchOptions{
+			Worktree: true, Profile: ProfileSyntaxOnly, TopK: 10, MaxIndexedFiles: 32,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, result := range response.Results {
+		if result.FilePath == "sessions/focus.md" {
+			t.Fatalf("universe/university collision admitted unrelated session: %#v", response.Results)
+		}
+	}
+}
+
+// TestSearchRepositoryListInterrogativeReservesTailForDistinctParents covers
+// the allocation policy through the public repository-search entrypoint rather
+// than only checking its query-shape helper.
+func TestSearchRepositoryListInterrogativeReservesTailForDistinctParents(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, "sessions/lantern.md", "# Archive\n\n## Lantern\n")
+	write(t, repo, "sessions/vessel.md", "# Archive\n\n## Vessel\n")
+	for index := 0; index < 12; index++ {
+		write(t, repo, fmt.Sprintf("sessions/distractor-%02d.md", index), fmt.Sprintf(
+			"# Archive records mention marker%d ridge%d route%d\n",
+			index, index, index,
+		))
+	}
+
+	response, err := SearchRepository(
+		t.Context(), repo, "test", "which archive records mention lanterns and vessels", SearchOptions{
+			Worktree: true, Profile: ProfileSyntaxOnly, TopK: 10, MaxIndexedFiles: 32,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := 0; index < 3; index++ {
+		want := fmt.Sprintf("sessions/distractor-%02d.md", index)
+		if response.Results[index].FilePath != want {
+			t.Fatalf("preserved list head[%d] = %q, want %q", index, response.Results[index].FilePath, want)
+		}
+	}
+	wantPaths := map[string]bool{"sessions/lantern.md": false, "sessions/vessel.md": false}
+	for _, result := range response.Results {
+		if _, ok := wantPaths[result.FilePath]; ok {
+			wantPaths[result.FilePath] = true
+		}
+	}
+	for path, found := range wantPaths {
+		if !found {
+			t.Fatalf("list evidence parent %s missing: %#v", path, response.Results)
+		}
+	}
+}
+
+func TestSearchRepositorySingularSEndingQuestionPreservesOrdinaryHead(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, "sessions/focus.md", `# Amber
+
+## Orchard
+
+## Ledger
+
+## Braided
+
+## Lantern
+`)
+	for index := 0; index < 12; index++ {
+		write(t, repo, fmt.Sprintf("sessions/distractor-%02d.md", index), fmt.Sprintf(
+			"# Status amber orchard ledger braided marker%d ridge%d vessel%d\n",
+			index, index, index,
+		))
+	}
+
+	response, err := SearchRepository(
+		t.Context(), repo, "test", "what is the status of amber orchard ledger braided lantern", SearchOptions{
+			Worktree: true, Profile: ProfileSyntaxOnly, TopK: 10, MaxIndexedFiles: 32,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := 0; index < 5; index++ {
+		want := fmt.Sprintf("sessions/distractor-%02d.md", index)
+		if response.Results[index].FilePath != want {
+			t.Fatalf("ordinary head[%d] = %q, want %q", index, response.Results[index].FilePath, want)
+		}
+	}
+	for _, result := range response.Results {
+		if result.FilePath == "sessions/focus.md" {
+			if result.Rank != 6 {
+				t.Fatalf("distributed session rank = %d, want ordinary first-tail slot 6", result.Rank)
+			}
+			return
+		}
+	}
+	t.Fatalf("distributed session missing from ordinary tail: %#v", response.Results)
 }
 
 func TestSearchRepositoryDoesNotConflateUnsafeProseSuffixes(t *testing.T) {

--- a/internal/sem/search_prose_session_test.go
+++ b/internal/sem/search_prose_session_test.go
@@ -190,6 +190,8 @@ func TestSafeProseInflectionMatchSupportsBoundedWordFamilies(t *testing.T) {
 		{left: "incomplete", right: "complete", want: false},
 		{left: "authorized", right: "unauthorized", want: false},
 		{left: "unauthorized", right: "authorized", want: false},
+		{left: "permissionless", right: "permission", want: false},
+		{left: "authorizationfree", right: "authorization", want: false},
 	}
 	for _, testCase := range tests {
 		if got := safeProseInflectionMatch(testCase.left, testCase.right); got != testCase.want {
@@ -221,6 +223,8 @@ func TestProseParentHeadCountReservesMoreTailForListQuestions(t *testing.T) {
 	}{
 		{query: "find the archive implementation", want: 5},
 		{query: "which archives contain lanterns", want: 3},
+		{query: "which archive records contain lanterns", want: 3},
+		{query: "which old archives contain lanterns", want: 3},
 		{query: "what records exist other than the ledger", want: 3},
 		{query: "what item exists other than the ledger", want: 3},
 		{query: "where are the travel notes", want: 3},
@@ -234,6 +238,10 @@ func TestProseParentHeadCountReservesMoreTailForListQuestions(t *testing.T) {
 		{query: "what always follows deployment", want: 5},
 		{query: "what series covers deployment", want: 5},
 		{query: "what physics explains motion", want: 5},
+		{query: "which status happens after deployment", want: 5},
+		{query: "which analysis occurs after deployment", want: 5},
+		{query: "which series always follows deployment", want: 5},
+		{query: "which physics explains motion", want: 5},
 	}
 	for _, testCase := range tests {
 		if got := proseParentHeadCount(buildSearchQuery(testCase.query), 10); got != testCase.want {
@@ -272,7 +280,7 @@ The approval was recorded in this session.
 			}
 
 			response, err := SearchRepository(
-				t.Context(), repo, "test", fmt.Sprintf("which notes about %s were before the third review", testCase.query), SearchOptions{
+				t.Context(), repo, "test", fmt.Sprintf("which notes contain %s before the third review", testCase.query), SearchOptions{
 					Worktree: true, Profile: ProfileSyntaxOnly, TopK: 10, MaxIndexedFiles: 32,
 				},
 			)
@@ -313,7 +321,7 @@ The fallback note was recorded in this session.
 	}
 
 	response, err := SearchRepository(
-		t.Context(), repo, "test", "which notes about impossible were before the third review", SearchOptions{
+		t.Context(), repo, "test", "which notes contain impossible before the third review", SearchOptions{
 			Worktree: true, Profile: ProfileSyntaxOnly, TopK: 10, MaxIndexedFiles: 32,
 		},
 	)
@@ -323,6 +331,34 @@ The fallback note was recorded in this session.
 	for _, result := range response.Results {
 		if result.FilePath == "sessions/focus.md" {
 			t.Fatalf("negating edge compound admitted opposing evidence: %#v", response.Results)
+		}
+	}
+}
+
+func TestSearchRepositoryDoesNotAdmitOpposingEdgeSuffix(t *testing.T) {
+	repo := t.TempDir()
+	write(t, repo, "sessions/focus.md", `# Permission review entry
+
+The fallback note was recorded in this session.
+`)
+	for index := 0; index < 12; index++ {
+		write(t, repo, fmt.Sprintf("sessions/distractor-%02d.md", index), fmt.Sprintf(
+			"# Third review notes before marker%d ridge%d vessel%d\n",
+			index, index, index,
+		))
+	}
+
+	response, err := SearchRepository(
+		t.Context(), repo, "test", "which notes contain permissionless before the third review", SearchOptions{
+			Worktree: true, Profile: ProfileSyntaxOnly, TopK: 10, MaxIndexedFiles: 32,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, result := range response.Results {
+		if result.FilePath == "sessions/focus.md" {
+			t.Fatalf("opposing edge suffix admitted contradictory evidence: %#v", response.Results)
 		}
 	}
 }
@@ -386,10 +422,17 @@ func TestSearchRepositoryListInterrogativeReservesTailForDistinctParents(t *test
 		}
 	}
 	wantPaths := map[string]bool{"sessions/lantern.md": false, "sessions/vessel.md": false}
+	firstEvidenceRank := 0
 	for _, result := range response.Results {
 		if _, ok := wantPaths[result.FilePath]; ok {
 			wantPaths[result.FilePath] = true
+			if firstEvidenceRank == 0 || result.Rank < firstEvidenceRank {
+				firstEvidenceRank = result.Rank
+			}
 		}
+	}
+	if firstEvidenceRank != 4 {
+		t.Fatalf("first fair-tail evidence rank = %d, want 4: %#v", firstEvidenceRank, response.Results)
 	}
 	for path, found := range wantPaths {
 		if !found {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/38
<!-- entire-trail-link-end -->

## Summary

- add bounded, deterministic prose-only word-family matching for safe verb and derivational variants
- preserve the existing exact/plural path and keep code search behavior unchanged
- reserve more result tail for independent prose parents on list-style questions so evidence can span sessions
- document the fairness constraints and verification plan for this follow-up

This is a stacked follow-up to #84 and should not be merged before that PR.

## Fairness and scope

- no benchmark-specific vocabulary, case IDs, expected answers, prompts, or holdout data in product code
- no reader, grader, API, credential, network, dependency, or provider change
- changes are gated to the existing Markdown/prose-parent path
- no paid QA benchmark was run for this branch
- the local retrieval audit used only a previously retired 30-case LOCOMO / 5-case LongMemEval-S tune selector; it is development evidence, not a publishable benchmark win
- a fresh blinded evaluation remains separately gated

## Verification

- `go test ./internal/sem -count=1`
- `go vet ./...`
- `go test -count=1 ./...`
- `go build -o /tmp/entire-graph-v53-ranking ./cmd/entire-graph`
- candidate binary SHA-256: `06dac86768418bc44aec1134c695736db8449489d90e1eb83b1c5deb212466e7`

Exact base-vs-new no-API retrieval audit on the retired selector:

| Dataset | Cases | Base recall@10 | New recall@10 | Delta |
|---|---:|---:|---:|---:|
| LOCOMO | 30 | 0.9388888889 | 0.9388888889 | 0.0000000000 |
| LongMemEval-S | 5 | 1.0000000000 | 1.0000000000 | 0.0000000000 |

All 35 per-case recall@10 values were identical; nonzero-to-zero regressions: 0.

## Review

- task-level independent reviews: approved
- full-branch independent review: approved after three adversarial fix/re-review rounds with no remaining Critical, Important, or Minor findings
