### PR TITLE
docs: clarify index cache variants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,14 +97,14 @@ entire graph checkpoint <id> --json                 # the commit behind an Entir
 
 **When:** judging whether a change is safe to keep / revert / continue, or reviewing a branch/PR. High dependent counts on a signature change = run tests first.
 
-### 🏗️ index — *build / warm the cache*
-Prebuilds the durable, query-independent committed-tree index and verifies it was written, before latency-sensitive work.
+### 🏗️ index — *build / warm one cache variant*
+Prebuilds a durable, complete committed-tree snapshot and verifies it was written, before latency-sensitive work. The entry is not query-independent: a later `--head` query reuses it only when caching is enabled and it resolves the same cache directory, profile, and ordered ignore/include inputs, with unchanged input-file contents and `.graphignore`.
 
 ```sh
 entire graph index --repo . --head --profile full --cache-dir /path/to/cache --format json
 ```
 
-**When:** once, up front, on a large repo before a batch of `--head` searches/neighbors queries. Re-running it is also how you "refresh" a committed-tree cache — same tree hits, changed tree rebuilds.
+**When:** once, up front, on a large repo before a batch of `--head` searches/neighbors queries that use the SAME profile. `index` defaults to `--profile full` while `search` defaults to `fast`, so the command above does not warm a default `search --head`, nor the default working-tree agent path — match the profile or the entry is simply never found. Re-running it is also how you "refresh" that cache variant — same tree hits, changed tree rebuilds.
 
 ### 🧭 capabilities / doctor / version — *feature-detect*
 ```sh

--- a/docs/DETAILS.md
+++ b/docs/DETAILS.md
@@ -292,7 +292,7 @@ Savings scale with symbol connectivity: single-digit for narrow symbols, 280x+ f
 - **Full-graph build:** linear in repository size; 23K relations in 1.5s up to 2.27M relations in 25.6s across the repos above.
 - **Streaming output:** `snapshot` emits records as it parses, so memory stays bounded on very large repositories.
 - **Cached committed-tree search:** reuses a tree-keyed compressed index across invocations, in the platform's per-user cache directory unless `--cache-dir`/`ENTIRE_PLUGIN_DATA_DIR` redirect it, so repeated queries on an unchanged tree skip re-parsing. The working tree is never cached. A complete prepared index derives the exact query-selected view, so relation expansion cannot escape that file set.
-- **Explicit preindex:** `index --head` builds and verifies that query-independent artifact before latency-sensitive work; cached `search` and `neighbors` calls then report the hit directly.
+- **Explicit preindex:** `index --head` builds and verifies that artifact before latency-sensitive work; `search` and `neighbors` calls then report the hit directly — provided they resolve the same cache variant, which includes the profile (`index` defaults to `full`, `search` to `fast`).
 
 ### Compact snapshot NDJSON v1
 

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -86,9 +86,9 @@ var commandDocs = []commandDoc{
 	{
 		name:    "index",
 		group:   groupSetup,
-		summary: "Build/warm the committed-tree cache before a batch of queries",
+		summary: "Build/warm a committed-tree cache variant for matching queries",
 		usage:   []string{"entire graph index --repo . [--head] [--force] [--profile syntax-only|fast|full] [--cache-dir path] [--report GRAPH_REPORT.md] [--format text|json|auto]"},
-		long: "Prebuilds the durable, query-independent committed-tree index so latency-sensitive --head searches/neighbors reuse it. Re-running index is also how you refresh a committed-tree cache: an unchanged tree hits, a changed tree rebuilds. Pass --force to rebuild and overwrite the entry even when the tree is unchanged.\n\n" +
+		long: "Prebuilds a durable, complete committed-tree snapshot. Later --head searches/neighbors can reuse it when caching is enabled and they resolve the same cache directory, profile, and ordered ignore/include inputs, with unchanged input-file contents and .graphignore. index defaults to full while search defaults to fast, so a default index does not warm a default search --head. Re-running index refreshes that cache variant: an unchanged tree hits, while a changed tree rebuilds. Pass --force to rebuild and overwrite the entry even when the tree is unchanged.\n\n" +
 			"At a terminal it draws a live progress bar on stderr (only when it actually builds — a cache hit returns instantly) and prints a readable summary; piped or with --format json it emits the schema-versioned JSON summary that agents and CI consume. --report writes a human-readable GRAPH_REPORT.md rendered from the snapshot, so the same tree always renders the same bytes. The cache defaults to the platform per-user cache dir (macOS ~/Library/Caches/entire-graph; XDG_CACHE_HOME or ~/.cache elsewhere); --cache-dir and ENTIRE_PLUGIN_DATA_DIR override it.\n\n" +
 			"A repo-root .graphignore (gitignore syntax) is honored by every graph command, on top of .gitignore. Use it for tracked-but-vendored/generated sources — e.g. tree-sitter parser.c blobs — that otherwise surface as E_FILE_TOO_LARGE/E_PARSE_ERROR partial failures and a \"degraded\" completeness. Oversized/minified skips also no longer count toward \"degraded\" on their own.",
 		flags: []flagDoc{


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/62
<!-- entire-trail-link-end -->

## What changed

- scope `index` prewarming to matching committed-tree cache variants
- document the `index` `full` versus `search` `fast` default mismatch
- retain the existing refresh and `--force` guidance

## Why

The previous help text implied that one preindex warmed every `--head` search or neighbors query. Cache reuse actually requires compatible profile, cache-directory, and file-rule inputs. Incompatible variants safely rebuild, but users could otherwise pay for preindexing and still see an unexpected cold query.

## Impact

Help text becomes precise; cache behavior and public command semantics are unchanged.

## Validation

- `mise exec -- go test ./internal/cli -run 'Help|RegistryMatchesDispatch|EveryCommandDocResolvesToUsage' -count=1`
- rendered `entire graph index --help` inspected for the approved copy
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0a3cac9fcfc6c086b0f5f1608c209ee667b3d263. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->