### PR TITLE
fix: make ShowFileLimited's ceiling hold when the probe is silent

### DIFF
--- a/internal/cli/def.go
+++ b/internal/cli/def.go
@@ -174,8 +174,13 @@ func runDef(ctx context.Context, opts Options, args []string) error {
 		return err
 	}
 	// Only the source-quoting formats read source. Opening before the format
-	// switch spawned a git cat-file child that `--format json` never touched, and
-	// charged its setup to index_latency_ms.
+	// switch spawned a git cat-file child that `--format json` never touched.
+	//
+	// That is all this gate fixes. The open still happens before indexLatency is
+	// taken below, so text and agent runs continue to report the spawn as index
+	// time — as do impact and neighbors, which open unconditionally. Changing
+	// that is a change to what a published latency field MEANS, so it belongs in
+	// its own commit across all three verbs rather than as a side effect here.
 	var readSource lineReader
 	if flags.Format == "text" || flags.Format == "agent" {
 		var closeSource func() error

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -533,9 +533,17 @@ func ShowFile(ctx context.Context, repo, rev, path string) (string, bool, error)
 	return out, true, nil
 }
 
-// ShowFileLimited is ShowFile with a ceiling that is applied BEFORE the blob is
-// read: a larger blob is reported unreadable without its bytes ever being
-// materialized.
+// ShowFileLimited is ShowFile with a size ceiling: a larger blob is always
+// reported unreadable, and is normally refused before its bytes are read.
+//
+// The two halves of that sentence are guaranteed differently, and the difference
+// is the contract. Refusing an oversized blob is UNCONDITIONAL — it holds even
+// when the size probe below says nothing. Refusing it without materializing it
+// holds whenever the probe answers, which is every ordinary run; when the probe
+// cannot answer, the fallback read is bounded on its result rather than on its
+// allocation. An earlier version of this comment promised the absolute form
+// after the probe had already been made best effort, which is the sort of claim
+// a caller sizing a buffer would rely on.
 //
 // ShowFile buffers all of git's stdout, so a caller that only wants small files
 // could not express that — checking len(content) afterwards bounds the ANSWER
@@ -553,26 +561,47 @@ func ShowFile(ctx context.Context, repo, rev, path string) (string, bool, error)
 // rare fallback for a Git path containing a newline.
 //
 // The size probe cannot make an answer WORSE than ShowFile's: it is best effort,
-// and anything it fails to establish falls through to the unbounded read, which
-// keeps its own absent-vs-failed classification.
+// and anything it fails to establish falls through to the read, which keeps its
+// own absent-vs-failed classification.
 func ShowFileLimited(ctx context.Context, repo, rev, path string, maxBytes int64) (string, bool, error) {
+	return showFileLimited(ctx, repo, rev, path, maxBytes, blobSizeAtRev)
+}
+
+// showFileLimited takes the probe as an argument so a test can exercise the
+// no-answer path, which is otherwise unreachable: the probe and the read resolve
+// the same object through the same git, so making one fail while the other
+// succeeds is not something a fixture repository can arrange.
+func showFileLimited(
+	ctx context.Context,
+	repo, rev, path string,
+	maxBytes int64,
+	probe func(ctx context.Context, repo, rev, path string) (int64, bool),
+) (string, bool, error) {
 	if maxBytes <= 0 {
 		return ShowFile(ctx, repo, rev, path)
 	}
-	// The probe only ever ADDS a refusal. Every outcome it cannot speak to —
-	// missing path, bad revision, a git whose diagnostics are worded differently,
-	// a size that will not parse — falls through to ShowFile, which stays the one
-	// place absent-vs-failed is decided. Classifying a second command's stderr
-	// with a matcher written for `git show` would have put that contract at the
-	// mercy of another command's wording.
-	if size, known := blobSizeAtRev(ctx, repo, rev, path); known && size > maxBytes {
+	// The probe only ever ADDS an early refusal. Every outcome it cannot speak to
+	// — missing path, bad revision, a git whose diagnostics are worded
+	// differently, a size that will not parse — falls through to ShowFile, which
+	// stays the one place absent-vs-failed is decided. Classifying a second
+	// command's stderr with a matcher written for `git show` would have put that
+	// contract at the mercy of another command's wording.
+	if size, known := probe(ctx, repo, rev, path); known && size > maxBytes {
 		// Refused, not failed: a blob this caller cannot quote, exactly like a
 		// missing one. No content was read to learn this.
 		return "", false, nil
 	}
 	// The commit is immutable, so a size measured above is the size that will be
 	// read — there is no grow-between-calls race to guard against here.
-	return ShowFile(ctx, repo, rev, path)
+	content, ok, err := ShowFile(ctx, repo, rev, path)
+	if ok && int64(len(content)) > maxBytes {
+		// Only reachable when the probe gave no answer. The bytes are already
+		// allocated, so this cannot restore the memory bound — but it keeps the
+		// ANSWER identical either way, so a caller never receives content it
+		// declared too large to accept.
+		return "", false, nil
+	}
+	return content, ok, err
 }
 
 // blobSizeAtRev reports the size of the blob at rev:path without reading it.

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -688,6 +688,48 @@ func TestShowFileLimitedTreatsAnUnreachableCeilingAsNoCeiling(t *testing.T) {
 	}
 }
 
