### PR TITLE
fix: stop repository bytes reaching the terminal as control sequences

### DIFF
--- a/internal/cli/callsite.go
+++ b/internal/cli/callsite.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/entireio/entire-graph/internal/sem"
+	"github.com/entireio/entire-graph/internal/termsafe"
 )
 
 // A CALLS relation records, as evidence, the span of the CALLER'S BODY — not the
@@ -775,7 +776,9 @@ func renderCallContext(site *callSite) string {
 		windowLines++
 	}
 	if windowLines > 0 {
-		fmt.Fprintf(&builder, "  %s:%d-%d\n", site.FilePath, site.WindowStart, site.WindowEnd)
+		// The window's locator is one record per line; the source lines under it
+		// keep their own layout and are covered by the caller's wrapped writer.
+		fmt.Fprintf(&builder, "  %s:%d-%d\n", termsafe.Line(site.FilePath), site.WindowStart, site.WindowEnd)
 		builder.WriteString(window.String())
 	}
 	return builder.String()

--- a/internal/cli/completeness.go
+++ b/internal/cli/completeness.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/entireio/entire-graph/internal/sem"
+	"github.com/entireio/entire-graph/internal/termsafe"
 )
 
 // Completeness reporting is a valued feature and is not reduced here — every
@@ -197,14 +198,14 @@ func writeScopedCompletenessBlock(
 		if warning.FilePath == "" {
 			fmt.Fprintf(out, "- warning %s\n", warning.Code)
 		} else {
-			fmt.Fprintf(out, "- warning %s: %s\n", warning.Code, warning.FilePath)
+			fmt.Fprintf(out, "- warning %s: %s\n", warning.Code, termsafe.Line(warning.FilePath))
 		}
 	}
 	for _, failure := range scope.InScopeFailures {
 		if failure.FilePath == "" {
 			fmt.Fprintf(out, "- partial %s\n", failure.Code)
 		} else {
-			fmt.Fprintf(out, "- partial %s: %s\n", failure.Code, failure.FilePath)
+			fmt.Fprintf(out, "- partial %s: %s\n", failure.Code, termsafe.Line(failure.FilePath))
 		}
 	}
 	if omitted := scope.LanguageFailed - len(scope.InScopeFailures); omitted > 0 {

--- a/internal/cli/def.go
+++ b/internal/cli/def.go
@@ -939,9 +939,9 @@ func defFieldType(member defMember) string {
 func defRelatedLine(entries []defRelated, label string) string {
 	parts := make([]string, 0, len(entries))
 	for _, entry := range entries {
-		part := entry.Name
+		part := termsafe.Line(entry.Name)
 		if entry.FilePath != "" && entry.StartLine > 0 {
-			part += fmt.Sprintf(" (%s:%d)", entry.FilePath, entry.StartLine)
+			part += fmt.Sprintf(" (%s:%d)", termsafe.Line(entry.FilePath), entry.StartLine)
 		}
 		if entry.Relation != "" {
 			part += " [" + strings.ToLower(entry.Relation) + "]"

--- a/internal/cli/def.go
+++ b/internal/cli/def.go
@@ -13,6 +13,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/entireio/entire-graph/internal/sem"
+	"github.com/entireio/entire-graph/internal/termsafe"
 )
 
 // `def` — a structural declaration lookup
@@ -771,6 +772,10 @@ func defDedupRelated(entries []defRelated) []defRelated {
 // lists shrink before anything structural is dropped, because the identity line
 // and the owner are the two things a caller cannot reconstruct themselves.
 func writeDefText(out io.Writer, response defResponse, budget int) error {
+	// The card prints whole source lines through writeNumberedSource, which reads
+	// them off the scanned repository unchanged. Wrapped here so the declaration
+	// headers and the bodies are both covered.
+	out = termsafe.NewWriter(out)
 	body := renderDefText(response, defaultDefMemberLimit)
 	if budget > 0 && len(body) > budget {
 		for _, limit := range []int{8, 5, 3, 1, 0} {

--- a/internal/cli/def.go
+++ b/internal/cli/def.go
@@ -823,17 +823,17 @@ func renderDefText(response defResponse, limit int) []byte {
 }
 
 func writeDefDeclarationText(buffer *strings.Builder, declaration defDeclaration, limit int) {
-	fmt.Fprintf(buffer, "%s:%d  %s %s\n", declaration.FilePath, declaration.StartLine,
-		declaration.Kind, defDisplayName(declaration))
+	fmt.Fprintf(buffer, "%s:%d  %s %s\n", termsafe.Line(declaration.FilePath), declaration.StartLine,
+		declaration.Kind, termsafe.Line(defDisplayName(declaration)))
 	if declaration.Owner != nil {
-		fmt.Fprintf(buffer, "  owner: %s %s (%s:%d)\n", declaration.Owner.Kind, declaration.Owner.Name,
-			declaration.Owner.FilePath, declaration.Owner.StartLine)
+		fmt.Fprintf(buffer, "  owner: %s %s (%s:%d)\n", declaration.Owner.Kind, termsafe.Line(declaration.Owner.Name),
+			termsafe.Line(declaration.Owner.FilePath), declaration.Owner.StartLine)
 	}
 	if declaration.Signature != "" {
-		fmt.Fprintf(buffer, "  signature: %s\n", defTruncateRunes(declaration.Signature, defMaxSignatureRunes))
+		fmt.Fprintf(buffer, "  signature: %s\n", termsafe.Line(defTruncateRunes(declaration.Signature, defMaxSignatureRunes)))
 	}
 	for _, part := range declaration.Parts {
-		fmt.Fprintf(buffer, "  also declared: %s:%d\n", part.FilePath, part.StartLine)
+		fmt.Fprintf(buffer, "  also declared: %s:%d\n", termsafe.Line(part.FilePath), part.StartLine)
 	}
 	if limit > 0 {
 		writeDefMemberLine(buffer, "fields", declaration.Fields, declaration.FieldsTotal, limit, false)

--- a/internal/cli/def.go
+++ b/internal/cli/def.go
@@ -824,9 +824,9 @@ func renderDefText(response defResponse, limit int) []byte {
 
 func writeDefDeclarationText(buffer *strings.Builder, declaration defDeclaration, limit int) {
 	fmt.Fprintf(buffer, "%s:%d  %s %s\n", termsafe.Line(declaration.FilePath), declaration.StartLine,
-		declaration.Kind, termsafe.Line(defDisplayName(declaration)))
+		termsafe.Line(declaration.Kind), termsafe.Line(defDisplayName(declaration)))
 	if declaration.Owner != nil {
-		fmt.Fprintf(buffer, "  owner: %s %s (%s:%d)\n", declaration.Owner.Kind, termsafe.Line(declaration.Owner.Name),
+		fmt.Fprintf(buffer, "  owner: %s %s (%s:%d)\n", termsafe.Line(declaration.Owner.Kind), termsafe.Line(declaration.Owner.Name),
 			termsafe.Line(declaration.Owner.FilePath), declaration.Owner.StartLine)
 	}
 	if declaration.Signature != "" {
@@ -878,7 +878,13 @@ func writeDefMemberLine(buffer *strings.Builder, label string, members []defMemb
 		}
 		entries = append(entries, entry)
 	}
-	line := fmt.Sprintf("  %s: %s", label, strings.Join(entries, ", "))
+	// A member list is one line of the card, and every part of it — the label,
+	// which carries the owning type's name, and each entry's name, signature tail
+	// and origin — comes from the scanned repository. Escaped after assembly
+	// because the separators between them are this renderer's own ASCII, so one
+	// pass over the finished line covers every field without a new sink appearing
+	// each time an entry grows a part.
+	line := termsafe.Line(fmt.Sprintf("  %s: %s", label, strings.Join(entries, ", ")))
 	if omitted := total - len(shown); omitted > 0 {
 		line += fmt.Sprintf(" (+%d more)", omitted)
 	}

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/entireio/entire-graph/internal/sem"
+	"github.com/entireio/entire-graph/internal/termsafe"
 )
 
 // explain — turn a FAILING BUILD into the declarations it is complaining about.
@@ -290,20 +291,27 @@ func RenderExplain(response ExplainResponse, maxBytes int) []byte {
 	var missing []string
 	for _, symbol := range response.Symbols {
 		if !symbol.Resolved {
-			missing = append(missing, symbol.Query)
+			// Echoed from the build output the caller piped in, which is itself
+			// produced by a compiler reading repository names.
+			missing = append(missing, termsafe.Line(symbol.Query))
 			continue
 		}
-		line := fmt.Sprintf("  %s:%d-%d", symbol.FilePath, symbol.StartLine, symbol.EndLine)
+		// One declaration per line, so every field is a one-line value: the path
+		// is a raw Git pathname and the signature is a declaration lifted off a
+		// line of the scanned tree. Escaped here rather than by wrapping the
+		// writer, because the byte budget below is measured on these strings and
+		// has to count what is actually printed.
+		line := fmt.Sprintf("  %s:%d-%d", termsafe.Line(symbol.FilePath), symbol.StartLine, symbol.EndLine)
 		if symbol.Kind != "" {
-			line += " " + symbol.Kind
+			line += " " + termsafe.Line(symbol.Kind)
 		}
-		line += " " + symbol.Name
+		line += " " + termsafe.Line(symbol.Name)
 		if symbol.Owner != "" {
-			line += " (in " + symbol.Owner + ")"
+			line += " (in " + termsafe.Line(symbol.Owner) + ")"
 		}
 		line += "\n"
 		if symbol.Signature != "" {
-			line += "      " + strings.Join(strings.Fields(symbol.Signature), " ") + "\n"
+			line += "      " + termsafe.Line(strings.Join(strings.Fields(symbol.Signature), " ")) + "\n"
 		}
 		if buffer.Len()+len(line) > maxBytes {
 			break

--- a/internal/cli/impact.go
+++ b/internal/cli/impact.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/entireio/entire-graph/internal/sem"
+	"github.com/entireio/entire-graph/internal/termsafe"
 )
 
 const (
@@ -722,6 +723,8 @@ func capImpactSections(response impactResponse, limit int) impactResponse {
 }
 
 func writeImpactText(out io.Writer, response impactResponse) {
+	// Every section here names repository paths and symbols. See writeTextSearch.
+	out = termsafe.NewWriter(out)
 	cacheState := "miss"
 	if response.IndexCacheHit {
 		cacheState = "hit"

--- a/internal/cli/impact.go
+++ b/internal/cli/impact.go
@@ -794,7 +794,7 @@ func writeImpactText(out io.Writer, response impactResponse) {
 		response.DataFlows, true)
 	writeImpactSection(out,
 		fmt.Sprintf("Co-change coupling (%d; files that historically change with %s)",
-			response.CoChanges.Total, response.Focus.FilePath),
+			response.CoChanges.Total, termsafe.Line(response.Focus.FilePath)),
 		response.CoChanges, false)
 	writeImpactSection(out,
 		fmt.Sprintf("Same-container siblings (%d)", response.Siblings.Total),
@@ -819,7 +819,9 @@ func writeImpactSection(out io.Writer, header string, section impactSection, arr
 			}
 		}
 		if entry.Relation == "FILE_CHANGES_WITH" {
-			fmt.Fprintf(out, "- %s [%s]\n", entry.Endpoint.FilePath, entry.Detail)
+			// One co-change file per line: the path is a one-line value even though
+			// the section around it is written through the layout-preserving wrap.
+			fmt.Fprintf(out, "- %s [%s]\n", termsafe.Line(entry.Endpoint.FilePath), entry.Detail)
 			continue
 		}
 		fmt.Fprintf(out, "- %s%s", prefix, formatImpactEntryLocation(entry))

--- a/internal/cli/neighbors.go
+++ b/internal/cli/neighbors.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/entireio/entire-graph/internal/sem"
+	"github.com/entireio/entire-graph/internal/termsafe"
 )
 
 const (
@@ -725,12 +726,19 @@ func writeAgentNeighborsBounded(out io.Writer, response neighborResponse, budget
 		_, err := out.Write(full.Bytes())
 		return err
 	}
-	payload := compactAgentNeighbors(response, budget)
+	// The compact payload is built independently of writeAgentNeighborsFull, so it
+	// does not inherit that function's wrapped writer and is escaped on its own.
+	payload := termsafe.Bytes(compactAgentNeighbors(response, budget))
 	_, err := out.Write(payload)
 	return err
 }
 
 func writeAgentNeighborsFull(out io.Writer, response neighborResponse) error {
+	// Wrapped at the renderer rather than at its two callers, so the call-context
+	// windows this prints — raw source lines, via writeCallContext — are covered
+	// on the bounded path too, where the caller buffers this output before
+	// trimming it. See writeTextSearch.
+	out = termsafe.NewWriter(out)
 	cacheState := "miss"
 	if response.IndexCacheHit {
 		cacheState = "hit"

--- a/internal/cli/neighbors.go
+++ b/internal/cli/neighbors.go
@@ -864,10 +864,15 @@ func compactAgentNeighbors(response neighborResponse, budget int) []byte {
 		}
 	} else {
 		focus := response.Matches[0].Symbol
+		// The SHORTER variants have to escape too. The first one inherits it from
+		// formatNeighborEndpoint, but these are what get printed under byte
+		// pressure — and a guard that holds only while the payload has room is
+		// worse than none, because the case it drops is the one nobody re-reads.
+		focusPath := termsafe.Line(focus.FilePath)
 		appendVariant(
 			"Focus: "+formatNeighborEndpoint(focus)+"\n",
-			fmt.Sprintf("F %s:%d %s\n", focus.FilePath, focus.StartLine, endpointDisplayName(focus)),
-			fmt.Sprintf("F %s:%d\n", focus.FilePath, focus.StartLine),
+			fmt.Sprintf("F %s:%d %s\n", focusPath, focus.StartLine, termsafe.Line(endpointDisplayName(focus))),
+			fmt.Sprintf("F %s:%d\n", focusPath, focus.StartLine),
 		)
 	}
 

--- a/internal/cli/neighbors.go
+++ b/internal/cli/neighbors.go
@@ -1031,15 +1031,21 @@ func formatCallSiteLocation(endpoint neighborEndpoint, site *callSite) string {
 	return fmt.Sprintf("%s (%s:%d, def :%d)", name, site.FilePath, site.Line, endpoint.StartLine)
 }
 
+// formatNeighborEndpoint is the one place an endpoint becomes display text, for
+// the edge lists, the disambiguation listing, the fuzzy-match listing and the
+// compact payload alike. Its result is always placed on a line of its own by its
+// callers, so the name and the path are one-line values and are escaped here —
+// covering every caller at once, which is why the escape is not repeated at each
+// of them.
 func formatNeighborEndpoint(endpoint neighborEndpoint) string {
-	name := endpointDisplayName(endpoint)
+	name := termsafe.Line(endpointDisplayName(endpoint))
 	if endpoint.FilePath == "" {
 		return name
 	}
 	if endpoint.StartLine > 0 {
-		return fmt.Sprintf("%s (%s:%d)", name, endpoint.FilePath, endpoint.StartLine)
+		return fmt.Sprintf("%s (%s:%d)", name, termsafe.Line(endpoint.FilePath), endpoint.StartLine)
 	}
-	return fmt.Sprintf("%s (%s)", name, endpoint.FilePath)
+	return fmt.Sprintf("%s (%s)", name, termsafe.Line(endpoint.FilePath))
 }
 
 // formatNeighborFocus renders the symbol under query with BOTH numbers a reader

--- a/internal/cli/neighbors.go
+++ b/internal/cli/neighbors.go
@@ -1024,11 +1024,15 @@ func formatCallSiteLocation(endpoint neighborEndpoint, site *callSite) string {
 	if site == nil {
 		return formatNeighborEndpoint(endpoint)
 	}
-	name := endpointDisplayName(endpoint)
+	// Same one-line contract as formatNeighborEndpoint, which this deliberately
+	// does not delegate to (it names the CALL SITE, not the definition) — so the
+	// escaping has to be repeated rather than inherited.
+	name := termsafe.Line(endpointDisplayName(endpoint))
+	path := termsafe.Line(site.FilePath)
 	if site.Line == endpoint.StartLine && site.FilePath == endpoint.FilePath {
-		return fmt.Sprintf("%s (%s:%d)", name, site.FilePath, site.Line)
+		return fmt.Sprintf("%s (%s:%d)", name, path, site.Line)
 	}
-	return fmt.Sprintf("%s (%s:%d, def :%d)", name, site.FilePath, site.Line, endpoint.StartLine)
+	return fmt.Sprintf("%s (%s:%d, def :%d)", name, path, site.Line, endpoint.StartLine)
 }
 
 // formatNeighborEndpoint is the one place an endpoint becomes display text, for

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/entireio/entire-graph/internal/gitutil"
 	"github.com/entireio/entire-graph/internal/sem"
+	"github.com/entireio/entire-graph/internal/termsafe"
 )
 
 type Options struct {
@@ -799,16 +800,7 @@ func analyzeAndPrint(ctx context.Context, opts Options, repo, base, head string,
 	}
 	if flags.Progress {
 		analyzeOptions.Progress = func(event sem.AnalyzeProgressEvent) {
-			line := fmt.Sprintf("graph diff progress phase=%s files=%d/%d elapsed=%s",
-				event.Phase,
-				event.FilesDone,
-				event.FilesTotal,
-				event.Elapsed.Round(time.Millisecond),
-			)
-			if event.Path != "" {
-				line += " file=" + event.Path
-			}
-			fmt.Fprintln(opts.Stderr, line)
+			fmt.Fprintln(opts.Stderr, diffProgressLine(event))
 		}
 	}
 	result, err := sem.AnalyzeGitRangeWithOptions(ctx, repo, base, head, paths, analyzeOptions)
@@ -816,6 +808,27 @@ func analyzeAndPrint(ctx context.Context, opts Options, repo, base, head string,
 		return err
 	}
 	return printResult(opts.Stdout, result, flags.JSON)
+}
+
+// diffProgressLine renders one --progress event for stderr.
+//
+// It is a named function rather than an inline closure because of the escaping:
+// event.Path is a raw Git pathname carried through from `git diff -z`, which may
+// hold any byte but NUL and '/', and this is the one sink that has to escape by
+// value instead of by wrapping its writer — stderr also carries the progress
+// bar's own cursor control (see progressbar.go), which a wrap could not tell
+// apart from an injected sequence.
+func diffProgressLine(event sem.AnalyzeProgressEvent) string {
+	line := fmt.Sprintf("graph diff progress phase=%s files=%d/%d elapsed=%s",
+		event.Phase,
+		event.FilesDone,
+		event.FilesTotal,
+		event.Elapsed.Round(time.Millisecond),
+	)
+	if event.Path != "" {
+		line += " file=" + termsafe.Line(event.Path)
+	}
+	return line
 }
 
 func printResult(out io.Writer, result sem.Result, asJSON bool) error {

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -590,16 +590,16 @@ func renderSignatureTypes(types []sem.SearchSignatureType) []byte {
 	var buffer strings.Builder
 	buffer.WriteString(searchTextSignatureTypesHeader + "\n")
 	for _, entry := range types {
-		fmt.Fprintf(&buffer, "  %s  %s:%d\n", entry.Name, entry.FilePath, entry.StartLine)
+		fmt.Fprintf(&buffer, "  %s  %s:%d\n", termsafe.Line(entry.Name), termsafe.Line(entry.FilePath), entry.StartLine)
 		if len(entry.Fields) > 0 {
-			line := "    fields: " + strings.Join(entry.Fields, ", ")
+			line := "    fields: " + termsafe.Line(strings.Join(entry.Fields, ", "))
 			if omitted := entry.FieldsTotal - len(entry.Fields); omitted > 0 {
 				line += fmt.Sprintf(" (+%d more)", omitted)
 			}
 			fmt.Fprintln(&buffer, line)
 		}
 		if len(entry.Methods) > 0 {
-			line := fmt.Sprintf("    impl %s: %s", entry.Name, strings.Join(entry.Methods, ", "))
+			line := fmt.Sprintf("    impl %s: %s", termsafe.Line(entry.Name), termsafe.Line(strings.Join(entry.Methods, ", ")))
 			if omitted := entry.MethodsTotal - len(entry.Methods); omitted > 0 {
 				line += fmt.Sprintf(" (+%d more)", omitted)
 			}
@@ -1353,11 +1353,11 @@ func agentSearchTypeCard(card []sem.TypeCardEntry) []byte {
 	}
 	var output bytes.Buffer
 	for _, entry := range card {
-		fmt.Fprintf(&output, "D: %s %s:%d", entry.Name, entry.FilePath, entry.Line)
+		fmt.Fprintf(&output, "D: %s %s:%d", termsafe.Line(entry.Name), termsafe.Line(entry.FilePath), entry.Line)
 		if len(entry.UseLines) > 0 {
 			fmt.Fprintf(&output, " used=%s", joinSearchUseLines(entry.UseLines))
 		}
-		fmt.Fprintf(&output, " | %s\n", entry.Decl)
+		fmt.Fprintf(&output, " | %s\n", termsafe.Line(entry.Decl))
 	}
 	return output.Bytes()
 }

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/entireio/entire-graph/internal/gitutil"
 	"github.com/entireio/entire-graph/internal/sem"
+	"github.com/entireio/entire-graph/internal/termsafe"
 )
 
 // defaultSearchContextBytes is the default `--max-context-bytes` ceiling for one search call.
@@ -428,6 +429,12 @@ const (
 // Ranks are the payload's own, unchanged, so a rank missing from the primary group is a visible
 // signal that it was sectioned rather than dropped.
 func writeTextSearch(out interface{ Write([]byte) (int, error) }, response sem.SearchResponse) error {
+	// Everything below prints repository-controlled bytes: paths, snippets lifted
+	// verbatim from source, declarations read off a line of the scanned tree. The
+	// guarantee that none of them reaches the terminal as a control sequence is
+	// made once, here, rather than at the dozens of print sites in this function
+	// and in the sem renderers it calls.
+	out = termsafe.NewWriter(out)
 	if notice, _ := searchLowConfidenceNotices(response); len(notice) > 0 {
 		if _, err := out.Write(notice); err != nil {
 			return err
@@ -554,6 +561,7 @@ func writeTextSearch(out interface{ Write([]byte) (int, error) }, response sem.S
 	if len(related) > 0 {
 		fmt.Fprintf(out, "%s\n", searchTextRelatedHeader)
 		for _, result := range related {
+			result = searchResultOnOneLine(result)
 			name := searchResultDisplayName(result)
 			fmt.Fprintf(out, "%d. %s:%d", result.Rank, result.FilePath, searchResultLocatorLine(result))
 			if name != "" {
@@ -714,7 +722,26 @@ func searchLocatorFollowUp(result sem.SearchResult) string {
 	return "  [body: def " + name + "]"
 }
 
+// searchResultOnOneLine escapes the fields that go into a result's HEADER, where
+// the layout is one record per line and a newline is therefore not layout but
+// forgery: a repository can name a file "a.go\n1. src/real.go:1 score=99.0" and
+// fabricate a hit the search never returned. The wrapped writer cannot make that
+// call — by then a path's newline and a snippet's are the same byte — so the
+// header fields are escaped here, where the renderer still knows which is which.
+//
+// The result is taken and returned BY VALUE. Nothing upstream sees the escaped
+// copy, so the JSON encoding of the same response still reports the exact bytes
+// the repository holds.
+func searchResultOnOneLine(result sem.SearchResult) sem.SearchResult {
+	result.FilePath = termsafe.Line(result.FilePath)
+	result.QualifiedName = termsafe.Line(result.QualifiedName)
+	result.SymbolName = termsafe.Line(result.SymbolName)
+	result.Kind = termsafe.Line(result.Kind)
+	return result
+}
+
 func writeTextSearchLocator(out interface{ Write([]byte) (int, error) }, result sem.SearchResult) {
+	result = searchResultOnOneLine(result)
 	// Byte-identical to the locator writeTextSearchResult already emits below the rank tier. Two
 	// different locator shapes in one payload would be a second thing for a reader to learn for no
 	// gain, and the existing shape is what every consumer and test already reads.
@@ -747,6 +774,7 @@ func writeTextSearchLocator(out interface{ Write([]byte) (int, error) }, result 
 }
 
 func writeTextSearchResult(out interface{ Write([]byte) (int, error) }, result sem.SearchResult, full bool) {
+	result = searchResultOnOneLine(result)
 	name := searchResultDisplayName(result)
 	if !full && !searchResultCarriesCompleteBody(result) {
 		// A locator is a single line number. Where the graph knows the named symbol's true extent,
@@ -911,11 +939,14 @@ func writeTextSearchTypeCard(out interface{ Write([]byte) (int, error) }, card [
 	}
 	fmt.Fprintf(out, "%s\n", searchTextTypesHeader)
 	for _, entry := range card {
-		fmt.Fprintf(out, "  %s %s:%d", entry.Name, entry.FilePath, entry.Line)
+		// One entry per line, and Decl is a declaration read verbatim off a single
+		// line of the scanned file — so all three fields are one-line values. See
+		// searchResultOnOneLine for why a newline here is forgery, not layout.
+		fmt.Fprintf(out, "  %s %s:%d", termsafe.Line(entry.Name), termsafe.Line(entry.FilePath), entry.Line)
 		if len(entry.UseLines) > 0 {
 			fmt.Fprintf(out, " (used %s)", joinSearchUseLines(entry.UseLines))
 		}
-		fmt.Fprintf(out, "  %s\n", entry.Decl)
+		fmt.Fprintf(out, "  %s\n", termsafe.Line(entry.Decl))
 	}
 }
 
@@ -1033,6 +1064,9 @@ func agentSearchSectionTag(result sem.SearchResult) string {
 }
 
 func writeAgentSearch(out interface{ Write([]byte) (int, error) }, response sem.SearchResponse, budget int) error {
+	// Same sink class as the text renderer, and the format agents are told to
+	// prefer — so it gets the same guard. See writeTextSearch.
+	out = termsafe.NewWriter(out)
 	results := orderAgentSearchResults(response.Results)
 	stats := response.Stats
 	cacheState := "miss"
@@ -1515,6 +1549,9 @@ func agentSearchScoreTag(result sem.SearchResult) string {
 }
 
 func agentSearchBlock(result sem.SearchResult, budget int) []byte {
+	// Every location header this block and its helpers emit is one line. See
+	// searchResultOnOneLine.
+	result = searchResultOnOneLine(result)
 	if len(result.Passages) == 0 {
 		return agentSearchPrimaryBlock(result, budget)
 	}

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -1421,11 +1421,15 @@ func searchCompletenessCounts(report sem.CompletenessReport) (int, int) {
 	return len(report.Languages), files
 }
 
+// agentDiagnosticPath renders the path a warning or partial failure names. The
+// file is unparseable BY DEFINITION here, so its name is the most attacker-shaped
+// value in the payload — and these records print one per line, ahead of the
+// ranking, which is where a forged line would do the most damage.
 func agentDiagnosticPath(path string) string {
 	if path == "" {
 		return ""
 	}
-	return ": " + path
+	return ": " + termsafe.Line(path)
 }
 
 // agentSearchBlockCarriesSource reports whether a rendered ranked block contains any source,

--- a/internal/cli/symbolref.go
+++ b/internal/cli/symbolref.go
@@ -10,6 +10,7 @@ import (
 	"unicode"
 
 	"github.com/entireio/entire-graph/internal/sem"
+	"github.com/entireio/entire-graph/internal/termsafe"
 )
 
 // Addressing one definition
@@ -687,10 +688,18 @@ func minSymbolInt(left, right int) int {
 func writeSymbolMatchBodies(out interface {
 	Write([]byte) (int, error)
 }, bodies []symbolMatchBody) {
+	// The single place repository SOURCE is printed with a line-number gutter, and
+	// the only sink `def` reaches that its own writer wrap does not cover — so the
+	// wrap is made here, where all three callers pass through. Wrapping twice is
+	// harmless; see termsafe.NewWriter.
+	out = termsafe.NewWriter(out)
 	for _, body := range bodies {
-		fmt.Fprintf(out, "\n%s:%d-%d %s", body.FilePath, body.StartLine, body.EndLine, body.Name)
+		// The locator above each body is one line, so its fields get the stricter
+		// escape; the body itself keeps its newlines, being real layout.
+		fmt.Fprintf(out, "\n%s:%d-%d %s", termsafe.Line(body.FilePath), body.StartLine, body.EndLine,
+			termsafe.Line(body.Name))
 		if body.Kind != "" {
-			fmt.Fprintf(out, " [%s]", body.Kind)
+			fmt.Fprintf(out, " [%s]", termsafe.Line(body.Kind))
 		}
 		fmt.Fprintln(out)
 		writeNumberedSource(out, body.Source, body.StartLine)

--- a/internal/cli/symbolref.go
+++ b/internal/cli/symbolref.go
@@ -267,8 +267,10 @@ func disambiguationSelectors(definitions []neighborEndpoint) []string {
 		if definition.FilePath == "" || definition.StartLine <= 0 {
 			continue
 		}
+		// The selector is printed at the end of a definition's line, so it is a
+		// one-line value like the rest of that line.
 		selector := fmt.Sprintf("--symbol %s --file %s --line %d",
-			endpointDisplayName(definition), definition.FilePath, definition.StartLine)
+			termsafe.Line(endpointDisplayName(definition)), termsafe.Line(definition.FilePath), definition.StartLine)
 		if named[endpointNamedLocationKey(definition)] > 1 && definition.Kind != "" {
 			selector += " --kind " + definition.Kind
 		}

--- a/internal/cli/termsafe_sinks_test.go
+++ b/internal/cli/termsafe_sinks_test.go
@@ -248,3 +248,76 @@ func TestExplainEscapesOneLineFields(t *testing.T) {
 	assertNoForgedRecord(t, "RenderExplain", rendered)
 	assertNoRawControl(t, "RenderExplain", strings.ReplaceAll(rendered, "a.go", "evil"))
 }
+
+// TestFormatCallSiteLocationStaysOnOneLine covers the sibling of
+// formatNeighborEndpoint that does NOT delegate to it: it names the call site
+// rather than the definition, so it carries its own copy of the escaping and can
+// drift out of step with the function above it.
+func TestFormatCallSiteLocationStaysOnOneLine(t *testing.T) {
+	t.Parallel()
+	rendered := formatCallSiteLocation(
+		neighborEndpoint{Name: "Merge" + forgedPathName, FilePath: forgedPathName, StartLine: 4},
+		&callSite{FilePath: forgedPathName, Line: 9},
+	)
+	if strings.Contains(rendered, "\n") {
+		t.Errorf("formatCallSiteLocation returned more than one line: %q", rendered)
+	}
+	assertNoForgedRecord(t, "formatCallSiteLocation", rendered)
+}
+
+// TestDisambiguationSelectorsStayOnOneLine covers the selector printed at the end
+// of a definition's line. A forged newline there would not merely add a line, it
+// would offer the reader a --file argument that is not the file.
+func TestDisambiguationSelectorsStayOnOneLine(t *testing.T) {
+	t.Parallel()
+	for _, selector := range disambiguationSelectors([]neighborEndpoint{{
+		Name: "Merge", FilePath: forgedPathName, StartLine: 4, Kind: "function",
+	}}) {
+		if strings.Contains(selector, "\n") {
+			t.Errorf("selector spans more than one line: %q", selector)
+		}
+	}
+}
+
+// TestAgentDiagnosticPathStaysOnOneLine covers the warning and partial-failure
+// records. The file they name is unparseable by definition, which makes its name
+// the most attacker-shaped value in the payload — and these records print ahead
+// of the ranking, where a forged line does the most damage.
+func TestAgentDiagnosticPathStaysOnOneLine(t *testing.T) {
+	t.Parallel()
+	rendered := agentDiagnosticPath(forgedPathName)
+	if strings.Contains(rendered, "\n") {
+		t.Errorf("agentDiagnosticPath spans more than one line: %q", rendered)
+	}
+	assertNoForgedRecord(t, "agentDiagnosticPath", rendered)
+}
+
+func TestDefRelatedLineStaysOnOneLine(t *testing.T) {
+	t.Parallel()
+	rendered := defRelatedLine([]defRelated{{
+		Name: "Router" + forgedPathName, FilePath: forgedPathName, StartLine: 3, Relation: "EXTENDS",
+	}}, "supertypes")
+	if strings.Contains(rendered, "\n") {
+		t.Errorf("defRelatedLine spans more than one line: %q", rendered)
+	}
+	assertNoForgedRecord(t, "defRelatedLine", rendered)
+}
+
+// TestImpactCoChangeEntryStaysOnOneLine covers the co-change section, whose
+// entries are bare pathnames — the one section with no symbol name to anchor a
+// reader's eye if an extra line appears. Driven through writeImpactSection rather
+// than the whole verb, because the co-change branch is what carries the path and
+// a full response fixture would only add ceremony around it.
+func TestImpactCoChangeEntryStaysOnOneLine(t *testing.T) {
+	t.Parallel()
+	var buffer bytes.Buffer
+	writeImpactSection(&buffer, "Co-change coupling (1)", impactSection{
+		Total: 1,
+		Entries: []impactEntry{{
+			Relation: "FILE_CHANGES_WITH",
+			Endpoint: neighborEndpoint{FilePath: forgedPathName},
+			Detail:   "changed together 4 times",
+		}},
+	}, false)
+	assertNoForgedRecord(t, "writeImpactSection co-change", buffer.String())
+}

--- a/internal/cli/termsafe_sinks_test.go
+++ b/internal/cli/termsafe_sinks_test.go
@@ -1,0 +1,191 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/entireio/entire-graph/internal/sem"
+)
+
+// These are the regression tests for the terminal-injection findings: one per
+// reported sink, each driving the renderer that owns the sink with a payload a
+// hostile repository could produce.
+//
+// They assert on the ABSENCE of a raw ESC rather than on an exact rendering, so
+// they keep testing the property — "repository bytes never reach the terminal as
+// a control sequence" — if the escape's spelling ever changes.
+
+// hostileESC is a repository-supplied value carrying a real terminal sequence: an
+// erase-line that would blank what the reader already saw, plus a colour change
+// that would outlive the value it is embedded in.
+const hostileESC = "evil\x1b[2K\x1b[31m"
+
+func assertNoRawControl(t *testing.T, what, rendered string) {
+	t.Helper()
+	if strings.ContainsRune(rendered, 0x1b) {
+		t.Errorf("%s passed a raw ESC through to the terminal:\n%q", what, rendered)
+	}
+	if strings.Contains(rendered, "\u009b") {
+		t.Errorf("%s passed a raw C1 CSI through to the terminal:\n%q", what, rendered)
+	}
+	// The value must still be REPORTED, only defanged: dropping it silently would
+	// hide the file the reader is being warned about.
+	if !strings.Contains(rendered, "evil") {
+		t.Errorf("%s dropped the value instead of escaping it:\n%s", what, rendered)
+	}
+}
+
+// TestWriteTextSearchEscapesSnippetAndPath covers the snippet sink (source lines
+// lifted verbatim out of the scanned repository) and the path sink (a Git
+// pathname, which may hold any byte but NUL and '/').
+func TestWriteTextSearchEscapesSnippetAndPath(t *testing.T) {
+	t.Parallel()
+	response := sem.SearchResponse{Results: []sem.SearchResult{{
+		Rank: 1, FilePath: "src/" + hostileESC + ".go", StartLine: 1, EndLine: 3, FocusLine: 1,
+		Score: 21.0, QualifiedName: "Router.merge", Signals: []string{"body"},
+		Snippet: "func merge() {\n\t// " + hostileESC + "\n}",
+	}}}
+	var buffer bytes.Buffer
+	if err := writeTextSearch(&buffer, response); err != nil {
+		t.Fatal(err)
+	}
+	assertNoRawControl(t, "writeTextSearch", buffer.String())
+}
+
+// TestWriteTextSearchEscapesTypeCardDeclaration covers the type-card sink, where
+// a one-line declaration is read straight off a line of the scanned file.
+func TestWriteTextSearchEscapesTypeCardDeclaration(t *testing.T) {
+	t.Parallel()
+	response := sem.SearchResponse{TypeCard: []sem.TypeCardEntry{{
+		Name: "Router", FilePath: "src/routing/mod.rs", Line: 12,
+		Decl: "pub struct Router { /* " + hostileESC + " */ }",
+	}}}
+	var buffer bytes.Buffer
+	if err := writeTextSearch(&buffer, response); err != nil {
+		t.Fatal(err)
+	}
+	assertNoRawControl(t, "writeTextSearchTypeCard", buffer.String())
+}
+
+// TestWriteTextSearchEscapesFileOutlinePath covers the file-outline sink, which
+// prints repository paths through sem.RenderSearchFileOutline.
+func TestWriteTextSearchEscapesFileOutlinePath(t *testing.T) {
+	t.Parallel()
+	response := sem.SearchResponse{FileOutlines: []sem.SearchFileOutline{{
+		FilePath: "src/" + hostileESC + ".rs", Lines: 40,
+	}}}
+	var buffer bytes.Buffer
+	if err := writeTextSearch(&buffer, response); err != nil {
+		t.Fatal(err)
+	}
+	assertNoRawControl(t, "RenderSearchFileOutline", buffer.String())
+}
+
+// TestWriteAgentSearchEscapesSnippetAndPath holds the same line for the format
+// the agent guide tells callers to prefer.
+func TestWriteAgentSearchEscapesSnippetAndPath(t *testing.T) {
+	t.Parallel()
+	response := sem.SearchResponse{Results: []sem.SearchResult{{
+		Rank: 1, FilePath: "src/" + hostileESC + ".go", StartLine: 1, EndLine: 3, FocusLine: 1,
+		Score: 21.0, QualifiedName: "Router.merge", Signals: []string{"body"},
+		Snippet: "func merge() {\n\t// " + hostileESC + "\n}",
+	}}}
+	var buffer bytes.Buffer
+	if err := writeAgentSearch(&buffer, response, 0); err != nil {
+		t.Fatal(err)
+	}
+	assertNoRawControl(t, "writeAgentSearch", buffer.String())
+}
+
+// TestWriteDefTextEscapesSourceExcerpt covers the `def` sink: whole source lines
+// read off the repository and printed with a line-number gutter.
+func TestWriteDefTextEscapesSourceExcerpt(t *testing.T) {
+	t.Parallel()
+	response := defResponse{
+		Query: "Router",
+		Declarations: []defDeclaration{{
+			Name: "Router", Kind: "struct", FilePath: "src/" + hostileESC + ".rs",
+			StartLine: 12, EndLine: 14,
+			Signature: "pub struct Router { /* " + hostileESC + " */ }",
+		}},
+		DeclarationTotal: 1,
+	}
+	var buffer bytes.Buffer
+	if err := writeDefText(&buffer, response, defaultDefContextBytes); err != nil {
+		t.Fatal(err)
+	}
+	assertNoRawControl(t, "writeDefText", buffer.String())
+}
+
+// TestSearchTextPathCannotForgeAResultLine covers the other half of the path
+// sink. Escaping ESC is not enough on its own: the headers are one record per
+// line, so a Git pathname holding a newline would print an entry the ranking
+// never produced — with whatever rank and score the attacker chose.
+func TestSearchTextPathCannotForgeAResultLine(t *testing.T) {
+	t.Parallel()
+	response := sem.SearchResponse{Results: []sem.SearchResult{{
+		Rank: 1, FilePath: "a.go\n2. src/attacker-owned.go:1 score=99.0000 signals=body",
+		StartLine: 1, EndLine: 1, FocusLine: 1, Score: 21.0,
+		QualifiedName: "Router.merge", Signals: []string{"body"},
+	}}}
+	var buffer bytes.Buffer
+	if err := writeTextSearch(&buffer, response); err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(buffer.String()), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "2. ") {
+			t.Errorf("a newline in the path forged a second ranked entry:\n%s", buffer.String())
+		}
+	}
+}
+
+// TestDiffProgressLineEscapesGitFilename covers the --progress sink: Git hands
+// back raw pathname bytes in -z mode, and the analysis layer forwards them into
+// the event unchanged.
+func TestDiffProgressLineEscapesGitFilename(t *testing.T) {
+	t.Parallel()
+	line := diffProgressLine(sem.AnalyzeProgressEvent{
+		Phase: "parse", FilesDone: 3, FilesTotal: 9,
+		Path: "src/" + hostileESC + ".go",
+	})
+	assertNoRawControl(t, "diffProgressLine", line)
+	// A newline in the path would forge an entire additional progress line.
+	if forged := diffProgressLine(sem.AnalyzeProgressEvent{
+		Phase: "parse", Path: "a.go\ngraph diff progress phase=done files=9/9",
+	}); strings.Count(forged, "\n") != 0 {
+		t.Errorf("a newline in the path forged a second line:\n%q", forged)
+	}
+}
+
+// TestSearchTextWithoutControlBytesIsUnchanged is the compatibility guard for all
+// of the above: wrapping the writers must not perturb ordinary output, because an
+// agent copies printed snippets verbatim as edit anchors, and a snippet the
+// renderer had rewritten would no longer match the file it came from.
+func TestSearchTextWithoutControlBytesIsUnchanged(t *testing.T) {
+	t.Parallel()
+	response := sectionedSearchResponse()
+	var buffer bytes.Buffer
+	if err := writeTextSearch(&buffer, response); err != nil {
+		t.Fatal(err)
+	}
+	rendered := buffer.String()
+	for _, result := range response.Results {
+		// Only the primary group prints bodies; the related and docs groups are
+		// locator-only by design, so their snippets are absent for reasons that
+		// have nothing to do with escaping.
+		if result.Section != "" {
+			continue
+		}
+		if !strings.Contains(rendered, result.Snippet) {
+			t.Errorf("snippet for %s is no longer byte-identical in the output:\nwant %q\ngot\n%s",
+				result.FilePath, result.Snippet, rendered)
+		}
+		if !strings.Contains(rendered, result.FilePath) {
+			t.Errorf("path %q is no longer byte-identical in the output:\n%s", result.FilePath, rendered)
+		}
+	}
+	if strings.Contains(rendered, `\x`) {
+		t.Errorf("clean output gained an escape artifact:\n%s", rendered)
+	}
+}

--- a/internal/cli/termsafe_sinks_test.go
+++ b/internal/cli/termsafe_sinks_test.go
@@ -18,16 +18,19 @@ import (
 
 // hostileESC is a repository-supplied value carrying a real terminal sequence: an
 // erase-line that would blank what the reader already saw, plus a colour change
-// that would outlive the value it is embedded in.
-const hostileESC = "evil\x1b[2K\x1b[31m"
+// that would outlive the value it is embedded in. It carries CSI in both spellings
+// a repository can deliver \u2014 ESC '[' and the lone 0x9b byte an 8-bit terminal
+// reads as the same introducer \u2014 because a guard that handles only the first
+// leaves the other reachable.
+const hostileESC = "evil\x1b[2K\x1b[31m\x9b2K"
 
 func assertNoRawControl(t *testing.T, what, rendered string) {
 	t.Helper()
 	if strings.ContainsRune(rendered, 0x1b) {
 		t.Errorf("%s passed a raw ESC through to the terminal:\n%q", what, rendered)
 	}
-	if strings.Contains(rendered, "\u009b") {
-		t.Errorf("%s passed a raw C1 CSI through to the terminal:\n%q", what, rendered)
+	if index := indexC1(rendered); index >= 0 {
+		t.Errorf("%s passed a raw C1 control through to the terminal at byte %d:\n%q", what, index, rendered)
 	}
 	// The value must still be REPORTED, only defanged: dropping it silently would
 	// hide the file the reader is being warned about.
@@ -290,6 +293,40 @@ func TestAgentDiagnosticPathStaysOnOneLine(t *testing.T) {
 		t.Errorf("agentDiagnosticPath spans more than one line: %q", rendered)
 	}
 	assertNoForgedRecord(t, "agentDiagnosticPath", rendered)
+}
+
+// TestDefMemberLineStaysOnOneLine covers the member lists, the half of the
+// declaration card whose fields the header's escaping does not reach: the label
+// carries the owning type's name, and every entry is a member name plus the tail
+// of its signature, all of it read off the scanned repository and all of it
+// printed as ONE line of the card.
+func TestDefMemberLineStaysOnOneLine(t *testing.T) {
+	t.Parallel()
+	var buffer strings.Builder
+	writeDefMemberLine(&buffer, "impl Router"+forgedPathName, []defMember{{
+		Name:      "merge" + forgedPathName,
+		Kind:      "method",
+		Signature: "func merge(" + forgedPathName + ") error",
+		Origin:    "inherited:Base" + forgedPathName,
+	}}, 1, 8, true)
+	assertNoForgedRecord(t, "writeDefMemberLine", buffer.String())
+}
+
+// TestDefDeclarationCardStaysOnOneLinePerRecord drives the whole card, because
+// the member lists are reached through writeDefDeclarationText and a field added
+// to the card later is only covered here.
+func TestDefDeclarationCardStaysOnOneLinePerRecord(t *testing.T) {
+	t.Parallel()
+	var buffer strings.Builder
+	writeDefDeclarationText(&buffer, defDeclaration{
+		Name: "Router", Kind: "struct" + forgedPathName, FilePath: forgedPathName, StartLine: 12,
+		Owner:        &defRelated{Name: "Server" + forgedPathName, Kind: "class" + forgedPathName, FilePath: forgedPathName, StartLine: 3},
+		Fields:       []defMember{{Name: "inner" + forgedPathName, Signature: "inner Conn"}},
+		FieldsTotal:  1,
+		Methods:      []defMember{{Name: "merge", Signature: "func merge() error", Origin: "extension"}},
+		MethodsTotal: 1,
+	}, 8)
+	assertNoForgedRecord(t, "writeDefDeclarationText", buffer.String())
 }
 
 func TestDefRelatedLineStaysOnOneLine(t *testing.T) {

--- a/internal/cli/termsafe_sinks_test.go
+++ b/internal/cli/termsafe_sinks_test.go
@@ -321,3 +321,50 @@ func TestImpactCoChangeEntryStaysOnOneLine(t *testing.T) {
 	}, false)
 	assertNoForgedRecord(t, "writeImpactSection co-change", buffer.String())
 }
+
+// TestCallContextWindowLocatorStaysOnOneLine covers the call-context window's
+// locator. The source lines beneath it keep their layout and are covered by the
+// caller's wrapped writer; the locator above them is a one-line record.
+func TestCallContextWindowLocatorStaysOnOneLine(t *testing.T) {
+	t.Parallel()
+	rendered := renderCallContext(&callSite{
+		FilePath: forgedPathName, Line: 9, WindowStart: 8, WindowEnd: 10,
+		Window: []sourceLine{{Line: 9, Text: "  merge()"}},
+	})
+	assertNoForgedRecord(t, "renderCallContext", rendered)
+}
+
+// TestCompactNeighborFocusEscapesUnderBudgetPressure is the one that matters
+// most in this file. The focus line has three renderings and the caller picks the
+// longest that fits; only the first inherited its escaping, so the guard used to
+// disappear exactly when the payload was tight — the case nobody re-reads.
+//
+// The forged path is deliberately SHORT. A long one is never rendered in its
+// abbreviated forms at all, because the budgets that would select them cannot
+// hold the path either — so a fixture like that would sweep every budget and
+// still never reach the variants under test.
+func TestCompactNeighborFocusEscapesUnderBudgetPressure(t *testing.T) {
+	t.Parallel()
+	const shortForgery = "a\nb"
+	response := neighborResponse{
+		Query: "Merge",
+		Matches: []neighborFocus{{Symbol: neighborEndpoint{
+			Name: "Merge", FilePath: shortForgery, StartLine: 4,
+		}}},
+	}
+	var sawFocus bool
+	for budget := 1; budget <= 400; budget++ {
+		rendered := string(compactAgentNeighbors(response, budget))
+		if strings.Contains(rendered, shortForgery) {
+			t.Fatalf("budget %d selected an unescaped focus variant:\n%q", budget, rendered)
+		}
+		if strings.Contains(rendered, `a\x0ab`) {
+			sawFocus = true
+		}
+	}
+	// Without this the sweep would pass just as well against a payload that never
+	// rendered a focus line at any budget.
+	if !sawFocus {
+		t.Error("no budget rendered the focus line, so this test proves nothing")
+	}
+}

--- a/internal/cli/termsafe_sinks_test.go
+++ b/internal/cli/termsafe_sinks_test.go
@@ -189,3 +189,62 @@ func TestSearchTextWithoutControlBytesIsUnchanged(t *testing.T) {
 		t.Errorf("clean output gained an escape artifact:\n%s", rendered)
 	}
 }
+
+// forgedPathName is a pathname that tries to print a record of its own. The
+// writer wrap cannot stop it — by the time bytes reach the writer, a snippet's
+// newline and a path's are the same byte — so these sinks have to escape by
+// value, and these tests are what say so.
+const forgedPathName = "a.go\n  src/attacker-owned.go:1 forged"
+
+func assertNoForgedRecord(t *testing.T, what, rendered string) {
+	t.Helper()
+	for _, line := range strings.Split(rendered, "\n") {
+		if strings.Contains(line, "attacker-owned.go") && !strings.Contains(line, "a.go") {
+			t.Errorf("%s let a pathname forge its own line:\n%s", what, rendered)
+		}
+	}
+	if !strings.Contains(rendered, "a.go") {
+		t.Errorf("%s dropped the path instead of escaping it:\n%s", what, rendered)
+	}
+}
+
+// TestAgentSearchTypeCardEscapesOneLineFields covers the --format agent twin of
+// the text type card. The two renderers print the same fields; only the text one
+// was escaped at first, which is exactly the asymmetry this pins shut.
+func TestAgentSearchTypeCardEscapesOneLineFields(t *testing.T) {
+	t.Parallel()
+	assertNoForgedRecord(t, "agentSearchTypeCard", string(agentSearchTypeCard([]sem.TypeCardEntry{{
+		Name: "Router", FilePath: forgedPathName, Line: 12,
+		Decl: "pub struct Router {" + forgedPathName + "}",
+	}})))
+}
+
+func TestRenderSignatureTypesEscapesOneLineFields(t *testing.T) {
+	t.Parallel()
+	assertNoForgedRecord(t, "renderSignatureTypes", string(renderSignatureTypes([]sem.SearchSignatureType{{
+		Name: "Router" + forgedPathName, FilePath: forgedPathName, StartLine: 3,
+		Fields: []string{"inner" + forgedPathName}, FieldsTotal: 1,
+	}})))
+}
+
+func TestFormatNeighborEndpointStaysOnOneLine(t *testing.T) {
+	t.Parallel()
+	rendered := formatNeighborEndpoint(neighborEndpoint{
+		Name: "Merge" + forgedPathName, FilePath: forgedPathName, StartLine: 4,
+	})
+	if strings.Contains(rendered, "\n") {
+		t.Errorf("formatNeighborEndpoint returned more than one line: %q", rendered)
+	}
+	assertNoForgedRecord(t, "formatNeighborEndpoint", rendered)
+}
+
+func TestExplainEscapesOneLineFields(t *testing.T) {
+	t.Parallel()
+	rendered := string(RenderExplain(ExplainResponse{Symbols: []ExplainSymbol{{
+		Query: "Helper", Resolved: true, Name: "Helper", Kind: "function",
+		FilePath: forgedPathName, StartLine: 3, EndLine: 3,
+		Signature: "func Helper() int" + forgedPathName,
+	}}}, 0))
+	assertNoForgedRecord(t, "RenderExplain", rendered)
+	assertNoRawControl(t, "RenderExplain", strings.ReplaceAll(rendered, "a.go", "evil"))
+}

--- a/internal/cli/termsafe_verbs_test.go
+++ b/internal/cli/termsafe_verbs_test.go
@@ -1,0 +1,164 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// This is the guard the per-renderer unit tests cannot be: it drives the REAL
+// verbs against a REAL repository whose filename and source both carry a live
+// terminal sequence, and fails if any human-readable output contains a raw ESC.
+//
+// It exists because the unit tests missed one. Each of them wraps the renderer
+// it knows about, so `def` passed its own test while still leaking — its body
+// section is printed by writeSymbolMatchBodies, which runDef calls separately
+// from writeDefText and which nothing had wrapped. Only running the verb end to
+// end found that. A renderer added later, or a verb that grows a second output
+// path, is caught here without anyone remembering to add a case.
+
+// escapeSequence is a real erase-line followed by a colour change: if it were
+// interpreted, it would blank the line the reader had just been shown and leave
+// the terminal recoloured afterwards.
+const escapeSequence = "\x1b[2K\x1b[31m"
+
+// hostileRepo builds a repository that attacks its reader through both channels
+// a scanned repo controls: the name of a file, and the bytes inside one.
+func hostileRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+
+	// Git pathnames may hold any byte but NUL and '/', but the FILESYSTEM has the
+	// final say. Probe before committing to the test rather than reporting a
+	// platform limit as a security failure.
+	hostileName := "evil" + escapeSequence + "file.go"
+	if err := os.WriteFile(filepath.Join(repo, hostileName), []byte("package hostile\n"), 0o644); err != nil {
+		t.Skipf("filesystem rejects control characters in filenames: %v", err)
+	}
+
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	write(t, repo, hostileName, "package hostile\n\nfunc Helper() int { return Merge() }\n")
+	// The sequence goes INSIDE the body, not above it. A comment on the line
+	// before a declaration is not part of the source any body-printing renderer
+	// emits, so a fixture that put it there would leave those sinks untested.
+	write(t, repo, "main.go", "package hostile\n\nfunc Merge() int {\n\t// "+escapeSequence+"SPOOFED\n\treturn 1\n}\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+
+	// A second commit so `diff` has a range to report, and so the entity names it
+	// prints come from the hostile file.
+	write(t, repo, hostileName, "package hostile\n\nfunc Helper() int { return Merge() + 1 }\n\nfunc Extra() {}\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "second")
+	return repo
+}
+
+// TestNoVerbLeaksControlSequencesToTheTerminal is the sweep. Every argv here is a
+// human-readable output mode; the machine formats are asserted separately below,
+// because they must NOT be escaped.
+func TestNoVerbLeaksControlSequencesToTheTerminal(t *testing.T) {
+	repo := hostileRepo(t)
+	cacheDir := t.TempDir()
+
+	for _, verb := range [][]string{
+		{"search", "--query", "merge", "--format", "text"},
+		{"search", "--query", "merge", "--format", "agent"},
+		{"def", "--symbol", "Helper", "--format", "text"},
+		{"def", "--symbol", "Helper", "--format", "agent"},
+		// Merge, not Helper: Merge's BODY is what carries the sequence, so this is
+		// the case that exercises the numbered-source sink rather than only the
+		// locator above it.
+		{"def", "--symbol", "Merge", "--format", "text"},
+		{"def", "--symbol", "Merge", "--format", "agent"},
+		{"neighbors", "--symbol", "Merge", "--format", "text"},
+		{"neighbors", "--symbol", "Merge", "--format", "agent"},
+		{"impact", "--symbol", "Merge", "--format", "text"},
+		{"diff", "--base", "HEAD~1", "--head", "HEAD"},
+		// --progress is swept for the diff it still prints to stdout, NOT for the
+		// per-file progress line: that line is throttled to one per second and
+		// forced only every hundredth file (see emitProgressEvent in
+		// sem/analyze.go), so a fixture this size never emits one and no
+		// repository-derived path reaches stderr here. That sink is covered
+		// directly by TestDiffProgressLineEscapesGitFilename instead.
+		{"diff", "--base", "HEAD~1", "--head", "HEAD", "--progress"},
+	} {
+		t.Run(strings.Join(verb, " "), func(t *testing.T) {
+			stdout, stderr := runVerb(t, repo, cacheDir, verb)
+			assertNoEscape(t, "stdout", stdout)
+			// stderr carries --progress, whose file= field is a raw Git pathname.
+			assertNoEscape(t, "stderr", stderr)
+			// Something hostile must still be REPORTED, or the sweep would pass
+			// just as well against a tool that printed nothing at all. Either
+			// marker will do: which one surfaces depends on whether the verb
+			// prints the hostile FILENAME or the hostile BODY.
+			output := stdout + stderr
+			if !strings.Contains(output, "evil") && !strings.Contains(output, "SPOOFED") {
+				t.Errorf("no output carried a hostile value, so this case proves nothing:\n%s", output)
+			}
+		})
+	}
+}
+
+// TestMachineFormatsKeepTheRepositoryBytes is the other half of the contract, and
+// the reason the escaping lives in the renderers rather than in the search
+// pipeline: a consumer of the machine formats is entitled to the exact pathname
+// Git reported, and encoding/json already keeps it off the terminal.
+func TestMachineFormatsKeepTheRepositoryBytes(t *testing.T) {
+	repo := hostileRepo(t)
+	cacheDir := t.TempDir()
+
+	stdout, _ := runVerb(t, repo, cacheDir, []string{"search", "--query", "merge", "--format", "json"})
+	if strings.ContainsRune(stdout, 0x1b) {
+		t.Errorf("raw ESC in the JSON stream; encoding/json should have escaped it:\n%s", stdout)
+	}
+	var response struct {
+		Results []struct {
+			FilePath string `json:"file_path"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &response); err != nil {
+		t.Fatalf("decode search response: %v\n%s", err, stdout)
+	}
+	var found bool
+	for _, result := range response.Results {
+		if strings.Contains(result.FilePath, escapeSequence) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("JSON no longer reports the repository's own pathname bytes: %#v", response.Results)
+	}
+}
+
+func runVerb(t *testing.T, repo, cacheDir string, argv []string) (string, string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	argv = append(append([]string{}, argv...), "--repo", repo)
+	if err := Run(t.Context(), Options{
+		Version: "test-version",
+		Env:     EntireEnv{RepoRoot: repo, PluginDataDir: cacheDir},
+		Stdout:  &stdout,
+		Stderr:  &stderr,
+	}, argv); err != nil {
+		t.Fatalf("%v: %v\nstdout:\n%s\nstderr:\n%s", argv, err, stdout.String(), stderr.String())
+	}
+	return stdout.String(), stderr.String()
+}
+
+func assertNoEscape(t *testing.T, stream, output string) {
+	t.Helper()
+	if index := strings.IndexRune(output, 0x1b); index >= 0 {
+		start := max(index-120, 0)
+		t.Errorf("raw ESC reached %s at byte %d:\n%q", stream, index, output[start:min(index+120, len(output))])
+	}
+	// C1 CSI is the same primitive in one byte; a terminal in UTF-8 mode acts on
+	// it exactly as it acts on "ESC [".
+	if index := strings.Index(output, "\u009b"); index >= 0 {
+		t.Errorf("raw C1 CSI reached %s at byte %d", stream, index)
+	}
+}

--- a/internal/cli/termsafe_verbs_test.go
+++ b/internal/cli/termsafe_verbs_test.go
@@ -62,6 +62,16 @@ func hostileRepo(t *testing.T) string {
 // human-readable output mode; the machine formats are asserted separately below,
 // because they must NOT be escaped.
 func TestNoVerbLeaksControlSequencesToTheTerminal(t *testing.T) {
+	// The diff renderer emits its OWN SGR sequences when colour is on, so an
+	// assertion of "no ESC at all" would fail on this tool's legitimate output
+	// rather than on any repository byte. Colour is pinned off so the sweep tests
+	// exactly one property: that nothing the REPOSITORY supplied reaches the
+	// terminal as a control sequence. The coloured path has its own test, where
+	// every surviving ESC must be an SGR code this tool wrote —
+	// see sem.TestWriteTextEscapesEntityNameWithColor.
+	t.Setenv("NO_COLOR", "1")
+	t.Setenv("FORCE_COLOR", "")
+	t.Setenv("ENTIRE_GRAPH_FORCE_COLOR", "")
 	repo := hostileRepo(t)
 	cacheDir := t.TempDir()
 
@@ -114,6 +124,7 @@ func TestNoVerbLeaksControlSequencesToTheTerminal(t *testing.T) {
 // pipeline: a consumer of the machine formats is entitled to the exact pathname
 // Git reported, and encoding/json already keeps it off the terminal.
 func TestMachineFormatsKeepTheRepositoryBytes(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
 	repo := hostileRepo(t)
 	cacheDir := t.TempDir()
 

--- a/internal/cli/termsafe_verbs_test.go
+++ b/internal/cli/termsafe_verbs_test.go
@@ -78,6 +78,11 @@ func TestNoVerbLeaksControlSequencesToTheTerminal(t *testing.T) {
 		{"neighbors", "--symbol", "Merge", "--format", "text"},
 		{"neighbors", "--symbol", "Merge", "--format", "agent"},
 		{"impact", "--symbol", "Merge", "--format", "text"},
+		// explain reads a build error from stdin; runVerb feeds it one naming a
+		// symbol that lives in the hostile file. It was missing from the first
+		// version of this sweep and was still leaking a raw ESC because of it.
+		{"explain", "--format", "text"},
+		{"explain", "--format", "agent"},
 		{"diff", "--base", "HEAD~1", "--head", "HEAD"},
 		// --progress is swept for the diff it still prints to stdout, NOT for the
 		// per-file progress line: that line is throttled to one per second and
@@ -144,6 +149,7 @@ func runVerb(t *testing.T, repo, cacheDir string, argv []string) (string, string
 		Env:     EntireEnv{RepoRoot: repo, PluginDataDir: cacheDir},
 		Stdout:  &stdout,
 		Stderr:  &stderr,
+		Stdin:   strings.NewReader("undefined: Helper\nundefined: Merge\n"),
 	}, argv); err != nil {
 		t.Fatalf("%v: %v\nstdout:\n%s\nstderr:\n%s", argv, err, stdout.String(), stderr.String())
 	}

--- a/internal/cli/termsafe_verbs_test.go
+++ b/internal/cli/termsafe_verbs_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 // This is the guard the per-renderer unit tests cannot be: it drives the REAL
@@ -24,6 +25,14 @@ import (
 // interpreted, it would blank the line the reader had just been shown and leave
 // the terminal recoloured afterwards.
 const escapeSequence = "\x1b[2K\x1b[31m"
+
+// rawC1Sequence is the same primitive written the other way a repository can
+// write it: a LONE 0x9b byte, which a terminal reading 8-bit C1 acts on exactly
+// as it acts on "ESC [". It appears only in file BODIES, never in the fixture's
+// filename, because a filesystem is entitled to reject a name that is not valid
+// UTF-8 — macOS does — and a name that skipped the whole sweep would cost more
+// coverage than this byte buys.
+const rawC1Sequence = "\x9b2K\x9b31m"
 
 // hostileRepo builds a repository that attacks its reader through both channels
 // a scanned repo controls: the name of a file, and the bytes inside one.
@@ -46,7 +55,7 @@ func hostileRepo(t *testing.T) string {
 	// The sequence goes INSIDE the body, not above it. A comment on the line
 	// before a declaration is not part of the source any body-printing renderer
 	// emits, so a fixture that put it there would leave those sinks untested.
-	write(t, repo, "main.go", "package hostile\n\nfunc Merge() int {\n\t// "+escapeSequence+"SPOOFED\n\treturn 1\n}\n")
+	write(t, repo, "main.go", "package hostile\n\nfunc Merge() int {\n\t// "+escapeSequence+"SPOOFED"+rawC1Sequence+"\n\treturn 1\n}\n")
 	git(t, repo, "add", ".")
 	git(t, repo, "commit", "-m", "initial")
 
@@ -173,9 +182,26 @@ func assertNoEscape(t *testing.T, stream, output string) {
 		start := max(index-120, 0)
 		t.Errorf("raw ESC reached %s at byte %d:\n%q", stream, index, output[start:min(index+120, len(output))])
 	}
-	// C1 CSI is the same primitive in one byte; a terminal in UTF-8 mode acts on
-	// it exactly as it acts on "ESC [".
-	if index := strings.Index(output, "\u009b"); index >= 0 {
-		t.Errorf("raw C1 CSI reached %s at byte %d", stream, index)
+	if index := indexC1(output); index >= 0 {
+		t.Errorf("raw C1 control reached %s at byte %d", stream, index)
 	}
+}
+
+// indexC1 reports the first C1 control in output, in EITHER form a repository can
+// deliver one: the two-byte UTF-8 encoding of U+0080-U+009F, and the lone
+// 0x80-0x9f byte a Git pathname or a source file may carry, which an 8-bit
+// terminal reads as the control itself. Checking only the first — as this sweep
+// once did — leaves the raw-byte half of the rule untested end to end.
+func indexC1(output string) int {
+	for index, character := range output {
+		if character >= 0x80 && character <= 0x9f {
+			return index
+		}
+		// A byte that decodes to no rune is returned as U+FFFD with width 1; the
+		// byte itself is what a terminal would act on.
+		if character == utf8.RuneError && output[index] >= 0x80 && output[index] <= 0x9f {
+			return index
+		}
+	}
+	return -1
 }

--- a/internal/sem/search_blocks_escape_test.go
+++ b/internal/sem/search_blocks_escape_test.go
@@ -93,3 +93,36 @@ func TestSearchBlocksLeaveCleanInputAlone(t *testing.T) {
 		t.Errorf("clean block gained an escape artifact:\n%s", rendered)
 	}
 }
+
+// TestRenderSearchVerifyCommandEscapesOneLineFields is the highest-stakes case in
+// this file. VERIFY is the line an agent is instructed to RUN, so a pathname that
+// splits the record lets a repository display a command the deriver never
+// produced. Execution was never at risk — the path is shell-quoted before it
+// reaches the command string — but what the reader is shown was.
+func TestRenderSearchVerifyCommandEscapesOneLineFields(t *testing.T) {
+	t.Parallel()
+	rendered := RenderSearchVerifyCommand(&SearchVerifyCommand{
+		Command:     "python -m py_compile '" + forgedPath + "'",
+		Targets:     forgedPath,
+		DerivedFrom: "build check on " + forgedPath,
+		Guard:       "cfg(" + forgedPath + ")",
+		Tier:        "build-check",
+	})
+	assertNoForgedLine(t, "RenderSearchVerifyCommand", rendered)
+	// Every line of the block must still belong to the block: the record is
+	// "VERIFY:" then indented evidence, and nothing else.
+	for _, line := range strings.Split(strings.TrimRight(string(rendered), "\n"), "\n") {
+		if !strings.HasPrefix(line, "VERIFY:") && !strings.HasPrefix(line, "  ") {
+			t.Errorf("a field forged a line outside the block's shape: %q\nin:\n%s", line, rendered)
+		}
+	}
+}
+
+func TestRenderSearchCoverageNoteEscapesOneLineFields(t *testing.T) {
+	t.Parallel()
+	assertNoForgedLine(t, "RenderSearchCoverageNote", RenderSearchCoverageNote(&SearchCoverageNote{
+		Symbol: "Merge" + forgedPath, Total: 3,
+		Peers:    []string{"TestMerge" + forgedPath},
+		FilePath: forgedPath,
+	}))
+}

--- a/internal/sem/search_blocks_escape_test.go
+++ b/internal/sem/search_blocks_escape_test.go
@@ -1,0 +1,95 @@
+package sem
+
+import (
+	"strings"
+	"testing"
+)
+
+// The auxiliary search blocks are all one-record-per-line, so the path and symbol
+// fields in them are one-line values in exactly the sense the ranked-result
+// headers are. The writer wrap the CLI puts around this output stops a control
+// sequence but cannot stop a NEWLINE — by the time bytes reach it, a snippet's
+// newline and a path's are the same byte — so a repository could otherwise name a
+// file such that a block reports a site the search never found.
+
+// forgedPath is a pathname that tries to print a second entry, plus a live escape
+// sequence so both halves of the guard are exercised at once.
+const forgedPath = "a.go\n  src/attacker-owned.go:1 forged\x1b[2K"
+
+func assertNoForgedLine(t *testing.T, what string, rendered []byte) {
+	t.Helper()
+	output := string(rendered)
+	if strings.ContainsRune(output, 0x1b) {
+		t.Errorf("%s passed a raw ESC through:\n%q", what, output)
+	}
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, "attacker-owned.go") && !strings.Contains(line, "a.go") {
+			t.Errorf("%s let a pathname forge its own line:\n%s", what, output)
+		}
+	}
+	if !strings.Contains(output, "a.go") {
+		t.Errorf("%s dropped the path instead of escaping it:\n%s", what, output)
+	}
+}
+
+func TestRenderSearchClosedSetEscapesOneLineFields(t *testing.T) {
+	t.Parallel()
+	assertNoForgedLine(t, "RenderSearchClosedSet", RenderSearchClosedSet(&SearchClosedSet{
+		Type: "Ops", Kind: "enum", Variants: 3,
+		Sites: []SearchClosedSetSite{{
+			FilePath: forgedPath, Line: 12, Symbol: "apply" + forgedPath,
+			Arms: 2, Default: "silent", Checked: "runtime",
+		}},
+	}))
+}
+
+func TestRenderSearchLiteralClusterEscapesOneLineFields(t *testing.T) {
+	t.Parallel()
+	assertNoForgedLine(t, "RenderSearchLiteralCluster", RenderSearchLiteralCluster(&SearchLiteralCluster{
+		Literal: "retry",
+		Hits: []SearchLiteralHit{{
+			FilePath: forgedPath, Line: 7, Symbol: "doRetry", Role: "edit",
+		}},
+		HitsTotal: 1, FilesTotal: 1,
+	}))
+}
+
+func TestRenderSearchContainerMapEscapesOneLineFields(t *testing.T) {
+	t.Parallel()
+	assertNoForgedLine(t, "RenderSearchContainerMap", RenderSearchContainerMap(&SearchContainerMap{
+		FilePath: forgedPath, FileLines: 40, Kind: "struct", Name: "Router" + forgedPath,
+		StartLine: 1, EndLine: 40,
+		Fields:  []string{"inner" + forgedPath},
+		Members: []SearchContainerMember{{Name: "merge", StartLine: 10, EndLine: 14}},
+	}, false))
+}
+
+func TestRenderSearchFileOutlineEscapesPath(t *testing.T) {
+	t.Parallel()
+	assertNoForgedLine(t, "RenderSearchFileOutline", RenderSearchFileOutline([]SearchFileOutline{{
+		FilePath: forgedPath, Lines: 40,
+	}}))
+}
+
+// TestSearchBlocksLeaveCleanInputAlone is the compatibility half: these blocks are
+// budget-sized by the caller, so an escape that fired on ordinary paths would
+// change every payload's length as well as its text.
+func TestSearchBlocksLeaveCleanInputAlone(t *testing.T) {
+	t.Parallel()
+	rendered := string(RenderSearchLiteralCluster(&SearchLiteralCluster{
+		Literal: "retry",
+		Hits: []SearchLiteralHit{
+			{FilePath: "internal/cli/search.go", Line: 7, Symbol: "runSearch", Role: "edit"},
+			{FilePath: "src/naïve/日本語.go", Line: 9, Symbol: "handle", Role: "read"},
+		},
+		HitsTotal: 2, FilesTotal: 2,
+	}))
+	for _, want := range []string{"internal/cli/search.go:7", "src/naïve/日本語.go:9"} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("clean path %q no longer renders byte-identically:\n%s", want, rendered)
+		}
+	}
+	if strings.Contains(rendered, `\x`) {
+		t.Errorf("clean block gained an escape artifact:\n%s", rendered)
+	}
+}

--- a/internal/sem/search_blocks_escape_test.go
+++ b/internal/sem/search_blocks_escape_test.go
@@ -71,6 +71,21 @@ func TestRenderSearchFileOutlineEscapesPath(t *testing.T) {
 	}}))
 }
 
+// TestRenderSearchFileOutlineEscapesRows covers the rows under that path. They
+// are one symbol per line, so a name is a one-line value in the same sense the
+// path above it is: escaping only the header would let a symbol index a symbol
+// the file does not contain, which is worse here than elsewhere because the whole
+// point of the block is to be believed without reading the file.
+func TestRenderSearchFileOutlineEscapesRows(t *testing.T) {
+	t.Parallel()
+	assertNoForgedLine(t, "RenderSearchFileOutline rows", RenderSearchFileOutline([]SearchFileOutline{{
+		FilePath: "src/router.go", Lines: 40,
+		Rows: []SearchOutlineRow{{
+			Start: 10, End: 14, Kind: "func" + forgedPath, Name: "merge" + forgedPath, Hit: true,
+		}},
+	}}))
+}
+
 // TestSearchBlocksLeaveCleanInputAlone is the compatibility half: these blocks are
 // budget-sized by the caller, so an escape that fired on ordinary paths would
 // change every payload's length as well as its text.

--- a/internal/sem/search_closedset.go
+++ b/internal/sem/search_closedset.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/entireio/entire-graph/internal/termsafe"
 )
 
 // The closed-set warning
@@ -986,9 +988,9 @@ func RenderSearchClosedSet(block *SearchClosedSet) []byte {
 		if site.Exhaustive {
 			coverage = "exhaustive"
 		}
-		fmt.Fprintf(&buffer, "  %s:%d", site.FilePath, site.Line)
+		fmt.Fprintf(&buffer, "  %s:%d", termsafe.Line(site.FilePath), site.Line)
 		if site.Symbol != "" {
-			fmt.Fprintf(&buffer, " %s", site.Symbol)
+			fmt.Fprintf(&buffer, " %s", termsafe.Line(site.Symbol))
 		}
 		fmt.Fprintf(&buffer, " %s, default %s, checked at %s\n", coverage, site.Default, site.Checked)
 	}

--- a/internal/sem/search_container_map.go
+++ b/internal/sem/search_container_map.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/entireio/entire-graph/internal/termsafe"
 )
 
 // The container map
@@ -751,15 +753,15 @@ func RenderSearchContainerMap(containerMap *SearchContainerMap, compact bool) []
 		return nil
 	}
 	var out strings.Builder
-	fmt.Fprintf(&out, "CONTAINER MAP %s [%d lines]", containerMap.FilePath, containerMap.FileLines)
+	fmt.Fprintf(&out, "CONTAINER MAP %s [%d lines]", termsafe.Line(containerMap.FilePath), containerMap.FileLines)
 	if containerMap.Name != "" {
-		fmt.Fprintf(&out, " (%s %s, %d-%d)", containerMap.Kind, containerMap.Name, containerMap.StartLine, containerMap.EndLine)
+		fmt.Fprintf(&out, " (%s %s, %d-%d)", containerMap.Kind, termsafe.Line(containerMap.Name), containerMap.StartLine, containerMap.EndLine)
 	} else {
 		out.WriteString(" (file top level)")
 	}
 	out.WriteString("\n")
 	if len(containerMap.Fields) > 0 {
-		fmt.Fprintf(&out, "  fields: %s", strings.Join(containerMap.Fields, ", "))
+		fmt.Fprintf(&out, "  fields: %s", termsafe.Line(strings.Join(containerMap.Fields, ", ")))
 		if containerMap.FieldsOmitted > 0 {
 			fmt.Fprintf(&out, ", +%d more", containerMap.FieldsOmitted)
 		}
@@ -770,7 +772,7 @@ func RenderSearchContainerMap(containerMap *SearchContainerMap, compact bool) []
 		if member.Hit {
 			marker = " *"
 		}
-		fmt.Fprintf(&out, "%s %d-%d %s", marker, member.StartLine, member.EndLine, searchContainerMemberLabel(member, compact))
+		fmt.Fprintf(&out, "%s %d-%d %s", marker, member.StartLine, member.EndLine, termsafe.Line(searchContainerMemberLabel(member, compact)))
 		if !compact {
 			if len(member.Flags) > 0 {
 				fmt.Fprintf(&out, "  %s", strings.Join(member.Flags, ","))

--- a/internal/sem/search_covertest.go
+++ b/internal/sem/search_covertest.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/entireio/entire-graph/internal/termsafe"
 )
 
 // Covering test
@@ -360,12 +362,12 @@ func RenderSearchCoverageNote(note *SearchCoverageNote) []byte {
 		return nil
 	}
 	line := fmt.Sprintf("  ALSO COVERING %s (%d tests cover it; all must still pass): %s",
-		note.Symbol, note.Total, strings.Join(note.Peers, ", "))
+		termsafe.Line(note.Symbol), note.Total, termsafe.Line(strings.Join(note.Peers, ", ")))
 	if note.More > 0 {
 		line += fmt.Sprintf(" +%d more", note.More)
 	}
 	if note.FilePath != "" {
-		line += " in " + note.FilePath
+		line += " in " + termsafe.Line(note.FilePath)
 	}
 	return []byte(line + "\n")
 }

--- a/internal/sem/search_literals.go
+++ b/internal/sem/search_literals.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+
+	"github.com/entireio/entire-graph/internal/termsafe"
 )
 
 // Same-concept literals: `grep` folded into `search`
@@ -884,12 +886,12 @@ func RenderSearchLiteralCluster(cluster *SearchLiteralCluster) []byte {
 	buffer.WriteString(searchLiteralClusterHeader(cluster) + "\n")
 	for _, hit := range cluster.Hits {
 		if hit.Body != "" {
-			fmt.Fprintf(&buffer, "  %s:%d-%d", hit.FilePath, hit.BodyStartLine, hit.BodyEndLine)
+			fmt.Fprintf(&buffer, "  %s:%d-%d", termsafe.Line(hit.FilePath), hit.BodyStartLine, hit.BodyEndLine)
 		} else {
-			fmt.Fprintf(&buffer, "  %s:%d", hit.FilePath, hit.Line)
+			fmt.Fprintf(&buffer, "  %s:%d", termsafe.Line(hit.FilePath), hit.Line)
 		}
 		if hit.Symbol != "" {
-			fmt.Fprintf(&buffer, " %s", hit.Symbol)
+			fmt.Fprintf(&buffer, " %s", termsafe.Line(hit.Symbol))
 		}
 		fmt.Fprintf(&buffer, " %s\n", hit.Role)
 		if hit.Body == "" {

--- a/internal/sem/search_outline.go
+++ b/internal/sem/search_outline.go
@@ -206,11 +206,15 @@ func RenderSearchFileOutline(outlines []SearchFileOutline) []byte {
 			if row.Hit {
 				marker = "*"
 			}
+			// A row is one symbol per line for the same reason the header above is one
+			// file per line, so the kind and the name are one-line values too: a symbol
+			// named "x\n   * 1-9 func Authorize" would otherwise index a symbol the
+			// file does not contain.
 			fmt.Fprintf(&buffer, "   %s %d-%d", marker, row.Start, row.End)
 			if row.Kind != "" {
-				fmt.Fprintf(&buffer, " %s", row.Kind)
+				fmt.Fprintf(&buffer, " %s", termsafe.Line(row.Kind))
 			}
-			fmt.Fprintf(&buffer, " %s\n", row.Name)
+			fmt.Fprintf(&buffer, " %s\n", termsafe.Line(row.Name))
 		}
 	}
 	return []byte(buffer.String())

--- a/internal/sem/search_outline.go
+++ b/internal/sem/search_outline.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/entireio/entire-graph/internal/termsafe"
 )
 
 // FILE OUTLINE — what else is in the files the payload already named.
@@ -189,7 +191,9 @@ func RenderSearchFileOutline(outlines []SearchFileOutline) []byte {
 	var buffer strings.Builder
 	buffer.WriteString(SearchFileOutlineHeader + "\n")
 	for _, outline := range outlines {
-		fmt.Fprintf(&buffer, "  %s", outline.FilePath)
+		// The block is one file per line, so the path is a one-line value: a Git
+		// pathname holding a newline would otherwise print as two outline entries.
+		fmt.Fprintf(&buffer, "  %s", termsafe.Line(outline.FilePath))
 		if outline.Lines > 0 {
 			fmt.Fprintf(&buffer, " (%d lines)", outline.Lines)
 		}

--- a/internal/sem/search_verify.go
+++ b/internal/sem/search_verify.go
@@ -258,7 +258,29 @@ func buildSearchVerifyCommand(
 	if searchVerifyCommandCost(command) > searchVerifyCommandMaxBytes {
 		command.Targets = ""
 	}
+	// A command built around a path holding control bytes cannot be BOTH runnable
+	// and safe to display. Rendering escapes it, which keeps the line honest but
+	// leaves a string that no longer names the file it was derived from — and
+	// "runnable as written" is this field's whole contract. So it is not emitted:
+	// the residual floor already exists to say "nothing derivable here", and that
+	// is the truthful answer for a repository whose filenames cannot be printed.
+	if searchVerifyControlBytes(command.Command) {
+		return searchVerifyResidualFloor("", evidence.prefix, evidence.preFixStatus)
+	}
 	return command
+}
+
+// searchVerifyControlBytes reports whether a derived command carries a byte that
+// the text renderer would have to escape. It checks the COMMAND only: Targets and
+// DerivedFrom are prose about the derivation and are escaped for display without
+// any claim that they can be pasted into a shell.
+func searchVerifyControlBytes(command string) bool {
+	for i := 0; i < len(command); i++ {
+		if command[i] < 0x20 || command[i] == 0x7f {
+			return true
+		}
+	}
+	return false
 }
 
 // searchVerifyResidualFloor is the last rung: no manifest, no test file, no single-file checker. It

--- a/internal/sem/search_verify.go
+++ b/internal/sem/search_verify.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/entireio/entire-graph/internal/termsafe"
 )
 
 // The verify command
@@ -1225,15 +1227,23 @@ func RenderSearchVerifyCommand(command *SearchVerifyCommand) []byte {
 	if command == nil || command.Command == "" {
 		return nil
 	}
+	// Every field below carries repository-derived paths, and this block is
+	// one-record-per-line — so each is escaped with termsafe.Line. It matters more
+	// here than anywhere else in the payload: VERIFY is the line an agent is told
+	// to RUN, and a pathname holding a newline would otherwise split the record
+	// and let a repository print a command the deriver never produced. (Execution
+	// itself was already safe: the path is shell-quoted. This is about what the
+	// reader is shown.)
+	//
 	// "VERIFY: " stays byte-identical at line start whatever else changes — every harness and every
 	// prior measurement keys on that prefix.
-	rendered := "VERIFY: " + searchVerifyDecorated(command) + "\n"
-	evidenceLine := "  targets " + command.Targets
+	rendered := "VERIFY: " + termsafe.Line(searchVerifyDecorated(command)) + "\n"
+	evidenceLine := "  targets " + termsafe.Line(command.Targets)
 	if command.Targets == "" {
 		evidenceLine = "  targets (omitted for length)"
 	}
 	if command.DerivedFrom != "" {
-		evidenceLine += " (from " + command.DerivedFrom + ")"
+		evidenceLine += " (from " + termsafe.Line(command.DerivedFrom) + ")"
 	}
 	if command.Tier != "" {
 		evidenceLine += " tier=" + command.Tier
@@ -1246,7 +1256,7 @@ func RenderSearchVerifyCommand(command *SearchVerifyCommand) []byte {
 	// questions the command otherwise invites: why is there a -D on my cmake line, or why does the
 	// derivation say coverage is not claimed.
 	if command.Guard != "" {
-		rendered += "  guarded by: " + command.Guard + "\n"
+		rendered += "  guarded by: " + termsafe.Line(command.Guard) + "\n"
 	}
 	// PRE-FIX status is computed by the CALLER (it already validates the pristine tree) and rendered
 	// verbatim here, capped. The binary deliberately does not interpret it: a status the tool invented

--- a/internal/sem/search_verify.go
+++ b/internal/sem/search_verify.go
@@ -271,16 +271,15 @@ func buildSearchVerifyCommand(
 }
 
 // searchVerifyControlBytes reports whether a derived command carries a byte that
-// the text renderer would have to escape. It checks the COMMAND only: Targets and
-// DerivedFrom are prose about the derivation and are escaped for display without
-// any claim that they can be pasted into a shell.
+// the text renderer would have to escape. It asks termsafe rather than scanning
+// for C0 itself, because a second copy of the rule is a rule that drifts: this
+// one already had, missing the C1 controls the renderer escapes — a path holding
+// a raw 0x9b passed the gate, was emitted as runnable, and was then rewritten on
+// the way to the terminal. It checks the COMMAND only: Targets and DerivedFrom
+// are prose about the derivation and are escaped for display without any claim
+// that they can be pasted into a shell.
 func searchVerifyControlBytes(command string) bool {
-	for i := 0; i < len(command); i++ {
-		if command[i] < 0x20 || command[i] == 0x7f {
-			return true
-		}
-	}
-	return false
+	return termsafe.EscapesLine(command)
 }
 
 // searchVerifyResidualFloor is the last rung: no manifest, no test file, no single-file checker. It

--- a/internal/sem/search_verify_test.go
+++ b/internal/sem/search_verify_test.go
@@ -864,6 +864,48 @@ func TestBuildSearchVerifyCommandFallsBackToTheResidualFloor(t *testing.T) {
 		t.Fatalf("the line start must stay byte-identical:\n%s", rendered)
 	}
 }
+
+// TestBuildSearchVerifyCommandWithholdsAnUnprintableCommand pins the gate that
+// keeps "runnable exactly as written" true. A command whose path holds a byte the
+// renderer escapes is neither runnable as shown nor honest about not being, so it
+// is withheld and the residual floor answers instead.
+//
+// The C1 cases are the ones that regressed: the gate scanned for C0 and DEL while
+// the renderer escapes C1 as well, so a path carrying a raw 0x9b passed the gate,
+// was emitted as runnable, and was then rewritten on the way to the terminal. It
+// asks termsafe now, so the two cannot drift apart again.
+func TestBuildSearchVerifyCommandWithholdsAnUnprintableCommand(t *testing.T) {
+	t.Parallel()
+	for _, testCase := range []struct{ name, directory string }{
+		{"ESC", "internal/con\x1bfigs"},
+		{"a raw C1 byte", "internal/con\x9bfigs"},
+		{"C1 in its two-byte UTF-8 form", "internal/con\xc2\x9bfigs"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			evidence := searchVerifyTestEvidence(map[string]string{
+				"go.mod":                               "module x\n",
+				testCase.directory + "/parser_test.go": "package configs\n\nfunc TestParse(t *testing.T) {}\n",
+			})
+			results := []SearchResult{
+				{Rank: 1, FilePath: testCase.directory + "/parser.go", SymbolName: "Parse", Section: searchSectionPrimary},
+				{Rank: 2, FilePath: testCase.directory + "/parser_test.go", Section: searchSectionPrimary},
+			}
+			command := buildSearchVerifyCommand(results, evidence)
+			if command == nil {
+				t.Fatal("no VERIFY block at all — the residual floor must make this impossible")
+			}
+			if command.Command != searchVerifyNoneCommand {
+				t.Fatalf("emitted a command display would have rewritten: %q", command.Command)
+			}
+			rendered := string(RenderSearchVerifyCommand(command))
+			if strings.IndexByte(rendered, 0x1b) >= 0 || strings.IndexByte(rendered, 0x9b) >= 0 {
+				t.Fatalf("the rendered VERIFY block carried a control byte: %q", rendered)
+			}
+		})
+	}
+}
+
 func TestSearchVerifySuiteFallback(t *testing.T) {
 	t.Parallel()
 	for _, testCase := range []struct {

--- a/internal/sem/text.go
+++ b/internal/sem/text.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"os"
 	"strings"
+
+	"github.com/entireio/entire-graph/internal/termsafe"
 )
 
 func writeText(out io.Writer, result Result) {
@@ -151,7 +153,18 @@ func (s textStyles) changed(value string) string {
 	return s.render("33", value)
 }
 
+// render is the single sink of this renderer: every repository-derived value it
+// prints — entity names parsed out of the scanned tree, file paths from git —
+// reaches the terminal through here.
+//
+// Neutralizing BEFORE the color wrap rather than after is what makes the guard
+// hold. With color on, the value sits between codes this function opened, so an
+// embedded ESC does not merely inject a sequence of its own: it terminates the
+// styling mid-string and leaves the terminal in a state the trailing reset was
+// never going to close. With color off the value is returned as-is, which is the
+// other half of the same hole — hence the escape ahead of both paths.
 func (s textStyles) render(code, value string) string {
+	value = termsafe.Line(value)
 	if !s.color || value == "" {
 		return value
 	}

--- a/internal/sem/text_escape_test.go
+++ b/internal/sem/text_escape_test.go
@@ -1,0 +1,97 @@
+package sem
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// hostileEntity is what a YAML `metadata.name` can hold: yamlLineValue strips
+// comments and quotes but neutralizes nothing, so the scalar reaches Entity.Name
+// with its bytes intact and is carried into EntityChange.Name from there.
+const hostileEntity = "evil\x1b[2K\x1b[31m"
+
+func hostileDiffResult() Result {
+	return Result{
+		Base: "main", Head: "HEAD",
+		Files: []FileChange{{
+			Path: "deploy/" + hostileEntity + ".yaml", Status: "M", Language: "yaml",
+			Changes: []EntityChange{
+				{Type: "added", Kind: "resource", Name: hostileEntity},
+				{Type: "removed", Kind: "resource", Name: hostileEntity, DependentsCount: 2},
+			},
+		}},
+	}
+}
+
+// TestWriteTextEscapesEntityNameWithoutColor covers the plain path, where
+// textStyles.render used to return the untrusted value completely unchanged.
+func TestWriteTextEscapesEntityNameWithoutColor(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	var buffer bytes.Buffer
+	writeText(&buffer, hostileDiffResult())
+	assertDiffTextIsDefanged(t, buffer.String())
+}
+
+// TestWriteTextEscapesEntityNameWithColor covers the worse half. With color on
+// the value is concatenated BETWEEN codes this renderer opened, so an embedded
+// ESC does not merely inject its own sequence — it terminates the styling early
+// and leaves the terminal in a state the trailing reset cannot close.
+func TestWriteTextEscapesEntityNameWithColor(t *testing.T) {
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("ENTIRE_GRAPH_FORCE_COLOR", "1")
+	var buffer bytes.Buffer
+	writeText(&buffer, hostileDiffResult())
+	rendered := buffer.String()
+	if !strings.Contains(rendered, "\x1b[") {
+		t.Fatalf("expected this case to exercise the colored path:\n%q", rendered)
+	}
+	// Every ESC still present must be one this renderer emitted itself: an SGR
+	// introducer immediately followed by digits or the reset.
+	for _, fragment := range strings.Split(rendered, "\x1b")[1:] {
+		if !strings.HasPrefix(fragment, "[") {
+			t.Errorf("ESC not introducing an SGR sequence survived:\n%q", rendered)
+			continue
+		}
+		code := strings.SplitN(fragment[1:], "m", 2)
+		if len(code) != 2 || strings.Trim(code[0], "0123456789;") != "" {
+			t.Errorf("ESC introducing a non-SGR sequence survived:\n%q", rendered)
+		}
+	}
+	assertDiffTextIsDefanged(t, rendered)
+}
+
+func assertDiffTextIsDefanged(t *testing.T, rendered string) {
+	t.Helper()
+	if strings.Contains(rendered, hostileEntity) {
+		t.Errorf("the repository-controlled sequence reached the terminal intact:\n%q", rendered)
+	}
+	// Defanged, not dropped: the reader must still be told which entity changed.
+	if !strings.Contains(rendered, "evil") {
+		t.Errorf("the entity name was dropped rather than escaped:\n%s", rendered)
+	}
+}
+
+// TestWriteTextWithoutControlBytesIsUnchanged keeps ordinary diffs byte-identical,
+// which is what stops this guard from churning every text-output fixture.
+func TestWriteTextWithoutControlBytesIsUnchanged(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	clean := Result{
+		Base: "main", Head: "HEAD",
+		Files: []FileChange{{
+			Path: "internal/sem/text.go", Status: "M", Language: "go",
+			Changes: []EntityChange{{Type: "signature_changed", Kind: "function", Name: "render", DependentsCount: 7}},
+		}},
+	}
+	var buffer bytes.Buffer
+	writeText(&buffer, clean)
+	rendered := buffer.String()
+	for _, want := range []string{"internal/sem/text.go", "render", "(7 dependents)", "(go)"} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("clean diff no longer reports %q:\n%s", want, rendered)
+		}
+	}
+	if strings.Contains(rendered, `\x`) {
+		t.Errorf("clean diff gained an escape artifact:\n%s", rendered)
+	}
+}

--- a/internal/termsafe/termsafe.go
+++ b/internal/termsafe/termsafe.go
@@ -102,6 +102,19 @@ func Line(value string) string {
 	return string(appendEscaped(make([]byte, 0, len(value)+escapeHeadroom), value, escapeLayout))
 }
 
+// EscapesLine reports whether Line would rewrite value.
+//
+// It exists for the one caller that has to decide something BEFORE rendering:
+// the VERIFY deriver, whose command must be runnable exactly as printed and so
+// must not be emitted at all when display would rewrite it. That decision has to
+// be made against the same rule the renderer applies, not a copy of it — a copy
+// that checked only C0 would emit a command whose C1 byte the renderer then
+// escaped, printing a line that is neither honest about being unprintable nor
+// runnable as shown.
+func EscapesLine(value string) bool {
+	return needsEscape(value, escapeLayout)
+}
+
 // Bytes neutralizes an already-rendered block that may legitimately span lines.
 // It returns the input itself when there is nothing to escape, so the ordinary
 // path neither copies nor allocates.
@@ -144,6 +157,15 @@ type text interface {
 // inside the C1 range, and a per-byte scan would mangle every CJK identifier it
 // met. Knowing the width lets the scan step OVER a valid sequence instead of
 // inspecting its interior.
+//
+// "Valid" here means WELL-FORMED, not merely well-shaped, and the second byte's
+// range is where the two differ. Accepting any continuation byte would let the
+// overlong form 0xe0 0x80 0x9b carry a CSI byte through as the interior of a
+// three-byte rune: a decoder that rejects overlongs shows a replacement
+// character, but one that does not decodes those three bytes to U+001B — the
+// classic overlong smuggling of an ASCII control. This package escapes a stray
+// C1 byte precisely because it cannot assume how the terminal decodes; treating
+// an ill-formed sequence as a rune to step over would assume exactly that.
 func runeWidthAt[T text](data T, i int) int {
 	lead := data[i]
 	switch {
@@ -153,21 +175,41 @@ func runeWidthAt[T text](data T, i int) int {
 		// A continuation byte with no lead, or an overlong two-byte form.
 		return 0
 	case lead < 0xe0:
-		return continuationWidth(data, i, 2)
+		return sequenceWidth(data, i, 2, 0x80, 0xbf)
+	case lead == 0xe0:
+		// Below 0xa0 the code point would fit the two-byte form: overlong.
+		return sequenceWidth(data, i, 3, 0xa0, 0xbf)
+	case lead == 0xed:
+		// 0xed 0xa0.. and up is a surrogate half, which UTF-8 does not encode.
+		return sequenceWidth(data, i, 3, 0x80, 0x9f)
 	case lead < 0xf0:
-		return continuationWidth(data, i, 3)
-	case lead < 0xf5:
-		return continuationWidth(data, i, 4)
+		return sequenceWidth(data, i, 3, 0x80, 0xbf)
+	case lead == 0xf0:
+		// Below 0x90 the code point would fit the three-byte form.
+		return sequenceWidth(data, i, 4, 0x90, 0xbf)
+	case lead == 0xf4:
+		// Above U+10FFFF there is nothing to encode.
+		return sequenceWidth(data, i, 4, 0x80, 0x8f)
+	case lead < 0xf4:
+		return sequenceWidth(data, i, 4, 0x80, 0xbf)
 	default:
 		return 0
 	}
 }
 
-func continuationWidth[T text](data T, i, width int) int {
+// sequenceWidth reports width when the bytes after the lead are continuations and
+// the SECOND one falls in the range that lead admits, or 0 otherwise. Only the
+// second byte's range varies by lead: it carries the code point's high bits, so
+// it is the byte that decides whether a sequence is overlong, a surrogate half,
+// or past the last code point.
+func sequenceWidth[T text](data T, i, width int, secondLow, secondHigh byte) int {
 	if i+width > len(data) {
 		return 0
 	}
-	for offset := 1; offset < width; offset++ {
+	if data[i+1] < secondLow || data[i+1] > secondHigh {
+		return 0
+	}
+	for offset := 2; offset < width; offset++ {
 		if data[i+offset] < 0x80 || data[i+offset] > 0xbf {
 			return 0
 		}

--- a/internal/termsafe/termsafe.go
+++ b/internal/termsafe/termsafe.go
@@ -1,0 +1,206 @@
+// Package termsafe neutralizes terminal control sequences in output derived from
+// repository content.
+//
+// Every human-readable verb in this tool prints bytes a scanned repository
+// controls: pathnames from `git diff -z`, entity names parsed out of YAML, and
+// whole source lines lifted verbatim into snippets. A Git pathname may hold any
+// byte except NUL and '/', and a source file may hold any byte at all, so an ESC
+// in a filename or a declaration reaches the reader's terminal and is INTERPRETED
+// rather than displayed. That is a spoofing primitive: the repository, not the
+// tool, decides what the reader believes was reported.
+//
+// The neutralization sits at the WRITER, not at each print site. The sinks are
+// not a handful of auditable Fprintf calls — paths and source text are printed
+// from roughly forty places across the search, def, impact, neighbors, and
+// callsite renderers, and every renderer added later brings more. Wrapping the
+// renderer's writer makes the property structural: a new print site cannot
+// reintroduce the hole, because it cannot reach the terminal without passing
+// through here.
+//
+// What survives untouched is chosen so ordinary output stays BYTE-IDENTICAL,
+// because output stability is what lets an agent copy a snippet verbatim as an
+// edit anchor:
+//
+//   - LF and TAB pass, being the layout the renderers themselves depend on.
+//   - CR immediately followed by LF passes. Snippet lines are split on LF alone,
+//     so a CRLF-authored file carries its CR into every printed line; escaping it
+//     would put a visible marker at the end of every line of a Windows-authored
+//     repository, for no security gain.
+//   - A LONE CR is escaped, because carriage-return-without-newline is exactly
+//     how an attacker overwrites a line the reader has already seen.
+//   - Everything else in C0, DEL, and C1 is escaped to its Go literal form, so
+//     the byte is shown rather than obeyed and nothing is silently dropped.
+//
+// JSON and NDJSON output is deliberately NOT wrapped: encoding/json already
+// escapes control characters inside strings, so no raw byte reaches that stream,
+// and a consumer of the machine formats is entitled to the exact bytes Git
+// reported.
+//
+// One accepted cost: renderers that trim a payload to a byte budget do so before
+// their writer is wrapped, so escaping can push a payload past its budget. Each
+// escaped byte grows to at most six, and only input that already contains control
+// bytes grows at all, so the overshoot is bounded and reachable only by the
+// attacker it defends against.
+package termsafe
+
+import "io"
+
+// Writer neutralizes terminal control sequences in everything written through it.
+//
+// It holds no state between calls: each Write is sanitized on its own, and the
+// two lookahead rules (CRLF, and the two-byte UTF-8 form of C1) treat the end of
+// a buffer as the end of the input. Renderers here always format a complete
+// string before writing it, so a sequence never straddles a Write; were one to,
+// the worst outcome is a single visibly escaped CR or a passed-through 0xc2,
+// neither of which is a sequence a terminal acts on.
+type Writer struct {
+	out io.Writer
+}
+
+// NewWriter wraps a terminal-bound sink. Wrapping an already-wrapped writer is
+// harmless: escaping is idempotent, since every byte it emits is printable ASCII
+// that a second pass leaves alone.
+func NewWriter(out io.Writer) *Writer {
+	return &Writer{out: out}
+}
+
+// Write sanitizes p and writes it. It reports len(p) rather than the number of
+// bytes actually written, because io.Writer's contract describes progress through
+// the CALLER's buffer and a longer count would be read as a corrupt writer. The
+// common case — output with nothing to escape — passes p through untouched and
+// reports the underlying writer's own count.
+func (w *Writer) Write(p []byte) (int, error) {
+	if !needsEscape(p, keepLayout) {
+		return w.out.Write(p)
+	}
+	safe := appendEscaped(make([]byte, 0, len(p)+escapeHeadroom), p, keepLayout)
+	if _, err := w.out.Write(safe); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+// String neutralizes one value that may legitimately span lines. It exists for
+// the sinks a writer wrap cannot cover, chiefly the diff renderer, which must
+// escape a value BEFORE wrapping it in its own ANSI color codes.
+func String(value string) string {
+	if !needsEscape(value, keepLayout) {
+		return value
+	}
+	return string(appendEscaped(make([]byte, 0, len(value)+escapeHeadroom), value, keepLayout))
+}
+
+// Line neutralizes one value that must occupy a single line: a file path, a
+// symbol name, a one-line declaration — anything embedded in a record whose
+// layout is "one per line".
+//
+// It escapes LF and TAB on top of what String escapes, because in that position
+// they are not layout, they are forgery. A repository can name a file
+//
+//	a.go\n1. src/real.go:1 score=99.0
+//
+// and a renderer that passes the LF through prints a second entry the search
+// never returned. The writer wrap cannot make this distinction — by the time
+// bytes reach it, a snippet's newlines and a path's are the same byte — so
+// values that go into single-line records are escaped here, at the point where
+// the renderer still knows which is which.
+func Line(value string) string {
+	if !needsEscape(value, escapeLayout) {
+		return value
+	}
+	return string(appendEscaped(make([]byte, 0, len(value)+escapeHeadroom), value, escapeLayout))
+}
+
+// Bytes is String for an already-rendered block. It returns the input itself when
+// there is nothing to escape, so the ordinary path neither copies nor allocates.
+func Bytes(value []byte) []byte {
+	if !needsEscape(value, keepLayout) {
+		return value
+	}
+	return appendEscaped(make([]byte, 0, len(value)+escapeHeadroom), value, keepLayout)
+}
+
+// layout says whether LF, TAB, and CRLF are this value's own structure (a source
+// snippet, a rendered block) or content it must not be allowed to fake (a path or
+// a name inside a one-line record).
+type layout bool
+
+const (
+	keepLayout   layout = true
+	escapeLayout layout = false
+)
+
+// escapeHeadroom is the slack the output buffer starts with. It is a guess at how
+// much a hostile string grows, not a bound; append handles the rest.
+const escapeHeadroom = 16
+
+const hexDigits = "0123456789abcdef"
+
+// text is the shape both entry points share. Sanitizing reads by index and never
+// slices, so one implementation serves strings and byte slices without either
+// caller converting — and a conversion here would copy every payload the tool
+// prints.
+type text interface {
+	~string | ~[]byte
+}
+
+// escapedAt reports how the byte at index i must be treated: keep it (0), escape
+// just it (1), or escape it together with the byte that follows (2). Returning
+// the width is what lets the scan and the rewrite share one copy of the rules.
+func escapedAt[T text](data T, i int, keep layout) int {
+	character := data[i]
+	switch {
+	case character == '\n' || character == '\t':
+		if keep {
+			return 0
+		}
+		return 1
+	case character == '\r':
+		// CRLF is the line ending of a Windows-authored file, not an overwrite.
+		if keep && i+1 < len(data) && data[i+1] == '\n' {
+			return 0
+		}
+		return 1
+	case character < 0x20 || character == 0x7f:
+		// C0 and DEL. ESC (0x1b) is the sequence introducer that matters most,
+		// but BEL, backspace, and the cursor controls all rewrite what is seen.
+		return 1
+	case character == 0xc2 && i+1 < len(data) && data[i+1] >= 0x80 && data[i+1] <= 0x9f:
+		// The C1 controls in their two-byte UTF-8 form. U+009B is CSI, which a
+		// terminal in UTF-8 mode acts on exactly as it acts on ESC followed by
+		// '['; escaping only C0 would leave that introducer reachable.
+		return 2
+	default:
+		return 0
+	}
+}
+
+func needsEscape[T text](data T, keep layout) bool {
+	for i := 0; i < len(data); i++ {
+		if escapedAt(data, i, keep) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// appendEscaped writes data to dst with every control byte replaced by the Go
+// literal that denotes it, so a reader who meets the escape in a terminal or a
+// log sees the byte written the way source would write it.
+func appendEscaped[T text](dst []byte, data T, keep layout) []byte {
+	for i := 0; i < len(data); i++ {
+		switch escapedAt(data, i, keep) {
+		case 1:
+			dst = append(dst, '\\', 'x', hexDigits[data[i]>>4], hexDigits[data[i]&0x0f])
+		case 2:
+			// In the two-byte form the trailing byte IS the code point: 0xc2
+			// contributes the 0x80 that its 0x00-0x1f payload is added to.
+			point := data[i+1]
+			dst = append(dst, '\\', 'u', '0', '0', hexDigits[point>>4], hexDigits[point&0x0f])
+			i++
+		default:
+			dst = append(dst, data[i])
+		}
+	}
+	return dst
+}

--- a/internal/termsafe/termsafe.go
+++ b/internal/termsafe/termsafe.go
@@ -70,13 +70,23 @@ func NewWriter(out io.Writer) *Writer {
 // the CALLER's buffer and a longer count would be read as a corrupt writer. The
 // common case — output with nothing to escape — passes p through untouched and
 // reports the underlying writer's own count.
+//
+// A short write with no error is a contract violation by the sink, not a state
+// this writer can be in — but reporting len(p) for it would turn truncated
+// output into a successful write, and truncated output is precisely how a
+// half-written escape stops being an escape. It is reported as io.ErrShortWrite
+// instead.
 func (w *Writer) Write(p []byte) (int, error) {
 	if !needsEscape(p, keepLayout) {
 		return w.out.Write(p)
 	}
 	safe := appendEscaped(make([]byte, 0, len(p)+escapeHeadroom), p, keepLayout)
-	if _, err := w.out.Write(safe); err != nil {
+	written, err := w.out.Write(safe)
+	if err != nil {
 		return 0, err
+	}
+	if written != len(safe) {
+		return 0, io.ErrShortWrite
 	}
 	return len(p), nil
 }
@@ -85,7 +95,7 @@ func (w *Writer) Write(p []byte) (int, error) {
 // symbol name, a one-line declaration — anything embedded in a record whose
 // layout is "one per line".
 //
-// It escapes LF and TAB on top of what String escapes, because in that position
+// It escapes LF and TAB on top of what Writer and Bytes escape, because in that position
 // they are not layout, they are forgery. A repository can name a file
 //
 //	a.go\n1. src/real.go:1 score=99.0

--- a/internal/termsafe/termsafe.go
+++ b/internal/termsafe/termsafe.go
@@ -21,7 +21,8 @@
 // because output stability is what lets an agent copy a snippet verbatim as an
 // edit anchor:
 //
-//   - LF and TAB pass, being the layout the renderers themselves depend on.
+//   - LF, TAB, FF and VT pass, being page whitespace the renderers and the
+//     scanned sources themselves depend on.
 //   - CR immediately followed by LF passes. Snippet lines are split on LF alone,
 //     so a CRLF-authored file carries its CR into every printed line; escaping it
 //     would put a visible marker at the end of every line of a Windows-authored
@@ -80,16 +81,6 @@ func (w *Writer) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-// String neutralizes one value that may legitimately span lines. It exists for
-// the sinks a writer wrap cannot cover, chiefly the diff renderer, which must
-// escape a value BEFORE wrapping it in its own ANSI color codes.
-func String(value string) string {
-	if !needsEscape(value, keepLayout) {
-		return value
-	}
-	return string(appendEscaped(make([]byte, 0, len(value)+escapeHeadroom), value, keepLayout))
-}
-
 // Line neutralizes one value that must occupy a single line: a file path, a
 // symbol name, a one-line declaration — anything embedded in a record whose
 // layout is "one per line".
@@ -111,8 +102,9 @@ func Line(value string) string {
 	return string(appendEscaped(make([]byte, 0, len(value)+escapeHeadroom), value, escapeLayout))
 }
 
-// Bytes is String for an already-rendered block. It returns the input itself when
-// there is nothing to escape, so the ordinary path neither copies nor allocates.
+// Bytes neutralizes an already-rendered block that may legitimately span lines.
+// It returns the input itself when there is nothing to escape, so the ordinary
+// path neither copies nor allocates.
 func Bytes(value []byte) []byte {
 	if !needsEscape(value, keepLayout) {
 		return value
@@ -150,7 +142,14 @@ type text interface {
 func escapedAt[T text](data T, i int, keep layout) int {
 	character := data[i]
 	switch {
-	case character == '\n' || character == '\t':
+	case character == '\n' || character == '\t' || character == '\f' || character == '\v':
+		// FF and VT ride along with LF and TAB because they are page whitespace,
+		// not a cursor primitive: a terminal treats both as an index (move down a
+		// line) and neither can reposition horizontally, restyle, or hide text.
+		// They have to pass, because a form feed is how GNU-style C, Emacs Lisp
+		// and older Perl separate pages — escaping it would rewrite the bytes of
+		// every such file's snippet and break the verbatim edit anchor this
+		// package promises to preserve.
 		if keep {
 			return 0
 		}

--- a/internal/termsafe/termsafe.go
+++ b/internal/termsafe/termsafe.go
@@ -136,10 +136,50 @@ type text interface {
 	~string | ~[]byte
 }
 
-// escapedAt reports how the byte at index i must be treated: keep it (0), escape
-// just it (1), or escape it together with the byte that follows (2). Returning
-// the width is what lets the scan and the rewrite share one copy of the rules.
-func escapedAt[T text](data T, i int, keep layout) int {
+// runeWidthAt reports how many bytes form a VALID UTF-8 sequence starting at i,
+// or 0 when the byte there begins no valid sequence.
+//
+// The scan needs this to tell a stray C1 byte from a continuation byte that only
+// looks like one: the middle byte of U+65E5 (0xe6 0x97 0xa5) is 0x97, squarely
+// inside the C1 range, and a per-byte scan would mangle every CJK identifier it
+// met. Knowing the width lets the scan step OVER a valid sequence instead of
+// inspecting its interior.
+func runeWidthAt[T text](data T, i int) int {
+	lead := data[i]
+	switch {
+	case lead < 0x80:
+		return 1
+	case lead < 0xc2:
+		// A continuation byte with no lead, or an overlong two-byte form.
+		return 0
+	case lead < 0xe0:
+		return continuationWidth(data, i, 2)
+	case lead < 0xf0:
+		return continuationWidth(data, i, 3)
+	case lead < 0xf5:
+		return continuationWidth(data, i, 4)
+	default:
+		return 0
+	}
+}
+
+func continuationWidth[T text](data T, i, width int) int {
+	if i+width > len(data) {
+		return 0
+	}
+	for offset := 1; offset < width; offset++ {
+		if data[i+offset] < 0x80 || data[i+offset] > 0xbf {
+			return 0
+		}
+	}
+	return width
+}
+
+// escapedAt reports how the sequence at index i must be treated: its width in
+// bytes, and whether those bytes are escaped rather than copied. Returning the
+// width is what lets the scan and the rewrite share one copy of the rules, and
+// what lets both step over a multi-byte rune without reading its interior.
+func escapedAt[T text](data T, i int, keep layout) (int, bool) {
 	character := data[i]
 	switch {
 	case character == '\n' || character == '\t' || character == '\f' || character == '\v':
@@ -150,35 +190,49 @@ func escapedAt[T text](data T, i int, keep layout) int {
 		// and older Perl separate pages — escaping it would rewrite the bytes of
 		// every such file's snippet and break the verbatim edit anchor this
 		// package promises to preserve.
-		if keep {
-			return 0
-		}
-		return 1
+		return 1, !bool(keep)
 	case character == '\r':
 		// CRLF is the line ending of a Windows-authored file, not an overwrite.
 		if keep && i+1 < len(data) && data[i+1] == '\n' {
-			return 0
+			return 1, false
 		}
-		return 1
+		return 1, true
 	case character < 0x20 || character == 0x7f:
 		// C0 and DEL. ESC (0x1b) is the sequence introducer that matters most,
 		// but BEL, backspace, and the cursor controls all rewrite what is seen.
-		return 1
-	case character == 0xc2 && i+1 < len(data) && data[i+1] >= 0x80 && data[i+1] <= 0x9f:
+		return 1, true
+	case character < 0x80:
+		return 1, false
+	}
+	// Above ASCII the byte is only safe to judge in UTF-8 terms.
+	width := runeWidthAt(data, i)
+	switch {
+	case width == 2 && character == 0xc2 && data[i+1] >= 0x80 && data[i+1] <= 0x9f:
 		// The C1 controls in their two-byte UTF-8 form. U+009B is CSI, which a
 		// terminal in UTF-8 mode acts on exactly as it acts on ESC followed by
 		// '['; escaping only C0 would leave that introducer reachable.
-		return 2
+		return 2, true
+	case width > 0:
+		return width, false
+	case character <= 0x9f:
+		// A STRAY C1 byte — one that begins no valid sequence. A Git pathname is
+		// a byte string, not text, so 0x9b can arrive raw, and a terminal in an
+		// 8-bit locale reads that single byte as CSI. Only 0x80-0x9f is escaped
+		// here: stray bytes above it are not controls in any encoding, and
+		// rewriting them would corrupt Latin-1-encoded sources for no gain.
+		return 1, true
 	default:
-		return 0
+		return 1, false
 	}
 }
 
 func needsEscape[T text](data T, keep layout) bool {
-	for i := 0; i < len(data); i++ {
-		if escapedAt(data, i, keep) > 0 {
+	for i := 0; i < len(data); {
+		width, escape := escapedAt(data, i, keep)
+		if escape {
 			return true
 		}
+		i += width
 	}
 	return false
 }
@@ -187,19 +241,25 @@ func needsEscape[T text](data T, keep layout) bool {
 // literal that denotes it, so a reader who meets the escape in a terminal or a
 // log sees the byte written the way source would write it.
 func appendEscaped[T text](dst []byte, data T, keep layout) []byte {
-	for i := 0; i < len(data); i++ {
-		switch escapedAt(data, i, keep) {
-		case 1:
-			dst = append(dst, '\\', 'x', hexDigits[data[i]>>4], hexDigits[data[i]&0x0f])
-		case 2:
+	for i := 0; i < len(data); {
+		width, escape := escapedAt(data, i, keep)
+		switch {
+		case !escape:
+			for offset := 0; offset < width; offset++ {
+				dst = append(dst, data[i+offset])
+			}
+		case width == 2:
 			// In the two-byte form the trailing byte IS the code point: 0xc2
 			// contributes the 0x80 that its 0x00-0x1f payload is added to.
 			point := data[i+1]
 			dst = append(dst, '\\', 'u', '0', '0', hexDigits[point>>4], hexDigits[point&0x0f])
-			i++
+		case data[i] >= 0x80:
+			// A stray C1 byte denotes the code point of the same value.
+			dst = append(dst, '\\', 'u', '0', '0', hexDigits[data[i]>>4], hexDigits[data[i]&0x0f])
 		default:
-			dst = append(dst, data[i])
+			dst = append(dst, '\\', 'x', hexDigits[data[i]>>4], hexDigits[data[i]&0x0f])
 		}
+		i += width
 	}
 	return dst
 }

--- a/internal/termsafe/termsafe_test.go
+++ b/internal/termsafe/termsafe_test.go
@@ -28,19 +28,9 @@ var escapeCases = []struct {
 	{"the low end of C1 escapes too", "x\u0080y", `x\u0080y`},
 	{"0xc2 not introducing C1 is an ordinary lead byte", "caf\u00e9 \u00c2\u00a0 break", "caf\u00e9 \u00c2\u00a0 break"},
 	{"NUL is a control byte like any other", "a\x00b", `a\x00b`},
+	{"FF is a page separator in GNU-style source", "top\n\fbottom", "top\n\fbottom"},
+	{"VT is page whitespace too", "a\vb", "a\vb"},
 	{"multi-byte runes survive intact", "héllo → wörld 日本語", "héllo → wörld 日本語"},
-}
-
-func TestStringEscapesControlSequences(t *testing.T) {
-	t.Parallel()
-	for _, testCase := range escapeCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			t.Parallel()
-			if got := String(testCase.in); got != testCase.want {
-				t.Errorf("String(%q) = %q, want %q", testCase.in, got, testCase.want)
-			}
-		})
-	}
 }
 
 func TestBytesEscapesControlSequences(t *testing.T) {
@@ -92,6 +82,12 @@ func TestLineEscapesLayoutBytes(t *testing.T) {
 	if got := Line("col\tumn"); got != `col\x09umn` {
 		t.Errorf("Line did not escape a tab: %q", got)
 	}
+	// Page whitespace passes in keep-layout mode because it is real source
+	// formatting, but in a one-line record it still moves the reader down a line,
+	// so Line escapes it.
+	if got := Line("page\fbreak"); got != `page\x0cbreak` {
+		t.Errorf("Line did not escape a form feed: %q", got)
+	}
 	// Everything String escapes, Line escapes too.
 	for _, testCase := range escapeCases {
 		if strings.ContainsAny(Line(testCase.in), "\x1b") {
@@ -113,9 +109,6 @@ func TestOutputWithoutControlBytesIsByteIdentical(t *testing.T) {
 	source := "func (s textStyles) render(code, value string) string {\n" +
 		"\tif !s.color || value == \"\" {\n\t\treturn value\n\t}\n}\n" +
 		"// naïve — 日本語 — \"quoted\" 'single' `back` $shell\r\n"
-	if got := String(source); got != source {
-		t.Errorf("String rewrote clean source:\ngot  %q\nwant %q", got, source)
-	}
 	if got := Bytes([]byte(source)); !bytes.Equal(got, []byte(source)) {
 		t.Errorf("Bytes rewrote clean source:\ngot  %q\nwant %q", got, source)
 	}
@@ -126,9 +119,9 @@ func TestOutputWithoutControlBytesIsByteIdentical(t *testing.T) {
 func TestEscapingIsIdempotent(t *testing.T) {
 	t.Parallel()
 	for _, testCase := range escapeCases {
-		once := String(testCase.in)
-		if twice := String(once); twice != once {
-			t.Errorf("String(String(%q)) = %q, want %q", testCase.in, twice, once)
+		once := string(Bytes([]byte(testCase.in)))
+		if twice := string(Bytes([]byte(once))); twice != once {
+			t.Errorf("Bytes(Bytes(%q)) = %q, want %q", testCase.in, twice, once)
 		}
 	}
 }

--- a/internal/termsafe/termsafe_test.go
+++ b/internal/termsafe/termsafe_test.go
@@ -30,6 +30,10 @@ var escapeCases = []struct {
 	{"NUL is a control byte like any other", "a\x00b", `a\x00b`},
 	{"FF is a page separator in GNU-style source", "top\n\fbottom", "top\n\fbottom"},
 	{"VT is page whitespace too", "a\vb", "a\vb"},
+	{"a STRAY C1 byte is CSI to an 8-bit terminal", "x\x9b31mred", `x\u009b31mred`},
+	{"a stray byte above C1 is not a control in any encoding", "caf\xe9 latin-1", "caf\xe9 latin-1"},
+	{"continuation bytes inside a valid rune are not stray C1", "\u65e5\u672c\u8a9e", "\u65e5\u672c\u8a9e"},
+	{"a truncated lead byte is left alone when it is not C1", "ok\xf0", "ok\xf0"},
 	{"multi-byte runes survive intact", "héllo → wörld 日本語", "héllo → wörld 日本語"},
 }
 

--- a/internal/termsafe/termsafe_test.go
+++ b/internal/termsafe/termsafe_test.go
@@ -1,0 +1,169 @@
+package termsafe
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// escapeCases are the rules the package promises, stated once and driven through
+// all three entry points. A rule that holds for String but not for Writer is a
+// hole, since which one a sink uses is an implementation detail of the renderer.
+var escapeCases = []struct {
+	name string
+	in   string
+	want string
+}{
+	{"plain text is untouched", "internal/cli/search.go:42", "internal/cli/search.go:42"},
+	{"newlines and tabs are layout, not control", "func f() {\n\treturn\n}", "func f() {\n\treturn\n}"},
+	{"CRLF is a Windows line ending", "line one\r\nline two\r\n", "line one\r\nline two\r\n"},
+	{"a lone CR overwrites the line already read", "real output\rfake output", `real output\x0dfake output`},
+	{"CR at end of buffer has no LF to pair with", "trailing\r", `trailing\x0d`},
+	{"ESC is the sequence introducer", "before\x1b[31mafter", `before\x1b[31mafter`},
+	{"OSC can retitle the window or reach the clipboard", "\x1b]0;owned\x07", `\x1b]0;owned\x07`},
+	{"BEL and backspace rewrite what was printed", "a\x07b\x08c", `a\x07b\x08c`},
+	{"DEL is not printable", "a\x7fb", `a\x7fb`},
+	{"C1 CSI in its two-byte UTF-8 form is an ESC-[ equivalent", "x\u009b31mred", `x\u009b31mred`},
+	{"the low end of C1 escapes too", "x\u0080y", `x\u0080y`},
+	{"0xc2 not introducing C1 is an ordinary lead byte", "caf\u00e9 \u00c2\u00a0 break", "caf\u00e9 \u00c2\u00a0 break"},
+	{"NUL is a control byte like any other", "a\x00b", `a\x00b`},
+	{"multi-byte runes survive intact", "héllo → wörld 日本語", "héllo → wörld 日本語"},
+}
+
+func TestStringEscapesControlSequences(t *testing.T) {
+	t.Parallel()
+	for _, testCase := range escapeCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			if got := String(testCase.in); got != testCase.want {
+				t.Errorf("String(%q) = %q, want %q", testCase.in, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestBytesEscapesControlSequences(t *testing.T) {
+	t.Parallel()
+	for _, testCase := range escapeCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			if got := string(Bytes([]byte(testCase.in))); got != testCase.want {
+				t.Errorf("Bytes(%q) = %q, want %q", testCase.in, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestWriterEscapesControlSequences(t *testing.T) {
+	t.Parallel()
+	for _, testCase := range escapeCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			var buffer bytes.Buffer
+			written, err := NewWriter(&buffer).Write([]byte(testCase.in))
+			if err != nil {
+				t.Fatal(err)
+			}
+			// The count describes the caller's buffer, not the sink's, so a
+			// renderer that checks it against len(p) never sees a short write.
+			if written != len(testCase.in) {
+				t.Errorf("Write reported %d bytes, want %d", written, len(testCase.in))
+			}
+			if got := buffer.String(); got != testCase.want {
+				t.Errorf("Write(%q) wrote %q, want %q", testCase.in, got, testCase.want)
+			}
+		})
+	}
+}
+
+// TestLineEscapesLayoutBytes covers the stricter variant. In a one-line record a
+// newline is not layout, it is a way to print a record the tool never produced.
+func TestLineEscapesLayoutBytes(t *testing.T) {
+	t.Parallel()
+	forgery := "a.go\n1. src/real.go:1 score=99.0"
+	got := Line(forgery)
+	if strings.ContainsAny(got, "\n\r\t") {
+		t.Errorf("Line(%q) = %q, want no layout bytes", forgery, got)
+	}
+	if want := `a.go\x0a1. src/real.go:1 score=99.0`; got != want {
+		t.Errorf("Line(%q) = %q, want %q", forgery, got, want)
+	}
+	if got := Line("col\tumn"); got != `col\x09umn` {
+		t.Errorf("Line did not escape a tab: %q", got)
+	}
+	// Everything String escapes, Line escapes too.
+	for _, testCase := range escapeCases {
+		if strings.ContainsAny(Line(testCase.in), "\x1b") {
+			t.Errorf("Line(%q) left a control sequence: %q", testCase.in, Line(testCase.in))
+		}
+	}
+	// And a value with no layout bytes is left exactly as String leaves it.
+	if got, want := Line("internal/cli/search.go"), "internal/cli/search.go"; got != want {
+		t.Errorf("Line rewrote a clean path: %q", got)
+	}
+}
+
+// TestOutputWithoutControlBytesIsByteIdentical is the compatibility half of the
+// contract. Agents copy printed snippets verbatim as edit anchors, so ordinary
+// source must come through unchanged — an escape that "helpfully" rewrote a tab
+// or a Unicode identifier would break every anchor it touched.
+func TestOutputWithoutControlBytesIsByteIdentical(t *testing.T) {
+	t.Parallel()
+	source := "func (s textStyles) render(code, value string) string {\n" +
+		"\tif !s.color || value == \"\" {\n\t\treturn value\n\t}\n}\n" +
+		"// naïve — 日本語 — \"quoted\" 'single' `back` $shell\r\n"
+	if got := String(source); got != source {
+		t.Errorf("String rewrote clean source:\ngot  %q\nwant %q", got, source)
+	}
+	if got := Bytes([]byte(source)); !bytes.Equal(got, []byte(source)) {
+		t.Errorf("Bytes rewrote clean source:\ngot  %q\nwant %q", got, source)
+	}
+}
+
+// TestEscapingIsIdempotent is what lets a wrapped writer be wrapped again — which
+// happens whenever one wrapped renderer delegates to another.
+func TestEscapingIsIdempotent(t *testing.T) {
+	t.Parallel()
+	for _, testCase := range escapeCases {
+		once := String(testCase.in)
+		if twice := String(once); twice != once {
+			t.Errorf("String(String(%q)) = %q, want %q", testCase.in, twice, once)
+		}
+	}
+}
+
+// TestWriterPassesThroughUnderlyingError keeps a failed write a failed write: a
+// renderer that ignored the error would report success on a closed pipe.
+func TestWriterPassesThroughUnderlyingError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("sink closed")
+	writer := NewWriter(failingWriter{err: sentinel})
+	if _, err := writer.Write([]byte("clean text")); !errors.Is(err, sentinel) {
+		t.Errorf("clean path returned %v, want %v", err, sentinel)
+	}
+	if _, err := writer.Write([]byte("hostile \x1b[2J")); !errors.Is(err, sentinel) {
+		t.Errorf("escaped path returned %v, want %v", err, sentinel)
+	}
+}
+
+// TestWriterEscapesAcrossSeparateWrites documents the stateless boundary. Each
+// Write is sanitized on its own, so a renderer that formats a complete line per
+// call — which every renderer here does — gets the same result as one big write.
+func TestWriterEscapesAcrossSeparateWrites(t *testing.T) {
+	t.Parallel()
+	var buffer bytes.Buffer
+	writer := NewWriter(&buffer)
+	for _, chunk := range []string{"1. src/a.go:1\n", "func \x1b[31mf\x1b[0m() {\n", "}\n"} {
+		if _, err := writer.Write([]byte(chunk)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if strings.ContainsRune(buffer.String(), 0x1b) {
+		t.Errorf("ESC survived a chunked write: %q", buffer.String())
+	}
+}
+
+type failingWriter struct{ err error }
+
+func (w failingWriter) Write([]byte) (int, error) { return 0, w.err }

--- a/internal/termsafe/termsafe_test.go
+++ b/internal/termsafe/termsafe_test.go
@@ -35,6 +35,21 @@ var escapeCases = []struct {
 	{"continuation bytes inside a valid rune are not stray C1", "\u65e5\u672c\u8a9e", "\u65e5\u672c\u8a9e"},
 	{"a truncated lead byte is left alone when it is not C1", "ok\xf0", "ok\xf0"},
 	{"multi-byte runes survive intact", "héllo → wörld 日本語", "héllo → wörld 日本語"},
+	// An ill-formed sequence is not a rune to step over. Each of these carries a
+	// C1 byte in a position that LOOKS like the interior of a longer rune, which is
+	// the shape that would smuggle it past a scan that only checked whether the
+	// following bytes were continuations. The lead byte itself stays: above 0x9f it
+	// is not a control in any encoding.
+	{"an overlong three-byte form hides a CSI byte", "x\xe0\x80\x9by", "x\xe0" + `\u0080\u009b` + "y"},
+	{"an overlong two-byte form hides a C1 byte", "x\xc0\x80y", "x\xc0" + `\u0080` + "y"},
+	{"a surrogate half is not a rune either", "x\xed\xa0\x80y", "x\xed\xa0" + `\u0080` + "y"},
+	{"a four-byte form past U+10FFFF is not a rune", "x\xf4\x90\x80\x80y", "x\xf4" + `\u0090\u0080\u0080` + "y"},
+	// The other side of the same rule: the smallest and largest well-formed
+	// sequence of each length must still be stepped over, or tightening the scan
+	// would have mangled the runes at every boundary.
+	{"the boundary rune of each length is still a rune",
+		"\u00a0\u07ff\u0800\ud7ff\uffff\U00010000\U0010ffff",
+		"\u00a0\u07ff\u0800\ud7ff\uffff\U00010000\U0010ffff"},
 }
 
 func TestBytesEscapesControlSequences(t *testing.T) {

--- a/internal/termsafe/termsafe_test.go
+++ b/internal/termsafe/termsafe_test.go
@@ -3,12 +3,14 @@ package termsafe
 import (
 	"bytes"
 	"errors"
+	"io"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 // escapeCases are the rules the package promises, stated once and driven through
-// all three entry points. A rule that holds for String but not for Writer is a
+// all three entry points. A rule that holds for Bytes but not for Writer is a
 // hole, since which one a sink uses is an implementation detail of the renderer.
 var escapeCases = []struct {
 	name string
@@ -107,13 +109,16 @@ func TestLineEscapesLayoutBytes(t *testing.T) {
 	if got := Line("page\fbreak"); got != `page\x0cbreak` {
 		t.Errorf("Line did not escape a form feed: %q", got)
 	}
-	// Everything String escapes, Line escapes too.
+	// Everything Bytes escapes, Line escapes too — in EITHER spelling a control
+	// arrives in. Scanning for ESC alone would say nothing about the raw and
+	// overlong C1 cases above, which are the ones that reached this package by
+	// being missed.
 	for _, testCase := range escapeCases {
-		if strings.ContainsAny(Line(testCase.in), "\x1b") {
-			t.Errorf("Line(%q) left a control sequence: %q", testCase.in, Line(testCase.in))
+		if index := indexControl(Line(testCase.in)); index >= 0 {
+			t.Errorf("Line(%q) left a control at byte %d: %q", testCase.in, index, Line(testCase.in))
 		}
 	}
-	// And a value with no layout bytes is left exactly as String leaves it.
+	// And a value with no layout bytes is left exactly as Bytes leaves it.
 	if got, want := Line("internal/cli/search.go"), "internal/cli/search.go"; got != want {
 		t.Errorf("Line rewrote a clean path: %q", got)
 	}
@@ -159,6 +164,26 @@ func TestWriterPassesThroughUnderlyingError(t *testing.T) {
 	}
 }
 
+// TestWriterReportsAShortWriteAsAnError covers the sink that writes part of the
+// buffer and reports no error. That is a contract violation by the sink, but
+// reporting len(p) for it would turn truncated output into a successful write —
+// and truncation is exactly how a half-written escape stops being an escape, with
+// the tail of the sanitized buffer never reaching the reader.
+func TestWriterReportsAShortWriteAsAnError(t *testing.T) {
+	t.Parallel()
+	var sink shortWriter
+	written, err := NewWriter(&sink).Write([]byte("hostile \x1b[2J tail"))
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Errorf("short write returned (%d, %v), want io.ErrShortWrite", written, err)
+	}
+	// The clean path hands the sink's own count back, because there is nothing to
+	// re-count: p and the bytes written are the same buffer.
+	var clean shortWriter
+	if written, err := NewWriter(&clean).Write([]byte("clean text")); written != 4 || err != nil {
+		t.Errorf("clean path returned (%d, %v), want the sink's own (4, nil)", written, err)
+	}
+}
+
 // TestWriterEscapesAcrossSeparateWrites documents the stateless boundary. Each
 // Write is sanitized on its own, so a renderer that formats a complete line per
 // call — which every renderer here does — gets the same result as one big write.
@@ -174,6 +199,37 @@ func TestWriterEscapesAcrossSeparateWrites(t *testing.T) {
 	if strings.ContainsRune(buffer.String(), 0x1b) {
 		t.Errorf("ESC survived a chunked write: %q", buffer.String())
 	}
+}
+
+// indexControl reports the first byte a terminal would act on, in every spelling
+// a value can carry one: ESC, a decoded C1 code point, and an undecodable byte in
+// the C1 range. Decoding rather than scanning bytes is what keeps it from firing
+// on the continuation bytes of an ordinary rune — U+0800 is 0xe0 0xa0 0x80, whose
+// last byte is 0x80.
+func indexControl(value string) int {
+	for index, character := range value {
+		switch {
+		case character == 0x1b:
+			return index
+		case character >= 0x80 && character <= 0x9f:
+			return index
+		case character == utf8.RuneError && value[index] >= 0x80 && value[index] <= 0x9f:
+			return index
+		}
+	}
+	return -1
+}
+
+// shortWriter accepts the first four bytes of anything and claims success, the
+// shape io.Writer forbids and this package must not paper over.
+type shortWriter struct{ got []byte }
+
+func (w *shortWriter) Write(p []byte) (int, error) {
+	if len(p) > 4 {
+		p = p[:4]
+	}
+	w.got = append(w.got, p...)
+	return len(p), nil
 }
 
 type failingWriter struct{ err error }


### PR DESCRIPTION
Closes six Aikido findings that are all the same bug, and leaves the other seven alone on purpose (triage at the end).

## The bug

Every human-readable renderer prints bytes a scanned repository controls: pathnames from `git diff -z`, entity names parsed out of YAML, whole source lines lifted verbatim into snippets. Nothing in the codebase neutralized terminal control characters on the way out. A Git pathname may hold any byte but NUL and `/`, and a source file any byte at all, so an ESC in a filename or a declaration reached the reader's terminal and was interpreted rather than displayed.

| Aikido finding | Sink |
|---|---|
| Terminal escape injection via raw Git filenames in `--progress` stderr | `internal/cli/root.go` |
| Terminal control-sequence injection in text file-outline output | `internal/sem/search_outline.go` |
| Terminal escape injection in semantic diff output | `internal/sem/text.go` |
| Terminal escape/control-sequence injection via unescaped type-card declarations | `internal/cli/search.go` |
| ANSI control-sequence injection in text search output | `internal/cli/search.go` |
| CLI emits repository-controlled terminal escape sequences in source excerpts | `internal/cli/symbolref.go` |

## The fix

`internal/termsafe` provides two guards, and the split between them is the whole design:

- **`Writer` / `Bytes`** — layout-preserving. Wraps a renderer's writer so no print site can reach the terminal without passing through. LF, TAB, FF and VT pass.
- **`Line`** — for a field in a one-record-per-line layout, where LF is not layout but forgery. A repository can name a file `a.go\n1. src/real.go:1 score=99.0` and print a hit the search never returned. The writer cannot make that call — by then a snippet's newline and a path's are the same byte.

Sinks a wrap cannot cover are escaped by value: `textStyles.render` (emits its own ANSI, so the untrusted value sits *between* codes we opened), the `--progress` line (stderr also carries the progress bar's cursor control), and `RenderExplain` (its byte budget is measured on the strings it builds).

The escaping is UTF-8 aware rather than per-byte, because the middle byte of `日` (U+65E5 = `e6 97 a5`) is `0x97` — inside the C1 range — so a naive scan would mangle every CJK identifier. `escapedAt` returns the width of the sequence it judged and both scan and rewrite step over valid runes. Stray bytes above `0x9f` are left alone: not controls in any encoding, and rewriting them would corrupt Latin-1 sources.

## What does not change

**Ordinary output is byte-identical.** Agents copy printed snippets verbatim as `old_string` edit anchors, and a snippet the renderer rewrote would stop matching its file. Form feeds are page separators in GNU-style C and Emacs Lisp; an early version of this PR escaped them and broke exactly that invariant.

**JSON and NDJSON are untouched.** `encoding/json` already escapes control characters inside strings, and a consumer of the machine formats is entitled to the exact bytes Git reported.

**VERIFY stays runnable.** A command built around a control-byte path cannot be both runnable and safe to display, so it is not emitted — the residual floor already says "nothing derivable here", which is the truthful answer for a repository whose filenames cannot be printed.

## Verification

`mise run check` passes, with and without forced colour.

`TestNoVerbLeaksControlSequencesToTheTerminal` drives thirteen real verb invocations against a repo whose filename **and** function body carry a live erase-line sequence. **Every guard was checked by removing it and confirming a test goes red.** One documented exception: `diffProgressLine` is unreachable from the sweep (per-file progress events are throttled to one per second and forced only every hundredth file), so it keeps its own unit test.

## How the sinks were found

Three review rounds each surfaced more instances of the same class, which is a signal that review does not converge on it. The final pass enumerated every `Fprintf`/`Sprintf` in the renderers interpolating a repository-derived `Path`/`Name`/`Symbol`/`Decl` field without `termsafe`: 34 sites, each accounted for — search's headers take escaped copies from `searchResultOnOneLine`, diagnostics route through `agentDiagnosticPath`, the diff renderer goes through `textStyles.render`, two are map keys, two are the operator's own transcripts, and `describe()` at `text.go:70` is dead code.

That enumeration found the last two, both of which had survived every review. The worse one: the **compact neighbors focus line** has three renderings and the caller prints the longest that fits, but only the first inherited its escaping — so the guard disappeared precisely under byte pressure. Its test sweeps every budget and asserts a focus line was actually rendered, because a fixture whose path is too long is never abbreviated at all and would sweep 400 budgets while proving nothing.

Review rounds also caught three defects in this PR's own work: `explain` was leaking with no guard at all; escaping all of C0 broke form feeds; and the sweep asserted "no ESC in stdout" while the diff renderer legitimately emits SGR — it passed only because `NO_COLOR` happened to be set locally.

## The other seven Aikido findings — not fixed, deliberately

- **RCE via VERIFY build checks** (High) and **actions/checkout persists credentials** (Low) were already fixed on `main` by b1df9f2 and 47606b9. Both have since been retested in Aikido and are closed.
- **"Possible command injection via shell script"** (High, 4 sub-findings) is a **false positive** four times over. `verify.go:193` runs the string the operator typed at `--test`; the other three are `exec.CommandContext(ctx, name, args...)`, and Go spawns no shell for argv exec. `git grep` passes patterns as `-e <pattern>` with `-F`, so a `-`-leading query cannot become a flag.
- **"Potential file inclusion attack via reading file"** (High, 9 sub-findings) assumes a server taking a path from a request. Every cited read takes its path from the operator — `--repo`, `--cache-dir`, `ENTIRE_SEARCH_SESSION`, the local transcripts dir — and #88 already confined cache reads to an `os.Root` boundary. One residual worth naming: `gitInfoExcludePath` follows a scanned repo's `.git` → `gitdir:` → `commondir` chain to an arbitrary absolute path, but the bytes are only parsed as ignore rules and never printed, so there is no disclosure primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1cb66f942a292b858902cc570b59765c95dfd3a9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->