### PR TITLE
release: publish installable plugin archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,32 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "1.26.x"
+      - name: Install LLVM-MinGW for Windows ARM64
+        if: matrix.goos == 'windows' && matrix.goarch == 'arm64'
+        shell: pwsh
+        run: |
+          $version = "20260616"
+          $expected = "312593669435bd0bfc1a43ac3fba23c8b27e0610bade88b2738e5a01702a99ba"
+          $archive = Join-Path $env:RUNNER_TEMP "llvm-mingw-$version-ucrt-aarch64.zip"
+          $destination = Join-Path $env:RUNNER_TEMP "llvm-mingw"
+          $url = "https://github.com/mstorsjo/llvm-mingw/releases/download/$version/llvm-mingw-$version-ucrt-aarch64.zip"
+
+          Invoke-WebRequest -Uri $url -OutFile $archive
+          $actual = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLowerInvariant()
+          if ($actual -ne $expected) {
+            throw "LLVM-MinGW checksum mismatch: expected $expected, got $actual"
+          }
+
+          Expand-Archive -Path $archive -DestinationPath $destination
+          $toolchain = Get-ChildItem -Path $destination -Directory | Select-Object -First 1
+          $cc = Join-Path $toolchain.FullName "bin/aarch64-w64-mingw32-clang.exe"
+          $cxx = Join-Path $toolchain.FullName "bin/aarch64-w64-mingw32-clang++.exe"
+          if (!(Test-Path $cc) -or !(Test-Path $cxx)) {
+            throw "LLVM-MinGW ARM64 compiler wrappers were not found"
+          }
+          "CC=$cc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CXX=$cxx" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          & $cc --version
       - name: Select artifact version
         id: version
         shell: bash
@@ -96,7 +122,8 @@ jobs:
           else
             (cd dist && shasum -a 256 -c checksums.txt)
           fi