+// When the size probe gives no answer the read is unbounded, so the ceiling can
+// only be enforced on the result. That path was previously untested and the doc
+// comment claimed a guarantee it no longer had: the refusal must survive a
+// silent probe, or a caller receives content it declared too large.
+func TestShowFileLimitedRefusesOversizedBlobWhenTheProbeIsSilent(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	git(t, repo, "config", "commit.gpgsign", "false")
+
+	const ceiling = 1 << 10
+	write := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(repo, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("over.txt", strings.Repeat("x", ceiling+1))
+	write("under.txt", strings.Repeat("y", ceiling))
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "probe fixture")
+
+	silent := func(context.Context, string, string, string) (int64, bool) { return 0, false }
+
+	if out, ok, err := showFileLimited(t.Context(), repo, "HEAD", "over.txt", ceiling, silent); err != nil || ok || out != "" {
+		t.Errorf("oversized blob with a silent probe = (%d bytes, ok %v, err %v), want (\"\", false, nil)", len(out), ok, err)
+	}
+	// A silent probe must not turn into a blanket refusal either: everything at
+	// or under the ceiling still has to come back.
+	if out, ok, err := showFileLimited(t.Context(), repo, "HEAD", "under.txt", ceiling, silent); err != nil || !ok || len(out) != ceiling {
+		t.Errorf("blob at the ceiling with a silent probe = (%d bytes, ok %v, err %v), want (%d bytes, true, nil)", len(out), ok, err, ceiling)
+	}
+	// And absent-vs-failed still comes from ShowFile, not from the probe.
+	if out, ok, err := showFileLimited(t.Context(), repo, "HEAD", "missing.txt", ceiling, silent); err != nil || ok || out != "" {
+		t.Errorf("missing path with a silent probe = (%q, ok %v, err %v), want (\"\", false, nil)", out, ok, err)
+	}
+	if out, ok, err := showFileLimited(t.Context(), repo, "BADREV", "under.txt", ceiling, silent); err == nil || ok || out != "" {
+		t.Errorf("bad rev with a silent probe = (%q, ok %v, err %v), want (\"\", false, non-nil)", out, ok, err)
+	}
+}
+
 func TestNewCmdPinsSubprocessLocaleToC(t *testing.T) {
 	// ShowFile classifies file-absent by matching git's English stderr text, so
 	// diagnostic subprocesses run with a pinned C locale. LC_ALL=C must come


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/59
<!-- entire-trail-link-end -->

Post-merge follow-up to #99.

## Problem

Making the `cat-file -s` size probe best effort (so it could never misclassify absent-vs-failed) turned the documented ceiling into an advisory one. `blobSizeAtRev` collapses every failure into `known=false`, and `ShowFileLimited` then falls through to the **unbounded** `ShowFile`. In any environment where the probe fails while `git show` on the same spec succeeds, a `--head` query on a newline-bearing path returns a blob of any size in full — the exact case `TestShowFileLimitedNeverMaterializesAnOversizedBlob` exists to prevent, and silently, where before it was an error.

The doc comment still promised the absolute form: *"a larger blob is reported unreadable without its bytes ever being materialized"*. That is the kind of claim a caller sizing a buffer would rely on.

## Change

Refusing an oversized blob is now **unconditional** — the fallback read is bounded on its result. That cannot restore the memory bound once the bytes are allocated, so the comment now states the two guarantees separately rather than claiming the strong one for both:

- **always** refused if larger than the ceiling
- **normally** refused before its bytes are read — whenever the probe answers, which is every ordinary run

Absent-vs-failed still comes from `ShowFile` alone, so the property the probe was made best-effort for is untouched.

## Testing the untestable path

The no-answer path is unreachable from a fixture repository: probe and read resolve the same object through the same git, so no repo state makes one fail while the other succeeds. The probe is therefore passed into an unexported `showFileLimited`, and the new test drives it silent, asserting the oversized refusal, that a blob at the ceiling still comes back (a silent probe must not become a blanket refusal), and that missing-path and bad-rev classification are unchanged.

Mutation-checked: dropping the result bound makes it fail with `1025 bytes, ok true` under a 1 KiB ceiling.

Also corrects a comment in `def.go` that implied the format gate fixed the `index_latency_ms` accounting — it fixed only the wasted spawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRZZprZMazfmyRkdDPVbDV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit fb66b547cee299c545e3275b3012606d2696fcdd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->