### PR TITLE
fix: keep --head source output on the committed tree

### DIFF
--- a/internal/cli/callsite.go
+++ b/internal/cli/callsite.go
@@ -138,6 +138,36 @@ func openSnapshotLineReader(
 	return read, batch.Close, nil
 }
 
+// openSnapshotLineReaderOrDegrade opens the provenance-correct reader and, when
+// that cannot be done, reports no source instead of failing the command.
+//
+// Quoted source is enrichment, not the answer. Every other read failure in this
+// file — missing file, binary, oversized, path outside the root — already
+// degrades to the definition line, and a `--head` answer without source windows
+// still answers the graph question. Only the opening of the git child process
+// was fatal, so an fd exhaustion or a fork failure turned a complete relation
+// answer into no output at all. The failure is reported on stderr, which never
+// reaches an agent's payload.
+func openSnapshotLineReaderOrDegrade(
+	ctx context.Context,
+	snapshot sem.ProviderSnapshot,
+	worktree bool,
+	warn io.Writer,
+) (lineReader, func() error) {
+	read, closeSource, err := openSnapshotLineReader(ctx, snapshot, worktree)
+	if err != nil {
+		if warn != nil {
+			fmt.Fprintf(warn, "graph: committed source unavailable (%v); reporting locations without source\n", err)
+		}
+		return noSourceLineReader, nil
+	}
+	return read, closeSource
+}
+
+// noSourceLineReader reports no source for every path, so that a degraded reader
+// is indistinguishable from a file that could not be quoted.
+func noSourceLineReader(string) ([]string, bool) { return nil, false }
+
 // newRepoLineReader reads files under repoRoot, memoizing per path so several
 // call sites in one file cost one read. It refuses oversized and NUL-bearing
 // files: neither can usefully be quoted.

--- a/internal/cli/callsite.go
+++ b/internal/cli/callsite.go
@@ -118,11 +118,12 @@ func openSnapshotLineReader(
 		if strings.Contains(relPath, "\n") {
 			// The batch protocol is line based, so a newline-bearing Git path
 			// needs the argv-safe one-shot reader. It still reads the same commit;
-			// failure never falls back to the dirty working tree.
-			content, ok, readErr = gitutil.ShowFile(ctx, snapshot.Header.RepoRoot, snapshot.Header.Commit, relPath)
-			if int64(len(content)) > callSiteMaxFileBytes {
-				ok = false
-			}
+			// failure never falls back to the dirty working tree. The ceiling is
+			// passed DOWN rather than applied to the returned string: the sibling
+			// readers refuse an oversized blob before materializing it, and a path
+			// that reaches here can come from an ingested snapshot record, so this
+			// one must not be the exception that allocates first and checks after.
+			content, ok, readErr = gitutil.ShowFileLimited(ctx, snapshot.Header.RepoRoot, snapshot.Header.Commit, relPath, callSiteMaxFileBytes)
 		} else {
 			content, ok, readErr = batch.ReadFile(relPath)
 		}

--- a/internal/cli/callsite.go
+++ b/internal/cli/callsite.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/entireio/entire-graph/internal/gitutil"
 	"github.com/entireio/entire-graph/internal/sem"
 	"github.com/entireio/entire-graph/internal/termsafe"
 )
