### PR TITLE
fix(cli): make repoRoot a boundary for call-site reads, not a prefix

### DIFF
--- a/internal/cli/callsite.go
+++ b/internal/cli/callsite.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -81,6 +82,20 @@ type lineReader func(relPath string) ([]string, bool)
 // newRepoLineReader reads files under repoRoot, memoizing per path so several
 // call sites in one file cost one read. It refuses oversized and NUL-bearing
 // files: neither can usefully be quoted.
+//
+// repoRoot is a boundary, not a prefix. Reads go through os.Root, so a relPath
+// containing `..`, an absolute path, or a component that is a symlink pointing
+// outside the tree cannot resolve to a file the caller did not mean to expose.
+// filepath.Join alone gave none of that: it happily normalizes `../secret` into
+// a path above the root, and os.Lstat only guarded the FINAL component, so an
+// intermediate symlink was followed by the subsequent read.
+//
+// Nothing reaches this with an untrusted relPath today — the three callers pass
+// paths from a snapshot this process built, and both snapshot sources omit
+// symlinks. That is a property of today's callers, held by nothing: the
+// signature takes any string, and this package already ships a verb that
+// ingests externally supplied snapshot records. Making the boundary structural
+// costs one syscall per distinct file and removes the question.
 func newRepoLineReader(repoRoot string) lineReader {
 	cache := map[string][]string{}
 	return func(relPath string) ([]string, bool) {
@@ -90,21 +105,46 @@ func newRepoLineReader(repoRoot string) lineReader {
 		if lines, ok := cache[relPath]; ok {
 			return lines, lines != nil
 		}
-		full := filepath.Join(repoRoot, filepath.FromSlash(relPath))
-		info, err := os.Lstat(full)
-		if err != nil || !info.Mode().IsRegular() || info.Size() > callSiteMaxFileBytes {
+		lines, ok := readRepoFileLines(repoRoot, relPath)
+		if !ok {
 			cache[relPath] = nil
 			return nil, false
 		}
-		content, err := os.ReadFile(full)
-		if err != nil || strings.IndexByte(string(content), 0) >= 0 {
-			cache[relPath] = nil
-			return nil, false
-		}
-		lines := strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n")
 		cache[relPath] = lines
 		return lines, true
 	}
+}
+
+// readRepoFileLines performs one contained read. It is separate from the memo so
+// the containment can be tested without reasoning about cache state.
+func readRepoFileLines(repoRoot, relPath string) ([]string, bool) {
+	root, err := os.OpenRoot(repoRoot)
+	if err != nil {
+		return nil, false
+	}
+	defer root.Close()
+
+	// Lstat before Open keeps the previous refusal of a symlinked final component,
+	// so containment is the only behavior this function changes. Root.Lstat does
+	// not traverse the link, and Root.Open would not leave the root anyway.
+	name := filepath.FromSlash(relPath)
+	info, err := root.Lstat(name)
+	if err != nil || !info.Mode().IsRegular() || info.Size() > callSiteMaxFileBytes {
+		return nil, false
+	}
+	file, err := root.Open(name)
+	if err != nil {
+		return nil, false
+	}
+	defer file.Close()
+
+	// Bound the read by the same ceiling rather than trusting the stat: the file
+	// can grow between the two calls.
+	content, err := io.ReadAll(io.LimitReader(file, callSiteMaxFileBytes+1))
+	if err != nil || int64(len(content)) > callSiteMaxFileBytes || bytes.IndexByte(content, 0) >= 0 {
+		return nil, false
+	}
+	return strings.Split(strings.ReplaceAll(string(content), "\r\n", "\n"), "\n"), true
 }
 
 // callEvidenceSpan extracts the caller-body span and the written call text from

--- a/internal/cli/callsite_test.go
+++ b/internal/cli/callsite_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -546,5 +548,93 @@ func TestCallEvidenceSpanReadsCallSiteEvidence(t *testing.T) {
 	}
 	if _, _, _, _, ok := callEvidenceSpan([]sem.Evidence{{Kind: "import", StartLine: 3}}); ok {
 		t.Fatal("callEvidenceSpan accepted non-call evidence")
+	}
+}
+
+// TestRepoLineReaderConfinesReadsToRepoRoot pins repoRoot as a boundary rather than a prefix.
+// Every case here READ SUCCESSFULLY before os.Root was introduced, because filepath.Join
+// normalizes `..` away and os.Lstat only guarded the final path component. Nothing feeds this
+// an untrusted relPath today; these assertions are what keep that from mattering.
+func TestRepoLineReaderConfinesReadsToRepoRoot(t *testing.T) {
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "repo")
+	outside := filepath.Join(parent, "outside")
+	for _, dir := range []string{repo, outside} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("SECRET\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "inside.go"), []byte("package a\n\nfunc A() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	read := newRepoLineReader(repo)
+
+	if lines, ok := read("inside.go"); !ok || len(lines) == 0 || lines[0] != "package a" {
+		t.Fatalf("ordinary in-repo read broke: lines=%q ok=%v", lines, ok)
+	}
+
+	for _, name := range []string{
+		"../outside/secret.txt",
+		"./../outside/secret.txt",
+		"sub/../../outside/secret.txt",
+		filepath.Join(outside, "secret.txt"),
+	} {
+		if lines, ok := read(name); ok {
+			t.Errorf("read(%q) escaped the repo root and returned %q", name, lines)
+		}
+	}
+}
+
+// TestRepoLineReaderRefusesSymlinkEscapes covers both halves: a symlinked FINAL component was
+// already refused by the Lstat check and must stay refused, while a symlinked INTERMEDIATE
+// component was silently followed by the read that came after it.
+func TestRepoLineReaderRefusesSymlinkEscapes(t *testing.T) {
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "repo")
+	outside := filepath.Join(parent, "outside")
+	for _, dir := range []string{repo, outside} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("SECRET\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join("..", "outside"), filepath.Join(repo, "escape")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := os.Symlink(filepath.Join("..", "outside", "secret.txt"), filepath.Join(repo, "direct.txt")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	read := newRepoLineReader(repo)
+	if lines, ok := read("escape/secret.txt"); ok {
+		t.Errorf("intermediate symlink was followed out of the repo: %q", lines)
+	}
+	if lines, ok := read("direct.txt"); ok {
+		t.Errorf("symlinked final component was read: %q", lines)
+	}
+}
+
+// TestRepoLineReaderKeepsSizeAndBinaryRefusals guards the behavior that already existed, since
+// the read now goes through a limit reader rather than os.ReadFile.
+func TestRepoLineReaderKeepsSizeAndBinaryRefusals(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "binary.go"), []byte("package a\x00\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "huge.go"), make([]byte, callSiteMaxFileBytes+1), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	read := newRepoLineReader(repo)
+	if _, ok := read("binary.go"); ok {
+		t.Error("NUL-bearing file was accepted")
+	}
+	if _, ok := read("huge.go"); ok {
+		t.Error("oversized file was accepted")
 	}
 }


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/48
<!-- entire-trail-link-end -->

Salvages the one worthwhile change from #89, which was closed. Rewritten rather than cherry-picked, and scoped to this single concern.

## What is wrong

`newRepoLineReader` resolves a relation's file path with `filepath.Join` and guards it with `os.Lstat`. Neither confines the read: `Join` normalizes `../outside/secret` into a path *above* the root, and `Lstat` inspects only the **final** component, so an intermediate symlink is followed by the `os.ReadFile` that comes after it.

Against the pre-change implementation, all four of these returned the file's contents:

```
read("../outside/secret.txt")         -> "SECRET"
read("./../outside/secret.txt")       -> "SECRET"
read("sub/../../outside/secret.txt")  -> "SECRET"
read("escape/secret.txt")             -> "SECRET"    (escape -> ../outside)
```

Absolute paths are neutralized, but only by `filepath.Join(root, "/abs")` concatenating rather than by any check.

## This is not a live vulnerability

The three callers — `impact`, `neighbors`, `symbolref` — pass paths from a snapshot this process built, and both snapshot sources omit symlinks. The working-tree walk skips symlink entries outright (`provider.go:10199`) and `WalkDir` does not descend into symlinked directories; the committed-tree path lists a symlink as a blob and emits nothing beneath it. Verified on a repository containing a symlinked directory pointing outside the tree:

```
worktree walk   -> paths: ['real/a.go']   under link/: NONE
committed tree  -> paths: ['real/a.go']   under link/: NONE
```

So nothing reaches this with an untrusted `relPath` today.

## Why fix it anyway

That safety is a property of *today's callers* and is held by nothing else — not the signature (`relPath string`), not a type, not a test. This package already ships a verb that ingests externally supplied snapshot records (`snapshot-query`, which currently only re-encodes them), and the documented downstream consumer of this NDJSON is a separate process. The day any caller feeds this a path it did not build, the reader is an arbitrary-file read, and nothing in the code would flag it.

Routing through `os.Root` makes the boundary structural: `..`, absolute paths and escaping symlinks are rejected by construction, so a future caller cannot reintroduce the hole by accident.

## What does not change

`Root.Lstat` before `Root.Open` preserves the existing refusal of a symlinked *final* component, so containment is the only behavioral difference. The size and NUL-byte refusals are preserved, now bounded by a limit reader rather than trusting a stat a growing file can outrun. `neighbors` output on this repository is byte-identical apart from its latency line, and call-site windows still render.

Cost is one extra syscall per **distinct** file; the per-path memo is unchanged, so several call sites in one file still cost one read.

## Tests

`TestRepoLineReaderConfinesReadsToRepoRoot`, `TestRepoLineReaderRefusesSymlinkEscapes`, `TestRepoLineReaderKeepsSizeAndBinaryRefusals` — each checked against the pre-change body to confirm they fail without the fix:

```
--- FAIL: TestRepoLineReaderConfinesReadsToRepoRoot
    read("../outside/secret.txt") escaped the repo root and returned ["SECRET" ""]
--- FAIL: TestRepoLineReaderRefusesSymlinkEscapes
    intermediate symlink was followed out of the repo: ["SECRET" ""]
```

`gofmt -l -s` clean, `go vet ./...` clean, `go test ./...` green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e0e8c40028a886198c6a582e1744e74ebe9fdd7d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->