### PR TITLE
fix: validate init-agents markers before writes

### DIFF
--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"os"
@@ -96,14 +97,6 @@ func runInitAgents(opts Options, args []string) error {
 	}
 
 	guidePath := filepath.Join(root, ".entire", "graph-agent.md")
-	if err := os.MkdirAll(filepath.Dir(guidePath), 0o755); err != nil {
-		return err
-	}
-	if err := os.WriteFile(guidePath, []byte(agentGuide), 0o644); err != nil {
-		return err
-	}
-	fmt.Fprintf(opts.Stdout, "wrote %s\n", guidePath)
-
 	pointer := agentPointerBegin + "\n" +
 		"This repo has the entire-graph code graph installed. Before exploring code with\n" +
 		"grep/find/whole-file reads, read .entire/graph-agent.md — resolution-first guidance\n" +
@@ -112,53 +105,146 @@ func runInitAgents(opts Options, args []string) error {
 		agentPointerEnd + "\n"
 
 	agentsPath := filepath.Join(root, "AGENTS.md")
-	if err := upsertPointerBlock(agentsPath, pointer); err != nil {
+	claudePath := filepath.Join(root, "CLAUDE.md")
+	agentsInfo, err := inspectInstructionFile(agentsPath)
+	if err != nil {
+		return fmt.Errorf("init-agents: %w", err)
+	}
+	claudeInfo, err := inspectInstructionFile(claudePath)
+	if err != nil {
+		return fmt.Errorf("init-agents: %w", err)
+	}
+
+	sharedInstructions := agentsInfo != nil && claudeInfo != nil && os.SameFile(agentsInfo, claudeInfo)
+	agentsSource, agentsBegin, agentsEnd, err := readAndValidateInstructionFile(agentsPath)
+	if err != nil {
+		return fmt.Errorf("init-agents: %w", err)
+	}
+	var claudeSource []byte
+	claudeBegin, claudeEnd := -1, -1
+	if !sharedInstructions {
+		claudeSource, claudeBegin, claudeEnd, err = readAndValidateInstructionFile(claudePath)
+		if err != nil {
+			return fmt.Errorf("init-agents: %w", err)
+		}
+	}
+
+	// Compute every byte that depends on instruction-file reads before creating or
+	// modifying anything. In particular, Claude import detection must see the same
+	// validated snapshot that is rendered below.
+	agentsContent := renderPointerBlock(agentsSource, agentsBegin, agentsEnd, pointer)
+	claudeBlock := pointer
+	if !sharedInstructions && claudeDirectlyImportsAgents(claudeSource, claudePath, agentsPath) {
+		claudeBlock = agentPointerBegin + "\n<!-- Entire Graph instructions are inherited through AGENTS.md. -->\n" + agentPointerEnd + "\n"
+	}
+	var claudeContent []byte
+	if !sharedInstructions {
+		claudeContent = renderPointerBlock(claudeSource, claudeBegin, claudeEnd, claudeBlock)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(guidePath), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(guidePath, []byte(agentGuide), 0o644); err != nil {
+		return err
+	}
+	fmt.Fprintf(opts.Stdout, "wrote %s\n", guidePath)
+
+	if err := os.WriteFile(agentsPath, agentsContent, 0o644); err != nil {
 		return fmt.Errorf("init-agents: AGENTS.md: %w", err)
 	}
 	fmt.Fprintf(opts.Stdout, "updated %s\n", agentsPath)
 
-	claudePath := filepath.Join(root, "CLAUDE.md")
-	agentsInfo, err := os.Stat(agentsPath)
-	if err != nil {
-		return fmt.Errorf("init-agents: AGENTS.md: %w", err)
-	}
-	claudeInfo, err := os.Stat(claudePath)
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("init-agents: CLAUDE.md: %w", err)
-	}
-	if err == nil && os.SameFile(agentsInfo, claudeInfo) {
+	if sharedInstructions {
 		// A symlink or hard link already gives Claude the AGENTS.md pointer. Updating the
 		// same inode a second time could replace that pointer with an inheritance notice
 		// that no longer has anything to inherit from.
 		return nil
 	}
-
-	importsAgents, err := claudeDirectlyImportsAgents(claudePath, agentsPath)
+	// Preserve the existing first-run behavior for a dangling AGENTS.md/CLAUDE.md alias:
+	// writing AGENTS.md may have created the shared target that did not exist at preflight.
+	agentsInfo, err = os.Stat(agentsPath)
 	if err != nil {
+		return fmt.Errorf("init-agents: AGENTS.md: %w", err)
+	}
+	claudeInfo, err = os.Stat(claudePath)
+	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("init-agents: CLAUDE.md: %w", err)
 	}
-	claudeBlock := pointer
-	if importsAgents {
-		claudeBlock = agentPointerBegin + "\n<!-- Entire Graph instructions are inherited through AGENTS.md. -->\n" + agentPointerEnd + "\n"
+	if err == nil && os.SameFile(agentsInfo, claudeInfo) {
+		return nil
 	}
-	if err := upsertPointerBlock(claudePath, claudeBlock); err != nil {
+	if err := os.WriteFile(claudePath, claudeContent, 0o644); err != nil {
 		return fmt.Errorf("init-agents: CLAUDE.md: %w", err)
 	}
 	fmt.Fprintf(opts.Stdout, "updated %s\n", claudePath)
 	return nil
 }
 
+// inspectInstructionFile identifies existing aliases and rejects targets that cannot be safely
+// read as instruction files. A missing target—including a dangling alias—is preserved as the
+// empty-file case supported by init-agents.
+func inspectInstructionFile(path string) (os.FileInfo, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%s: inspect target: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s: expected a regular file, found %s", path, info.Mode().Type())
+	}
+	return info, nil
+}
+
+func readAndValidateInstructionFile(path string) ([]byte, int, int, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, -1, -1, nil
+		}
+		return nil, -1, -1, fmt.Errorf("%s: read file: %w", path, err)
+	}
+	begin, end, err := validatePointerMarkers(path, content)
+	if err != nil {
+		return nil, -1, -1, err
+	}
+	return content, begin, end, nil
+}
+
+// validatePointerMarkers intentionally counts the raw marker tokens. Markers in examples,
+// comments, or other Markdown regions are still managed-marker tokens and must not make the
+// replacement range ambiguous.
+func validatePointerMarkers(path string, content []byte) (int, int, error) {
+	beginToken := []byte(agentPointerBegin)
+	endToken := []byte(agentPointerEnd)
+	beginCount := bytes.Count(content, beginToken)
+	endCount := bytes.Count(content, endToken)
+	begin := bytes.Index(content, beginToken)
+	end := bytes.Index(content, endToken)
+
+	if beginCount == 0 && endCount == 0 {
+		return -1, -1, nil
+	}
+	if beginCount == 1 && endCount == 1 && begin < end {
+		return begin, end, nil
+	}
+
+	reason := fmt.Sprintf("found %d begin marker(s) and %d end marker(s)", beginCount, endCount)
+	if beginCount == 1 && endCount == 1 {
+		reason = "the end marker appears before the begin marker"
+	}
+	return -1, -1, fmt.Errorf(
+		"%s: malformed Entire Graph managed markers (%s); back up the file, preserve user-owned text, reduce it to zero markers or exactly one complete %q / %q pair with begin before end, then rerun init-agents",
+		path, reason, agentPointerBegin, agentPointerEnd,
+	)
+}
+
 // claudeDirectlyImportsAgents recognizes a standalone @path directive outside the Markdown
 // regions where Claude suppresses imports. Ambiguous syntax returns false so the direct pointer
 // remains in place.
