### PR TITLE
Disable persisted checkout credentials

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with: { go-version: "1.24.x" }
       - run: go vet ./...
@@ -31,6 +33,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with: { go-version: "1.24.x" }
       - run: go build ./...
@@ -42,6 +46,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with: { go-version: "1.24.x" }
       - run: go test ./...
@@ -55,6 +61,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with: { go-version: "1.24.x" }
       - run: go build -o entire-graph ./cmd/entire-graph


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/47
<!-- entire-trail-link-end -->

## Summary

- Configure all four `actions/checkout@v6` steps with `persist-credentials: false`.
- Prevent the workflow's default `GITHUB_TOKEN` from remaining in the repository's local Git configuration.

## Why

`actions/checkout` persists its authentication token by default. Later workflow steps or compromised third-party actions could read that credential from Git configuration. Disabling credential persistence reduces that attack surface without changing expected behavior because these jobs do not perform subsequent authenticated Git operations.

## Validation

- `mise run check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f51d1ad9f6be1e3de7582e92fefb627445009c10. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->