### PR TITLE
docs: add holdout numbers and CMM zero-retrieval detail to v52 tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,15 +156,24 @@ competitor.
 \* CMM v0.9.0 indexed the Markdown conversations as `Section` nodes, but its
 public natural-language `search_graph(query=...)` BM25 path excludes that node
 type. Its separate `search_code` verb can find literal source phrases, but the
-unchanged benchmark question is not a literal source pattern. The CMM column
-therefore reports that public route on an off-domain corpus and is not a claim
-about CMM's code-search quality.
+unchanged benchmark question is not a literal source pattern. That route
+retrieved nothing at all here: all 1,050 CMM cells returned a byte-identical
+empty context (24 bytes, zero hits), so the CMM QA percentages are the shared
+reader answering from the question alone. The CMM column therefore reports that
+public route on an off-domain corpus and is not a claim about CMM's code-search
+quality.
+
+**Holdout (tune-disjoint).** The 300 + 50 full set is not tune-disjoint: 35 of
+the 350 cases overlap the tune phase. The clean generalization estimate is the
+sealed holdout, where Entire Graph scored 75.6% LOCOMO QA accuracy and 0.900
+recall@10 (n=30; the LongMemEval-S holdout is n=5).
 
 All 3,150 raw cells, 3,150 blinded primary grades, and 630 fixed audit cells
 passed the sealed integrity gates. The Opus audit agreed with the primary judge
 on 98.41% of cells (Cohen's kappa 0.9682), and there were zero invalid attempts.
 Across all 350 paired memory cases, Entire minus Graphify semantic accuracy was
-+0.1648 (cluster 95% CI +0.1034 to +0.2146; McNemar p=1.70e-11).
++0.1648 (95% CI +0.1034 to +0.2146, a bootstrap clustered by conversation over
+10 effective LOCOMO clusters; McNemar p=1.70e-11).
 
 This is a **public-protocol reimplementation**, not a reproduction of
 Graphify's historical README run: Graphify's advertised memory harness and

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -13,7 +13,15 @@ LOCOMO QA accuracy, and 76.0% vs. 68.0% on LongMemEval-S QA accuracy. All
 systems used zero build-time LLM credits. Codebase Memory MCP is present in the
 release as an off-domain native diagnostic: v0.9.0 indexes the Markdown content
 as `Section` nodes but excludes that node type from its public natural-language
-BM25 route, so its column is not a third apples-to-apples memory comparison.
+BM25 route, so its column is not a third apples-to-apples memory comparison. On
+that route it retrieved nothing at all — all 1,050 CMM cells returned a
+byte-identical empty context (24 bytes, zero hits), so its QA number is the
+shared reader answering from the question alone.
+
+Those 300 + 50 cases are not tune-disjoint: 35 of the 350 overlap the tune
+phase. The tune-disjoint holdout is the clean generalization estimate — Entire
+Graph scored 75.6% LOCOMO QA accuracy and 0.900 recall@10 on it (n=30; the
+LongMemEval-S holdout is n=5).
 
 The product under test is commit
 `c9641bf1caaf41d64ce8a4a421f041939feecca3`. Its native JSON result contains a


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/39
<!-- entire-trail-link-end -->

Precision follow-up to the v52 documentation in #84. Two facts established by offline
recomputation of the `memory-native-v52` raw cells are not currently disclosed next to the
tables, and both change how the numbers should be quoted.

**CMM's column is literally zero retrieval.** The existing footnote already explains that
CMM v0.9.0 indexes the conversations as `Section` nodes and that its public natural-language
BM25 route excludes that node type. What it does not say is the consequence: on that route all
1,050 CMM cells returned a byte-identical empty context (24 bytes, zero hits). The CMM QA
percentages are therefore the shared reader answering from the question alone, not a retrieval
score. One sentence added to the footnote in `README.md` and to the equivalent prose in
`docs/benchmarks.md`.

**The 300 + 50 full set is not tune-disjoint.** 35 of the 350 cases overlap the tune phase, so
the headline figures are not a clean generalization estimate. The sealed holdout is: 75.6%
LOCOMO QA accuracy and 0.900 recall@10 at n=30 (the LongMemEval-S holdout is n=5). Added beside
the full numbers in both files with the n visible, so a reader quoting the table can see which
number answers which question.

No numbers are changed or removed; this only adds the qualifiers that make the existing ones
safe to quote.
