### PR TITLE
fix(sem): key both caches on the resolved file cap, not the raw option

### DIFF
--- a/internal/sem/records_cache.go
+++ b/internal/sem/records_cache.go
@@ -19,7 +19,7 @@ import (
 // set of options. Recomputing them on every call is expensive on large repos, so
 // we cache the raw NDJSON bytes keyed on the HEAD tree hash plus everything else
 // that changes the output. This mirrors the search-snapshot cache next door.
-const providerRecordsCacheVersion = "provider-records-v2"
+const providerRecordsCacheVersion = "provider-records-v3"
 
 // cachedProviderRecords is the on-disk envelope for a cached record stream. The
 // key alone is authoritative (sha256 over version+tree+mode+profile+options+
@@ -62,9 +62,10 @@ func providerRecordsKey(absRepo, repositoryKey, providerVersion, tree, mode stri
 	writePart(mode)
 	writePart(string(options.Profile))
 	writePart(fmt.Sprintf("%d", options.MaxParseBytes))
-	// Same graph-shaping argument as searchSnapshotKey: a capped build must not answer an uncapped
-	// caller. This cache is the one that is ON BY DEFAULT, so the hole mattered more here.
-	writePart(fmt.Sprintf("max-files=%d", options.MaxFiles))
+	// Same graph-shaping argument as searchSnapshotKey, resolved for the same reason: the env var
+	// behind the option has to reach the key too. This cache is the one that is ON BY DEFAULT, so
+	// the hole mattered more here.
+	writePart(fmt.Sprintf("max-files=%d", resolveMaxSourceFiles(options.MaxFiles)))
 	onlyFiles := append([]string(nil), options.OnlyFiles...)
 	sort.Strings(onlyFiles)
 	writePart("only-files")

--- a/internal/sem/records_cache_test.go
+++ b/internal/sem/records_cache_test.go
@@ -207,6 +207,60 @@ func TestProviderRecordsKeyDiscriminatesRepoIdentity(t *testing.T) {
 }
 
 // The search snapshot cache had the same cap hole; identity was already keyed upstream.
+// The cap can be set two ways and only one of them was ever tested. Both existing
+// cap tests pass MaxFiles explicitly, so they pinned the option half of the term
+// while ENTIRE_GRAPH_MAX_FILES stayed out of the key — which is how a capped
+// index came to answer an uncapped search despite a test named for that exact
+// hole. These cannot be t.Parallel: t.Setenv forbids it, which is itself part of
+// why the env path was easy to leave uncovered.
+func TestSearchSnapshotKeyDiscriminatesEnvFileCap(t *testing.T) {
+	repo := t.TempDir()
+	uncapped, err := searchSnapshotKey(repo, "id", "v", "tree", ProviderSnapshotOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(maxSourceFilesEnv, "5")
+	capped, err := searchSnapshotKey(repo, "id", "v", "tree", ProviderSnapshotOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capped == uncapped {
+		t.Fatalf("%s=5 and uncapped search snapshots share a key", maxSourceFilesEnv)
+	}
+	// And the env var must land on the same term as the option: setting one to the
+	// value the other already has must NOT produce a third key space.
+	explicit, err := searchSnapshotKey(repo, "id", "v", "tree", ProviderSnapshotOptions{MaxFiles: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if explicit != capped {
+		t.Fatalf("%s=5 and MaxFiles=5 key differently; the env var must resolve onto the option's term", maxSourceFilesEnv)
+	}
+}
+
+func TestProviderRecordsKeyDiscriminatesEnvFileCap(t *testing.T) {
+	repo := t.TempDir()
+	uncapped, err := providerRecordsKey(repo, "id", "v", "tree", "snapshot", ProviderSnapshotOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(maxSourceFilesEnv, "5")
+	capped, err := providerRecordsKey(repo, "id", "v", "tree", "snapshot", ProviderSnapshotOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capped == uncapped {
+		t.Fatalf("%s=5 and uncapped provider records share a key", maxSourceFilesEnv)
+	}
+	explicit, err := providerRecordsKey(repo, "id", "v", "tree", "snapshot", ProviderSnapshotOptions{MaxFiles: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if explicit != capped {
+		t.Fatalf("%s=5 and MaxFiles=5 key differently; the env var must resolve onto the option's term", maxSourceFilesEnv)
+	}
+}
+
 func TestSearchSnapshotKeyDiscriminatesFileCap(t *testing.T) {
 	t.Parallel()
 	repo := t.TempDir()

--- a/internal/sem/records_cache_test.go
+++ b/internal/sem/records_cache_test.go
@@ -236,6 +236,17 @@ func TestSearchSnapshotKeyDiscriminatesEnvFileCap(t *testing.T) {
 	if explicit != capped {
 		t.Fatalf("%s=5 and MaxFiles=5 key differently; the env var must resolve onto the option's term", maxSourceFilesEnv)
 	}
+	// The converse direction matters just as much: LOWERING the cap must not reuse
+	// the larger entry, or a caller who asked to see less is handed more of the
+	// tree than it asked for. Neither direction announces itself in the answer.
+	t.Setenv(maxSourceFilesEnv, "2")
+	lowered, err := searchSnapshotKey(repo, "id", "v", "tree", ProviderSnapshotOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lowered == capped {
+		t.Fatalf("%s=2 reuses the %s=5 entry", maxSourceFilesEnv, maxSourceFilesEnv)
+	}
 }
 
 func TestProviderRecordsKeyDiscriminatesEnvFileCap(t *testing.T) {
@@ -258,6 +269,17 @@ func TestProviderRecordsKeyDiscriminatesEnvFileCap(t *testing.T) {
 	}
 	if explicit != capped {
 		t.Fatalf("%s=5 and MaxFiles=5 key differently; the env var must resolve onto the option's term", maxSourceFilesEnv)
+	}
+	// The converse direction matters just as much: LOWERING the cap must not reuse
+	// the larger entry, or a caller who asked to see less is handed more of the
+	// tree than it asked for. Neither direction announces itself in the answer.
+	t.Setenv(maxSourceFilesEnv, "2")
+	lowered, err := providerRecordsKey(repo, "id", "v", "tree", "snapshot", ProviderSnapshotOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lowered == capped {
+		t.Fatalf("%s=2 reuses the %s=5 entry", maxSourceFilesEnv, maxSourceFilesEnv)
 	}
 }
 

--- a/internal/sem/search_cache.go
+++ b/internal/sem/search_cache.go
@@ -799,6 +799,10 @@ func searchSnapshotKey(absRepo, repositoryKey, providerVersion, tree string, opt
 	// left the env var out of the key entirely, so an ENTIRE_GRAPH_MAX_FILES=1 index and an uncapped
 	// search both keyed on max-files=0 and shared an entry — the exact poisoning this term exists to
 	// prevent, just reached by the other half of the same input.
+	//
+	// It cuts both ways, which is why the term has to be the resolved value rather than a lower
+	// bound: an entry built with a HIGHER cap also survives a later LOWERED one, handing back more
+	// of the tree than the caller asked to see. Neither direction announces itself.
 	writePart(fmt.Sprintf("max-files=%d", resolveMaxSourceFiles(options.MaxFiles)))
 	// Working-tree entries live in their own key space. The marker is only
 	// written for them so committed-tree keys — and every cache already on disk

--- a/internal/sem/search_cache.go
+++ b/internal/sem/search_cache.go
@@ -24,7 +24,7 @@ import (
 // and any prior-version directory can simply be deleted wholesale — cleanup is
 // "remove old version dirs" instead of per-entry reachability analysis.
 // (v5 isolated the tree-only key layout; v6, on main, supersedes it.)
-const searchSnapshotCacheVersion = "search-snapshot-v7"
+const searchSnapshotCacheVersion = "search-snapshot-v8"
 
 type cachedSymbolByteRange struct {
 	Start int `json:"start"`
@@ -793,7 +793,13 @@ func searchSnapshotKey(absRepo, repositoryKey, providerVersion, tree string, opt
 	// uncapped caller. Measured on this repo: a cap-5 build wrote 28 symbols, and the next uncapped
 	// search was served those 28 instead of rebuilding to 5740 — 99.5% of the graph silently absent.
 	// One capped ingest therefore poisons every later query on the same tree.
-	writePart(fmt.Sprintf("max-files=%d", options.MaxFiles))
+	//
+	// RESOLVED, not raw: the cap that shaped the build is resolveMaxSourceFiles(options.MaxFiles),
+	// which falls back to ENTIRE_GRAPH_MAX_FILES and then to the default. Hashing options.MaxFiles
+	// left the env var out of the key entirely, so an ENTIRE_GRAPH_MAX_FILES=1 index and an uncapped
+	// search both keyed on max-files=0 and shared an entry — the exact poisoning this term exists to
+	// prevent, just reached by the other half of the same input.
+	writePart(fmt.Sprintf("max-files=%d", resolveMaxSourceFiles(options.MaxFiles)))
 	// Working-tree entries live in their own key space. The marker is only
 	// written for them so committed-tree keys — and every cache already on disk
 	// built under them — stay byte-identical.


### PR DESCRIPTION
Found while reviewing #109, whose premise is that incompatible cache variants safely rebuild. For one input they don't.

## The bug

`searchSnapshotKey` and `providerRecordsKey` both hash the **raw** `options.MaxFiles`. The cap that actually shaped the build is `resolveMaxSourceFiles(options.MaxFiles)`, which falls back to `ENTIRE_GRAPH_MAX_FILES` and then to the default. So the env var never reached either key: an `ENTIRE_GRAPH_MAX_FILES=1` index and an uncapped search both key on `max-files=0` and share an entry.

It cuts both ways:

- a **capped** entry serves a later **uncapped** query — a truncated graph presented as complete
- a **higher-cap** entry survives a later **lowered** cap — more of the tree than the caller asked to see

Neither direction announces itself. Measured on a two-file repo, after a capped index:

| | uncapped `search --head --profile full` |
|---|---|
| before | `symbols_considered=1` — served the truncated graph |
| after | `symbols_considered=2` — rebuilds |

The answer arrives with `W_FILE_LIMIT` suppressed, so nothing in it says the graph is partial. The records cache has the same bug and is **on by default**.

## How it got here

`5751d26` — the commit that fixed *"the file cap is not keyed"* — introduced it:

- its commit message says *"options.MaxFiles (and ENTIRE_GRAPH_MAX_FILES behind it) ... Both keys now fold it in"*
- the ADR it shipped (`0002`, decision 2) says the key uses *"`resolveMaxSourceFiles(options.MaxFiles)`, the resolved value, so `ENTIRE_GRAPH_MAX_FILES` is covered by the same term as the option"*
- the code it shipped hashes the raw value
- both regression tests it added pass `ProviderSnapshotOptions{MaxFiles: 5}` — the option path only. No test in the repo sets `ENTIRE_GRAPH_MAX_FILES`; the one test that references the constant asserts a warning string.

The quoted mutation check ("removing the key terms makes both regression tests fail") could only ever prove the option half, because nothing exercised the other. Doc and commit message asserted the strong claim, the tests confirmed the weak one, and the gap between them was exactly the env var. That commit added Decision 2's resolved requirement and the raw hashing in the same change — it was never resolved and later regressed.

## Change

Both keys hash the resolved cap. Versions bump (`search-snapshot-v8`, `provider-records-v3`) because the resolved default differs from the raw zero, so every existing entry re-keys — a bump makes that a rename rather than a silent hash change. Only ever turns hits into misses.

New tests cover the env path for both caches, assert `ENTIRE_GRAPH_MAX_FILES=5` keys identically to `MaxFiles=5` (so the two halves cannot drift onto separate terms again), and assert the lowered-cap direction. Mutation-checked: reverting either key line fails both with "share a key".

An independent pass over the pre-fix code reached the same conclusion and named the same commit; the symmetric framing above came from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRZZprZMazfmyRkdDPVbDV

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 058efe5e7f56147903f77acb5bbfbd08488ee2de. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->