### PR TITLE
feat: report explain's source view in the JSON answer

### DIFF
--- a/internal/cli/explain.go
+++ b/internal/cli/explain.go
@@ -104,6 +104,13 @@ type ExplainResponse struct {
 	// Scanned is how many candidate names the error text yielded, so a truncated answer is visible.
 	Scanned int `json:"scanned"`
 	Omitted int `json:"omitted,omitempty"`
+	// Commit / Tree / WorktreeSnapshot are the provenance of the declarations above: WHICH tree these
+	// line numbers and signatures describe. The text form says it in its header; without these a JSON
+	// consumer had no way to tell a --head answer from a working-tree one, and on a clean tree the two
+	// were byte-identical. Same field names and semantics as def, neighbors, and impact.
+	Commit           string `json:"commit,omitempty"`
+	Tree             string `json:"tree,omitempty"`
+	WorktreeSnapshot bool   `json:"worktree_snapshot,omitempty"`
 }
 
 type explainFlags struct {
@@ -187,13 +194,18 @@ func runExplain(ctx context.Context, opts Options, args []string) error {
 		return err
 	}
 	response := buildExplainResponse(snapshot, names)
+	// One decision, both renderings. The text header and the JSON fields are computed from the same
+	// expression so they can never disagree about which tree was read — the disagreement this command's
+	// provenance work exists to remove.
+	useHead := !flags.Worktree && snapshot.Header.Commit != ""
+	response.Commit, response.Tree = snapshot.Header.Commit, snapshot.Header.Tree
+	response.WorktreeSnapshot = !useHead
 	switch flags.Format {
 	case "json":
 		encoder := json.NewEncoder(opts.Stdout)
 		encoder.SetEscapeHTML(false)
 		return encoder.Encode(response)
 	case "text", "agent":
-		useHead := !flags.Worktree && snapshot.Header.Commit != ""
 		_, err := opts.Stdout.Write(RenderExplainWithProvenance(response, flags.MaxContextBytes, useHead))
 		return err
 	default:

--- a/internal/cli/head_source_provenance_test.go
+++ b/internal/cli/head_source_provenance_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -195,6 +196,41 @@ func TestExplainHeaderReportsSelectedTree(t *testing.T) {
 	}
 	if firstLine(head) == firstLine(worktree) {
 		t.Fatalf("explain used the same provenance header for --head and worktree:\n%s", head)
+	}
+}
+
+// The text header names the tree it read. A JSON consumer has no header to read,
+// so the same fact has to be a field.
+func TestExplainJSONReportsSelectedTree(t *testing.T) {
+	repo, cacheDir := newDirtySourceViewRepo(t)
+	const buildFailure = "./definition.go:3:1: undefined: InspectDefinition\n"
+
+	decode := func(output string) ExplainResponse {
+		t.Helper()
+		var response ExplainResponse
+		if err := json.Unmarshal([]byte(output), &response); err != nil {
+			t.Fatalf("decode explain json: %v\n%s", err, output)
+		}
+		if len(response.Symbols) == 0 {
+			t.Fatalf("explain resolved nothing, so provenance is untested:\n%s", output)
+		}
+		return response
+	}
+
+	worktree := decode(runSourceViewCommand(t, repo, cacheDir, buildFailure, "explain", "--no-echo", "--format", "json"))
+	if !worktree.WorktreeSnapshot {
+		t.Error("working-tree explain does not report worktree_snapshot")
+	}
+
+	head := decode(runSourceViewCommand(t, repo, cacheDir, buildFailure, "explain", "--no-echo", "--head", "--format", "json"))
+	if head.WorktreeSnapshot {
+		t.Error("--head explain reports its answer as working-tree")
+	}
+	if head.Commit == "" || head.Tree == "" {
+		t.Errorf("--head explain omits its provenance: commit=%q tree=%q", head.Commit, head.Tree)
+	}
+	if head.Commit != rev(t, repo, "HEAD") {
+		t.Errorf("--head explain reports commit %q, want HEAD %q", head.Commit, rev(t, repo, "HEAD"))
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/56
<!-- entire-trail-link-end -->

Follow-up from the review of #99. Stacked on `agent/fix-head-source-provenance`; GitHub will retarget this to `main` when #99 merges.

## Problem

#99 made `explain` state which tree it read — but only in the text/agent header. `ExplainResponse` carried no provenance at all, so `explain --head --format json` and `explain --format json` were **byte-identical on a clean tree**. A machine consumer could not tell whether the declarations, line numbers and signatures it just received described the committed tree or the working tree.

## Change

`ExplainResponse` gains `commit`, `tree`, and `worktree_snapshot` — the same field names and semantics `def`, `neighbors` and `impact` already expose. Schema `1.x` is frozen and additive-only, so new optional fields stay in contract.

The text header and the JSON fields are now computed from **one** expression (`useHead`), so the two renderings cannot drift apart about which tree they read — the exact defect class #99 exists to remove.

## Verification

`go vet ./internal/cli`, `go test ./...` — all pass. New `TestExplainJSONReportsSelectedTree` asserts `worktree_snapshot` flips between the two modes and that `--head` reports the actual HEAD commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRZZprZMazfmyRkdDPVbDV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 626604a9fc4f6703b8dea48078839cbf2c1fad39. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->