### PR TITLE
chore: move to Go 1.26

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
-        with: { go-version: "1.24.x" }
+        with: { go-version: "1.26.x" }
       - run: go vet ./...
       - run: |
           unformatted=$(gofmt -l -s .)
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
-        with: { go-version: "1.24.x" }
+        with: { go-version: "1.26.x" }
       - run: go build ./...
 
   test:
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
-        with: { go-version: "1.24.x" }
+        with: { go-version: "1.26.x" }
       - run: go test ./...
 
   # The status line is a POSIX shell script with its own shell suite; `go test` never runs it.
@@ -56,6 +56,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
-        with: { go-version: "1.24.x" }
+        with: { go-version: "1.26.x" }
       - run: go build -o entire-graph ./cmd/entire-graph
       - run: sh scripts/entire-graph-statusline_test.sh

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/entireio/entire-graph
 
-go 1.24
+go 1.26
 
 require github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = { version = "1.24" }
+go = { version = "1.26" }
 
 [tasks.fmt]
 description = "Run gofmt"


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/45
<!-- entire-trail-link-end -->

## What

The repo pinned Go **1.24** in three places. This bumps all of them together so the dev toolchain, the module language version and CI cannot drift apart.

```
go.mod                      go 1.24  ->  go 1.26
mise.toml                   1.24     ->  1.26
.github/workflows/test.yml  1.24.x   ->  1.26.x   (4 occurrences)
```

1.26.5 is the current stable release.

## Verified against go1.26.5

This matters more than a usual version bump because the provider builds tree-sitter grammars through **CGO**, so a toolchain change can break the C side rather than the Go side. I ran the repo's own gate rather than assuming:

```
go build ./...        ok
go vet ./...          clean
gofmt -l              clean
go test ./...         every package ok   (internal/sem 59.951s)
go test -race ./...   every package ok   (internal/sem 171.896s)
```

## One compatibility note

Raising the `go` directive to 1.26 raises the module's **minimum toolchain**, so anything vendoring this as a library needs 1.26 as well. That is the intent here since the plugin ships as a binary, but it is a real edge and worth stating in review rather than discovering downstream. If you'd rather keep the floor low, the alternative is leaving `go 1.24` in go.mod and adding `toolchain go1.26.5` — say the word and I'll switch it.

## Relationship to #92

Independent. #92 is a search-cache fix in `internal/sem` / `internal/gitutil`; this touches only version pins. They rebase cleanly in either order.