@@ -23,7 +25,8 @@ import (
 // The call line is recovered from the source rather than from the parser, so
 // this stays entirely inside the relation-output layer: the caller's body span
 // is known, the call expression's text is known (evidence detail), and the file
-// is on disk. Everything below is deterministic and language-agnostic.
+// comes from the same source view as the graph. Everything below is
+// deterministic and language-agnostic.
 
 const (
 	// callContextGuardLimit caps how many enclosing block headers are quoted.
@@ -80,6 +83,61 @@ type sourceLine struct {
 // files report false; callers degrade to the definition line.
 type lineReader func(relPath string) ([]string, bool)
 
+// openSnapshotLineReader returns one memoized source reader whose provenance
+// matches snapshot. A committed snapshot must never be annotated with dirty
+// working-tree source, so --head reads through one command-lifetime git
+// cat-file process bound to the snapshot's commit. Worktree snapshots, and the
+// provider's no-HEAD fallback, keep the contained on-disk reader.
+func openSnapshotLineReader(
+	ctx context.Context,
+	snapshot sem.ProviderSnapshot,
+	worktree bool,
+) (lineReader, func() error, error) {
+	if worktree || snapshot.Header.Commit == "" {
+		return newRepoLineReader(snapshot.Header.RepoRoot), nil, nil
+	}
+
+	batch, err := gitutil.NewBatchFileReader(ctx, snapshot.Header.RepoRoot, snapshot.Header.Commit)
+	if err != nil {
+		return nil, nil, err
+	}
+	batch.SetMaxBytes(callSiteMaxFileBytes)
+
+	cache := map[string][]string{}
+	read := func(relPath string) ([]string, bool) {
+		if relPath == "" || snapshot.Header.RepoRoot == "" {
+			return nil, false
+		}
+		if lines, ok := cache[relPath]; ok {
+			return lines, lines != nil
+		}
+
+		var content string
+		var ok bool
+		var readErr error
+		if strings.Contains(relPath, "\n") {
+			// The batch protocol is line based, so a newline-bearing Git path
+			// needs the argv-safe one-shot reader. It still reads the same commit;
+			// failure never falls back to the dirty working tree.
+			content, ok, readErr = gitutil.ShowFile(ctx, snapshot.Header.RepoRoot, snapshot.Header.Commit, relPath)
+			if int64(len(content)) > callSiteMaxFileBytes {
+				ok = false
+			}
+		} else {
+			content, ok, readErr = batch.ReadFile(relPath)
+		}
+		if readErr != nil || !ok || strings.IndexByte(content, 0) >= 0 {
+			cache[relPath] = nil
+			return nil, false
+		}
+
+		lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
+		cache[relPath] = lines
+		return lines, true
+	}
+	return read, batch.Close, nil
+}
+
 // newRepoLineReader reads files under repoRoot, memoizing per path so several
 // call sites in one file cost one read. It refuses oversized and NUL-bearing
 // files: neither can usefully be quoted.
@@ -91,8 +149,8 @@ type lineReader func(relPath string) ([]string, bool)
 // a path above the root, and os.Lstat only guarded the FINAL component, so an
 // intermediate symlink was followed by the subsequent read.
 //
-// Nothing reaches this with an untrusted relPath today — the three callers pass
-// paths from a snapshot this process built, and both snapshot sources omit
+// Nothing reaches this with an untrusted relPath today — callers pass paths
+// from a snapshot this process built, and both snapshot sources omit
 // symlinks. That is a property of today's callers, held by nothing: the
 // signature takes any string, and this package already ships a verb that
 // ingests externally supplied snapshot records. Making the boundary structural

--- a/internal/cli/def.go
+++ b/internal/cli/def.go
@@ -173,6 +173,13 @@ func runDef(ctx context.Context, opts Options, args []string) error {
 	if err != nil {
 		return err
 	}
+	readSource, closeSource, err := openSnapshotLineReader(ctx, snapshot, flags.Worktree)
+	if err != nil {
+		return err
+	}
+	if closeSource != nil {
+		defer closeSource()
+	}
 	indexLatency := time.Since(totalStarted)
 	queryStarted := time.Now()
 	symbols := flags.Symbols
@@ -207,7 +214,7 @@ func runDef(ctx context.Context, opts Options, args []string) error {
 			if err := writeDefText(opts.Stdout, response, flags.MaxContextBytes); err != nil {
 				return err
 			}
-			writeDefBodies(opts.Stdout, response, repo, query.From)
+			writeDefBodiesFromReader(opts.Stdout, response, readSource, query.From)
 		default:
 			return fmt.Errorf("def --format must be json, text, or agent, got %q", flags.Format)
 		}
@@ -221,7 +228,14 @@ func runDef(ctx context.Context, opts Options, args []string) error {
 // on carbon: the agent got a body it could not navigate, cut it with `head -80`, lost the line it
 // needed and spent 87 turns grepping instead. The card alone was never the whole answer.
 func writeDefBodies(out io.Writer, response defResponse, repoRoot string, from int) {
-	if len(response.Declarations) == 0 || repoRoot == "" {
+	if repoRoot == "" {
+		return
+	}
+	writeDefBodiesFromReader(out, response, newRepoLineReader(repoRoot), from)
+}
+
+func writeDefBodiesFromReader(out io.Writer, response defResponse, read lineReader, from int) {
+	if len(response.Declarations) == 0 || read == nil {
 		return
 	}
 	records := make([]sem.SymbolRecord, 0, len(response.Declarations))
@@ -235,7 +249,7 @@ func writeDefBodies(out io.Writer, response defResponse, repoRoot string, from i
 			FilePath: declaration.FilePath, StartLine: start, EndLine: declaration.EndLine,
 		})
 	}
-	writeSymbolMatchBodies(out, symbolMatchBodies(repoRoot, records, len(records)))
+	writeSymbolMatchBodies(out, symbolMatchBodiesFromReader(read, records, len(records)))
 }
 
 func parseDefFlags(args []string) (defFlags, error) {

--- a/internal/cli/def.go
+++ b/internal/cli/def.go
@@ -173,12 +173,16 @@ func runDef(ctx context.Context, opts Options, args []string) error {
 	if err != nil {
 		return err
 	}
-	readSource, closeSource, err := openSnapshotLineReader(ctx, snapshot, flags.Worktree)
-	if err != nil {
-		return err
-	}
-	if closeSource != nil {
-		defer closeSource()
+	// Only the source-quoting formats read source. Opening before the format
+	// switch spawned a git cat-file child that `--format json` never touched, and
+	// charged its setup to index_latency_ms.
+	var readSource lineReader
+	if flags.Format == "text" || flags.Format == "agent" {
+		var closeSource func() error
+		readSource, closeSource = openSnapshotLineReaderOrDegrade(ctx, snapshot, flags.Worktree, opts.Stderr)
+		if closeSource != nil {
+			defer closeSource()
+		}
 	}
 	indexLatency := time.Since(totalStarted)
 	queryStarted := time.Now()

--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -173,8 +173,9 @@ func runExplain(ctx context.Context, opts Options, args []string) error {
 	if cacheDir == "" {
 		cacheDir = opts.Env.PluginDataDir
 	}
-	// Worktree semantics on purpose: the agent has just edited the tree, and a declaration read from
-	// HEAD would describe code that no longer exists.
+	// Worktree is the default on purpose: the agent has just edited the tree, and a declaration read
+	// from HEAD would describe code that no longer exists. --head remains available for callers that
+	// explicitly want the committed baseline.
 	snapshot, _, err := sem.LoadOrBuildProviderSnapshot(ctx, repo, opts.Version, sem.ProviderSnapshotOptions{
 		NoNetwork:    true,
 		Worktree:     flags.Worktree,
@@ -192,7 +193,8 @@ func runExplain(ctx context.Context, opts Options, args []string) error {
 		encoder.SetEscapeHTML(false)
 		return encoder.Encode(response)
 	case "text", "agent":
-		_, err := opts.Stdout.Write(RenderExplain(response, flags.MaxContextBytes))
+		useHead := !flags.Worktree && snapshot.Header.Commit != ""
+		_, err := opts.Stdout.Write(RenderExplainWithProvenance(response, flags.MaxContextBytes, useHead))
 		return err
 	default:
 		return fmt.Errorf("explain --format must be json, text, or agent, got %q", flags.Format)
@@ -280,6 +282,13 @@ func buildExplainResponse(snapshot sem.ProviderSnapshot, names []string) Explain
 // RenderExplain prints the block. Unresolved names are listed last and on one line: they are a short
 // negative fact, not an entry worth a paragraph.
 func RenderExplain(response ExplainResponse, maxBytes int) []byte {
+	return RenderExplainWithProvenance(response, maxBytes, false)
+}
+
+// RenderExplainWithProvenance renders the same declaration block while making
+// its source view explicit. useHead is true only when a committed snapshot was
+// actually selected; the no-HEAD fallback therefore keeps the worktree label.
+func RenderExplainWithProvenance(response ExplainResponse, maxBytes int, useHead bool) []byte {
 	if len(response.Symbols) == 0 {
 		return nil
 	}
@@ -287,7 +296,11 @@ func RenderExplain(response ExplainResponse, maxBytes int) []byte {
 		maxBytes = explainMaxBytes
 	}
 	var buffer strings.Builder
-	buffer.WriteString(ExplainHeader + "\n")
+	header := ExplainHeader
+	if useHead {
+		header = ExplainHeadHeader
+	}
+	buffer.WriteString(header + "\n")
 	var missing []string
 	for _, symbol := range response.Symbols {
 		if !symbol.Resolved {
@@ -330,6 +343,9 @@ func RenderExplain(response ExplainResponse, maxBytes int) []byte {
 // ExplainHeader is exported so the guide and its test cannot drift from what is printed, the same
 // discipline the literal-cluster and file-outline block names are under.
 const ExplainHeader = "DECLARATIONS THE BUILD ERROR NAMED (from the working tree, so your own edits are included)"
+
+// ExplainHeadHeader labels the explicit committed-tree view selected by --head.
+const ExplainHeadHeader = "DECLARATIONS THE BUILD ERROR NAMED (from committed HEAD, so working-tree edits are excluded)"
 
 func parseExplainFlags(args []string) (explainFlags, error) {
 	flags := explainFlags{

--- a/internal/cli/head_source_provenance_test.go
+++ b/internal/cli/head_source_provenance_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -56,6 +57,30 @@ func TestHeadSnapshotLineReaderPreservesCommittedFileContract(t *testing.T) {
 		t.Fatalf("close committed reader: %v", err)
 	}
 	closeReader = nil
+}
+
+// A committed reader that cannot be opened must cost the answer its source
+// windows, not the answer itself.
+func TestSnapshotLineReaderDegradesWhenCommittedReaderCannotOpen(t *testing.T) {
+	var warn bytes.Buffer
+	read, closeReader := openSnapshotLineReaderOrDegrade(t.Context(), sem.ProviderSnapshot{
+		Header: sem.SnapshotHeader{
+			RepoRoot: filepath.Join(t.TempDir(), "not-a-directory"),
+			Commit:   "0000000000000000000000000000000000000000",
+		},
+	}, false, &warn)
+	if read == nil {
+		t.Fatal("degraded reader is nil, but call-site annotation reads through it unconditionally")
+	}
+	if closeReader != nil {
+		t.Fatal("degraded reader reported a close function for a process that never started")
+	}
+	if lines, ok := read("anything.go"); ok || lines != nil {
+		t.Fatalf("degraded reader returned source: %q ok=%v", lines, ok)
+	}
+	if !strings.Contains(warn.String(), "committed source unavailable") {
+		t.Fatalf("degradation was silent, so a missing source view looks like a file with no source: %q", warn.String())
+	}
 }
 
 func TestDefSourceBodiesFollowSelectedTree(t *testing.T) {

--- a/internal/cli/head_source_provenance_test.go
+++ b/internal/cli/head_source_provenance_test.go
@@ -1,0 +1,273 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/entireio/entire-graph/internal/sem"
+)
+
+func TestHeadSnapshotLineReaderPreservesCommittedFileContract(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Tests")
+	git(t, repo, "config", "user.email", "tests@entire.local")
+	write(t, repo, "tracked.go", "committed\r\nline\r\n")
+	write(t, repo, "contains-nul.go", "before\x00after\n")
+	write(t, repo, "oversized.go", strings.Repeat("x", callSiteMaxFileBytes+1))
+	write(t, repo, "line\nbreak.go", "committed-newline-path\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "committed reader fixture")
+
+	write(t, repo, "tracked.go", "dirty\nline\n")
+	write(t, repo, "line\nbreak.go", "dirty-newline-path\n")
+	write(t, repo, "dirty-only.go", "must not be visible from HEAD\n")
+
+	read, closeReader, err := openSnapshotLineReader(t.Context(), sem.ProviderSnapshot{
+		Header: sem.SnapshotHeader{RepoRoot: repo, Commit: rev(t, repo, "HEAD")},
+	}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if closeReader == nil {
+		t.Fatal("committed reader has no close function")
+	}
+	defer func() {
+		if closeReader != nil {
+			_ = closeReader()
+		}
+	}()
+
+	lines, ok := read("tracked.go")
+	if !ok || strings.Join(lines, "|") != "committed|line|" {
+		t.Fatalf("committed CRLF source = %q, ok=%v", lines, ok)
+	}
+	lines, ok = read("line\nbreak.go")
+	if !ok || strings.Join(lines, "|") != "committed-newline-path|" {
+		t.Fatalf("committed newline-path source = %q, ok=%v", lines, ok)
+	}
+	for _, path := range []string{"dirty-only.go", "contains-nul.go", "oversized.go"} {
+		if lines, ok := read(path); ok {
+			t.Errorf("committed reader accepted %q: %q", path, lines)
+		}
+	}
+	if err := closeReader(); err != nil {
+		t.Fatalf("close committed reader: %v", err)
+	}
+	closeReader = nil
+}
+
+func TestDefSourceBodiesFollowSelectedTree(t *testing.T) {
+	repo, cacheDir := newDirtySourceViewRepo(t)
+
+	for _, format := range []string{"text", "agent"} {
+		format := format
+		t.Run(format, func(t *testing.T) {
+			head := runSourceViewCommand(t, repo, cacheDir, "", "def", "--symbol", "InspectDefinition", "--head", "--format", format)
+			requireSourceView(t, head,
+				[]string{"committed-def-body"},
+				[]string{"dirty-def-body"},
+			)
+
+			worktree := runSourceViewCommand(t, repo, cacheDir, "", "def", "--symbol", "InspectDefinition", "--format", format)
+			requireSourceView(t, worktree,
+				[]string{"dirty-def-body"},
+				[]string{"committed-def-body"},
+			)
+		})
+	}
+}
+
+func TestNeighborsSourceAnnotationsFollowSelectedTree(t *testing.T) {
+	repo, cacheDir := newDirtySourceViewRepo(t)
+
+	headCallSite := runSourceViewCommand(t, repo, cacheDir, "", "neighbors",
+		"--symbol", "Target", "--direction", "in", "--head", "--format", "text")
+	requireSourceView(t, headCallSite,
+		[]string{"calls.go:7, def :5", "if committedGuard {", "committed-call-window"},
+		[]string{"calls.go:8, def :5", "dirtyGuard", "dirty-before-call", "dirty-call-window"},
+	)
+
+	worktreeCallSite := runSourceViewCommand(t, repo, cacheDir, "", "neighbors",
+		"--symbol", "Target", "--direction", "in", "--format", "text")
+	requireSourceView(t, worktreeCallSite,
+		[]string{"calls.go:8, def :5", "if dirtyGuard {", "dirty-before-call", "dirty-call-window"},
+		[]string{"calls.go:7, def :5", "committedGuard", "committed-call-window"},
+	)
+
+	headMatches := runSourceViewCommand(t, repo, cacheDir, "", "neighbors",
+		"--symbol", "Ambiguous", "--head", "--format", "text")
+	requireSourceView(t, headMatches,
+		[]string{"committed-alpha-body", "committed-beta-body"},
+		[]string{"dirty-alpha-body", "dirty-beta-body"},
+	)
+
+	worktreeMatches := runSourceViewCommand(t, repo, cacheDir, "", "neighbors",
+		"--symbol", "Ambiguous", "--format", "text")
+	requireSourceView(t, worktreeMatches,
+		[]string{"dirty-alpha-body", "dirty-beta-body"},
+		[]string{"committed-alpha-body", "committed-beta-body"},
+	)
+}
+
+func TestImpactSourceAnnotationsFollowSelectedTree(t *testing.T) {
+	repo, cacheDir := newDirtySourceViewRepo(t)
+
+	headCallSite := runSourceViewCommand(t, repo, cacheDir, "", "impact",
+		"--symbol", "Target", "--head", "--format", "text")
+	requireSourceView(t, headCallSite,
+		[]string{"calls.go:7, def :5"},
+		[]string{"calls.go:8, def :5"},
+	)
+
+	worktreeCallSite := runSourceViewCommand(t, repo, cacheDir, "", "impact",
+		"--symbol", "Target", "--format", "text")
+	requireSourceView(t, worktreeCallSite,
+		[]string{"calls.go:8, def :5"},
+		[]string{"calls.go:7, def :5"},
+	)
+
+	headMatches := runSourceViewCommand(t, repo, cacheDir, "", "impact",
+		"--symbol", "Ambiguous", "--head", "--format", "text")
+	requireSourceView(t, headMatches,
+		[]string{"committed-alpha-body", "committed-beta-body"},
+		[]string{"dirty-alpha-body", "dirty-beta-body"},
+	)
+
+	worktreeMatches := runSourceViewCommand(t, repo, cacheDir, "", "impact",
+		"--symbol", "Ambiguous", "--format", "text")
+	requireSourceView(t, worktreeMatches,
+		[]string{"dirty-alpha-body", "dirty-beta-body"},
+		[]string{"committed-alpha-body", "committed-beta-body"},
+	)
+}
+
+func TestExplainHeaderReportsSelectedTree(t *testing.T) {
+	repo, cacheDir := newDirtySourceViewRepo(t)
+	const buildFailure = "./definition.go:3:1: undefined: InspectDefinition\n"
+
+	worktree := runSourceViewCommand(t, repo, cacheDir, buildFailure, "explain", "--no-echo", "--format", "text")
+	if !strings.Contains(worktree, "from the working tree") {
+		t.Fatalf("worktree explain output does not identify its source view:\n%s", worktree)
+	}
+
+	head := runSourceViewCommand(t, repo, cacheDir, buildFailure, "explain", "--no-echo", "--head", "--format", "text")
+	if strings.Contains(head, "from the working tree") || !strings.Contains(strings.ToLower(head), "committed") {
+		t.Fatalf("--head explain output does not identify its committed source view:\n%s", head)
+	}
+	if firstLine(head) == firstLine(worktree) {
+		t.Fatalf("explain used the same provenance header for --head and worktree:\n%s", head)
+	}
+}
+
+func newDirtySourceViewRepo(t *testing.T) (repo, cacheDir string) {
+	t.Helper()
+	repo = t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Tests")
+	git(t, repo, "config", "user.email", "tests@entire.local")
+
+	write(t, repo, "definition.go", `package fixture
+
+func InspectDefinition() string {
+	return "committed-def-body"
+}
+`)
+	write(t, repo, "calls.go", `package fixture
+
+func Target() {}
+
+func Caller(committedGuard bool) {
+	if committedGuard {
+		Target()
+	}
+	_ = "committed-call-window"
+}
+`)
+	write(t, repo, "alpha.go", `package fixture
+
+func Ambiguous() string { return "committed-alpha-body" }
+`)
+	write(t, repo, "beta.go", `package fixture
+
+func Ambiguous() string { return "committed-beta-body" }
+`)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "committed source view")
+
+	write(t, repo, "definition.go", `package fixture
+
+func InspectDefinition() string {
+	return "dirty-def-body"
+}
+`)
+	write(t, repo, "calls.go", `package fixture
+
+func Target() {}
+
+func Caller(dirtyGuard bool) {
+	_ = "dirty-before-call"
+	if dirtyGuard {
+		Target()
+	}
+	_ = "dirty-call-window"
+}
+`)
+	write(t, repo, "alpha.go", `package fixture
+
+func Ambiguous() string { return "dirty-alpha-body" }
+`)
+	write(t, repo, "beta.go", `package fixture
+
+func Ambiguous() string { return "dirty-beta-body" }
+`)
+	return repo, t.TempDir()
+}
+
+func runSourceViewCommand(t *testing.T, repo, cacheDir, stdin string, args ...string) string {
+	t.Helper()
+	if len(args) == 0 {
+		t.Fatal("runSourceViewCommand requires a command")
+	}
+	commandArgs := []string{args[0], "--repo", repo, "--cache-dir", cacheDir}
+	commandArgs = append(commandArgs, args[1:]...)
+	var stdout, stderr bytes.Buffer
+	options := Options{
+		Version: "0.1.0",
+		Env: EntireEnv{
+			RepoRoot:      repo,
+			PluginDataDir: cacheDir,
+		},
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}
+	if stdin != "" {
+		options.Stdin = strings.NewReader(stdin)
+	}
+	if err := Run(t.Context(), options, commandArgs); err != nil {
+		t.Fatalf("entire graph %s: %v\nstderr:\n%s\nstdout:\n%s", strings.Join(commandArgs, " "), err, stderr.String(), stdout.String())
+	}
+	return stdout.String()
+}
+
+func requireSourceView(t *testing.T, output string, wants, rejects []string) {
+	t.Helper()
+	for _, want := range wants {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing selected-tree source %q:\n%s", want, output)
+		}
+	}
+	for _, reject := range rejects {
+		if strings.Contains(output, reject) {
+			t.Fatalf("output leaked other-tree source %q:\n%s", reject, output)
+		}
+	}
+}
+
+func firstLine(text string) string {
+	if end := strings.IndexByte(text, '\n'); end >= 0 {
+		return text[:end]
+	}
+	return text
+}

--- a/internal/cli/head_source_provenance_test.go
+++ b/internal/cli/head_source_provenance_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -17,12 +18,21 @@ func TestHeadSnapshotLineReaderPreservesCommittedFileContract(t *testing.T) {
 	write(t, repo, "tracked.go", "committed\r\nline\r\n")
 	write(t, repo, "contains-nul.go", "before\x00after\n")
 	write(t, repo, "oversized.go", strings.Repeat("x", callSiteMaxFileBytes+1))
-	write(t, repo, "line\nbreak.go", "committed-newline-path\n")
+	// A newline in a path is legal in Git and drives the one-shot `git show`
+	// fallback, but Windows cannot create such a file at all. Everything else
+	// this test pins — CRLF, NUL, the size ceiling, worktree isolation — is
+	// cross-platform, so only the newline case is skipped rather than the test.
+	newlinePaths := runtime.GOOS != "windows"
+	if newlinePaths {
+		write(t, repo, "line\nbreak.go", "committed-newline-path\n")
+	}
 	git(t, repo, "add", ".")
 	git(t, repo, "commit", "-m", "committed reader fixture")
 
 	write(t, repo, "tracked.go", "dirty\nline\n")
-	write(t, repo, "line\nbreak.go", "dirty-newline-path\n")
+	if newlinePaths {
+		write(t, repo, "line\nbreak.go", "dirty-newline-path\n")
+	}
 	write(t, repo, "dirty-only.go", "must not be visible from HEAD\n")
 
 	read, closeReader, err := openSnapshotLineReader(t.Context(), sem.ProviderSnapshot{
@@ -44,9 +54,11 @@ func TestHeadSnapshotLineReaderPreservesCommittedFileContract(t *testing.T) {
 	if !ok || strings.Join(lines, "|") != "committed|line|" {
 		t.Fatalf("committed CRLF source = %q, ok=%v", lines, ok)
 	}
-	lines, ok = read("line\nbreak.go")
-	if !ok || strings.Join(lines, "|") != "committed-newline-path|" {
-		t.Fatalf("committed newline-path source = %q, ok=%v", lines, ok)
+	if newlinePaths {
+		lines, ok = read("line\nbreak.go")
+		if !ok || strings.Join(lines, "|") != "committed-newline-path|" {
+			t.Fatalf("committed newline-path source = %q, ok=%v", lines, ok)
+		}
 	}
 	for _, path := range []string{"dirty-only.go", "contains-nul.go", "oversized.go"} {
 		if lines, ok := read(path); ok {

--- a/internal/cli/impact.go
+++ b/internal/cli/impact.go
@@ -147,10 +147,17 @@ func runImpact(ctx context.Context, opts Options, args []string) error {
 	if err != nil {
 		return err
 	}
+	readSource, closeSource, err := openSnapshotLineReader(ctx, snapshot, flags.Worktree)
+	if err != nil {
+		return err
+	}
+	if closeSource != nil {
+		defer closeSource()
+	}
 	indexLatency := time.Since(indexStarted)
 	queryStarted := time.Now()
-	response := buildImpactResponse(snapshot, flags)
-	annotateImpactCallSites(&response, newRepoLineReader(snapshot.Header.RepoRoot))
+	response := buildImpactResponseFromReader(snapshot, flags, readSource)
+	annotateImpactCallSites(&response, readSource)
 	// The verdict is computed once, on the finished response, so the text marker and the JSON fields
 	// can never disagree about whether this answer was worth reading.
 	if reason := impactDegenerateReason(response); reason != "" {
@@ -324,6 +331,14 @@ func impactNonCodeMention(relation sem.RelationRecord, endpoint neighborEndpoint
 }
 
 func buildImpactResponse(snapshot sem.ProviderSnapshot, flags impactFlags) impactResponse {
+	return buildImpactResponseFromReader(snapshot, flags, newRepoLineReader(snapshot.Header.RepoRoot))
+}
+
+func buildImpactResponseFromReader(
+	snapshot sem.ProviderSnapshot,
+	flags impactFlags,
+	readSource lineReader,
+) impactResponse {
 	endpoints := make(map[string]neighborEndpoint, len(snapshot.Symbols)+len(snapshot.Externals))
 	// Relation records carry no language, and file endpoints carry no kind beyond
 	// "file", so the language an edge came from has to be looked up by endpoint ID.
@@ -380,7 +395,7 @@ func buildImpactResponse(snapshot sem.ProviderSnapshot, flags impactFlags) impac
 			if !fuzzyMatch && len(focuses) <= 1 {
 				return nil
 			}
-			return symbolMatchBodies(snapshot.Header.RepoRoot, focuses, symbolAmbiguousBodyLimit)
+			return symbolMatchBodiesFromReader(readSource, focuses, symbolAmbiguousBodyLimit)
 		}(),
 		Warnings:          snapshot.Header.Warnings,
 		PartialFailures:   partialFailures,

--- a/internal/cli/impact.go
+++ b/internal/cli/impact.go
@@ -147,10 +147,7 @@ func runImpact(ctx context.Context, opts Options, args []string) error {
 	if err != nil {
 		return err
 	}
-	readSource, closeSource, err := openSnapshotLineReader(ctx, snapshot, flags.Worktree)
-	if err != nil {
-		return err
-	}
+	readSource, closeSource := openSnapshotLineReaderOrDegrade(ctx, snapshot, flags.Worktree, opts.Stderr)
 	if closeSource != nil {
 		defer closeSource()
 	}

--- a/internal/cli/neighbors.go
+++ b/internal/cli/neighbors.go
@@ -160,12 +160,20 @@ func runNeighbors(ctx context.Context, opts Options, args []string) error {
 	if err != nil {
 		return err
 	}
+	readSource, closeSource, err := openSnapshotLineReader(ctx, snapshot, flags.Worktree)
+	if err != nil {
+		return err
+	}
+	if closeSource != nil {
+		defer closeSource()
+	}
 	indexLatency := time.Since(indexStarted)
 	queryStarted := time.Now()
-	response := buildNeighborResponse(snapshot, flags)
-	// Call-site resolution reads the caller's source, so it needs the repo on
-	// disk. It runs after the graph query and is bounded by the answer's size.
-	annotateNeighborCallSites(&response, newRepoLineReader(snapshot.Header.RepoRoot))
+	response := buildNeighborResponseFromReader(snapshot, flags, readSource)
+	// Call-site resolution reads the caller's source from the same snapshot-bound
+	// reader as fuzzy and ambiguous bodies. It runs after the graph query and is
+	// bounded by the answer's size.
+	annotateNeighborCallSites(&response, readSource)
 	queryLatency := time.Since(queryStarted)
 	response.IndexCacheHit = cacheHit
 	response.IndexCacheDisabled = cacheDir == "" || flags.DisableCache
@@ -323,6 +331,14 @@ func parseNeighborFlags(args []string) (neighborFlags, error) {
 }
 
 func buildNeighborResponse(snapshot sem.ProviderSnapshot, flags neighborFlags) neighborResponse {
+	return buildNeighborResponseFromReader(snapshot, flags, newRepoLineReader(snapshot.Header.RepoRoot))
+}
+
+func buildNeighborResponseFromReader(
+	snapshot sem.ProviderSnapshot,
+	flags neighborFlags,
+	readSource lineReader,
+) neighborResponse {
 	endpoints := make(map[string]neighborEndpoint, len(snapshot.Symbols)+len(snapshot.Externals))
 	for _, file := range snapshot.Files {
 		endpoints[file.ID] = endpointForFile(file)
@@ -358,7 +374,7 @@ func buildNeighborResponse(snapshot sem.ProviderSnapshot, flags neighborFlags) n
 	focusMatchesTotal := len(focuses)
 	matchBodies := []symbolMatchBody(nil)
 	if fuzzyMatch || focusMatchesTotal > 1 {
-		matchBodies = symbolMatchBodies(snapshot.Header.RepoRoot, focuses, symbolAmbiguousBodyLimit)
+		matchBodies = symbolMatchBodiesFromReader(readSource, focuses, symbolAmbiguousBodyLimit)
 	}
 	focusMatchesTruncated := focusMatchesTotal > flags.Limit
 	if focusMatchesTruncated {

--- a/internal/cli/neighbors.go
+++ b/internal/cli/neighbors.go
@@ -160,10 +160,7 @@ func runNeighbors(ctx context.Context, opts Options, args []string) error {
 	if err != nil {
 		return err
 	}
-	readSource, closeSource, err := openSnapshotLineReader(ctx, snapshot, flags.Worktree)
-	if err != nil {
-		return err
-	}
+	readSource, closeSource := openSnapshotLineReaderOrDegrade(ctx, snapshot, flags.Worktree, opts.Stderr)
 	if closeSource != nil {
 		defer closeSource()
 	}

--- a/internal/cli/symbolref.go
+++ b/internal/cli/symbolref.go
@@ -626,10 +626,19 @@ type symbolMatchBody struct {
 // (file gone, binary, oversized) is simply omitted: the locator list above it is still a complete
 // answer, and a missing body must never turn an answer back into a refusal.
 func symbolMatchBodies(repoRoot string, matches []sem.SymbolRecord, limit int) []symbolMatchBody {
-	if repoRoot == "" || limit <= 0 || len(matches) == 0 {
+	if repoRoot == "" {
 		return nil
 	}
-	read := newRepoLineReader(repoRoot)
+	return symbolMatchBodiesFromReader(newRepoLineReader(repoRoot), matches, limit)
+}
+
+// symbolMatchBodiesFromReader is the provenance-aware form used by commands
+// that may be reading a committed snapshot. The caller owns the reader and can
+// reuse it for every body and call-site annotation in the command.
+func symbolMatchBodiesFromReader(read lineReader, matches []sem.SymbolRecord, limit int) []symbolMatchBody {
+	if read == nil || limit <= 0 || len(matches) == 0 {
+		return nil
+	}
 	bodies := make([]symbolMatchBody, 0, minSymbolInt(limit, len(matches)))
 	for _, symbol := range matches {
 		if len(bodies) >= limit {

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -533,6 +533,66 @@ func ShowFile(ctx context.Context, repo, rev, path string) (string, bool, error)
 	return out, true, nil
 }
 
+// ShowFileLimited is ShowFile with a READ-SIDE ceiling: it never materializes
+// more than maxBytes+1 of the blob, and reports a larger blob as unreadable.
+//
+// ShowFile buffers all of git's stdout before returning, so a caller that only
+// wants small files could not express that: checking len(content) afterwards
+// enforces the ceiling on the ANSWER while the allocation has already happened.
+// Every other bounded read in this package refuses before materializing — the
+// batch reader streams an oversized blob to io.Discard off its header size, and
+// the on-disk reader reads through an io.LimitReader — so this closes the one
+// path where the bound arrived too late.
+//
+// The over-limit blob is not drained: cancelling the context stops git instead,
+// because the bytes were already refused and reading them to /dev/null is the
+// same wait this ceiling exists to avoid.
+func ShowFileLimited(ctx context.Context, repo, rev, path string, maxBytes int64) (string, bool, error) {
+	if maxBytes <= 0 {
+		return ShowFile(ctx, repo, rev, path)
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Same object spec and the same stderr-only classification as ShowFile; see
+	// there for why the revision is peeled to a tree first.
+	objectSpec := rev + "^{tree}:" + path
+	cmd := newCmd(ctx, repo, "git", "show", objectSpec)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", false, err
+	}
+	if err := cmd.Start(); err != nil {
+		return "", false, fmt.Errorf("git show %s: %w", objectSpec, err)
+	}
+	content, readErr := io.ReadAll(io.LimitReader(stdout, maxBytes+1))
+	oversized := int64(len(content)) > maxBytes
+	if oversized {
+		cancel()
+	}
+	waitErr := cmd.Wait()
+	switch {
+	case oversized:
+		// Refused, not failed: an oversized blob is a file this caller cannot
+		// quote, exactly like a missing one. waitErr here is the kill.
+		return "", false, nil
+	case readErr != nil:
+		return "", false, fmt.Errorf("git show %s: %w", objectSpec, readErr)
+	case waitErr != nil:
+		message := strings.TrimSpace(stderr.String())
+		if isMissingPathDiagnostic(message) {
+			return "", false, nil
+		}
+		if message == "" {
+			message = waitErr.Error()
+		}
+		return "", false, fmt.Errorf("git show %s: %s", objectSpec, message)
+	}
+	return string(content), true, nil
+}
+
 func isMissingPathDiagnostic(stderr string) bool {
 	// ShowFile runs git under the C locale, so only classify Git's specific
 	// missing-path diagnostics. Broad substring checks can match a bad revision

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -551,37 +551,43 @@ func ShowFile(ctx context.Context, repo, rev, path string) (string, bool, error)
 // awaitGoroutines forever. Nothing here now depends on process-tree teardown.
 // The extra `cat-file -s` is one small process on a path that is already the
 // rare fallback for a Git path containing a newline.
+//
+// The size probe cannot make an answer WORSE than ShowFile's: it is best effort,
+// and anything it fails to establish falls through to the unbounded read, which
+// keeps its own absent-vs-failed classification.
 func ShowFileLimited(ctx context.Context, repo, rev, path string, maxBytes int64) (string, bool, error) {
 	if maxBytes <= 0 {
 		return ShowFile(ctx, repo, rev, path)
 	}
-	// Same object spec and the same stderr-only classification as ShowFile — see
-	// there for why the revision is peeled to a tree first. `cat-file -s` emits
-	// the identical missing-path diagnostic, so absent stays absent here too.
-	objectSpec := rev + "^{tree}:" + path
-	out, stderr, err := runWithStderr(ctx, repo, "git", "cat-file", "-s", objectSpec)
-	if err != nil {
-		if isMissingPathDiagnostic(stderr) {
-			return "", false, nil
-		}
-		message := stderr
-		if message == "" {
-			message = err.Error()
-		}
-		return "", false, fmt.Errorf("git cat-file -s %s: %s", objectSpec, message)
-	}
-	size, parseErr := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
-	if parseErr != nil {
-		return "", false, fmt.Errorf("git cat-file -s %s: unparseable size %q", objectSpec, strings.TrimSpace(out))
-	}
-	if size > maxBytes {
+	// The probe only ever ADDS a refusal. Every outcome it cannot speak to —
+	// missing path, bad revision, a git whose diagnostics are worded differently,
+	// a size that will not parse — falls through to ShowFile, which stays the one
+	// place absent-vs-failed is decided. Classifying a second command's stderr
+	// with a matcher written for `git show` would have put that contract at the
+	// mercy of another command's wording.
+	if size, known := blobSizeAtRev(ctx, repo, rev, path); known && size > maxBytes {
 		// Refused, not failed: a blob this caller cannot quote, exactly like a
 		// missing one. No content was read to learn this.
 		return "", false, nil
 	}
-	// The commit is immutable, so the size just measured is the size that will be
+	// The commit is immutable, so a size measured above is the size that will be
 	// read — there is no grow-between-calls race to guard against here.
 	return ShowFile(ctx, repo, rev, path)
+}
+
+// blobSizeAtRev reports the size of the blob at rev:path without reading it.
+// It is BEST EFFORT by design: known=false means "no answer", never "absent" or
+// "broken", so a caller can only use it to refuse, not to conclude.
+func blobSizeAtRev(ctx context.Context, repo, rev, path string) (int64, bool) {
+	out, _, err := runWithStderr(ctx, repo, "git", "cat-file", "-s", rev+"^{tree}:"+path)
+	if err != nil {
+		return 0, false
+	}
+	size, parseErr := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+	if parseErr != nil {
+		return 0, false
+	}
+	return size, true
 }
 
 func isMissingPathDiagnostic(stderr string) bool {

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -548,7 +548,14 @@ func ShowFile(ctx context.Context, repo, rev, path string) (string, bool, error)
 // because the bytes were already refused and reading them to /dev/null is the
 // same wait this ceiling exists to avoid.
 func ShowFileLimited(ctx context.Context, repo, rev, path string, maxBytes int64) (string, bool, error) {
-	if maxBytes <= 0 {
+	// The read is bounded at maxBytes+1 so that "exceeded" is distinguishable
+	// from "exactly at the ceiling". At math.MaxInt64 that wraps negative, and a
+	// negative io.LimitReader EOFs at once: the blob would read as empty and the
+	// oversize test could not fire, leaving git blocked on a pipe nobody drains
+	// while Wait blocks on git. A ceiling no blob can reach is no ceiling, so it
+	// takes the unbounded path instead.
+	limit := maxBytes + 1
+	if maxBytes <= 0 || limit <= 0 {
 		return ShowFile(ctx, repo, rev, path)
 	}
 	ctx, cancel := context.WithCancel(ctx)
@@ -567,7 +574,7 @@ func ShowFileLimited(ctx context.Context, repo, rev, path string, maxBytes int64
 	if err := cmd.Start(); err != nil {
 		return "", false, fmt.Errorf("git show %s: %w", objectSpec, err)
 	}
-	content, readErr := io.ReadAll(io.LimitReader(stdout, maxBytes+1))
+	content, readErr := io.ReadAll(io.LimitReader(stdout, limit))
 	oversized := int64(len(content)) > maxBytes
 	if oversized {
 		cancel()

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -533,71 +533,55 @@ func ShowFile(ctx context.Context, repo, rev, path string) (string, bool, error)
 	return out, true, nil
 }
 
-// ShowFileLimited is ShowFile with a READ-SIDE ceiling: it never materializes
-// more than maxBytes+1 of the blob, and reports a larger blob as unreadable.
+// ShowFileLimited is ShowFile with a ceiling that is applied BEFORE the blob is
+// read: a larger blob is reported unreadable without its bytes ever being
+// materialized.
 //
-// ShowFile buffers all of git's stdout before returning, so a caller that only
-// wants small files could not express that: checking len(content) afterwards
-// enforces the ceiling on the ANSWER while the allocation has already happened.
-// Every other bounded read in this package refuses before materializing — the
-// batch reader streams an oversized blob to io.Discard off its header size, and
-// the on-disk reader reads through an io.LimitReader — so this closes the one
-// path where the bound arrived too late.
+// ShowFile buffers all of git's stdout, so a caller that only wants small files
+// could not express that — checking len(content) afterwards bounds the ANSWER
+// once the allocation has already happened. The other bounded readers here do
+// not work that way: the batch reader decides off the size in its header, and
+// the on-disk reader stats before it opens. This asks git for the size first,
+// for the same reason and with the same shape.
 //
-// The over-limit blob is not drained: cancelling the context stops git instead,
-// because the bytes were already refused and reading them to /dev/null is the
-// same wait this ceiling exists to avoid.
+// Deciding from the size, rather than reading through an io.LimitReader and
+// stopping git once the ceiling is passed, is deliberate. The reading form
+// deadlocked on Windows: killing git left a grandchild holding the inherited
+// stderr handle, so the copier goroutine never saw EOF and Cmd.Wait blocked in
+// awaitGoroutines forever. Nothing here now depends on process-tree teardown.
+// The extra `cat-file -s` is one small process on a path that is already the
+// rare fallback for a Git path containing a newline.
 func ShowFileLimited(ctx context.Context, repo, rev, path string, maxBytes int64) (string, bool, error) {
-	// The read is bounded at maxBytes+1 so that "exceeded" is distinguishable
-	// from "exactly at the ceiling". At math.MaxInt64 that wraps negative, and a
-	// negative io.LimitReader EOFs at once: the blob would read as empty and the
-	// oversize test could not fire, leaving git blocked on a pipe nobody drains
-	// while Wait blocks on git. A ceiling no blob can reach is no ceiling, so it
-	// takes the unbounded path instead.
-	limit := maxBytes + 1
-	if maxBytes <= 0 || limit <= 0 {
+	if maxBytes <= 0 {
 		return ShowFile(ctx, repo, rev, path)
 	}
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	// Same object spec and the same stderr-only classification as ShowFile; see
-	// there for why the revision is peeled to a tree first.
+	// Same object spec and the same stderr-only classification as ShowFile — see
+	// there for why the revision is peeled to a tree first. `cat-file -s` emits
+	// the identical missing-path diagnostic, so absent stays absent here too.
 	objectSpec := rev + "^{tree}:" + path
-	cmd := newCmd(ctx, repo, "git", "show", objectSpec)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	stdout, err := cmd.StdoutPipe()
+	out, stderr, err := runWithStderr(ctx, repo, "git", "cat-file", "-s", objectSpec)
 	if err != nil {
-		return "", false, err
-	}
-	if err := cmd.Start(); err != nil {
-		return "", false, fmt.Errorf("git show %s: %w", objectSpec, err)
-	}
-	content, readErr := io.ReadAll(io.LimitReader(stdout, limit))
-	oversized := int64(len(content)) > maxBytes
-	if oversized {
-		cancel()
-	}
-	waitErr := cmd.Wait()
-	switch {
-	case oversized:
-		// Refused, not failed: an oversized blob is a file this caller cannot
-		// quote, exactly like a missing one. waitErr here is the kill.
-		return "", false, nil
-	case readErr != nil:
-		return "", false, fmt.Errorf("git show %s: %w", objectSpec, readErr)
-	case waitErr != nil:
-		message := strings.TrimSpace(stderr.String())
-		if isMissingPathDiagnostic(message) {
+		if isMissingPathDiagnostic(stderr) {
 			return "", false, nil
 		}
+		message := stderr
 		if message == "" {
-			message = waitErr.Error()
+			message = err.Error()
 		}
-		return "", false, fmt.Errorf("git show %s: %s", objectSpec, message)
+		return "", false, fmt.Errorf("git cat-file -s %s: %s", objectSpec, message)
 	}
-	return string(content), true, nil
+	size, parseErr := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+	if parseErr != nil {
+		return "", false, fmt.Errorf("git cat-file -s %s: unparseable size %q", objectSpec, strings.TrimSpace(out))
+	}
+	if size > maxBytes {
+		// Refused, not failed: a blob this caller cannot quote, exactly like a
+		// missing one. No content was read to learn this.
+		return "", false, nil
+	}
+	// The commit is immutable, so the size just measured is the size that will be
+	// read — there is no grow-between-calls race to guard against here.
+	return ShowFile(ctx, repo, rev, path)
 }
 
 func isMissingPathDiagnostic(stderr string) bool {

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -2,6 +2,7 @@ package gitutil
 
 import (
 	"context"
+	"crypto/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -531,6 +532,107 @@ func TestShowFileClassifiesErrorsByStderrNotPath(t *testing.T) {
 	// An existing file at HEAD returns its content.
 	if out, ok, err := ShowFile(t.Context(), repo, "HEAD", path); err != nil || !ok || out != content {
 		t.Fatalf("ShowFile existing = (%q, ok %v, err %v), want (%q, true, nil)", out, ok, err, content)
+	}
+}
+
+// ShowFileLimited must refuse an oversized blob rather than materialize it, and
+// must keep every other ShowFile behavior: absent is absent, a real failure is
+// an error, and a blob at exactly the ceiling still reads.
+func TestShowFileLimitedBoundsTheReadNotTheAnswer(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows filenames cannot contain newlines")
+	}
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	git(t, repo, "config", "commit.gpgsign", "false")
+
+	const ceiling = 1 << 10
+	// A newline in the path is the case that reaches this reader at all: the
+	// cat-file batch protocol is line based, so those paths take the one-shot
+	// `git show` route and nothing else bounds them.
+	const oversizedPath = "big\nname.txt"
+	files := map[string]string{
+		oversizedPath: strings.Repeat("x", ceiling+1),
+		"exact.txt":   strings.Repeat("y", ceiling),
+		"small.txt":   "small\n",
+	}
+	for path, content := range files {
+		if err := os.WriteFile(filepath.Join(repo, path), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "size fixture")
+
+	if out, ok, err := ShowFileLimited(t.Context(), repo, "HEAD", oversizedPath, ceiling); err != nil || ok || out != "" {
+		t.Errorf("oversized blob = (%d bytes, ok %v, err %v), want (\"\", false, nil)", len(out), ok, err)
+	}
+	// The ceiling is inclusive, so the boundary blob is still an answer. This is
+	// what distinguishes a bounded read from an off-by-one refusal.
+	if out, ok, err := ShowFileLimited(t.Context(), repo, "HEAD", "exact.txt", ceiling); err != nil || !ok || out != files["exact.txt"] {
+		t.Errorf("blob at the ceiling = (%d bytes, ok %v, err %v), want (%d bytes, true, nil)", len(out), ok, err, ceiling)
+	}
+	if out, ok, err := ShowFileLimited(t.Context(), repo, "HEAD", "small.txt", ceiling); err != nil || !ok || out != files["small.txt"] {
+		t.Errorf("small blob = (%q, ok %v, err %v), want (%q, true, nil)", out, ok, err, files["small.txt"])
+	}
+	if out, ok, err := ShowFileLimited(t.Context(), repo, "HEAD", "does-not-exist.txt", ceiling); err != nil || ok || out != "" {
+		t.Errorf("missing path = (%q, ok %v, err %v), want (\"\", false, nil)", out, ok, err)
+	}
+	// Same stderr-only classification as ShowFile: a bad revision is a failure,
+	// not an absent file, even though the argv echoes a path.
+	if out, ok, err := ShowFileLimited(t.Context(), repo, "BADREV", "small.txt", ceiling); err == nil || ok || out != "" {
+		t.Errorf("bad rev = (%q, ok %v, err %v), want (\"\", false, non-nil)", out, ok, err)
+	}
+	// A non-positive ceiling means "no ceiling", so it must behave as ShowFile.
+	if out, ok, err := ShowFileLimited(t.Context(), repo, "HEAD", oversizedPath, 0); err != nil || !ok || out != files[oversizedPath] {
+		t.Errorf("unbounded call = (%d bytes, ok %v, err %v), want the whole blob", len(out), ok, err)
+	}
+}
+
+// The refusal above is observable either way — buffering the whole blob and THEN
+// reporting it oversized returns the same triple. What this pins is the part that
+// is not observable from the return value: the bytes are never allocated.
+func TestShowFileLimitedNeverMaterializesAnOversizedBlob(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	git(t, repo, "config", "commit.gpgsign", "false")
+
+	const blobSize = 32 << 20
+	const ceiling = 1 << 10
+	// Incompressible, so `git show` really does stream 32 MiB: a run of one byte
+	// would still decompress to the same size, but random content also rules out
+	// any future short-circuit on a cheap object.
+	blob := make([]byte, blobSize)
+	if _, err := rand.Read(blob); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "huge.bin"), blob, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "huge blob")
+	blob = nil
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	out, ok, err := ShowFileLimited(t.Context(), repo, "HEAD", "huge.bin", ceiling)
+	runtime.ReadMemStats(&after)
+
+	if err != nil || ok || out != "" {
+		t.Fatalf("oversized blob = (%d bytes, ok %v, err %v), want (\"\", false, nil)", len(out), ok, err)
+	}
+	// Generous by three orders of magnitude against the ceiling and by eight
+	// times against the blob: this fails on materialization, not on allocator
+	// noise.
+	const budget = 4 << 20
+	if allocated := after.TotalAlloc - before.TotalAlloc; allocated > budget {
+		t.Errorf("reading a %d-byte blob under a %d-byte ceiling allocated %d bytes, want under %d: the blob was materialized before the ceiling was applied",
+			blobSize, ceiling, allocated, budget)
 	}
 }
 

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -638,10 +638,12 @@ func TestShowFileLimitedNeverMaterializesAnOversizedBlob(t *testing.T) {
 	}
 }
 
-// A ceiling at math.MaxInt64 overflows the +1 the bounded read is built on. The
-// failure is not a wrong answer but a hang, so this asserts on the clock: the
-// blob is larger than a pipe buffer, which is what turns a mis-sized limit into
-// git blocking on a write nobody drains.
+// A ceiling no blob can reach must behave as no ceiling. This once guarded an
+// overflow in a maxBytes+1 limit; deciding from the blob's size removed that
+// arithmetic, but the guarantee is still worth pinning, and the clock-based
+// assertion still catches the failure mode this function has had twice: not a
+// wrong answer, a hang. The blob is larger than a pipe buffer, which is what
+// turns a stalled read into git blocking on a write nobody drains.
 func TestShowFileLimitedTreatsAnUnreachableCeilingAsNoCeiling(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -3,6 +3,7 @@ package gitutil
 import (
 	"context"
 	"crypto/rand"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestListFilesHandlesNewlinesInPaths(t *testing.T) {
@@ -633,6 +635,54 @@ func TestShowFileLimitedNeverMaterializesAnOversizedBlob(t *testing.T) {
 	if allocated := after.TotalAlloc - before.TotalAlloc; allocated > budget {
 		t.Errorf("reading a %d-byte blob under a %d-byte ceiling allocated %d bytes, want under %d: the blob was materialized before the ceiling was applied",
 			blobSize, ceiling, allocated, budget)
+	}
+}
+
+// A ceiling at math.MaxInt64 overflows the +1 the bounded read is built on. The
+// failure is not a wrong answer but a hang, so this asserts on the clock: the
+// blob is larger than a pipe buffer, which is what turns a mis-sized limit into
+// git blocking on a write nobody drains.
+func TestShowFileLimitedTreatsAnUnreachableCeilingAsNoCeiling(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	git(t, repo, "config", "commit.gpgsign", "false")
+
+	const blobSize = 1 << 20
+	blob := make([]byte, blobSize)
+	if _, err := rand.Read(blob); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "big.bin"), blob, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "pipe-filling blob")
+
+	type outcome struct {
+		out string
+		ok  bool
+		err error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		// t.Context() is cancelled when the test ends, so a hung git is reaped
+		// rather than outliving the run.
+		out, ok, err := ShowFileLimited(t.Context(), repo, "HEAD", "big.bin", math.MaxInt64)
+		done <- outcome{out, ok, err}
+	}()
+
+	select {
+	case got := <-done:
+		if got.err != nil || !got.ok || len(got.out) != blobSize {
+			t.Fatalf("unreachable ceiling = (%d bytes, ok %v, err %v), want (%d bytes, true, nil)", len(got.out), got.ok, got.err, blobSize)
+		}
+		if got.out != string(blob) {
+			t.Fatal("unreachable ceiling returned different bytes than the blob")
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("ShowFileLimited did not return: maxBytes+1 overflowed to a negative limit, so the read EOFed at once and git blocked writing to a pipe nobody drains")
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/58
<!-- entire-trail-link-end -->

## Summary

- bind `def`, `neighbors`, and `impact` source enrichment to the committed snapshot when `--head` is selected
- preserve default working-tree behavior and the no-HEAD fallback
- make `explain` identify committed versus working-tree provenance correctly
- add dirty-worktree regression coverage for source bodies, call sites, ambiguous matches, and reader safety

## Root cause

The graph snapshot respected `--head`, but several CLI presentation paths reopened files from disk afterward. A dirty working tree could therefore combine committed symbols and relations with uncommitted bodies, guards, windows, or line numbers.

## User impact

Explicit `--head` queries now return graph facts and displayed source from the same committed revision. The default agent workflow remains working-tree-first and is unchanged; this PR does not modify the README.

## Validation

- `mise run check` (format, vet, race tests, build, and status-line tests)
- `mise exec -- go test ./internal/cli -count=1`
- independent read-only diff review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how multiple CLI commands load and display source alongside graph answers; mistakes could still leak wrong-tree snippets or skip enrichment, but default worktree behavior is preserved and failures degrade rather than aborting queries.
> 
> **Overview**
> **`--head` could return a committed graph while still quoting dirty working-tree source.** Presentation paths for `def`, `neighbors`, and `impact` now read bodies, call-site windows, and ambiguous match snippets through a snapshot-bound **`lineReader`**: worktree (default) uses the repo on disk; a committed snapshot uses **`git cat-file --batch`** at that commit, with **`ShowFileLimited`** for newline paths.
> 
> If the git reader cannot start, commands **degrade** (stderr warning, locations without quoted source) instead of failing entirely. **`def`** only opens that reader for **`text`/`agent`** formats so **`json`** does not pay for unused **`cat-file`**. **`explain`** prints a header that distinguishes committed HEAD from the working tree when **`--head`** is used.
> 
> **`ShowFileLimited`** enforces size limits on the read side so oversized blobs are not fully buffered. Regression tests cover dirty-vs-committed output across those commands and reader safety.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c645ae2ff6280536721e1c91490dc91d360ec73a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->