### PR TITLE
fix(cli): reject unknown diff flags instead of filing them as paths

### DIFF
--- a/internal/cli/agentguide_test.go
+++ b/internal/cli/agentguide_test.go
@@ -316,6 +316,9 @@ func parserAcceptsFlag(command, flag string) (accepted, reachable bool) {
 	case "def":
 		_, err := parseDefFlags([]string{"contract-test", flag})
 		return parserRecognizedStrictFlag(err), true
+	case "diff", "analyze":
+		_, unknown, err := parseDiffFlags([]string{flag})
+		return err != nil || len(unknown) == 0, true
 	case "capabilities":
 		// capabilities has no flag parser: runCapabilities IS its argument validator, and it
 		// is side-effect-free apart from the JSON it encodes, so calling it with the discard

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -696,39 +696,87 @@ func runAnalyze(ctx context.Context, opts Options, args []string) error {
 	return runDiff(ctx, opts, args)
 }
 
-func runDiff(ctx context.Context, opts Options, args []string) error {
-	flags, rest, err := parseCommonFlags(args)
-	if err != nil {
-		return err
+// diffFlags is the parsed argument set for `diff` and its `analyze` alias.
+type diffFlags struct {
+	common commonFlags
+	base   string
+	head   string
+	paths  []string
+}
+
+// parseDiffFlags parses `diff`/`analyze` arguments, returning any flag-shaped argument it does
+// not recognize separately from the path filters, so the caller can reject it the way every
+// other verb does.
+//
+// Separating the two is the point. The parsing used to live inline in runDiff, whose default
+// branch filed EVERY unrecognized token under paths — so `diff --jsonn` exited 0 having filtered
+// the diff to a path that does not exist, and printed "No semantic entity changes detected". A
+// mistyped flag was answered with a confident empty result, which for a verb whose whole job is
+// telling you what changed is the worst possible way to be wrong.
+//
+// Paths that genuinely look like flags still work: that is what the documented `-- path...`
+// separator is for.
+func parseDiffFlags(args []string) (diffFlags, []string, error) {
+	parsed := diffFlags{base: "HEAD~1", head: "HEAD"}
+
+	// Split on `--` here rather than letting parseCommonFlags consume it: that function flattens
+	// everything after the separator into rest, which would leave a literal path named `--base`
+	// indistinguishable from the real flag.
+	flagArgs, literalPaths := args, []string(nil)
+	for i, arg := range args {
+		if arg == "--" {
+			flagArgs, literalPaths = args[:i], args[i+1:]
+			break
+		}
 	}
 
-	base := "HEAD~1"
-	head := "HEAD"
-	var paths []string
+	common, rest, err := parseCommonFlags(flagArgs)
+	if err != nil {
+		return diffFlags{}, nil, err
+	}
+	parsed.common = common
+
+	var unknown []string
 	for i := 0; i < len(rest); i++ {
 		switch rest[i] {
 		case "--base":
 			i++
 			if i >= len(rest) {
-				return errors.New("--base requires a value")
+				return diffFlags{}, nil, errors.New("--base requires a value")
 			}
-			base = rest[i]
+			parsed.base = rest[i]
 		case "--head":
 			i++
 			if i >= len(rest) {
-				return errors.New("--head requires a value")
+				return diffFlags{}, nil, errors.New("--head requires a value")
 			}
-			head = rest[i]
+			parsed.head = rest[i]
 		default:
-			paths = append(paths, rest[i])
+			if strings.HasPrefix(rest[i], "-") && rest[i] != "-" {
+				unknown = append(unknown, rest[i])
+				continue
+			}
+			parsed.paths = append(parsed.paths, rest[i])
 		}
 	}
+	parsed.paths = append(parsed.paths, literalPaths...)
+	return parsed, unknown, nil
+}
 
-	repo, err := resolveRepo(ctx, opts.Env, flags.Repo)
+func runDiff(ctx context.Context, opts Options, args []string) error {
+	parsed, unknown, err := parseDiffFlags(args)
 	if err != nil {
 		return err
 	}
-	return analyzeAndPrint(ctx, opts, repo, base, head, paths, flags)
+	if len(unknown) != 0 {
+		return unexpectedArgumentsError("diff", opts.Version, unknown)
+	}
+
+	repo, err := resolveRepo(ctx, opts.Env, parsed.common.Repo)
+	if err != nil {
+		return err
+	}
+	return analyzeAndPrint(ctx, opts, repo, parsed.base, parsed.head, parsed.paths, parsed.common)
 }
 
 func resolveRepo(ctx context.Context, env EntireEnv, explicit string) (string, error) {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -994,3 +994,99 @@ func TestMaxSecondsFlagValidation(t *testing.T) {
 		t.Fatalf("checkpoint must reject --max-seconds, got %v", err)
 	}
 }
+
+func TestParseDiffFlagsSeparatesUnknownFlagsFromPaths(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		base    string
+		head    string
+		paths   []string
+		unknown []string
+		json    bool
+	}{
+		{name: "defaults", args: nil, base: "HEAD~1", head: "HEAD"},
+		{
+			name: "base and head",
+			args: []string{"--base", "main", "--head", "HEAD"},
+			base: "main", head: "HEAD",
+		},
+		{
+			name: "bare paths stay paths",
+			args: []string{"--base", "main", "internal/cli", "README.md"},
+			base: "main", head: "HEAD",
+			paths: []string{"internal/cli", "README.md"},
+		},
+		{
+			name: "common flags still parse",
+			args: []string{"--json", "--base", "main"},
+			base: "main", head: "HEAD", json: true,
+		},
+		{
+			// The regression this parser exists for: an unrecognized flag used to be filed
+			// under paths, so the command exited 0 reporting no changes.
+			name: "typo'd flag is unknown, not a path",
+			args: []string{"--base", "main", "--jsonn"},
+			base: "main", head: "HEAD",
+			unknown: []string{"--jsonn"},
+		},
+		{
+			// After `--` a flag-shaped argument is a path again, which is what the separator
+			// is documented to be for.
+			name: "separator makes flag-shaped args literal paths",
+			args: []string{"--base", "main", "--", "--weird-path", "-x"},
+			base: "main", head: "HEAD",
+			paths: []string{"--weird-path", "-x"},
+		},
+		{
+			name: "separator protects a path named like a real flag",
+			args: []string{"--", "--base"},
+			base: "HEAD~1", head: "HEAD",
+			paths: []string{"--base"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parsed, unknown, err := parseDiffFlags(test.args)
+			if err != nil {
+				t.Fatalf("parseDiffFlags(%q): %v", test.args, err)
+			}
+			if parsed.base != test.base || parsed.head != test.head {
+				t.Errorf("base/head = %q/%q, want %q/%q", parsed.base, parsed.head, test.base, test.head)
+			}
+			if !reflect.DeepEqual(parsed.paths, test.paths) {
+				t.Errorf("paths = %#v, want %#v", parsed.paths, test.paths)
+			}
+			if !reflect.DeepEqual(unknown, test.unknown) {
+				t.Errorf("unknown = %#v, want %#v", unknown, test.unknown)
+			}
+			if parsed.common.JSON != test.json {
+				t.Errorf("JSON = %v, want %v", parsed.common.JSON, test.json)
+			}
+		})
+	}
+}
+
+func TestParseDiffFlagsRequiresRevisionValues(t *testing.T) {
+	for _, flag := range []string{"--base", "--head"} {
+		if _, _, err := parseDiffFlags([]string{flag}); err == nil {
+			t.Errorf("parseDiffFlags(%q) succeeded, want a requires-a-value error", flag)
+		}
+	}
+}
+
+// TestDiffRejectsUnknownFlag is the end-to-end half: before parseDiffFlags existed this exited 0
+// and printed an empty change list, so a mistyped flag looked like a clean diff.
+func TestDiffRejectsUnknownFlag(t *testing.T) {
+	repo := t.TempDir()
+	var out, errOut bytes.Buffer
+	opts := Options{Stdout: &out, Stderr: &errOut, Version: "test-version"}
+	err := runDiff(t.Context(), opts, []string{"--repo", repo, "--jsonn"})
+	if err == nil {
+		t.Fatal("runDiff accepted --jsonn; a typo'd flag must not be filed as a path")
+	}
+	if !strings.Contains(err.Error(), "--jsonn") {
+		t.Errorf("error %q does not name the offending flag", err)
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/46
<!-- entire-trail-link-end -->

The follow-up #87 deferred. Making `diff` reachable for the agent-guide contract test needed a real flag parser, and building one surfaced a live bug. Rebased onto `main` now that #87 has landed as 2b7ae47; targets `main` directly.

## The bug

`diff` parsed its arguments inline in `runDiff`, and the `default` branch of that loop filed **every** unrecognized token under `paths`. A mistyped flag became a path filter matching nothing:

```
$ entire graph diff --base HEAD~1 --head HEAD --jsonn
Semantic changes HEAD~1..HEAD

No semantic entity changes detected.
$ echo $?
0
```

Exit 0, no diagnostic, empty change list — from the one verb whose job is telling you what changed. The same typo silently downgraded `--json` to text output. `entire graph diff --bogus-flag` behaved identically.

After:

```
$ entire graph diff --base HEAD~1 --head HEAD --jsonn
diff does not accept --jsonn in entire-graph dev: this binary may be older than the
caller that built the command line; run "entire graph diff --help" for the flags it
does accept (unexpected: --jsonn)
$ echo $?
1
```

## The change

`parseDiffFlags` returns flag-shaped unknowns separately from path filters, so `runDiff` rejects them via the same `unexpectedArgumentsError` every other verb uses, with the version stamp those messages carry.

Paths that genuinely look like flags keep working. `parseDiffFlags` splits on `--` itself instead of letting `parseCommonFlags` flatten the separator away, so `diff -- --base` still means *the path named `--base`* — the previous code would have read it as the flag. Bare positional paths are unchanged.

## Why it is here

The extraction is what makes `diff` reachable for the agent-guide contract test, which is the follow-up #87 explicitly deferred. Measured:

| contract test | skipped parser checks before | after |
|---|---:|---:|
| shipped `agentGuide` const | 3 | **0** |
| `AGENTS.md` | 9 | **4** |

All 20 flag claims in the const are now checked against a real parser. The remaining 4 are `checkpoint`, `commit`, `doctor`, `version` — same missing-parser situation, same fix available, left alone here.

## Tests

- `TestParseDiffFlagsSeparatesUnknownFlagsFromPaths` — 7 cases: defaults, `--base`/`--head`, bare paths, common flags, the typo regression, and both `--` separator cases.
- `TestParseDiffFlagsRequiresRevisionValues` — `--base`/`--head` without a value.
- `TestDiffRejectsUnknownFlag` — end-to-end through `runDiff`; the error names the offending flag.

`gofmt -l -s` clean, `go vet ./...` clean, `go test ./...` green (6/6 packages).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 87cf5ceb889d4936be0b51591c459474a5d3310a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
