### PR TITLE
refactor: drop the on-disk line-reader shims from production code

### DIFF
--- a/internal/cli/def.go
+++ b/internal/cli/def.go
@@ -226,18 +226,12 @@ func runDef(ctx context.Context, opts Options, args []string) error {
 	return nil
 }
 
-// writeDefBodies prints the SOURCE of each declaration the card describes, numbered.
+// writeDefBodiesFromReader prints the SOURCE of each declaration the card describes, numbered,
+// through the reader the command owns.
 //
 // The card answers "what can I do with this"; agents call `def` to answer "show me the code". Measured
 // on carbon: the agent got a body it could not navigate, cut it with `head -80`, lost the line it
 // needed and spent 87 turns grepping instead. The card alone was never the whole answer.
-func writeDefBodies(out io.Writer, response defResponse, repoRoot string, from int) {
-	if repoRoot == "" {
-		return
-	}
-	writeDefBodiesFromReader(out, response, newRepoLineReader(repoRoot), from)
-}
-
 func writeDefBodiesFromReader(out io.Writer, response defResponse, read lineReader, from int) {
 	if len(response.Declarations) == 0 || read == nil {
 		return

--- a/internal/cli/def_navigation_test.go
+++ b/internal/cli/def_navigation_test.go
@@ -58,7 +58,7 @@ func TestSymbolMatchBodiesNeverStopMidSymbolSilently(t *testing.T) {
 	}
 	root := t.TempDir()
 	write(t, root, "big.go", strings.Join(huge, "\n"))
-	bodies := symbolMatchBodies(root, []sem.SymbolRecord{{
+	bodies := symbolMatchBodiesOnDisk(root, []sem.SymbolRecord{{
 		Name: "Huge", Kind: "function", FilePath: "big.go", StartLine: 1, EndLine: 500,
 	}}, 1)
 	if len(bodies) != 1 {
@@ -77,7 +77,7 @@ func TestSymbolMatchBodiesNeverStopMidSymbolSilently(t *testing.T) {
 		t.Fatalf("resume note missing %q:\n%s", want, out.String()[len(out.String())-200:])
 	}
 	// A unit that FITS says nothing: the note's presence has to mean something.
-	small := symbolMatchBodies(root, []sem.SymbolRecord{{
+	small := symbolMatchBodiesOnDisk(root, []sem.SymbolRecord{{
 		Name: "Small", FilePath: "big.go", StartLine: 1, EndLine: 3,
 	}}, 1)
 	var fits bytes.Buffer

--- a/internal/cli/head_source_provenance_test.go
+++ b/internal/cli/head_source_provenance_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -146,6 +147,49 @@ func TestNeighborsSourceAnnotationsFollowSelectedTree(t *testing.T) {
 		[]string{"dirty-alpha-body", "dirty-beta-body"},
 		[]string{"committed-alpha-body", "committed-beta-body"},
 	)
+}
+
+// The JSON answer carries call_site, resolved by reading the caller's source, so
+// the wired-up reader has to be right on the machine-readable path too — not
+// only on the path the text renderer takes.
+func TestNeighborsJSONCallSitesFollowSelectedTree(t *testing.T) {
+	repo, cacheDir := newDirtySourceViewRepo(t)
+
+	callSiteLines := func(output string) []int {
+		t.Helper()
+		var response neighborResponse
+		if err := json.Unmarshal([]byte(output), &response); err != nil {
+			t.Fatalf("decode neighbors json: %v\n%s", err, output)
+		}
+		var lines []int
+		for _, match := range response.Matches {
+			for _, edge := range match.Incoming {
+				if edge.CallSite != nil {
+					lines = append(lines, edge.CallSite.Line)
+				}
+			}
+		}
+		if len(lines) == 0 {
+			t.Fatalf("no call site resolved, so the reader is untested:\n%s", output)
+		}
+		return lines
+	}
+
+	head := callSiteLines(runSourceViewCommand(t, repo, cacheDir, "", "neighbors",
+		"--symbol", "Target", "--direction", "in", "--head", "--format", "json"))
+	for _, line := range head {
+		if line != 7 {
+			t.Errorf("--head call site at line %d, want the committed line 7", line)
+		}
+	}
+
+	worktree := callSiteLines(runSourceViewCommand(t, repo, cacheDir, "", "neighbors",
+		"--symbol", "Target", "--direction", "in", "--format", "json"))
+	for _, line := range worktree {
+		if line != 8 {
+			t.Errorf("working-tree call site at line %d, want the dirty line 8", line)
+		}
+	}
 }
 
 func TestImpactSourceAnnotationsFollowSelectedTree(t *testing.T) {

--- a/internal/cli/impact.go
+++ b/internal/cli/impact.go
@@ -327,10 +327,6 @@ func impactNonCodeMention(relation sem.RelationRecord, endpoint neighborEndpoint
 	return sem.InventoryOnlyLanguage(languages[endpoint.ID])
 }
 
-func buildImpactResponse(snapshot sem.ProviderSnapshot, flags impactFlags) impactResponse {
-	return buildImpactResponseFromReader(snapshot, flags, newRepoLineReader(snapshot.Header.RepoRoot))
-}
-
 func buildImpactResponseFromReader(
 	snapshot sem.ProviderSnapshot,
 	flags impactFlags,

--- a/internal/cli/impact_doc_mention_test.go
+++ b/internal/cli/impact_doc_mention_test.go
@@ -60,7 +60,7 @@ func docMentionSnapshot() sem.ProviderSnapshot {
 
 func TestImpactExcludesDocMentionsFromTransitiveExpansion(t *testing.T) {
 	t.Parallel()
-	response := buildImpactResponse(docMentionSnapshot(), impactFlags{
+	response := buildImpactResponseOnDisk(docMentionSnapshot(), impactFlags{
 		Symbol: "buildGroupIndex", Depth: 2, Limit: defaultImpactSectionLimit,
 	})
 	if response.Focus == nil || response.Focus.ID != "s-group" {
@@ -92,7 +92,7 @@ func TestImpactExcludesDocMentionsFromTransitiveExpansion(t *testing.T) {
 
 func TestImpactRanksDocMentionsLastAndLabelsThem(t *testing.T) {
 	t.Parallel()
-	response := buildImpactResponse(docMentionSnapshot(), impactFlags{
+	response := buildImpactResponseOnDisk(docMentionSnapshot(), impactFlags{
 		Symbol: "buildGroupIndex", Depth: 2, Limit: defaultImpactSectionLimit,
 	})
 	sawResolvedAfterMention := false
@@ -156,7 +156,7 @@ func TestImpactDocMentionsDoNotCrowdOutRealCallersUnderLimit(t *testing.T) {
 		FromID: "real", ToID: "focus", Type: "CALLS", Resolution: "import_resolved",
 	})
 
-	response := buildImpactResponse(snapshot, impactFlags{Symbol: "Target", Depth: 2, Limit: 3})
+	response := buildImpactResponseOnDisk(snapshot, impactFlags{Symbol: "Target", Depth: 2, Limit: 3})
 	if len(response.Callers.Entries) != 3 {
 		t.Fatalf("entries = %#v", response.Callers.Entries)
 	}

--- a/internal/cli/impact_test.go
+++ b/internal/cli/impact_test.go
@@ -43,7 +43,7 @@ func impactFixtureSnapshot() sem.ProviderSnapshot {
 
 func TestImpactBuildsAllSectionsFromSnapshot(t *testing.T) {
 	t.Parallel()
-	response := buildImpactResponse(impactFixtureSnapshot(), impactFlags{
+	response := buildImpactResponseOnDisk(impactFixtureSnapshot(), impactFlags{
 		Symbol: "Orders", Depth: 2, Limit: defaultImpactSectionLimit,
 	})
 	if response.DisambiguationRequired || response.FocusMatchesTotal != 1 {
@@ -93,7 +93,7 @@ func TestImpactBuildsAllSectionsFromSnapshot(t *testing.T) {
 
 func TestImpactDepthOneSkipsTransitiveCallers(t *testing.T) {
 	t.Parallel()
-	response := buildImpactResponse(impactFixtureSnapshot(), impactFlags{
+	response := buildImpactResponseOnDisk(impactFixtureSnapshot(), impactFlags{
 		Symbol: "Orders", Depth: 1, Limit: defaultImpactSectionLimit,
 	})
 	if response.Callers.Total != 1 || response.Callers.Transitive != 0 {
@@ -103,7 +103,7 @@ func TestImpactDepthOneSkipsTransitiveCallers(t *testing.T) {
 
 func TestImpactContainerFocusListsMembers(t *testing.T) {
 	t.Parallel()
-	response := buildImpactResponse(impactFixtureSnapshot(), impactFlags{
+	response := buildImpactResponseOnDisk(impactFixtureSnapshot(), impactFlags{
 		Symbol: "Service", Depth: 2, Limit: defaultImpactSectionLimit,
 	})
 	if response.Siblings.Total != 2 {
@@ -128,7 +128,7 @@ func TestImpactAmbiguousSymbolListsDefinitionsAndFileDisambiguates(t *testing.T)
 			{FromID: "caller", ToID: "a-target", Type: "CALLS"},
 		},
 	}
-	ambiguous := buildImpactResponse(snapshot, impactFlags{Symbol: "Target", Depth: 2, Limit: 15})
+	ambiguous := buildImpactResponseOnDisk(snapshot, impactFlags{Symbol: "Target", Depth: 2, Limit: 15})
 	if !ambiguous.DisambiguationRequired || ambiguous.FocusMatchesTotal != 2 {
 		t.Fatalf("ambiguous response = %#v", ambiguous)
 	}
@@ -148,7 +148,7 @@ func TestImpactAmbiguousSymbolListsDefinitionsAndFileDisambiguates(t *testing.T)
 		t.Fatalf("ambiguous text output:\n%s", text.String())
 	}
 
-	resolved := buildImpactResponse(snapshot, impactFlags{Symbol: "Target", File: "a.go", Depth: 2, Limit: 15})
+	resolved := buildImpactResponseOnDisk(snapshot, impactFlags{Symbol: "Target", File: "a.go", Depth: 2, Limit: 15})
 	if resolved.DisambiguationRequired || resolved.Focus == nil || resolved.Focus.ID != "a-target" {
 		t.Fatalf("--file did not disambiguate: %#v", resolved)
 	}
@@ -159,7 +159,7 @@ func TestImpactAmbiguousSymbolListsDefinitionsAndFileDisambiguates(t *testing.T)
 
 func TestImpactNoMatchTextSuggestsFile(t *testing.T) {
 	t.Parallel()
-	response := buildImpactResponse(sem.ProviderSnapshot{}, impactFlags{Symbol: "Missing", Depth: 2, Limit: 15})
+	response := buildImpactResponseOnDisk(sem.ProviderSnapshot{}, impactFlags{Symbol: "Missing", Depth: 2, Limit: 15})
 	var text bytes.Buffer
 	writeImpactText(&text, response)
 	if !strings.Contains(text.String(), `No symbols matched "Missing"`) {
@@ -182,7 +182,7 @@ func TestImpactSectionCapEmitsMoreMarker(t *testing.T) {
 			{FromID: "c3", ToID: "focus", Type: "CALLS"},
 		},
 	}
-	response := buildImpactResponse(snapshot, impactFlags{Symbol: "Focus", Depth: 1, Limit: 2})
+	response := buildImpactResponseOnDisk(snapshot, impactFlags{Symbol: "Focus", Depth: 1, Limit: 2})
 	if response.Callers.Total != 3 || len(response.Callers.Entries) != 2 {
 		t.Fatalf("capped callers = %#v", response.Callers)
 	}
@@ -207,7 +207,7 @@ func TestImpactBoundedOutputStaysUnderBudget(t *testing.T) {
 		})
 		relations = append(relations, sem.RelationRecord{FromID: id, ToID: "focus", Type: "CALLS"})
 	}
-	response := buildImpactResponse(
+	response := buildImpactResponseOnDisk(
 		sem.ProviderSnapshot{Symbols: symbols, Relations: relations},
 		impactFlags{Symbol: "Focus", Depth: 1, Limit: defaultImpactSectionLimit},
 	)

--- a/internal/cli/linereader_ondisk_test.go
+++ b/internal/cli/linereader_ondisk_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"github.com/entireio/entire-graph/internal/sem"
+)
+
+// The commands construct one reader per invocation and pass it down, so that a
+// committed snapshot is never annotated with working-tree source. The fixture
+// suites below predate that and only ever want the plain on-disk reader.
+//
+// These helpers live in the test build for a reason: while they lived in
+// neighbors.go / impact.go / symbolref.go they were production functions with no
+// production caller, hardwiring the reader the commands had just stopped using.
+// A regression in the wired-up path could not fail them, and their existence
+// made it look covered. The `OnDisk` suffix keeps the choice of reader visible
+// at each call site; the provenance-aware path is exercised end to end in
+// head_source_provenance_test.go.
+
+func buildNeighborResponseOnDisk(snapshot sem.ProviderSnapshot, flags neighborFlags) neighborResponse {
+	return buildNeighborResponseFromReader(snapshot, flags, newRepoLineReader(snapshot.Header.RepoRoot))
+}
+
+func buildImpactResponseOnDisk(snapshot sem.ProviderSnapshot, flags impactFlags) impactResponse {
+	return buildImpactResponseFromReader(snapshot, flags, newRepoLineReader(snapshot.Header.RepoRoot))
+}
+
+func symbolMatchBodiesOnDisk(repoRoot string, matches []sem.SymbolRecord, limit int) []symbolMatchBody {
+	if repoRoot == "" {
+		return nil
+	}
+	return symbolMatchBodiesFromReader(newRepoLineReader(repoRoot), matches, limit)
+}

--- a/internal/cli/neighbors.go
+++ b/internal/cli/neighbors.go
@@ -327,10 +327,6 @@ func parseNeighborFlags(args []string) (neighborFlags, error) {
 	return flags, nil
 }
 
-func buildNeighborResponse(snapshot sem.ProviderSnapshot, flags neighborFlags) neighborResponse {
-	return buildNeighborResponseFromReader(snapshot, flags, newRepoLineReader(snapshot.Header.RepoRoot))
-}
-
 func buildNeighborResponseFromReader(
 	snapshot sem.ProviderSnapshot,
 	flags neighborFlags,

--- a/internal/cli/neighbors_efficiency_test.go
+++ b/internal/cli/neighbors_efficiency_test.go
@@ -92,7 +92,7 @@ func TestNeighborsLimitBoundsAmbiguousFocusMatchesDeterministically(t *testing.T
 			{FromID: "focus-a-early", ToID: "callee", Type: "CALLS"},
 		},
 	}
-	response := buildNeighborResponse(snapshot, neighborFlags{
+	response := buildNeighborResponseOnDisk(snapshot, neighborFlags{
 		Symbol: "Target", Relation: "CALLS", Direction: "both", Depth: 1, Limit: 2,
 	})
 	if !response.Truncated || !response.FocusMatchesTruncated || response.FocusMatchesTotal != 3 {
@@ -152,7 +152,7 @@ func TestNeighborsExactSymbolIDDisambiguatesSameFileOverloads(t *testing.T) {
 		{id: "process-int", callee: "int-callee"},
 	} {
 		t.Run(test.id, func(t *testing.T) {
-			response := buildNeighborResponse(snapshot, neighborFlags{
+			response := buildNeighborResponseOnDisk(snapshot, neighborFlags{
 				Symbol: test.id, Relation: "CALLS", Direction: "out", Depth: 1, Limit: 20,
 			})
 			if response.DisambiguationRequired || response.FocusMatchesTotal != 1 || len(response.Matches) != 1 {
@@ -167,7 +167,7 @@ func TestNeighborsExactSymbolIDDisambiguatesSameFileOverloads(t *testing.T) {
 	// The ID already encodes the defining file, so a stale or mismatched
 	// --file must not turn a valid ID lookup into an empty result.
 	for _, staleFile := range []string{"other.go", "./service.go", `sub\service.go`, "/somewhere/else/service.go"} {
-		mismatchedFile := buildNeighborResponse(snapshot, neighborFlags{
+		mismatchedFile := buildNeighborResponseOnDisk(snapshot, neighborFlags{
 			Symbol: "process-string", File: staleFile, Relation: "CALLS", Direction: "out", Depth: 1, Limit: 20,
 		})
 		if mismatchedFile.FocusMatchesTotal != 1 || len(mismatchedFile.Matches) != 1 ||
@@ -176,7 +176,7 @@ func TestNeighborsExactSymbolIDDisambiguatesSameFileOverloads(t *testing.T) {
 		}
 	}
 
-	ambiguous := buildNeighborResponse(snapshot, neighborFlags{
+	ambiguous := buildNeighborResponseOnDisk(snapshot, neighborFlags{
 		Symbol: "Service.Process", Relation: "CALLS", Direction: "out", Depth: 1, Limit: 20,
 	})
 	var out bytes.Buffer
@@ -201,7 +201,7 @@ func TestNeighborsExactSymbolIDDisambiguatesSameFileOverloads(t *testing.T) {
 		line int
 		want string
 	}{{line: 10, want: "process-string"}, {line: 20, want: "process-int"}} {
-		resolved := buildNeighborResponse(snapshot, neighborFlags{
+		resolved := buildNeighborResponseOnDisk(snapshot, neighborFlags{
 			Symbol: "Service.Process", File: "service.go", Line: selector.line,
 			Relation: "CALLS", Direction: "out", Depth: 1, Limit: 20,
 		})
@@ -224,7 +224,7 @@ func TestNeighborsFileFilterNormalizesPathSpellings(t *testing.T) {
 	for _, file := range []string{
 		"src/one.py", "./src/one.py", "src//one.py", `src\one.py`, "/repo/root/src/one.py",
 	} {
-		response := buildNeighborResponse(snapshot, neighborFlags{
+		response := buildNeighborResponseOnDisk(snapshot, neighborFlags{
 			Symbol: "Target", File: file, Relation: "CALLS", Direction: "both", Depth: 1, Limit: 20,
 		})
 		if response.DisambiguationRequired || len(response.Matches) != 1 ||
@@ -252,7 +252,7 @@ func TestNeighborsHighDegreeFocusKeepsOnlyDeterministicTopLimit(t *testing.T) {
 			{FromID: "caller-a", ToID: "focus", Type: "CALLS"},
 		},
 	}
-	response := buildNeighborResponse(snapshot, neighborFlags{
+	response := buildNeighborResponseOnDisk(snapshot, neighborFlags{
 		Symbol: "Focus", Relation: "CALLS", Direction: "in", Depth: 1, Limit: 2,
 	})
 	if !response.Truncated || !response.endpointTruncated || len(response.Matches) != 1 {
@@ -285,7 +285,7 @@ func TestNeighborsHighDegreeRankingKeepsProductionCallerAheadOfTwentyTests(t *te
 		})
 	}
 
-	response := buildNeighborResponse(snapshot, neighborFlags{
+	response := buildNeighborResponseOnDisk(snapshot, neighborFlags{
 		Symbol: "Focus", Relation: "CALLS", Direction: "in", Depth: 1, Limit: 1,
 	})
 	if len(response.Matches) != 1 || len(response.Matches[0].Incoming) != 1 ||
@@ -391,7 +391,7 @@ func TestNeighborsScopeFiltersExternalAndTestEndpoints(t *testing.T) {
 			{FromID: "focus", ToID: "constructor", Type: "CONSTRUCTS"},
 		},
 	}
-	response := buildNeighborResponse(snapshot, neighborFlags{
+	response := buildNeighborResponseOnDisk(snapshot, neighborFlags{
 		Symbol: "Focus", Relation: "CALLS", Direction: "both", Depth: 2, Limit: 20,
 		InternalOnly: true, ExcludeTests: true,
 	})
@@ -421,7 +421,7 @@ func TestNeighborsExcludeTestsPreservesFocusInTestFile(t *testing.T) {
 		},
 		Relations: []sem.RelationRecord{{FromID: "caller", ToID: "focus", Type: "CALLS"}},
 	}
-	response := buildNeighborResponse(snapshot, neighborFlags{
+	response := buildNeighborResponseOnDisk(snapshot, neighborFlags{
 		Symbol: "Focus", Relation: "CALLS", Direction: "both", Depth: 1, Limit: 20,
 		ExcludeTests: true,
 	})

--- a/internal/cli/symbolref.go
+++ b/internal/cli/symbolref.go
@@ -622,19 +622,11 @@ type symbolMatchBody struct {
 	UnitEndLine int `json:"unit_end_line,omitempty"`
 }
 
-// symbolMatchBodies reads a compact body for the first `limit` records. A body that cannot be read
+// symbolMatchBodiesFromReader reads a compact body for the first `limit` records, through the
+// reader the command owns — one reader per command, reused for every body and call-site
+// annotation, so bodies come from the same tree the snapshot describes. A body that cannot be read
 // (file gone, binary, oversized) is simply omitted: the locator list above it is still a complete
 // answer, and a missing body must never turn an answer back into a refusal.
-func symbolMatchBodies(repoRoot string, matches []sem.SymbolRecord, limit int) []symbolMatchBody {
-	if repoRoot == "" {
-		return nil
-	}
-	return symbolMatchBodiesFromReader(newRepoLineReader(repoRoot), matches, limit)
-}
-
-// symbolMatchBodiesFromReader is the provenance-aware form used by commands
-// that may be reading a committed snapshot. The caller owns the reader and can
-// reuse it for every body and call-site annotation in the command.
 func symbolMatchBodiesFromReader(read lineReader, matches []sem.SymbolRecord, limit int) []symbolMatchBody {
 	if read == nil || limit <= 0 || len(matches) == 0 {
 		return nil

--- a/internal/cli/symbolref_test.go
+++ b/internal/cli/symbolref_test.go
@@ -258,7 +258,7 @@ func TestDisambiguationSelectorsAreUniqueAndUsable(t *testing.T) {
 func TestAmbiguityRemedyEndToEnd(t *testing.T) {
 	t.Parallel()
 	snapshot := ambiguitySnapshot()
-	ambiguous := buildImpactResponse(snapshot, impactFlags{Symbol: "State", Depth: 2, Limit: 15})
+	ambiguous := buildImpactResponseOnDisk(snapshot, impactFlags{Symbol: "State", Depth: 2, Limit: 15})
 	if !ambiguous.DisambiguationRequired || ambiguous.FocusMatchesTotal != 3 {
 		t.Fatalf("ambiguous response = %#v", ambiguous)
 	}
@@ -276,7 +276,7 @@ func TestAmbiguityRemedyEndToEnd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolved := buildImpactResponse(snapshot, flags)
+	resolved := buildImpactResponseOnDisk(snapshot, flags)
 	if resolved.DisambiguationRequired {
 		t.Fatalf("printed selector did not disambiguate: %#v", resolved)
 	}
@@ -298,7 +298,7 @@ func TestNeighborsAcceptsSameEscapeHatches(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	response := buildNeighborResponse(snapshot, flags)
+	response := buildNeighborResponseOnDisk(snapshot, flags)
 	if response.DisambiguationRequired || len(response.Matches) != 1 {
 		t.Fatalf("neighbors did not disambiguate: %#v", response)
 	}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/57
<!-- entire-trail-link-end -->

Follow-up from the review of #99. Stacked on `agent/fix-head-source-provenance`; GitHub will retarget this to `main` when #99 merges.

## Problem

#99 moved `def` / `neighbors` / `impact` onto a reader the command owns, so a committed snapshot is never annotated with working-tree source. That left four functions behind — `writeDefBodies`, `buildNeighborResponse`, `buildImpactResponse`, `symbolMatchBodies` — as **production functions with no production caller**, each hardwiring `newRepoLineReader`, the reader the commands had just stopped using.

The large fixture suites (`neighbors_efficiency_test.go`, `impact_test.go`, `impact_doc_mention_test.go`, `symbolref_test.go`, `def_navigation_test.go`) all still called them. So a regression in the wired-up path could not fail those tests, while the call graph made the path look covered.

## Change

- `writeDefBodies` had no callers at all — deleted; its "measured on carbon" rationale moves onto `writeDefBodiesFromReader`.
- The other three become `*OnDisk` helpers in `internal/cli/linereader_ondisk_test.go`. The reader choice is now visible at every call site, and no test-only path ships in the binary.
- New `TestNeighborsJSONCallSitesFollowSelectedTree`: `call_site` is resolved by reading the caller's source and is part of the JSON answer, so the machine-readable path deserved the same end-to-end coverage `--format text` got in #99.

## Verification

`gofmt`, `go vet ./...`, `go test ./...` — all pass. The new test was mutation-checked by forcing the on-disk reader in `openSnapshotLineReader`: it fails with `--head call site at line 8, want the committed line 7`, alongside the two text-path tests from #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRZZprZMazfmyRkdDPVbDV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 851dafc09168389a9c7b59c4e4d22e0b6b5d3ef0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->