### PR TITLE
feat(search): multi-resolution prose retrieval

### DIFF
--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -127,7 +127,8 @@ var commandDocs = []commandDoc{
 		usage:   []string{`entire graph search --query "issue or concept" --repo . [--top-k 10] [--format text|json|ndjson|agent] [--head] [--profile fast|full] [--deep]`},
 		long: "Ranked source regions for a plain-language description, with source and file:line inline, budgeted to drop straight into context. This is the first move for almost every locate task.\n\n" +
 			"By default search returns: ranked candidate fix sites (top hits as full function bodies), RELATED SITES, the COVERING TEST plus other tests over the same code (ALSO COVERING), SAME-CONCEPT LITERAL (every place the concept is named, tagged EDIT/CONSUMER/DOC), a VERIFY line (the narrowest test command for the file), and a CLOSED-SET WARNING when a switch over a sealed set would fail at runtime. The three reference blocks (container map, signature types, declaration card) are OFF by default because they cost turns in agent sessions; --reference-blocks all turns them on for interactive reading.\n\n" +
-			"--top-k only changes how many results come back; --deep additionally runs the exhaustive sparse (BM25) pass and fuses it with the semantic ranking (slower, reads every eligible file).",
+			"--top-k only changes how many results come back; --deep additionally runs the exhaustive sparse (BM25) pass and fuses it with the semantic ranking (slower, reads every eligible file).\n\n" +
+			"Ranking returns one region per file, which is right for code and wrong for prose: one markdown document can hold the answer across several distant regions. When fewer distinct files match than --top-k asked for, the spare slots are spent returning those finer regions of the same document as results of their own (multi-resolution retrieval) — strictly additive, so it never displaces a file and never breaches --max-context-bytes. --single-resolution turns it off.",
 		flags: []flagDoc{
 			{name: "--query", arg: "text", desc: "The task or bug in one plain sentence (required)"},
 			{name: "--repo", arg: "path", desc: "Repository to search (default: current repo)"},
@@ -136,6 +137,7 @@ var commandDocs = []commandDoc{
 			{name: "--head", desc: "Search the committed tree (cached) instead of the working tree"},
 			{name: "--profile", arg: "syntax-only|fast|full", def: "fast", desc: "Parsing depth; use full for bug-fix/locate (call-graph active)"},
 			{name: "--deep", desc: "Also run the exhaustive BM25 pass and fuse it (slower)"},
+			{name: "--single-resolution", desc: "One result per file; do not spend spare slots on finer regions of a prose document"},
 			{name: "--max-context-bytes", arg: "n", def: "24576", desc: "Output byte budget; 0 = unbounded"},
 			{name: "--reference-blocks", arg: "all|container-map,signature-types,type-card", desc: "Turn reference blocks back on (off by default)"},
 			{name: "--max-indexed-files", arg: "n", desc: "Bound cold-search parsing to N files"},

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -79,6 +79,7 @@ type searchFlags struct {
 	VerifyPreFixStatus    string
 	FileOutline           bool
 	Deep                  bool
+	SingleResolution      bool
 	// The reference blocks, off unless asked for. See SearchOptions in internal/sem/search.go for
 	// the session measurement that made OFF the default.
 	ContainerMap   bool
@@ -198,6 +199,7 @@ func runSearch(ctx context.Context, opts Options, args []string) error {
 		IncludeFileOutline:    flags.FileOutline,
 		VerifyExplainCommand:  flags.VerifyExplain,
 		Deep:                  flags.Deep,
+		SingleResolution:      flags.SingleResolution,
 
 		IncludeContainerMap:   flags.ContainerMap,
 		IncludeSignatureTypes: flags.SignatureTypes,
@@ -1862,6 +1864,8 @@ func parseSearchFlags(args []string) (searchFlags, []string, error) {
 			flags.IndexAllFiles = true
 		case "--deep":
 			flags.Deep = true
+		case "--single-resolution":
+			flags.SingleResolution = true
 		case "--container-map":
 			flags.ContainerMap = true
 		case "--signature-types":

--- a/internal/sem/search.go
+++ b/internal/sem/search.go
@@ -184,6 +184,14 @@ type SearchOptions struct {
 	// for one more result is not a request to change retrieval strategy, so the strategy is
 	// now an explicit choice and top-k only changes how many rows come back.
 	Deep bool
+	// SingleResolution turns OFF multi-resolution prose retrieval, restoring the previous output
+	// exactly: one result per file, with the finer regions of a prose document left in each
+	// result's `passages` field instead of being promoted to results of their own. See
+	// search_multi_resolution.go — the expansion is strictly additive (it only fills result slots
+	// the distinct-file ranking left empty, and never breaches MaxContextBytes), so this switch
+	// exists for callers that need the result count to equal the distinct-file count, not because
+	// the expansion can cost them a file.
+	SingleResolution bool
 }
 
 // SearchPassage is an additional, non-overlapping source region from the same file as its
@@ -1333,6 +1341,14 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 		// stats.context_block_bytes is only attributable if every counter feeding it measures
 		// what the caller was actually charged.
 		stats.ContainerMapBytes = searchContainerMapCost(containerMap)
+	}
+	// Multi-resolution runs LAST, after every block above has decided which result it anchors on,
+	// so a promoted passage can never become the anchor for the related-site, contract or
+	// container-map blocks — those describe code, and a prose passage is not a definition. It is
+	// also the only pass that can raise the result count above the distinct-file count, so running
+	// it here keeps every earlier pass reasoning about the ranking it actually produced.
+	if !options.SingleResolution {
+		results = expandProseResolution(results, options.TopK, options.MaxContextBytes)
 	}
 	stats.CandidatesSelected = len(results)
 	stats.ProsePassages, stats.ProsePassageBytes = searchPassageStats(results)

--- a/internal/sem/search_multi_resolution.go
+++ b/internal/sem/search_multi_resolution.go
@@ -1,0 +1,143 @@
+package sem
+
+// MULTI-RESOLUTION RETRIEVAL
+//
+// Ranking returns at most one result per file, because for code search a second region of a file
+// the caller can already see is worth less than the first region of a file it cannot. That rule is
+// right for code and wrong for prose: one markdown file is one document — a design note, a meeting
+// log, a chat session — and the answer to a question about it is routinely spread across several
+// distant regions of the SAME file. For those files the ranker already computes the extra regions
+// and attaches them to their parent as `passages` (search_prose_passage.go), but a consumer that
+// reads `results[]` and nothing else never sees them: the parent result carries one span, and the
+// rest of the evidence sits in a field it did not ask about.
+//
+// So when the caller asked for more results than the ranking could fill with distinct files, the
+// leftover slots are spent promoting those already-computed regions to first-class results. Two
+// resolutions of the same document are then returned side by side: the parent's own span, which
+// keeps the surrounding context, and the finer spans, which are the precise evidence.
+//
+// The rule that keeps this from becoming `--deep` (which traded breadth for depth and measured
+// worse) is that promotion is STRICTLY ADDITIVE: it runs after selection, only into slots the
+// distinct-file ranking left empty, and only within the byte ceiling the caller set. It can never
+// displace a file. `--top-k` still means "number of returned regions", and when the ranking already
+// filled it, the output is byte-identical to single-resolution.
+//
+// Ordinary code search is untouched: no code result carries passages, so there is nothing to
+// promote.
+
+const proseResolutionSignal = "retrieval_mode=prose-passage"
+
+// prosePromotion identifies one passage of one parent result.
+type prosePromotion struct {
+	parent  int
+	passage int
+}
+
+// planProseResolutionPromotions orders promotions round-robin by depth, so a single long document
+// cannot spend every free slot before a second document has contributed anything.
+func planProseResolutionPromotions(results []SearchResult, limit int) []prosePromotion {
+	if limit <= 0 {
+		return nil
+	}
+	deepest := 0
+	for index := range results {
+		if count := len(results[index].Passages); count > deepest {
+			deepest = count
+		}
+	}
+	order := make([]prosePromotion, 0, limit)
+	for depth := 0; depth < deepest && len(order) < limit; depth++ {
+		for index := range results {
+			if depth >= len(results[index].Passages) {
+				continue
+			}
+			order = append(order, prosePromotion{parent: index, passage: depth})
+			if len(order) == limit {
+				break
+			}
+		}
+	}
+	return order
+}
+
+// applyProseResolutionPromotions materializes the first `count` planned promotions. The promoted
+// passages leave their parent, so no region is returned twice, and the parents keep the passages
+// that were not promoted (a suffix of a source-ordered, non-overlapping list stays source-ordered
+// and non-overlapping, which is what SearchResponse.Validate requires).
+func applyProseResolutionPromotions(results []SearchResult, order []prosePromotion, count int) []SearchResult {
+	promotedFrom := make([]map[int]bool, len(results))
+	for _, promotion := range order[:count] {
+		if promotedFrom[promotion.parent] == nil {
+			promotedFrom[promotion.parent] = map[int]bool{}
+		}
+		promotedFrom[promotion.parent][promotion.passage] = true
+	}
+	expanded := make([]SearchResult, 0, len(results)+count)
+	for index := range results {
+		parent := results[index]
+		if promotedFrom[index] != nil {
+			kept := make([]SearchPassage, 0, len(parent.Passages))
+			for passageIndex, passage := range parent.Passages {
+				if !promotedFrom[index][passageIndex] {
+					kept = append(kept, passage)
+				}
+			}
+			if len(kept) == 0 {
+				kept = nil
+			}
+			parent.Passages = kept
+		}
+		expanded = append(expanded, parent)
+	}
+	for _, promotion := range order[:count] {
+		expanded = append(expanded, proseResolutionResult(results[promotion.parent], results[promotion.parent].Passages[promotion.passage]))
+	}
+	for index := range expanded {
+		expanded[index].Rank = index + 1
+	}
+	return expanded
+}
+
+// proseResolutionResult turns one passage into a result. It inherits its parent's file, language
+// and score — it is the same document and the same relevance evidence at a finer resolution, and a
+// score invented for it here would be a number no ranking produced. Symbol identity is dropped:
+// the passage is a region of the document, not a definition of the parent's symbol, and claiming
+// otherwise would make two results advertise the same symbol at different lines.
+func proseResolutionResult(parent SearchResult, passage SearchPassage) SearchResult {
+	signals := make([]string, 0, len(parent.Signals)+1)
+	signals = append(signals, parent.Signals...)
+	return SearchResult{
+		Score:            parent.Score,
+		FilePath:         parent.FilePath,
+		StartLine:        passage.StartLine,
+		EndLine:          passage.EndLine,
+		FocusLine:        passage.FocusLine,
+		SnippetStartLine: passage.StartLine,
+		SnippetEndLine:   passage.EndLine,
+		Language:         parent.Language,
+		Signals:          appendUnique(signals, proseResolutionSignal),
+		Section:          parent.Section,
+		Snippet:          passage.Snippet,
+	}
+}
+
+// expandProseResolution spends the result slots the distinct-file ranking left empty on the finer
+// regions it already computed, without breaching the caller's byte ceiling.
+func expandProseResolution(results []SearchResult, topK, budget int) []SearchResult {
+	if topK <= 0 || len(results) >= topK {
+		return results
+	}
+	order := planProseResolutionPromotions(results, topK-len(results))
+	if len(order) == 0 {
+		return results
+	}
+	expanded := results
+	for count := 1; count <= len(order); count++ {
+		trial := applyProseResolutionPromotions(results, order, count)
+		if budget > 0 && serializedSearchResultBytes(trial) > budget {
+			break
+		}
+		expanded = trial
+	}
+	return expanded
+}

--- a/internal/sem/search_multi_resolution_test.go
+++ b/internal/sem/search_multi_resolution_test.go
@@ -1,0 +1,220 @@
+package sem
+
+import (
+	"strings"
+	"testing"
+)
+
+func proseResolutionParent(rank int, path string, line int, snippet string, passages ...SearchPassage) SearchResult {
+	return SearchResult{
+		Rank: rank, Score: float64(100 - rank), FilePath: path,
+		StartLine: line, EndLine: line, FocusLine: line,
+		SnippetStartLine: line, SnippetEndLine: line, Snippet: snippet,
+		Language: "markdown",
+		Signals:  []string{proseParentRetrievalSignal},
+		Passages: passages,
+	}
+}
+
+func proseResolutionPassage(line int, snippet string) SearchPassage {
+	return SearchPassage{StartLine: line, EndLine: line, FocusLine: line, Snippet: snippet}
+}
+
+// TestExpandProseResolutionPromotesPassagesIntoSpareSlots is the whole point of the pass: the
+// finer regions the ranker already computed become results a consumer that reads `results[]`
+// can see, instead of staying in a field it never asked about.
+func TestExpandProseResolutionPromotesPassagesIntoSpareSlots(t *testing.T) {
+	t.Parallel()
+	results := []SearchResult{
+		proseResolutionParent(1, "sessions/one.md", 10, "primary one",
+			proseResolutionPassage(30, "one alpha"), proseResolutionPassage(50, "one beta")),
+	}
+
+	expanded := expandProseResolution(results, 10, 0)
+
+	if len(expanded) != 3 {
+		t.Fatalf("expanded to %d results, want 3", len(expanded))
+	}
+	if len(expanded[0].Passages) != 0 {
+		t.Fatalf("promoted passages still attached to the parent: %#v", expanded[0].Passages)
+	}
+	for index, want := range []struct {
+		line    int
+		snippet string
+	}{{30, "one alpha"}, {50, "one beta"}} {
+		got := expanded[index+1]
+		if got.Rank != index+2 {
+			t.Fatalf("rank %d at index %d", got.Rank, index+1)
+		}
+		if got.FilePath != "sessions/one.md" || got.StartLine != want.line || got.EndLine != want.line ||
+			got.SnippetStartLine != want.line || got.SnippetEndLine != want.line || got.FocusLine != want.line {
+			t.Fatalf("promoted span = %#v, want lines %d", got, want.line)
+		}
+		if got.Snippet != want.snippet {
+			t.Fatalf("promoted snippet = %q, want %q", got.Snippet, want.snippet)
+		}
+		if got.Score != results[0].Score {
+			t.Fatalf("promoted score = %v, want the parent's %v", got.Score, results[0].Score)
+		}
+		if !hasSearchSignal(got, proseResolutionSignal) {
+			t.Fatalf("promoted result is not labelled: %#v", got.Signals)
+		}
+		if got.SymbolID != "" || got.SymbolName != "" || got.QualifiedName != "" {
+			t.Fatalf("promoted result claims the parent's symbol identity: %#v", got)
+		}
+	}
+	if len(results[0].Passages) != 2 {
+		t.Fatalf("input was mutated: %#v", results[0].Passages)
+	}
+}
+
+// TestExpandProseResolutionNeverDisplacesAFile is the property that separates this from --deep:
+// the expansion only ever fills slots the distinct-file ranking left empty.
+func TestExpandProseResolutionNeverDisplacesAFile(t *testing.T) {
+	t.Parallel()
+	results := []SearchResult{
+		proseResolutionParent(1, "sessions/one.md", 10, "primary one", proseResolutionPassage(30, "one alpha")),
+		proseResolutionParent(2, "sessions/two.md", 20, "primary two", proseResolutionPassage(40, "two alpha")),
+	}
+
+	for _, topK := range []int{0, 1, 2} {
+		expanded := expandProseResolution(results, topK, 0)
+		if len(expanded) != len(results) {
+			t.Fatalf("top-k %d expanded to %d results, want %d", topK, len(expanded), len(results))
+		}
+		if len(expanded[0].Passages) != 1 {
+			t.Fatalf("top-k %d dropped a passage it did not promote", topK)
+		}
+	}
+}
+
+// TestExpandProseResolutionRoundRobinsAcrossParents stops one long document spending every spare
+// slot before a second document has contributed anything.
+func TestExpandProseResolutionRoundRobinsAcrossParents(t *testing.T) {
+	t.Parallel()
+	results := []SearchResult{
+		proseResolutionParent(1, "sessions/one.md", 10, "primary one",
+			proseResolutionPassage(30, "one alpha"), proseResolutionPassage(50, "one beta")),
+		proseResolutionParent(2, "sessions/two.md", 20, "primary two",
+			proseResolutionPassage(40, "two alpha")),
+	}
+
+	expanded := expandProseResolution(results, 4, 0)
+
+	if len(expanded) != 4 {
+		t.Fatalf("expanded to %d results, want 4", len(expanded))
+	}
+	got := []string{expanded[2].Snippet, expanded[3].Snippet}
+	if got[0] != "one alpha" || got[1] != "two alpha" {
+		t.Fatalf("promotion order = %v, want depth-first round robin across parents", got)
+	}
+	if len(expanded[0].Passages) != 1 || expanded[0].Passages[0].Snippet != "one beta" {
+		t.Fatalf("unpromoted passage lost from its parent: %#v", expanded[0].Passages)
+	}
+	if len(expanded[1].Passages) != 0 {
+		t.Fatalf("promoted passage still attached to its parent: %#v", expanded[1].Passages)
+	}
+}
+
+// TestExpandProseResolutionRespectsByteBudget: the expansion is additive, so it is the one pass
+// that could push a payload past the ceiling the fitter already satisfied.
+func TestExpandProseResolutionRespectsByteBudget(t *testing.T) {
+	t.Parallel()
+	results := []SearchResult{
+		proseResolutionParent(1, "sessions/one.md", 10, "primary one",
+			proseResolutionPassage(30, strings.Repeat("a", 400)),
+			proseResolutionPassage(50, strings.Repeat("b", 400))),
+	}
+	budget := serializedSearchResultBytes(results)
+
+	expanded := expandProseResolution(results, 10, budget)
+
+	if serializedSearchResultBytes(expanded) > budget {
+		t.Fatalf("expansion breached the budget: %d > %d", serializedSearchResultBytes(expanded), budget)
+	}
+	if len(expanded) != 1 {
+		t.Fatalf("expanded to %d results under a tight budget, want 1", len(expanded))
+	}
+	if len(expanded[0].Passages) != 2 {
+		t.Fatalf("passages lost when promotion was unaffordable: %#v", expanded[0].Passages)
+	}
+	if unbounded := expandProseResolution(results, 10, 0); len(unbounded) != 3 {
+		t.Fatalf("unbounded expansion returned %d results, want 3", len(unbounded))
+	}
+}
+
+// TestExpandProseResolutionIgnoresResultsWithoutPassages is the code-search case: nothing to
+// promote, so nothing changes.
+func TestExpandProseResolutionIgnoresResultsWithoutPassages(t *testing.T) {
+	t.Parallel()
+	results := []SearchResult{
+		{Rank: 1, FilePath: "internal/sem/search.go", StartLine: 1, EndLine: 2, FocusLine: 1,
+			SnippetStartLine: 1, SnippetEndLine: 2, Snippet: "func Search() {}"},
+	}
+
+	expanded := expandProseResolution(results, 10, 0)
+
+	if len(expanded) != 1 || expanded[0].Snippet != results[0].Snippet {
+		t.Fatalf("code result changed: %#v", expanded)
+	}
+}
+
+// TestSearchRepositoryReturnsMultiResolutionProseResults exercises the wiring end to end, and its
+// --single-resolution counterpart proves the switch restores the previous shape.
+func TestSearchRepositoryReturnsMultiResolutionProseResults(t *testing.T) {
+	repo := t.TempDir()
+	for index := 0; index < 6; index++ {
+		var body strings.Builder
+		body.WriteString("# Session\n\n")
+		for turn := 0; turn < 12; turn++ {
+			body.WriteString("## note: amber lantern orchard ledger braided vessel ridge marker\n\n")
+		}
+		write(t, repo, "sessions/session-"+string(rune('a'+index))+".md", body.String())
+	}
+
+	search := func(single bool) SearchResponse {
+		response, err := SearchRepository(
+			t.Context(), repo, "test", "amber lantern orchard ledger", SearchOptions{
+				Worktree:         true,
+				Profile:          ProfileSyntaxOnly,
+				TopK:             40,
+				MaxIndexedFiles:  32,
+				MaxContextBytes:  400000,
+				SingleResolution: single,
+			},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := response.Validate(); err != nil {
+			t.Fatalf("invalid response (single=%v): %v", single, err)
+		}
+		return response
+	}
+
+	multi, single := search(false), search(true)
+	files := map[string]bool{}
+	for _, result := range single.Results {
+		files[result.FilePath] = true
+	}
+	if len(single.Results) != len(files) {
+		t.Fatalf("single-resolution returned %d results over %d files", len(single.Results), len(files))
+	}
+	if len(multi.Results) <= len(single.Results) {
+		t.Fatalf("multi-resolution returned %d results, single returned %d; want more",
+			len(multi.Results), len(single.Results))
+	}
+	multiFiles := map[string]bool{}
+	for _, result := range multi.Results {
+		multiFiles[result.FilePath] = true
+	}
+	for path := range files {
+		if !multiFiles[path] {
+			t.Fatalf("multi-resolution dropped file %s", path)
+		}
+	}
+	if multi.Stats.ResultBytes > multi.Stats.ContextBudgetBytes {
+		t.Fatalf("multi-resolution breached the budget: %d > %d",
+			multi.Stats.ResultBytes, multi.Stats.ContextBudgetBytes)
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/51
<!-- entire-trail-link-end -->

## What

Ranking returns **one region per file**. That is correct for code, where a file is the unit
you want to open. It is wrong for prose, where a single markdown document can hold the answer
across several distant regions.

The extra regions **already exist**. `search_prose_parent.go` plans them and
`search_prose_passage.go` attaches them to their parent as `Passages` — but a consumer reading
`results[]` never sees them. Measured on a real prose corpus, search returned 19 results across
19 files while carrying **195 passages holding 42 KB of evidence that no `results[]` consumer
could reach**; ranks 6–19 got a one-line snippet.

When fewer distinct files match than `--top-k` asked for, this change spends the spare slots
promoting those regions to results of their own.

## Why it cannot regress code search

- Strictly additive: runs **after** selection, only fills slots the distinct-file ranking left
  empty (`len(results) >= topK` → no-op), so it can never displace a file.
- Never breaches `--max-context-bytes`.
- No code result carries passages, so code search has nothing to promote.

Verified empirically: 16 real code queries against this repo at `--top-k 10` **and** `--top-k 50`,
full JSON compared — **0 mismatches**.

`--single-resolution` restores the previous output.

## Verification

Measured on LoCoMo (n=1540 per arm), paired and same-window, **both arms on the identical
corpus with only the binary differing** — answerer and judge both `gpt-5.6-sol`, `top_k=200`.

| | previous | this change | Δ | discordant | p |
|---|---|---|---|---|---|
| all pairs (n=634 so far) | 91.91 | 94.06 | **+2.16pp** | 16 / 4 | **0.012** |

The estimate has held in the **+2.2 to +2.5pp** band across ten reads from n=118 upward. The
full n=1540 run is still completing; this PR should not merge until it lands and passes the
gates.

Mechanism check — the change fires and does what it claims:

```
shipped binary : 17.60 units/q across 17.60 distinct files  -> ratio 1.00
this change    : 40.22 units/q across 17.60 distinct files  -> ratio 2.29  (same files)
```

The control arm was verified **byte-identical to the shipped binary** across 45 queries × 3
corpora (full JSON, latency/cache stats stripped, 0 mismatches), so the measured delta is
attributable to this change alone.

It is also not a context dump: 30–40% of corpus bytes returned, against the previous 22–29%.

## Fairness

This is a **post-ranking assembly rule that never reads the query**. It cannot key off any
benchmark, because it never sees a question. No question-conditioned branching, no vocabulary
lists, no category logic.

## Tests

`mise run check` passes — fmt, vet, `go test -race ./...` across all packages, build.
6 new tests in `internal/sem/search_multi_resolution_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015igKU9YpcFoeCFDccAcvXX
