### PR TITLE
fix(cache): stop unindexable untracked files disabling the search cache

### DIFF
--- a/internal/gitutil/worktree.go
+++ b/internal/gitutil/worktree.go
@@ -32,14 +32,61 @@ import (
 // `--no-optional-locks` keeps this read-only probe from refreshing the index
 // and so from contending with a concurrent git command in the same repo.
 func WorktreeMatchesHEAD(ctx context.Context, repo string) (bool, error) {
+	paths, err := WorktreeDirtyPaths(ctx, repo)
+	if err != nil {
+		return false, err
+	}
+	return len(paths) == 0, nil
+}
+
+// WorktreeDirtyPaths returns every repo-relative path that makes the working
+// tree differ from HEAD: modified, staged, deleted, renamed, unmerged, or
+// untracked-but-not-ignored. An empty slice means the two views are equal, so
+// WorktreeMatchesHEAD is exactly len(paths)==0.
+//
+// It exists so a caller can ask the sharper question "does anything that
+// differs actually affect what I build?". WorktreeMatchesHEAD answers only
+// "does anything differ at all", which disables a tree-keyed cache for a stray
+// .DS_Store or a compiled binary — files no indexer reads. The caller owns that
+// judgement because only it knows which paths it consumes; this function stays
+// purely factual.
+//
+// Both sides of a rename are reported, since a rename both removes the old path
+// and adds the new one.
+//
+// Ignored files are excluded (git omits them without --ignored), matching the
+// provider's working-tree walk, which honours .gitignore.
+func WorktreeDirtyPaths(ctx context.Context, repo string) ([]string, error) {
 	// A repository with no commits has no HEAD tree to be equal to.
 	if _, err := RevParse(ctx, repo, "HEAD"); err != nil {
-		return false, err
+		return nil, err
 	}
 	out, err := run(ctx, repo, "git",
 		"--no-optional-locks", "status", "--porcelain", "--untracked-files=all", "-z")
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	return strings.Trim(out, "\x00\n\r \t") == "", nil
+	// -z emits NUL-terminated records "XY <path>". A rename or copy spends a
+	// SECOND record on its source path, with no status prefix of its own, so it
+	// must be consumed alongside the entry that introduced it rather than parsed
+	// as a malformed status line.
+	fields := strings.Split(out, "\x00")
+	paths := make([]string, 0, len(fields))
+	for i := 0; i < len(fields); i++ {
+		field := fields[i]
+		if len(field) < 4 || field[2] != ' ' {
+			continue
+		}
+		status, path := field[:2], field[3:]
+		if path != "" {
+			paths = append(paths, path)
+		}
+		if strings.ContainsAny(status, "RC") && i+1 < len(fields) {
+			i++
+			if source := fields[i]; source != "" {
+				paths = append(paths, source)
+			}
+		}
+	}
+	return paths, nil
 }

--- a/internal/gitutil/worktree_test.go
+++ b/internal/gitutil/worktree_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 )
 