-          grep -F "  $asset" dist/checksums.txt
+          read -r _ checksum_name < dist/checksums.txt
+          test "${checksum_name#\*}" = "$asset"
       - uses: actions/upload-artifact@v4
         with:
           name: release-${{ matrix.goos }}-${{ matrix.goarch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,158 @@
+name: release
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/release.yml
+      - scripts/release.sh
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build (${{ matrix.goos }}/${{ matrix.goarch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            goos: linux
+            goarch: amd64
+          - runner: ubuntu-24.04-arm
+            goos: linux
+            goarch: arm64
+          - runner: macos-15-intel
+            goos: darwin
+            goarch: amd64
+          - runner: macos-15
+            goos: darwin
+            goarch: arm64
+          - runner: windows-2025
+            goos: windows
+            goarch: amd64
+          - runner: windows-11-arm
+            goos: windows
+            goarch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.x"
+      - name: Select artifact version
+        id: version
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            version=$GITHUB_REF_NAME
+          else
+            version=v0.0.0-ci
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Build release archive
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          OUT_DIR: dist
+          ENTIRE_RELEASE_TARGETS: ${{ matrix.goos }}/${{ matrix.goarch }}
+        run: scripts/release.sh
+      - name: Verify release archive
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          set -euo pipefail
+          asset_version=${VERSION#v}
+          extension=tar.gz
+          binary=entire-graph
+          if [[ "$GOOS" == windows ]]; then
+            extension=zip
+            binary=entire-graph.exe
+          fi
+          asset="entire-graph_${asset_version}_${GOOS}_${GOARCH}.${extension}"
+          test -f "dist/$asset"
+
+          verify_dir=$(mktemp -d)
+          trap 'rm -rf "$verify_dir"' EXIT
+          if [[ "$GOOS" == windows ]]; then
+            7z x -bd -y -o"$verify_dir" "dist/$asset" >/dev/null
+          else
+            tar -xzf "dist/$asset" -C "$verify_dir"
+          fi
+          test -f "$verify_dir/$binary"
+          test "$("$verify_dir/$binary" version)" = "$VERSION"
+
+          if command -v sha256sum >/dev/null 2>&1; then
+            (cd dist && sha256sum -c checksums.txt)
+          else
+            (cd dist && shasum -a 256 -c checksums.txt)
+          fi
+          grep -F "  $asset" dist/checksums.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: |
+            dist/entire-graph_*.tar.gz
+            dist/entire-graph_*.zip
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: publish GitHub release
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          path: dist
+          merge-multiple: true
+      - name: Assemble and verify release
+        shell: bash
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          asset_version=${VERSION#v}
+          assets=(
+            "dist/entire-graph_${asset_version}_darwin_amd64.tar.gz"
+            "dist/entire-graph_${asset_version}_darwin_arm64.tar.gz"
+            "dist/entire-graph_${asset_version}_linux_amd64.tar.gz"
+            "dist/entire-graph_${asset_version}_linux_arm64.tar.gz"
+            "dist/entire-graph_${asset_version}_windows_amd64.zip"
+            "dist/entire-graph_${asset_version}_windows_arm64.zip"
+          )
+          for asset in "${assets[@]}"; do
+            test -f "$asset"
+          done
+          (cd dist && sha256sum entire-graph_* > checksums.txt)
+          test "$(wc -l < dist/checksums.txt)" -eq 6
+      - name: Publish release assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          assets=(dist/entire-graph_* dist/checksums.txt)
+          if gh release view "$VERSION" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release upload "$VERSION" "${assets[@]}" --clobber --repo "$GITHUB_REPOSITORY"
+          else
+            gh release create "$VERSION" "${assets[@]}" \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --generate-notes \
+              --title "$VERSION"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
           }
           "CC=$cc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "CXX=$cxx" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CGO_LDFLAGS=-static" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           & $cc --version
       - name: Select artifact version
         id: version

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,11 +5,42 @@ repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 cd "$repo_root"
 
 version=${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || printf 'dev')}
+asset_version=${version#v}
 out_dir=${OUT_DIR:-dist/release-$version}
 targets=${ENTIRE_RELEASE_TARGETS:-$(go env GOOS)/$(go env GOARCH)}
 
 mkdir -p "$out_dir"
-rm -f "$out_dir"/SHA256SUMS
+out_dir=$(CDPATH= cd -- "$out_dir" && pwd)
+rm -f "$out_dir"/checksums.txt "$out_dir"/SHA256SUMS
+
+checksum_artifact() {
+	artifact_name=${1##*/}
+	if command -v sha256sum >/dev/null 2>&1; then
+		(cd "$out_dir" && sha256sum "$artifact_name")
+		return
+	fi
+	if command -v shasum >/dev/null 2>&1; then
+		(cd "$out_dir" && shasum -a 256 "$artifact_name")
+		return
+	fi
+	printf 'neither sha256sum nor shasum is available\n' >&2
+	return 1
+}
+
+archive_windows() {
+	work=$1
+	archive=$2
+	if command -v zip >/dev/null 2>&1; then
+		(cd "$work" && zip -q -r "$archive" .)
+		return
+	fi
+	if command -v 7z >/dev/null 2>&1; then
+		(cd "$work" && 7z a -bd -y -tzip "$archive" . >/dev/null)
+		return
+	fi
+	printf 'neither zip nor 7z is available for a Windows archive\n' >&2
+	return 1
+}
 
 build_target() {
 	goos=${1%/*}
@@ -24,8 +55,13 @@ build_target() {
 		windows) bin="$bin.exe" ;;
 	esac
 
-	work="$out_dir/entire-graph-$version-$goos-$goarch"
-	archive="$out_dir/entire-graph-$version-$goos-$goarch.tar.gz"
+	asset="entire-graph_${asset_version}_${goos}_${goarch}"
+	work="$out_dir/$asset"
+	archive="$out_dir/$asset.tar.gz"
+	if [ "$goos" = "windows" ]; then
+		archive="$out_dir/$asset.zip"
+	fi
+	rm -f "$archive" "$archive.sig" "$archive.asc"
 	rm -rf "$work"
 	mkdir -p "$work"
 
@@ -35,9 +71,13 @@ build_target() {
 		-o "$work/$bin" ./cmd/entire-graph
 
 	cp README.md LICENSE entire-plugin.yml "$work/"
-	tar -C "$out_dir" -czf "$archive" "entire-graph-$version-$goos-$goarch"
+	if [ "$goos" = "windows" ]; then
+		archive_windows "$work" "$archive"
+	else
+		tar -C "$work" -czf "$archive" .
+	fi
 	rm -rf "$work"
-	shasum -a 256 "$archive" >> "$out_dir/SHA256SUMS"
+	checksum_artifact "$archive" >> "$out_dir/checksums.txt"
 	sign_artifact "$archive"
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/50
<!-- entire-trail-link-end -->

## What changed

- update `scripts/release.sh` to emit Entire CLI-compatible asset names and a basename-only `checksums.txt`
- package Windows targets as ZIP archives and macOS/Linux targets as tarballs
- add a tag-driven workflow that builds, executes, packages, and checksums native amd64 and arm64 binaries on macOS, Linux, and Windows
- publish a GitHub release only after all six target jobs succeed

## Why

The existing release script emitted hyphenated archive names and `SHA256SUMS`. Entire CLI v0.10.0 discovers underscore-delimited assets and verifies them through `checksums.txt`, so the current output cannot be installed from a GitHub release or the public plugin index.

Native jobs are required because Entire Graph embeds CGO-backed tree-sitter parsers. Cross-compiling by setting only `GOOS` and `GOARCH` does not produce trustworthy artifacts for the other operating systems.

## Impact

There is no runtime graph behavior change. Pull requests touching the release files build six verification artifacts. A `v*` tag publishes the same verified matrix to its GitHub release.

## Checks

- `go test ./...`
- `actionlint .github/workflows/release.yml`
- `sh -n scripts/release.sh`
- local macOS amd64 and arm64 archive builds
- checksum verification, extraction, architecture inspection, and `entire-graph version` execution for both local archives

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit eecc5cfe836939e5d3a765488ff8f28f91d00573. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->