### PR TITLE
fix(search): rank prose sections as independent candidates

### DIFF
--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -128,7 +128,7 @@ var commandDocs = []commandDoc{
 		long: "Ranked source regions for a plain-language description, with source and file:line inline, budgeted to drop straight into context. This is the first move for almost every locate task.\n\n" +
 			"By default search returns: ranked candidate fix sites (top hits as full function bodies), RELATED SITES, the COVERING TEST plus other tests over the same code (ALSO COVERING), SAME-CONCEPT LITERAL (every place the concept is named, tagged EDIT/CONSUMER/DOC), a VERIFY line (the narrowest test command for the file), and a CLOSED-SET WARNING when a switch over a sealed set would fail at runtime. The three reference blocks (container map, signature types, declaration card) are OFF by default because they cost turns in agent sessions; --reference-blocks all turns them on for interactive reading.\n\n" +
 			"--top-k only changes how many results come back; --deep additionally runs the exhaustive sparse (BM25) pass and fuses it with the semantic ranking (slower, reads every eligible file).\n\n" +
-			"Ranking returns one region per file, which is right for code and wrong for prose: one markdown document can hold the answer across several distant regions. When fewer distinct files match than --top-k asked for, the spare slots are spent returning those finer regions of the same document as results of their own (multi-resolution retrieval) — strictly additive, so it never displaces a file and never breaches --max-context-bytes. --single-resolution turns it off.",
+			"Ranking returns one region per unit, which is right for code and wrong for whole prose documents: one markdown document can hold the answer across several distant regions. So for prose the unit is the SECTION, not the file — a document's headed sections are ranked against every other section on their own scores, exactly as independent files would be (--document-resolution ranks a document as one unit instead). Prose with no heading structure has nothing to split on; there, when fewer distinct units match than --top-k asked for, the spare slots are spent returning finer regions of the same document as results of their own (multi-resolution retrieval) — strictly additive, so it never displaces a unit and never breaches --max-context-bytes. --single-resolution turns that off.",
 		flags: []flagDoc{
 			{name: "--query", arg: "text", desc: "The task or bug in one plain sentence (required)"},
 			{name: "--repo", arg: "path", desc: "Repository to search (default: current repo)"},
@@ -138,6 +138,7 @@ var commandDocs = []commandDoc{
 			{name: "--profile", arg: "syntax-only|fast|full", def: "fast", desc: "Parsing depth; use full for bug-fix/locate (call-graph active)"},
 			{name: "--deep", desc: "Also run the exhaustive BM25 pass and fuse it (slower)"},
 			{name: "--single-resolution", desc: "One result per file; do not spend spare slots on finer regions of a prose document"},
+			{name: "--document-resolution", desc: "Rank a prose document as one unit; do not rank its sections separately"},
 			{name: "--max-context-bytes", arg: "n", def: "24576", desc: "Output byte budget; 0 = unbounded"},
 			{name: "--reference-blocks", arg: "all|container-map,signature-types,type-card", desc: "Turn reference blocks back on (off by default)"},
 			{name: "--max-indexed-files", arg: "n", desc: "Bound cold-search parsing to N files"},

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -137,7 +137,7 @@ var commandDocs = []commandDoc{
 			{name: "--head", desc: "Search the committed tree (cached) instead of the working tree"},
 			{name: "--profile", arg: "syntax-only|fast|full", def: "fast", desc: "Parsing depth; use full for bug-fix/locate (call-graph active)"},
 			{name: "--deep", desc: "Also run the exhaustive BM25 pass and fuse it (slower)"},
-			{name: "--single-resolution", desc: "One result per file; do not spend spare slots on finer regions of a prose document"},
+			{name: "--single-resolution", desc: "One result per ranked unit; do not spend spare slots on finer regions of a prose document"},
 			{name: "--document-resolution", desc: "Rank a prose document as one unit; do not rank its sections separately"},
 			{name: "--max-context-bytes", arg: "n", def: "24576", desc: "Output byte budget; 0 = unbounded"},
 			{name: "--reference-blocks", arg: "all|container-map,signature-types,type-card", desc: "Turn reference blocks back on (off by default)"},

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -80,6 +80,7 @@ type searchFlags struct {
 	FileOutline           bool
 	Deep                  bool
 	SingleResolution      bool
+	DocumentResolution    bool
 	// The reference blocks, off unless asked for. See SearchOptions in internal/sem/search.go for
 	// the session measurement that made OFF the default.
 	ContainerMap   bool
@@ -200,6 +201,7 @@ func runSearch(ctx context.Context, opts Options, args []string) error {
 		VerifyExplainCommand:  flags.VerifyExplain,
 		Deep:                  flags.Deep,
 		SingleResolution:      flags.SingleResolution,
+		DocumentResolution:    flags.DocumentResolution,
 
 		IncludeContainerMap:   flags.ContainerMap,
 		IncludeSignatureTypes: flags.SignatureTypes,
@@ -1866,6 +1868,8 @@ func parseSearchFlags(args []string) (searchFlags, []string, error) {
 			flags.Deep = true
 		case "--single-resolution":
 			flags.SingleResolution = true
+		case "--document-resolution":
+			flags.DocumentResolution = true
 		case "--container-map":
 			flags.ContainerMap = true
 		case "--signature-types":

--- a/internal/sem/search.go
+++ b/internal/sem/search.go
@@ -192,6 +192,13 @@ type SearchOptions struct {
 	// exists for callers that need the result count to equal the distinct-file count, not because
 	// the expansion can cost them a file.
 	SingleResolution bool
+	// DocumentResolution turns OFF section-resolution prose ranking, restoring the previous
+	// behaviour: one prose document is one retrievable unit, so a corpus of N documents can never
+	// return more than N ranked regions however large --top-k is. With it unset (the default), a
+	// prose document's SECTIONS are the ranked units — each competes on its own score exactly as
+	// an independent file would — which is what every comparable document retriever does and what
+	// a reader asking a question about a long document actually wants. See search_prose_parent.go.
+	DocumentResolution bool
 }
 
 // SearchPassage is an additional, non-overlapping source region from the same file as its
@@ -1006,7 +1013,7 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 	applySearchBoilerplatePrior(candidates, q)
 	sortSearchCandidates(candidates)
 	candidates = collapseNearDuplicateCandidates(candidates)
-	semantic := selectSearchCandidates(candidates, q, options.TopK, options.MaxRegionsPerFile)
+	semantic := selectSearchCandidates(candidates, q, options.TopK, options.MaxRegionsPerFile, !options.DocumentResolution)
 	selected := semantic
 	if len(sparseCandidates) > 0 {
 		attachSparseCandidateSymbols(sparseCandidates, symbolsByFile)

--- a/internal/sem/search_multi_resolution_test.go
+++ b/internal/sem/search_multi_resolution_test.go
@@ -172,33 +172,60 @@ func TestSearchRepositoryReturnsMultiResolutionProseResults(t *testing.T) {
 		write(t, repo, "sessions/session-"+string(rune('a'+index))+".md", body.String())
 	}
 
-	search := func(single bool) SearchResponse {
+	// The switches are separate levers over the same corpus: --document-resolution makes the
+	// DOCUMENT the ranked unit again (one result per file), and --single-resolution stops the
+	// spare slots being spent on finer regions of whatever unit was ranked.
+	search := func(single, document bool) SearchResponse {
 		response, err := SearchRepository(
 			t.Context(), repo, "test", "amber lantern orchard ledger", SearchOptions{
-				Worktree:         true,
-				Profile:          ProfileSyntaxOnly,
-				TopK:             40,
-				MaxIndexedFiles:  32,
-				MaxContextBytes:  400000,
-				SingleResolution: single,
+				Worktree:           true,
+				Profile:            ProfileSyntaxOnly,
+				TopK:               40,
+				MaxIndexedFiles:    32,
+				MaxContextBytes:    400000,
+				SingleResolution:   single,
+				DocumentResolution: document,
 			},
 		)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if err := response.Validate(); err != nil {
-			t.Fatalf("invalid response (single=%v): %v", single, err)
+			t.Fatalf("invalid response (single=%v document=%v): %v", single, document, err)
 		}
 		return response
 	}
 
-	multi, single := search(false), search(true)
+	multi, single := search(false, true), search(true, true)
 	files := map[string]bool{}
 	for _, result := range single.Results {
 		files[result.FilePath] = true
 	}
 	if len(single.Results) != len(files) {
 		t.Fatalf("single-resolution returned %d results over %d files", len(single.Results), len(files))
+	}
+	// Section resolution is the default, and it must reach more of the corpus than either switch:
+	// twelve headed turns per document are twelve ranked units, not one.
+	sections := search(false, false)
+	if len(sections.Results) <= len(single.Results) {
+		t.Fatalf("section resolution returned %d results, document resolution returned %d; want more",
+			len(sections.Results), len(single.Results))
+	}
+	type span struct {
+		path       string
+		start, end int
+	}
+	sectionSpans := map[span]bool{}
+	for _, result := range sections.Results {
+		sectionSpans[span{result.FilePath, result.StartLine, result.EndLine}] = true
+	}
+	if len(sectionSpans) != len(sections.Results) {
+		t.Fatalf("section resolution returned %d results over %d distinct spans",
+			len(sections.Results), len(sectionSpans))
+	}
+	if sections.Stats.ResultBytes > sections.Stats.ContextBudgetBytes {
+		t.Fatalf("section resolution breached the budget: %d > %d",
+			sections.Stats.ResultBytes, sections.Stats.ContextBudgetBytes)
 	}
 	if len(multi.Results) <= len(single.Results) {
 		t.Fatalf("multi-resolution returned %d results, single returned %d; want more",

--- a/internal/sem/search_prose_parent.go
+++ b/internal/sem/search_prose_parent.go
@@ -210,32 +210,38 @@ func selectSearchCandidates(
 	return dropSelectedProsePassages(selected)
 }
 
-// dropSelectedProsePassages removes any planned passage that a later pass admitted as a result of
-// its own. A region must be returned once: as a ranked result if it earned a slot, and only
-// otherwise as a passage of the document region that did.
+// dropSelectedProsePassages keeps every returned region unique. Passages are planned per selected
+// unit over the whole document, so the same unselected region is planned once for EVERY selected
+// section of that document, and a region that won a slot of its own is also still planned as a
+// passage of its neighbours. Both are the same fault — the payload would show one region twice —
+// so both are dropped here: a region is returned as a ranked result if it earned a slot, otherwise
+// as a passage of exactly one result, the highest-ranked one that planned it.
 func dropSelectedProsePassages(selected []searchCandidate) []searchCandidate {
-	primaries := make(map[string][]SearchPassage, len(selected))
+	claimed := make(map[string][]SearchPassage, len(selected))
 	for index := range selected {
 		path := selected[index].result.FilePath
-		primaries[path] = append(primaries[path], primarySearchPassage(selected[index].result))
+		claimed[path] = append(claimed[path], primarySearchPassage(selected[index].result))
 	}
 	for index := range selected {
 		plan := selected[index].prosePassagePlan
 		if len(plan) == 0 {
 			continue
 		}
+		path := selected[index].result.FilePath
 		kept := plan[:0]
 		for _, passage := range plan {
 			taken := false
-			for _, primary := range primaries[selected[index].result.FilePath] {
-				if passagesOverlap(primary, passage) {
+			for _, existing := range claimed[path] {
+				if passagesOverlap(existing, passage) {
 					taken = true
 					break
 				}
 			}
-			if !taken {
-				kept = append(kept, passage)
+			if taken {
+				continue
 			}
+			claimed[path] = append(claimed[path], passage)
+			kept = append(kept, passage)
 		}
 		if len(kept) == 0 {
 			kept = nil

--- a/internal/sem/search_prose_parent.go
+++ b/internal/sem/search_prose_parent.go
@@ -2,6 +2,7 @@ package sem
 
 import (
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -10,10 +11,42 @@ const (
 	defaultProseParentHeadWindowLines = 80
 )
 
+// proseParent is one retrievable unit of a prose corpus: the regions that share it are ranked
+// against each other and only its best one is returned. Which regions share a unit is the whole
+// question this file answers — see proseParentKey.
 type proseParent struct {
+	key        string
 	path       string
 	best       *searchCandidate
 	candidates []*searchCandidate
+}
+
+// proseParentKey names the unit a prose region belongs to.
+//
+// THE UNIT OF RETRIEVAL FOR PROSE IS THE SECTION, NOT THE FILE. Ranking returns one region per
+// unit, which is right for code — a second region of a function the caller can already see is
+// worth less than the first region of one it cannot — and wrong for prose. A markdown document is
+// not one indivisible thing: it is a sequence of headed sections, and a reader asking a question
+// about a 400-turn chat log or a long design note wants the sections that answer it, not the one
+// span the ranker liked best in each file. Every comparable document retriever splits a document
+// on its headings for exactly this reason; keying the unit by file made entire-graph the outlier,
+// and it imposed a hard cap: a corpus of N documents could never return more than N regions
+// however large --top-k was, because there were only N units to rank.
+//
+// So a region that the parser recognized as belonging to a distinct section (markdown headings are
+// parsed as `section` symbols) is its own unit, and competes on its own score exactly as an
+// independent file would. A region with no symbol identity has no section to belong to, so it
+// falls back to the file — which is the previous behaviour, and is what prose formats with no
+// heading structure keep getting.
+//
+// The line is part of the key because a symbol ID names a heading, not an OCCURRENCE of one: a
+// document that heads twelve entries "## note" carries twelve identically-identified sections, and
+// keying by ID alone would collapse them back into the single unit this change exists to split.
+func proseParentKey(candidate searchCandidate, sectionUnits bool) string {
+	if !sectionUnits || candidate.result.SymbolID == "" {
+		return candidate.result.FilePath
+	}
+	return candidate.result.SymbolID + ":" + strconv.Itoa(candidate.result.StartLine)
 }
 
 type proseParentSeed struct {
@@ -61,21 +94,47 @@ func selectSearchCandidates(
 	q searchQuery,
 	topK int,
 	maxPerFile int,
+	sectionUnits bool,
 ) []searchCandidate {
 	baseline := selectDiverseCandidates(candidates, topK, maxPerFile)
-	parents := proseParents(candidates)
+	parents := proseParents(candidates, sectionUnits)
 	if !proseParentCorpus(parents) {
 		return baseline
+	}
+	// Passages are planned over the whole DOCUMENT even when the ranked unit is a section, because
+	// what a passage is for has not changed: it carries the distant same-document regions the
+	// one-region-per-unit rule discarded. Under section units those are the sections that lost the
+	// slot competition — dropping them would have taken evidence away from a caller reading a
+	// ten-result payload of an eighteen-document corpus, which is a docs repo, not a benchmark.
+	// dropSelectedProsePassages then removes the ones that won a slot after all.
+	documents := parents
+	if sectionUnits {
+		documents = proseParents(candidates, false)
 	}
 	terms := proseParentQueryTerms(q)
 	if len(terms) == 0 {
 		return baseline
 	}
 
+	selectedKeys := map[string]bool{}
 	selectedPaths := map[string]bool{}
+	// documentTarget is how many distinct documents this selection can represent at all. Until it
+	// is met, EVERY pass below admits only units from documents that have none yet — see the
+	// breadth rule at appendParent.
+	documentTarget := minInt(topK, proseParentDocumentCount(parents))
 	selected := make([]searchCandidate, 0, minInt(topK, len(parents)))
 	appendParent := func(parent *proseParent, fallback searchCandidate) bool {
-		if parent == nil || selectedPaths[parent.path] || len(selected) == topK {
+		if parent == nil || selectedKeys[parent.key] || len(selected) == topK {
+			return false
+		}
+		// BREADTH BEFORE DEPTH. A question is often answered by the one document nobody's terms
+		// ranked highly, so no document gets a SECOND region until every document that fits has
+		// one. The file-keyed unit got this for free — one unit per document meant selection could
+		// not return to a document — and it is the one property section units could lose: a pure
+		// score ranking hands every slot to whichever document's sections dominate the score list.
+		// It binds every pass, not just the first, because the per-term coverage pass is where a
+		// weakly-scoring document has always been admitted.
+		if sectionUnits && len(selectedPaths) < documentTarget && selectedPaths[parent.path] {
 			return false
 		}
 		candidate := fallback
@@ -83,21 +142,42 @@ func selectSearchCandidates(
 			candidate = *parent.best
 		}
 		candidate.result.Signals = appendUnique(candidate.result.Signals, proseParentRetrievalSignal)
-		candidate.prosePassagePlan = planProseParentPassages(parent, candidate, q, maxInt(0, topK-1))
+		candidate.prosePassagePlan = planProseParentPassages(documents[parent.path], candidate, q, maxInt(0, topK-1))
+		selectedKeys[parent.key] = true
 		selectedPaths[parent.path] = true
 		selected = append(selected, candidate)
 		return true
 	}
 
 	headParents := proseParentHeadCount(q, topK)
+	// The head: the best region of each document, in the ordinary region ranking's order.
+	// Unchanged — with section units the breadth rule already restricts it to one region per
+	// document, so `continue` only skips a candidate this pass was never going to take.
 	for _, candidate := range baseline {
-		if len(selected) == headParents {
+		if len(selected) >= headParents {
 			break
 		}
-		appendParent(parents[candidate.result.FilePath], candidate)
+		if sectionUnits && selectedPaths[candidate.result.FilePath] {
+			continue
+		}
+		appendParent(parents[proseParentKey(candidate, sectionUnits)], candidate)
+	}
+	// THEN MERIT: the best remaining sections overall, in score order (`candidates` is already
+	// sorted). This is the pass the file-keyed unit could not have: it is what lets the four
+	// sections of the one document that actually discusses the question all come back, and it
+	// ranks them against sections of every other document on their own scores rather than on
+	// their document's. It spends only the head budget, so the per-term coverage pass below keeps
+	// the tail it has always had.
+	if sectionUnits {
+		for _, candidate := range candidates {
+			if len(selected) >= headParents {
+				break
+			}
+			appendParent(parents[proseParentKey(candidate, sectionUnits)], candidate)
+		}
 	}
 
-	termLists := proseParentTermLists(candidates, parents, terms, topK)
+	termLists := proseParentTermLists(candidates, parents, terms, topK, sectionUnits)
 	for depth := 0; len(selected) < topK; depth++ {
 		sawDepth := false
 		for _, list := range termLists {
@@ -119,13 +199,48 @@ func selectSearchCandidates(
 		if len(selected) == topK {
 			break
 		}
-		appendParent(parents[candidate.result.FilePath], candidate)
+		appendParent(parents[proseParentKey(candidate, sectionUnits)], candidate)
 	}
 	for _, candidate := range candidates {
 		if len(selected) == topK {
 			break
 		}
-		appendParent(parents[candidate.result.FilePath], candidate)
+		appendParent(parents[proseParentKey(candidate, sectionUnits)], candidate)
+	}
+	return dropSelectedProsePassages(selected)
+}
+
+// dropSelectedProsePassages removes any planned passage that a later pass admitted as a result of
+// its own. A region must be returned once: as a ranked result if it earned a slot, and only
+// otherwise as a passage of the document region that did.
+func dropSelectedProsePassages(selected []searchCandidate) []searchCandidate {
+	primaries := make(map[string][]SearchPassage, len(selected))
+	for index := range selected {
+		path := selected[index].result.FilePath
+		primaries[path] = append(primaries[path], primarySearchPassage(selected[index].result))
+	}
+	for index := range selected {
+		plan := selected[index].prosePassagePlan
+		if len(plan) == 0 {
+			continue
+		}
+		kept := plan[:0]
+		for _, passage := range plan {
+			taken := false
+			for _, primary := range primaries[selected[index].result.FilePath] {
+				if passagesOverlap(primary, passage) {
+					taken = true
+					break
+				}
+			}
+			if !taken {
+				kept = append(kept, passage)
+			}
+		}
+		if len(kept) == 0 {
+			kept = nil
+		}
+		selected[index].prosePassagePlan = kept
 	}
 	return selected
 }
@@ -187,15 +302,15 @@ func proseParentHeadCount(q searchQuery, topK int) int {
 	return (topK + 1) / 2
 }
 
-func proseParents(candidates []searchCandidate) map[string]*proseParent {
+func proseParents(candidates []searchCandidate, sectionUnits bool) map[string]*proseParent {
 	parents := make(map[string]*proseParent)
 	for index := range candidates {
 		candidate := &candidates[index]
-		path := candidate.result.FilePath
-		parent := parents[path]
+		key := proseParentKey(*candidate, sectionUnits)
+		parent := parents[key]
 		if parent == nil {
-			parent = &proseParent{path: path, best: candidate}
-			parents[path] = parent
+			parent = &proseParent{key: key, path: candidate.result.FilePath, best: candidate}
+			parents[key] = parent
 		}
 		parent.candidates = append(parent.candidates, candidate)
 		if searchCandidateScoreLess(*candidate, *parent.best) {
@@ -205,17 +320,32 @@ func proseParents(candidates []searchCandidate) map[string]*proseParent {
 	return parents
 }
 
+// proseParentCorpus decides whether this is a prose corpus at all, and it is deliberately counted
+// over distinct FILES rather than over units: what makes a corpus prose is what the documents are,
+// not how finely they are subdivided, so the gate reads identically whichever unit is in force.
+func proseParentDocumentCount(parents map[string]*proseParent) int {
+	paths := make(map[string]bool, len(parents))
+	for _, parent := range parents {
+		paths[parent.path] = true
+	}
+	return len(paths)
+}
+
 func proseParentCorpus(parents map[string]*proseParent) bool {
-	if len(parents) < 4 {
+	paths := make(map[string]bool, len(parents))
+	for _, parent := range parents {
+		paths[parent.path] = true
+	}
+	if len(paths) < 4 {
 		return false
 	}
 	prose := 0
-	for path := range parents {
+	for path := range paths {
 		if proseParentPath(path) {
 			prose++
 		}
 	}
-	return prose*5 >= len(parents)*4
+	return prose*5 >= len(paths)*4
 }
 
 func proseParentPath(path string) bool {
@@ -251,6 +381,7 @@ func proseParentTermLists(
 	parents map[string]*proseParent,
 	terms []string,
 	limit int,
+	sectionUnits bool,
 ) [][]proseParentSeed {
 	bestByTerm := make([]map[string]*searchCandidate, len(terms))
 	for termIndex := range bestByTerm {
@@ -259,10 +390,10 @@ func proseParentTermLists(
 	matched := make([]bool, len(terms))
 	for candidateIndex := range candidates {
 		candidate := &candidates[candidateIndex]
-		path := candidate.result.FilePath
-		if !proseParentPath(path) {
+		if !proseParentPath(candidate.result.FilePath) {
 			continue
 		}
+		key := proseParentKey(*candidate, sectionUnits)
 		clear(matched)
 		allMatched := true
 		for termIndex, term := range terms {
@@ -282,18 +413,18 @@ func proseParentTermLists(
 			if !matches {
 				continue
 			}
-			best := bestByTerm[termIndex][path]
+			best := bestByTerm[termIndex][key]
 			if best == nil || searchCandidateScoreLess(*candidate, *best) {
-				bestByTerm[termIndex][path] = candidate
+				bestByTerm[termIndex][key] = candidate
 			}
 		}
 	}
 
 	termLists := make([][]proseParentSeed, len(terms))
 	for termIndex, bestByParent := range bestByTerm {
-		for path, candidate := range bestByParent {
+		for key, candidate := range bestByParent {
 			termLists[termIndex] = insertProseParentSeed(termLists[termIndex], proseParentSeed{
-				parent: parents[path], candidate: candidate,
+				parent: parents[key], candidate: candidate,
 			}, limit)
 		}
 	}
@@ -463,8 +594,8 @@ func proseParentSeedLess(left, right proseParentSeed) bool {
 	if left.candidate.score != right.candidate.score {
 		return left.candidate.score > right.candidate.score
 	}
-	if left.parent.path != right.parent.path {
-		return left.parent.path < right.parent.path
+	if left.parent.key != right.parent.key {
+		return left.parent.key < right.parent.key
 	}
 	return searchCandidateLess(*left.candidate, *right.candidate)
 }

--- a/internal/sem/search_prose_section_test.go
+++ b/internal/sem/search_prose_section_test.go
@@ -3,6 +3,7 @@ package sem
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -157,5 +158,55 @@ func TestSelectSearchCandidatesLeavesCodeSelectionUnchanged(t *testing.T) {
 		if !reflect.DeepEqual(document[index], section[index]) {
 			t.Fatalf("code result %d changed:\n want %#v\n  got %#v", index, document[index], section[index])
 		}
+	}
+}
+
+// Passages are planned per selected unit over the whole document, so without deduplication the
+// same region is attached to every selected section of that document and the payload shows one
+// region several times over.
+func TestSearchRepositoryReturnsEveryProseRegionOnce(t *testing.T) {
+	repo := t.TempDir()
+	for index := 0; index < 5; index++ {
+		var body strings.Builder
+		body.WriteString("# Session\n\n")
+		for turn := 0; turn < 9; turn++ {
+			fmt.Fprintf(&body, "## turn %d: amber lantern orchard ledger vessel ridge marker%d\n\n", turn, turn)
+		}
+		write(t, repo, fmt.Sprintf("sessions/session-%02d.md", index), body.String())
+	}
+
+	response, err := SearchRepository(
+		t.Context(), repo, "test", "amber lantern orchard ledger vessel", SearchOptions{
+			Worktree: true, Profile: ProfileSyntaxOnly, TopK: 20,
+			MaxIndexedFiles: 32, MaxContextBytes: 400000,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := response.Validate(); err != nil {
+		t.Fatalf("invalid response: %v", err)
+	}
+	type span struct {
+		path       string
+		start, end int
+	}
+	seen := map[span]int{}
+	total := 0
+	for _, result := range response.Results {
+		seen[span{result.FilePath, result.SnippetStartLine, result.SnippetEndLine}]++
+		total++
+		for _, passage := range result.Passages {
+			seen[span{result.FilePath, passage.StartLine, passage.EndLine}]++
+			total++
+		}
+	}
+	if len(seen) != total {
+		for key, count := range seen {
+			if count > 1 {
+				t.Errorf("region %v returned %d times", key, count)
+			}
+		}
+		t.Fatalf("%d regions returned over %d distinct spans", total, len(seen))
 	}
 }

--- a/internal/sem/search_prose_section_test.go
+++ b/internal/sem/search_prose_section_test.go
@@ -1,0 +1,161 @@
+package sem
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// proseSectionCandidates builds `files` documents of `sections` headed sections each. Section i of
+// every document carries the same terms, so the only thing separating them is score.
+func proseSectionCandidates(files, sections int) []searchCandidate {
+	candidates := make([]searchCandidate, 0, files*sections)
+	for file := 0; file < files; file++ {
+		for section := 0; section < sections; section++ {
+			candidates = append(candidates, proseTestCandidate(
+				fmt.Sprintf("sessions/session-%02d.md", file),
+				1+section*10,
+				float64(100-file*sections-section),
+				"# Amber lantern",
+				map[string]int{"amber": 1, "lantern": 1},
+			))
+		}
+	}
+	sortSearchCandidates(candidates)
+	return candidates
+}
+
+// A prose document is not one indivisible retrievable thing. Before this, the unit was the file, so
+// a corpus of N documents could never return more than N regions however large --top-k was: the
+// 4x6 corpus below returned 4 results for --top-k 12 and threw the other 20 ranked sections away.
+func TestSelectSearchCandidatesRanksProseSectionsAsUnits(t *testing.T) {
+	q := buildSearchQuery("amber lantern")
+	q.matchableWords = []string{"amber", "lantern"}
+	candidates := proseSectionCandidates(4, 6)
+
+	document := selectSearchCandidates(candidates, q, 12, 3, false)
+	if len(document) != 4 {
+		t.Fatalf("document resolution selected %d units, want one per file (4)", len(document))
+	}
+
+	section := selectSearchCandidates(candidates, q, 12, 3, true)
+	if len(section) != 12 {
+		t.Fatalf("section resolution selected %d units, want top-k 12", len(section))
+	}
+	seen := map[string]bool{}
+	for _, candidate := range section {
+		key := candidate.result.SymbolID
+		if seen[key] {
+			t.Fatalf("section %q returned twice: %#v", key, section)
+		}
+		seen[key] = true
+	}
+}
+
+// Every returned region must carry the score its own content earned. Promotion inherited the
+// parent's score, so a top-k of 200 over 19 documents came back with 19 distinct scores and a
+// consumer that sorts by score saw one document's regions before any of the next document's.
+func TestSelectSearchCandidatesScoresProseSectionsIndependently(t *testing.T) {
+	q := buildSearchQuery("amber lantern")
+	q.matchableWords = []string{"amber", "lantern"}
+	candidates := proseSectionCandidates(4, 6)
+
+	section := selectSearchCandidates(candidates, q, 12, 3, true)
+	scores := map[float64]bool{}
+	for _, candidate := range section {
+		scores[candidate.score] = true
+	}
+	if len(scores) != len(section) {
+		t.Fatalf("%d sections carry only %d distinct scores", len(section), len(scores))
+	}
+}
+
+// Breadth is the property the file-keyed unit bought, and it must survive: a question is often
+// answered by the one document whose terms nobody ranked highly. Document 3 holds the six WORST
+// scores in the corpus, so a pure score ranking would exclude it entirely.
+func TestSelectSearchCandidatesKeepsEveryProseDocumentRepresented(t *testing.T) {
+	q := buildSearchQuery("amber lantern")
+	q.matchableWords = []string{"amber", "lantern"}
+	candidates := proseSectionCandidates(4, 6)
+
+	section := selectSearchCandidates(candidates, q, 6, 3, true)
+	files := map[string]bool{}
+	for _, candidate := range section {
+		files[candidate.result.FilePath] = true
+	}
+	for file := 0; file < 4; file++ {
+		path := fmt.Sprintf("sessions/session-%02d.md", file)
+		if !files[path] {
+			t.Fatalf("document %s was excluded entirely: %#v", path, files)
+		}
+	}
+}
+
+// A prose format with no heading structure has no section to belong to. Those regions keep the
+// file as their unit, which is the previous behaviour exactly.
+func TestSelectSearchCandidatesFallsBackToFileWithoutSectionIdentity(t *testing.T) {
+	q := buildSearchQuery("amber lantern")
+	q.matchableWords = []string{"amber", "lantern"}
+	candidates := proseSectionCandidates(4, 6)
+	for index := range candidates {
+		candidates[index].result.SymbolID = ""
+	}
+	sortSearchCandidates(candidates)
+
+	section := selectSearchCandidates(candidates, q, 12, 3, true)
+	if len(section) != 4 {
+		t.Fatalf("selected %d units without section identity, want one per file (4)", len(section))
+	}
+}
+
+// The prose gate asks what the documents ARE, not how finely they are subdivided, so it must read
+// identically under either unit. Three documents is below the four-document floor whether they
+// contribute 3 units or 18.
+func TestProseParentCorpusCountsDocumentsNotSections(t *testing.T) {
+	candidates := proseSectionCandidates(3, 6)
+	if proseParentCorpus(proseParents(candidates, false)) {
+		t.Fatal("3 documents passed the prose gate at document resolution")
+	}
+	if proseParentCorpus(proseParents(candidates, true)) {
+		t.Fatal("3 documents passed the prose gate at section resolution")
+	}
+	wide := proseSectionCandidates(4, 6)
+	if !proseParentCorpus(proseParents(wide, false)) {
+		t.Fatal("4 documents failed the prose gate at document resolution")
+	}
+	if !proseParentCorpus(proseParents(wide, true)) {
+		t.Fatal("4 documents failed the prose gate at section resolution")
+	}
+}
+
+// Code search must be inert. A source corpus never reaches the prose selector, so section units
+// cannot reorder, add or drop a single code result.
+func TestSelectSearchCandidatesLeavesCodeSelectionUnchanged(t *testing.T) {
+	q := buildSearchQuery("amber lantern")
+	q.matchableWords = []string{"amber", "lantern"}
+	candidates := make([]searchCandidate, 0, 24)
+	for file := 0; file < 4; file++ {
+		for symbol := 0; symbol < 6; symbol++ {
+			candidate := proseTestCandidate(
+				fmt.Sprintf("internal/pkg/file%02d.go", file), 1+symbol*10,
+				float64(100-file*6-symbol), "func amberLantern() {}",
+				map[string]int{"amber": 1, "lantern": 1},
+			)
+			candidate.result.Language = "Go"
+			candidate.result.Kind = "function"
+			candidates = append(candidates, candidate)
+		}
+	}
+	sortSearchCandidates(candidates)
+
+	document := searchCandidateResults(selectSearchCandidates(candidates, q, 12, 3, false))
+	section := searchCandidateResults(selectSearchCandidates(candidates, q, 12, 3, true))
+	if len(document) != len(section) {
+		t.Fatalf("code selection changed size: %d -> %d", len(document), len(section))
+	}
+	for index := range document {
+		if !reflect.DeepEqual(document[index], section[index]) {
+			t.Fatalf("code result %d changed:\n want %#v\n  got %#v", index, document[index], section[index])
+		}
+	}
+}

--- a/internal/sem/search_prose_session_test.go
+++ b/internal/sem/search_prose_session_test.go
@@ -113,10 +113,17 @@ func TestSearchRepositoryRanksSafePluralMarkdownSession(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assertSearchResultGolden(t, response.Results, "402dfe1fae86d736a735d742dbcbd38871a61d9a4b280349291fe2c88ec72d0b")
+	// The admitted region is `## Vessels`, the section that carries the one query term no other
+	// document matches, rather than the document's globally best `# Ambers` heading: with the
+	// section as the ranked unit, the region that earned the slot is the region returned. Same
+	// rank, same score, same five regions.
+	assertSearchResultGolden(t, response.Results, "72795b2d906d1b141b4b040d82d8ef4e7d69d1a652bc16e72cbdb804524be5fc")
 	for _, result := range response.Results {
 		if result.FilePath == "sessions/focus.md" &&
 			containsString(result.Signals, "retrieval_mode=prose-parent") {
+			if result.StartLine != 9 {
+				t.Fatalf("admitted region start = %d, want the `## Vessels` section at 9", result.StartLine)
+			}
 			if result.Rank != 6 {
 				t.Fatalf("plural session rank = %d, want first fair tail slot 6", result.Rank)
 			}
@@ -208,7 +215,7 @@ func TestProseParentTermListsUseDerivedWordFamilyCoverage(t *testing.T) {
 	)
 	candidates := []searchCandidate{candidate}
 	lists := proseParentTermLists(
-		candidates, proseParents(candidates), []string{"navigate"}, 10,
+		candidates, proseParents(candidates, false), []string{"navigate"}, 10, false,
 	)
 	if len(lists) != 1 || len(lists[0]) != 1 || lists[0][0].parent.path != "sessions/focus.md" {
 		t.Fatalf("derived family did not seed prose parent: %#v", lists)
@@ -822,7 +829,7 @@ func TestSelectSearchCandidatesReturnsBestPassageForAdmittedParent(t *testing.T)
 		proseTestCandidate("sessions/focus.md", 80, 8, "# Amber overview", map[string]int{"amber": 1}),
 	)
 	sortSearchCandidates(candidates)
-	selected := selectSearchCandidates(candidates, q, 6, 3)
+	selected := selectSearchCandidates(candidates, q, 6, 3, false)
 	assertSearchResultGolden(t, searchCandidateResults(selected), "5ce0ba0a0d46c828e61092bbd325931fccd418b5b0bd6cae67ff4680bdcad95a")
 	for _, candidate := range selected {
 		if candidate.result.FilePath != "sessions/focus.md" {
@@ -842,16 +849,16 @@ func TestSelectSearchCandidatesHasLinearProseWorkingSet(t *testing.T) {
 	small := proseScaleCandidates(500)
 	large := proseScaleCandidates(1000)
 	smallAllocs := testing.AllocsPerRun(3, func() {
-		_ = selectSearchCandidates(small, q, 10, 3)
+		_ = selectSearchCandidates(small, q, 10, 3, false)
 	})
 	largeAllocs := testing.AllocsPerRun(3, func() {
-		_ = selectSearchCandidates(large, q, 10, 3)
+		_ = selectSearchCandidates(large, q, 10, 3, false)
 	})
 	if largeAllocs > smallAllocs*2.4 {
 		t.Fatalf("allocations grew superlinearly: 500=%0.f 1000=%0.f", smallAllocs, largeAllocs)
 	}
 	scale := proseScaleCandidates(4000)
-	selected := selectSearchCandidates(scale, q, 10, 3)
+	selected := selectSearchCandidates(scale, q, 10, 3, false)
 	if len(selected) != 10 {
 		t.Fatalf("selected %d candidates, want top-k 10", len(selected))
 	}
@@ -916,7 +923,7 @@ func BenchmarkSelectSearchCandidatesProse4000(b *testing.B) {
 	b.ResetTimer()
 	var selected []searchCandidate
 	for iteration := 0; iteration < b.N; iteration++ {
-		selected = selectSearchCandidates(candidates, q, 10, 3)
+		selected = selectSearchCandidates(candidates, q, 10, 3, false)
 	}
 	if len(selected) != 10 {
 		b.Fatalf("selected %d candidates, want 10", len(selected))


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/54
<!-- entire-trail-link-end -->

Stacked on #100. Base is `feat/multi-resolution-retrieval`, so the diff here is this change alone.

## The defect

`selectSearchCandidates` admits **one candidate per file**. For prose that is the wrong unit: a
markdown document's heading regions already exist in the graph as `section` entities
(`parser.go` `markdownEntities`) and are already scored — then collapsed to one per file.

#100 promotes the discarded regions back into empty top-k slots, but as **satellites**:
`proseResolutionResult` sets `Score: parent.Score` verbatim, promotions are ordered by a
round-robin over *parent index*, and every promotion is appended after every parent.

Artifact proof on a real prose corpus at `--top-k 200`:

```
200 results  ->  19 distinct scores
```

181 of 200 results are score-duplicates of one of 19 parents.

**The downstream consequence.** A consumer sorting by score with a stable sort gets 19 blocks —
one document's parent followed by all of its promoted regions, then the next. Truncate to the
top 50, 20 or 10 and you see only the first one or two documents. Any question needing evidence
stitched across documents structurally cannot get it.

## The change

The prose retrieval unit becomes the **section**, not the file (`proseParentKey`, keyed by the
heading's SymbolID, falling back to file path where a document has no section structure). A
section competes on its own score, as an independent file would.

Breadth is preserved: **no document gets a second region until every document that fits has
one** — that rule binds every selection pass, not just the first.

`--document-resolution` restores the previous behaviour.

The unit is decided by the parser's section entities and the file extension. Nothing reads the
query.

## Measured

152 questions on a real prose corpus, identical search arguments:

| | items/q | distinct regions/q | **distinct scores/q** | files/q | visible chars/q |
|---|---|---|---|---|---|
| before (#100) | 195.0 | 243.0 | **17.1** | 18.9 | 60,854 |
| **after** | **196.0** | **295.3** | **84.9** | **18.9** | **53,929** |
| `--document-resolution` | 195.0 | 243.0 | 17.1 | 18.9 | 60,854 |

Score diversity 17.1 → 84.9, document coverage unchanged at 18.9, and **11.4% fewer bytes** —
the previous build was computing regions and discarding them unread. The off switch is
byte-identical to the base branch on every metric.

## Code search is unaffected

**30 of 30 full-JSON payloads identical** — 15 real locate queries against this repo at
`--top-k 10` *and* `--top-k 50`, comparing the entire payload (results element by element plus
`stats`, `commit`, `tree`, `completeness`, `diagnostics`), latency telemetry excluded.

The prose branch sits behind `proseParentCorpus`, which requires ≥4 units and ≥80%
doc-extension paths. A source repo cannot reach it — verified rather than assumed: three
deliberately documentation-flavoured queries against this Go repo returned **zero** results
carrying `retrieval_mode=prose-parent` in either build.

## Benchmark result

LoCoMo, all 1540 questions, answerer and judge both `gpt-5.6-sol`, `top_k=200`, measured against
a mem0 OSS control **running concurrently in the same window**:

| | overall | single-hop | multi-hop | temporal | open-domain |
|---|---|---|---|---|---|
| **this branch** | **94.74** | **96.67** | **93.97** | **95.33** | 78.12 |
| mem0 OSS | 93.83 | 95.12 | 93.62 | 94.70 | **80.21** |

**+0.91pp overall, discordant 43–29, McNemar p = 0.125 — statistically tied, point estimate
favours entire-graph.** The wording follows a decision rule registered before the run finished.

**single-hop +1.55pp, p = 0.035** is the one cell that clears significance on its own.

Multi-hop moved from **−1.44 against mem0 to +0.35** — that was the deficit this change targets,
and it is the category the 19-distinct-scores collapse was starving.

No harness flag and no ingest change: this is the shipped corpus shape.

### Stated plainly

- Run-to-run noise on this harness is **0.65pp** — two identical mem0 runs scored 93.83 and 93.57.
- entire-graph delivers ~30% more context per question than mem0, and **mem0 is more
  context-efficient below ~25k chars**. Item-count parity at `top_k` is not context parity.
- Prose search is **2.1× slower per query** (0.300s → 0.628s) because passages are planned for
  ~196 units instead of 19. Code-search latency is unchanged, since the prose path never fires.

## Tests

`mise run check` green. Three regressions were found and fixed during development, each now
pinned by a test: whole-document exclusion at small top-k, loss of same-document passages at
tight top-k, and one region being returned up to seven times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015igKU9YpcFoeCFDccAcvXX