-func claudeDirectlyImportsAgents(claudePath, agentsPath string) (bool, error) {
-	content, err := os.ReadFile(claudePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
-		return false, err
-	}
+func claudeDirectlyImportsAgents(content []byte, claudePath, agentsPath string) bool {
 	var found, fence bool
 	var until string
 	var fenceChar byte
@@ -180,7 +266,7 @@ func claudeDirectlyImportsAgents(claudePath, agentsPath string) (bool, error) {
 			continue
 		}
 		if strings.Contains(line, agentPointerEnd) {
-			return false, nil
+			return false
 		}
 		if strings.Contains(line, "<!--") {
 			if !strings.Contains(line, "-->") {
@@ -189,7 +275,7 @@ func claudeDirectlyImportsAgents(claudePath, agentsPath string) (bool, error) {
 			continue
 		}
 		if strings.Contains(line, "-->") {
-			return false, nil
+			return false
 		}
 		if fence {
 			width := len(line) - len(strings.TrimLeft(line, string(fenceChar)))
@@ -227,7 +313,7 @@ func claudeDirectlyImportsAgents(claudePath, agentsPath string) (bool, error) {
 			found = true
 		}
 	}
-	return found && until == "" && !fence, nil
+	return found && until == "" && !fence
 }
 
 func markdownIndent(line string) int {
@@ -262,16 +348,11 @@ func nextCodeSpanWidth(line string, open int) int {
 	return open
 }
 
-// upsertPointerBlock appends the block to path (creating the file if absent), or replaces the
-// existing marker-delimited block in place, so repeated runs never duplicate content.
-func upsertPointerBlock(path, block string) error {
-	existing, err := os.ReadFile(path)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
+// renderPointerBlock appends the block to an empty/unmanaged snapshot, or replaces its already
+// validated marker-delimited block in place. It performs no I/O so callers can render all output
+// before the first write.
+func renderPointerBlock(existing []byte, begin, end int, block string) []byte {
 	content := string(existing)
-	begin := strings.Index(content, agentPointerBegin)
-	end := strings.Index(content, agentPointerEnd)
 	switch {
 	case begin >= 0 && end > begin:
 		content = content[:begin] + strings.TrimSuffix(block, "\n") + content[end+len(agentPointerEnd):]
@@ -283,5 +364,5 @@ func upsertPointerBlock(path, block string) error {
 		}
 		content += "\n" + block
 	}
-	return os.WriteFile(path, []byte(content), 0o644)
+	return []byte(content)
 }

--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -193,9 +193,33 @@ func inspectInstructionFile(path string) (os.FileInfo, error) {
 		return nil, fmt.Errorf("%s: inspect target: %w", path, err)
 	}
 	if !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("%s: expected a regular file, found %s", path, info.Mode().Type())
+		return nil, fmt.Errorf("%s: expected a regular file, found %s", path, fileTypeName(info.Mode()))
 	}
 	return info, nil
+}
+
+// fileTypeName names what was found in place of a regular file. FileMode.Type()
+// formats as permission bits ("d---------"), which tells whoever hit this nothing
+// about what to remove or move aside.
+func fileTypeName(mode os.FileMode) string {
+	switch {
+	case mode.IsDir():
+		return "directory"
+	case mode&os.ModeSymlink != 0:
+		return "symlink"
+	case mode&os.ModeNamedPipe != 0:
+		return "named pipe"
+	case mode&os.ModeSocket != 0:
+		return "socket"
+	case mode&os.ModeCharDevice != 0:
+		return "character device"
+	case mode&os.ModeDevice != 0:
+		return "device"
+	case mode&os.ModeIrregular != 0:
+		return "irregular file"
+	default:
+		return mode.Type().String()
+	}
 }
 
 func readAndValidateInstructionFile(path string) ([]byte, int, int, error) {

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -474,7 +474,10 @@ func TestInitAgentsRejectsNonRegularInstructionFileWithoutWrites(t *testing.T) {
 
 			var stdout bytes.Buffer
 			err := Run(context.Background(), Options{Stdout: &stdout, Stderr: &bytes.Buffer{}}, []string{"init-agents", "--repo", repo})
-			if err == nil || !strings.Contains(err.Error(), invalidName) || !strings.Contains(err.Error(), "regular file") {
+			// "directory", not the permission-bit form: the message has to say what
+			// is in the way for it to be actionable.
+			if err == nil || !strings.Contains(err.Error(), invalidName) ||
+				!strings.Contains(err.Error(), "regular file") || !strings.Contains(err.Error(), "found directory") {
 				t.Fatalf("init-agents error = %v, want %s regular-file error", err, invalidName)
 			}
 			if stdout.Len() != 0 {

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -283,6 +283,19 @@ func TestInitAgentsWritesSameFileOnlyOnce(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "CLAUDE hard-links to AGENTS",
+			createAliases: func(t *testing.T, repo string) {
+				t.Helper()
+				agentsPath := filepath.Join(repo, "AGENTS.md")
+				if err := os.WriteFile(agentsPath, []byte("# Shared rules\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Link(agentsPath, filepath.Join(repo, "CLAUDE.md")); err != nil {
+					t.Skipf("hard links unavailable: %v", err)
+				}
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -311,15 +324,205 @@ func TestInitAgentsWritesSameFileOnlyOnce(t *testing.T) {
 	}
 }
 
-func TestInitAgentsSurfacesClaudeReadErrors(t *testing.T) {
-	repo := t.TempDir()
-	if err := os.Mkdir(filepath.Join(repo, "CLAUDE.md"), 0o755); err != nil {
-		t.Fatal(err)
+func TestInitAgentsValidatePointerMarkersRequiresOneOrderedPair(t *testing.T) {
+	valid := []string{
+		"# No managed markers\n",
+		agentPointerBegin + agentPointerEnd,
+		"prefix\n" + agentPointerBegin + "\nmanaged\n" + agentPointerEnd + "\nsuffix\n",
 	}
-	var out bytes.Buffer
-	err := Run(context.Background(), Options{Stdout: &out, Stderr: &out}, []string{"init-agents", "--repo", repo})
-	if err == nil || !strings.Contains(err.Error(), "CLAUDE.md") {
-		t.Fatalf("init-agents error = %v, want CLAUDE.md read/stat error", err)
+	for i, content := range valid {
+		if _, _, err := validatePointerMarkers("VALID.md", []byte(content)); err != nil {
+			t.Errorf("valid case %d rejected: %v", i, err)
+		}
+	}
+
+	invalid := map[string]string{
+		"missing begin":     agentPointerEnd,
+		"missing end":       agentPointerBegin,
+		"reversed":          agentPointerEnd + "\n" + agentPointerBegin,
+		"duplicate begin":   agentPointerBegin + "\n" + agentPointerBegin + "\n" + agentPointerEnd,
+		"duplicate end":     agentPointerBegin + "\n" + agentPointerEnd + "\n" + agentPointerEnd,
+		"nested":            agentPointerBegin + "\n" + agentPointerBegin + "\n" + agentPointerEnd + "\n" + agentPointerEnd,
+		"multiple blocks":   agentPointerBegin + agentPointerEnd + agentPointerBegin + agentPointerEnd,
+		"marker in example": "example: `" + agentPointerBegin + "`",
+	}
+	for name, content := range invalid {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := validatePointerMarkers("BROKEN.md", []byte(content))
+			if err == nil {
+				t.Fatal("malformed markers were accepted")
+			}
+			for _, want := range []string{"BROKEN.md", "back up", "preserve user-owned text", "rerun init-agents"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error %q missing actionable text %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+func TestInitAgentsRejectsMalformedMarkersWithoutWrites(t *testing.T) {
+	tests := []struct {
+		name      string
+		malformed string
+	}{
+		{name: "AGENTS.md", malformed: agentPointerBegin + "\nunterminated\n"},
+		{name: "CLAUDE.md", malformed: agentPointerEnd + "\n" + agentPointerBegin + "\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := t.TempDir()
+			guidePath := filepath.Join(repo, ".entire", "graph-agent.md")
+			if err := os.MkdirAll(filepath.Dir(guidePath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			files := map[string][]byte{
+				guidePath:                        []byte("sentinel guide\n"),
+				filepath.Join(repo, "AGENTS.md"): []byte("# Agent sentinel\n"),
+				filepath.Join(repo, "CLAUDE.md"): []byte("# Claude sentinel\n"),
+			}
+			files[filepath.Join(repo, tt.name)] = []byte(tt.malformed)
+			for path, content := range files {
+				if err := os.WriteFile(path, content, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			var stdout, stderr bytes.Buffer
+			err := Run(context.Background(), Options{Stdout: &stdout, Stderr: &stderr}, []string{"init-agents", "--repo", repo})
+			if err == nil {
+				t.Fatal("init-agents accepted malformed markers")
+			}
+			for _, want := range []string{tt.name, "malformed", "back up", "rerun init-agents"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error %q missing %q", err, want)
+				}
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout was written before validation completed: %q", stdout.String())
+			}
+			for path, want := range files {
+				if got := readFileForTest(t, path); got != string(want) {
+					t.Fatalf("%s changed after validation error:\nwant: %q\n got: %q", path, want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestInitAgentsMalformedMarkersDoNotCreateMissingOutputs(t *testing.T) {
+	for _, malformedName := range []string{"AGENTS.md", "CLAUDE.md"} {
+		t.Run(malformedName, func(t *testing.T) {
+			repo := t.TempDir()
+			malformedPath := filepath.Join(repo, malformedName)
+			malformed := []byte(agentPointerBegin + "\nmissing end\n")
+			if err := os.WriteFile(malformedPath, malformed, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			counterpartName := "CLAUDE.md"
+			if malformedName == "CLAUDE.md" {
+				counterpartName = "AGENTS.md"
+			}
+
+			var stdout bytes.Buffer
+			err := Run(context.Background(), Options{Stdout: &stdout, Stderr: &bytes.Buffer{}}, []string{"init-agents", "--repo", repo})
+			if err == nil {
+				t.Fatal("init-agents accepted malformed markers")
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout was written before validation completed: %q", stdout.String())
+			}
+			if got := readFileForTest(t, malformedPath); got != string(malformed) {
+				t.Fatalf("malformed source changed: %q", got)
+			}
+			for _, path := range []string{
+				filepath.Join(repo, ".entire", "graph-agent.md"),
+				filepath.Join(repo, counterpartName),
+			} {
+				if _, statErr := os.Lstat(path); !os.IsNotExist(statErr) {
+					t.Fatalf("%s was created despite validation error (stat error %v)", path, statErr)
+				}
+			}
+		})
+	}
+}
+
+func TestInitAgentsRejectsNonRegularInstructionFileWithoutWrites(t *testing.T) {
+	for _, invalidName := range []string{"AGENTS.md", "CLAUDE.md"} {
+		t.Run(invalidName, func(t *testing.T) {
+			repo := t.TempDir()
+			guidePath := filepath.Join(repo, ".entire", "graph-agent.md")
+			if err := os.MkdirAll(filepath.Dir(guidePath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			guide := []byte("sentinel guide\n")
+			if err := os.WriteFile(guidePath, guide, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			counterpartName := "CLAUDE.md"
+			if invalidName == "CLAUDE.md" {
+				counterpartName = "AGENTS.md"
+			}
+			counterpartPath := filepath.Join(repo, counterpartName)
+			counterpart := []byte("# Counterpart sentinel\n")
+			if err := os.WriteFile(counterpartPath, counterpart, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Mkdir(filepath.Join(repo, invalidName), 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			var stdout bytes.Buffer
+			err := Run(context.Background(), Options{Stdout: &stdout, Stderr: &bytes.Buffer{}}, []string{"init-agents", "--repo", repo})
+			if err == nil || !strings.Contains(err.Error(), invalidName) || !strings.Contains(err.Error(), "regular file") {
+				t.Fatalf("init-agents error = %v, want %s regular-file error", err, invalidName)
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("stdout was written before inspection completed: %q", stdout.String())
+			}
+			if got := readFileForTest(t, guidePath); got != string(guide) {
+				t.Fatalf("guide changed after inspection error: %q", got)
+			}
+			if got := readFileForTest(t, counterpartPath); got != string(counterpart) {
+				t.Fatalf("counterpart changed after inspection error: %q", got)
+			}
+		})
+	}
+}
+
+func TestInitAgentsCreatesDanglingSharedAliasTargetOnce(t *testing.T) {
+	tests := []struct {
+		name   string
+		link   string
+		target string
+	}{
+		{name: "CLAUDE symlinks to AGENTS", link: "CLAUDE.md", target: "AGENTS.md"},
+		{name: "AGENTS symlinks to CLAUDE", link: "AGENTS.md", target: "CLAUDE.md"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := t.TempDir()
+			linkPath := filepath.Join(repo, tt.link)
+			if err := os.Symlink(tt.target, linkPath); err != nil {
+				t.Skipf("symlinks unavailable: %v", err)
+			}
+
+			runInitAgentsForTest(t, repo)
+			agents := readFileForTest(t, filepath.Join(repo, "AGENTS.md"))
+			claude := readFileForTest(t, filepath.Join(repo, "CLAUDE.md"))
+			if agents != claude || strings.Count(agents, agentPointerBegin) != 1 {
+				t.Fatalf("shared target was not created exactly once:\nAGENTS.md:\n%s\nCLAUDE.md:\n%s", agents, claude)
+			}
+			if info, err := os.Lstat(linkPath); err != nil || info.Mode()&os.ModeSymlink == 0 {
+				t.Fatalf("instruction alias was not preserved: info=%v error=%v", info, err)
+			}
+
+			before := agents
+			runInitAgentsForTest(t, repo)
+			if after := readFileForTest(t, filepath.Join(repo, "AGENTS.md")); after != before {
+				t.Fatalf("dangling-alias rerun was not byte-idempotent:\nbefore:\n%s\nafter:\n%s", before, after)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/60
<!-- entire-trail-link-end -->

## Summary

- inspect and validate both `AGENTS.md` and `CLAUDE.md` before creating or modifying any activation file
- accept only no Entire Graph markers or exactly one correctly ordered managed-marker pair
- reject malformed, reversed, or duplicate markers with a path-specific recovery error and no writes or success output
- render from the validated snapshots while preserving existing symlink/hard-link behavior, including first-run dangling aliases

## Why

`init-agents` previously overwrote `.entire/graph-agent.md` before inspecting either instruction file. Its block upsert then used the first raw opening and closing markers without validating their count or order. Malformed or duplicate markers could therefore append more blocks or replace an unexpectedly broad range after another activation file had already changed.

This patch makes marker/read preflight failures non-mutating. Successful activation still intentionally replaces the generated guide in full and preserves user-owned text outside one valid managed block.

## Verification

- `mise exec -- go test ./internal/cli -run '^TestInitAgents' -count=1`
- `mise exec -- go test ./internal/cli`
- `mise exec -- go test ./internal/cli -run '^TestCompactNDJSONRejectsTargetedRelationFilters$'`
- `mise run check`
- two independent focused reviews: clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a3f5e21846412d221ddcbb4a118ae4097499ce3c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->