@@ -137,5 +138,88 @@ func TestWorktreeMatchesHEADErrorsWithoutCommittedHEAD(t *testing.T) {
 	plain := t.TempDir()
 	if clean, err := WorktreeMatchesHEAD(context.Background(), plain); err == nil || clean {
 		t.Fatalf("non-repo = (%v, %v), want (false, error)", clean, err)
+	}
+}
+
+// WorktreeDirtyPaths is the factual half of the cleanliness question: it must
+// name every path that diverges, so a caller can decide which of them it
+// actually reads. A rename spends two records in porcelain -z output and must
+// yield BOTH paths, not a phantom entry parsed out of the source field.
+func TestWorktreeDirtyPaths(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		mutate func(t *testing.T, repo string)
+		want   []string
+	}{
+		{
+			name:   "clean tree reports nothing",
+			mutate: func(*testing.T, string) {},
+			want:   nil,
+		},
+		{
+			name: "untracked file is reported",
+			mutate: func(t *testing.T, repo string) {
+				if err := os.WriteFile(filepath.Join(repo, ".DS_Store"), []byte("\x00"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: []string{".DS_Store"},
+		},
+		{
+			name: "modified tracked file is reported",
+			mutate: func(t *testing.T, repo string) {
+				if err := os.WriteFile(filepath.Join(repo, "app.go"), []byte("package app\n\nfunc Run() { println(1) }\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: []string{"app.go"},
+		},
+		{
+			name: "rename reports both destination and source",
+			mutate: func(t *testing.T, repo string) {
+				git(t, repo, "mv", "app.go", "moved.go")
+			},
+			want: []string{"app.go", "moved.go"},
+		},
+		{
+			name: "ignored file is not reported",
+			mutate: func(t *testing.T, repo string) {
+				if err := os.WriteFile(filepath.Join(repo, "build.log"), []byte("noise\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			repo := newWorktreeRepo(t)
+			tc.mutate(t, repo)
+			got, err := WorktreeDirtyPaths(context.Background(), repo)
+			if err != nil {
+				t.Fatalf("WorktreeDirtyPaths: %v", err)
+			}
+			sort.Strings(got)
+			want := append([]string(nil), tc.want...)
+			sort.Strings(want)
+			if len(got) != len(want) {
+				t.Fatalf("paths = %q, want %q", got, want)
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("paths = %q, want %q", got, want)
+				}
+			}
+			// The bool wrapper must stay exactly len(paths)==0.
+			clean, err := WorktreeMatchesHEAD(context.Background(), repo)
+			if err != nil {
+				t.Fatalf("WorktreeMatchesHEAD: %v", err)
+			}
+			if clean != (len(got) == 0) {
+				t.Fatalf("WorktreeMatchesHEAD = %v with dirty paths %q", clean, got)
+			}
+		})
 	}
 }

--- a/internal/gitutil/worktree_test.go
+++ b/internal/gitutil/worktree_test.go
@@ -14,6 +14,16 @@ func newWorktreeRepo(t *testing.T) string {
 	git(t, repo, "init")
 	git(t, repo, "config", "user.name", "Entire Graph Test")
 	git(t, repo, "config", "user.email", "graph@example.com")
+	// Point core.excludesFile at an empty file OUTSIDE the repo. These cases assert exactly which
+	// paths git reports as dirty, and the developer's global ignore is part of that answer: the
+	// stock macOS one lists .DS_Store, which is the fixture the untracked case uses, so without
+	// this the suite is green in CI (runners have no global ignore) and red on the machine of
+	// anyone who followed GitHub's own macOS .gitignore advice.
+	excludes := filepath.Join(t.TempDir(), "empty-global-excludes")
+	if err := os.WriteFile(excludes, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "config", "core.excludesFile", excludes)
 	if err := os.WriteFile(filepath.Join(repo, ".gitignore"), []byte("ignored/\n*.log\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -10567,6 +10567,34 @@ type pythonPackageDirMapping struct {
 	Dir     string
 }
 
+// manifestImportFiles are the repo-root manifests whose CONTENT buildManifestImportResolver reads
+// to resolve imports. They are listed separately because a caller deciding whether a working-tree
+// change can be ignored cannot answer that from the file extension alone: go.mod and setup.cfg
+// carry no supported extension, yet editing either changes how every import in the repository
+// resolves. Keep this in sync with the readContent calls below — TestManifestImportFilesCoverReads
+// fails if they drift.
+var manifestImportFiles = []string{
+	"go.mod",
+	"package.json",
+	"tsconfig.json",
+	"pyproject.toml",
+	"setup.cfg",
+	"Cargo.toml",
+	"composer.json",
+	"pom.xml",
+}
+
+// isManifestImportFile reports whether a repo-relative path is one of those manifests.
+func isManifestImportFile(path string) bool {
+	slashed := filepath.ToSlash(path)
+	for _, manifest := range manifestImportFiles {
+		if slashed == manifest {
+			return true
+		}
+	}
+	return false
+}
+
 func buildManifestImportResolver(files []FileRecord, readContent contentReader) manifestImportResolver {
 	resolver := manifestImportResolver{goPackages: map[string]string{}, jsPackageExports: map[string]string{}, jsPackageImports: map[string]string{}, jsImportMap: map[string]string{}, jsModuleFiles: map[string]string{}, pythonSourceRoots: []string{"src"}, pythonModules: map[string]string{}, pythonNamespaces: map[string]bool{}, jvmTypes: map[string]string{}, jvmTypeEvidence: map[string]string{}, csharpNamespaces: map[string]string{}, csharpEvidence: map[string]string{}, csharpAmbiguous: map[string]bool{}, phpTypes: map[string]string{}, phpTypeEvidence: map[string]string{}, phpTypeAmbiguous: map[string]bool{}, rustModules: map[string]string{}, rustAliases: map[string]string{}, rustCrateNames: map[string]bool{}}
 	if content, ok := readContent("go.mod"); ok {

--- a/internal/sem/search_cache.go
+++ b/internal/sem/search_cache.go
@@ -115,12 +115,23 @@ func absOrRepo(repo string) string {
 // a relation cannot make a snapshot stale either, so it is not a reason to throw
 // one away.
 //
-// The test is extensionUnsupported, the same predicate the indexer uses to skip
-// a file, so the two can never disagree about what is read. It is deliberately
-// conservative in the safe direction: an extensionless path counts as
-// supported, because a shebang can make it a script, and any supported path
-// still bypasses the cache whatever its status. Only .gitignore'd files are out
-// of scope entirely — git omits them, matching the provider's walk.
+// The test is extensionUnsupported, which is what the indexer uses to decide whether to PARSE a
+// file — but parsing is not the only way a file reaches the graph. buildManifestImportResolver
+// also reads the CONTENT of the repo-root manifests, and two of those (go.mod, setup.cfg) carry
+// no supported extension while deciding how every import in the repository resolves. Forgiving
+// them served a snapshot whose call edges were still resolved against the previous module path.
+// They are excluded by name through isManifestImportFile, and TestManifestImportFilesCoverReads
+// fails if that list falls behind the manifests actually read.
+//
+// Otherwise the rule is deliberately conservative in the safe direction: an extensionless path
+// counts as supported, because a shebang can make it a script, and any supported path still
+// bypasses the cache whatever its status.
+//
+// Ignored files never reach this loop: git status omits them, and the provider's walk skips them
+// too, so neither side can serve what the other would have indexed. Note the two do not agree in
+// general — git never ignores a TRACKED file, while the walk applies the ignore stack to every
+// path — but that disagreement only ever reports a path as dirty that the walk would have
+// skipped, which costs a re-index and cannot serve a stale one.
 func worktreeSnapshotCacheable(ctx context.Context, absRepo string, options ProviderSnapshotOptions) bool {
 	if !options.Worktree {
 		return true
@@ -137,7 +148,7 @@ func worktreeSnapshotCacheable(ctx context.Context, absRepo string, options Prov
 		clean = false
 	}
 	for _, path := range dirty {
-		if !extensionUnsupported(path) {
+		if !extensionUnsupported(path) || isManifestImportFile(path) {
 			clean = false
 			break
 		}

--- a/internal/sem/search_cache.go
+++ b/internal/sem/search_cache.go
@@ -101,12 +101,26 @@ func absOrRepo(repo string) string {
 // and stored in, the tree-keyed snapshot cache.
 //
 // Committed-tree snapshots always could. A working-tree snapshot may too, but
-// only while the working tree is byte-identical to HEAD: then the tree hash
-// names its content exactly, which is the whole premise of the cache key. This
-// is what makes the relation verbs (neighbors/impact, which index the whole
-// repository) warm on their second call instead of re-indexing from scratch —
-// and it never hides a dirty edit, because a dirty tree fails the check and
-// bypasses the cache exactly as before.
+// only while the working tree's INDEXABLE content is identical to HEAD: then the
+// tree hash names that content exactly, which is the whole premise of the cache
+// key. This is what makes the relation verbs (neighbors/impact, which index the
+// whole repository) warm on their second call instead of re-indexing from
+// scratch — and it never hides a dirty edit, because a dirty indexable file
+// fails the check and bypasses the cache exactly as before.
+//
+// "Indexable" is the load-bearing word. Requiring a wholly pristine tree made a
+// stray untracked file that no parser ever opens — .DS_Store, a compiled binary,
+// a log, an editor swap file — disable the cache for the entire repository, so
+// every query re-indexed from scratch. A path that cannot contribute a symbol or
+// a relation cannot make a snapshot stale either, so it is not a reason to throw
+// one away.
+//
+// The test is extensionUnsupported, the same predicate the indexer uses to skip
+// a file, so the two can never disagree about what is read. It is deliberately
+// conservative in the safe direction: an extensionless path counts as
+// supported, because a shebang can make it a script, and any supported path
+// still bypasses the cache whatever its status. Only .gitignore'd files are out
+// of scope entirely — git omits them, matching the provider's walk.
 func worktreeSnapshotCacheable(ctx context.Context, absRepo string, options ProviderSnapshotOptions) bool {
 	if !options.Worktree {
 		return true
@@ -117,9 +131,16 @@ func worktreeSnapshotCacheable(ctx context.Context, absRepo string, options Prov
 			return verdict.clean
 		}
 	}
-	clean, err := gitutil.WorktreeMatchesHEAD(ctx, absRepo)
+	clean := true
+	dirty, err := gitutil.WorktreeDirtyPaths(ctx, absRepo)
 	if err != nil {
 		clean = false
+	}
+	for _, path := range dirty {
+		if !extensionUnsupported(path) {
+			clean = false
+			break
+		}
 	}
 	worktreeCleanVerdicts.Store(absRepo, worktreeCleanVerdict{clean: clean, checkedAt: time.Now()})
 	return clean

--- a/internal/sem/search_cache_worktree_test.go
+++ b/internal/sem/search_cache_worktree_test.go
@@ -177,3 +177,76 @@ func hasSymbolNamed(symbols []SymbolRecord, name string) bool {
 	}
 	return false
 }
+
+// The complement of the test above: a file no parser ever opens cannot change a
+// snapshot, so its presence must NOT throw the index away. Before this, a single
+// .DS_Store or a compiled binary in the tree made every query re-index the whole
+// repository from scratch.
+func TestWorktreeSnapshotStillCachesWithUnindexableUntrackedFiles(t *testing.T) {
+	repo := cacheTestRepo(t)
+	cacheDir := t.TempDir()
+	options := ProviderSnapshotOptions{Worktree: true, Profile: ProfileFull, NoNetwork: true}
+
+	first, _, err := LoadOrBuildProviderSnapshot(context.Background(), repo, "test", options, cacheDir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Every name here must carry an extension that maps to no language.
+	// An EXTENSIONLESS path stays conservative on purpose (a shebang can make it
+	// a script), so it keeps bypassing the cache — see the sibling assertion below.
+	for name, content := range map[string]string{
+		".DS_Store":           "\x00\x00binary junk",
+		"entire-graph.bin":    "\x7fELF not source",
+		"build.output.tar.gz": "\x1f\x8b",
+		"notes.swp":           "vim swap",
+	} {
+		if err := os.WriteFile(filepath.Join(repo, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	InvalidateWorktreeCleanVerdicts()
+	second, hit, err := LoadOrBuildProviderSnapshot(context.Background(), repo, "test", options, cacheDir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hit {
+		t.Fatal("unindexable untracked files disabled the cache")
+	}
+	if len(second.Symbols) != len(first.Symbols) {
+		t.Fatalf("cached snapshot differs: %d symbols vs %d", len(second.Symbols), len(first.Symbols))
+	}
+
+	// An extensionless untracked file stays conservative: a shebang can make it a
+	// script, so the graph must assume it is indexable and skip the cache.
+	if err := os.WriteFile(filepath.Join(repo, "somebinary"), []byte("\x7fELF"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	InvalidateWorktreeCleanVerdicts()
+	if _, hit, err := LoadOrBuildProviderSnapshot(context.Background(), repo, "test", options, cacheDir, false); err != nil {
+		t.Fatal(err)
+	} else if hit {
+		t.Fatal("extensionless untracked file was forgiven; shebang scripts would be missed")
+	}
+	if err := os.Remove(filepath.Join(repo, "somebinary")); err != nil {
+		t.Fatal(err)
+	}
+	InvalidateWorktreeCleanVerdicts()
+
+	// Adding ONE indexable untracked file alongside them must still bypass: the
+	// forgiveness is per-path, not a blanket "ignore untracked".
+	if err := os.WriteFile(filepath.Join(repo, "extra.go"), []byte("package app\n\nfunc Extra() { Beta() }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	InvalidateWorktreeCleanVerdicts()
+	third, hit, err := LoadOrBuildProviderSnapshot(context.Background(), repo, "test", options, cacheDir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hit {
+		t.Fatal("an indexable untracked file was hidden by a cached index")
+	}
+	if !hasSymbolNamed(third.Symbols, "Extra") {
+		t.Fatal("indexable untracked file was not indexed")
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/44
<!-- entire-trail-link-end -->

## What

`worktreeSnapshotCacheable` required a **wholly pristine** working tree before it would reuse a tree-keyed index. It asked `WorktreeMatchesHEAD`, which is a plain `git status --porcelain --untracked-files=all` compared against empty output. So a single file no parser ever opens — a `.DS_Store`, a compiled binary, a log, an editor swap file — disabled the search cache for the **entire repository**, and every query re-indexed from scratch.

A path that cannot contribute a symbol or a relation cannot make a snapshot stale, so it is not a reason to throw one away.

## Measured, on this repo

```
with a .DS_Store present
  run 1: cache_hit=False  index_ms=3704   total_ms=4480
  run 2: cache_hit=True   index_ms=131    total_ms=908
  run 3: cache_hit=True   index_ms=126    total_ms=887

control, untracked .go present (must NOT cache)
  run 1: cache_hit=False  index_ms=3598
  run 2: cache_hit=False  index_ms=3675
```

28x on index latency, 5x on total, and the control still bypasses correctly. Before the change the first case behaved like the control: never cached. On the working checkout this was `index_cache_hit=false` with `index_latency_ms=9062` on a back-to-back repeat of the same query.

## How

- `gitutil` gains **`WorktreeDirtyPaths`**, the factual list of paths that diverge from HEAD. `WorktreeMatchesHEAD` becomes `len(paths)==0` and keeps its exact contract, so its existing callers and tests are unaffected. Both sides of a rename are reported, since porcelain `-z` spends a second record on the source path and that record has no status prefix of its own.
- `worktreeSnapshotCacheable` forgives a dirty path only when **`extensionUnsupported`** says so — the same predicate the indexer uses to skip a file, so the two cannot disagree about what is read.

## Why this is safe

- **Conservative on extensionless paths.** `extensionUnsupported` treats them as supported, because a shebang can make one a script. A stray binary named `entire-graph` (no extension) therefore still bypasses the cache. That is deliberate, and asserted in a test.
- **Per-path, not a blanket "ignore untracked".** One indexable untracked file still bypasses, even alongside four unindexable ones.
- **`.gitignore` edits are not forgiven at all.** `.gitignore` maps to a recognized language, so `extensionUnsupported` returns false and it bypasses the cache like any other supported path. (This bullet previously argued the edit *was* forgiven and safe, on the grounds that ignore rules only affect untracked files. That reasoning was wrong — `walkWorktreeFiles` applies the nested ignore stack to tracked files too — but it was also moot, since the case never arises.)
- **Ignored files were already out of scope** — git omits them without `--ignored`, and the provider's walk skips them too. The two do not correspond exactly (git never ignores a *tracked* file, while the walk applies the ignore stack to every path), but that gap only ever reports a path as dirty that the walk would have skipped: it costs a re-index, it cannot serve a stale snapshot.

## Tests

- `TestWorktreeDirtyPaths` — clean / untracked / modified / **renamed (both paths)** / ignored, and asserts `WorktreeMatchesHEAD == (len(paths)==0)` in every case.
- `TestWorktreeSnapshotStillCachesWithUnindexableUntrackedFiles` — four unindexable untracked files keep the cache warm with an **identical symbol set**; an extensionless file still bypasses; an untracked `.go` still bypasses and is still indexed.
- The pre-existing `TestWorktreeSnapshotBypassesCacheForUntrackedFiles` (untracked `.go`) is unchanged and still passes.

`gofmt` clean, `go vet` clean, `go build ./...` clean, full `./internal/gitutil` and `./internal/sem` suites pass.

## Context

Found while measuring entire-graph's wall-clock cost on a benchmark: across 1,175 paired agent sessions the graph arm ran **7.9% slower** than the no-tool arm (127.0 h vs 117.7 h) while saving tokens. A never-hitting index cache is one contributor — an agent's checkout almost always has some untracked scratch file in it, so in practice the cache was off far more often than intended.


---

## Follow-up review commit (b189cdf)

Two defects found while reviewing, both fixed on this branch; the change's own win is unaffected (`.DS_Store`/`.log`/`.o` still keep the cache warm, an untracked `.go` still bypasses it).

**1. Two manifests are read by the indexer but forgiven by the gate.** `extensionUnsupported` decides whether a file is *parsed*, and parsing is not the only way a file reaches the graph — `buildManifestImportResolver` also reads the *content* of the repo-root manifests. Two of them, `go.mod` and `setup.cfg`, carry no supported extension yet decide how every import resolves. Reproduced with a module rename as the only dirty change:

```
before: Index: cache-hit   Callers: - main (main.go:5) [import_resolved]   <- stale
after:  Index: cache-miss  Callers: - none                                  <- correct
```

Fixed via `manifestImportFiles` / `isManifestImportFile`, with `TestManifestImportFilesCoverReads` walking `buildManifestImportResolver`'s AST for `readContent` literals so the list cannot fall behind.

**2. `TestWorktreeDirtyPaths` could not pass on a stock macOS checkout.** `newWorktreeRepo` left `core.excludesFile` alone, so `git status` honoured the developer's global ignore — which lists `.DS_Store`, the fixture the untracked case asserts on. Green on CI runners (no global ignore), red locally. The fixture now points `core.excludesFile` at an empty file outside the repo, making all five subtests hermetic.

The doc comment on `worktreeSnapshotCacheable` was rewritten to drop the "same predicate ... can never disagree" claim that led to the first defect.
