### PR TITLE
release: statically link Windows archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,6 @@ jobs:
           }
           "CC=$cc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "CXX=$cxx" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "CGO_LDFLAGS=-static" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           & $cc --version
       - name: Select artifact version
         id: version
@@ -125,6 +124,34 @@ jobs:
           fi
           read -r _ checksum_name < dist/checksums.txt
           test "${checksum_name#\*}" = "$asset"
+      - name: Verify Windows archive without toolchain DLLs
+        if: matrix.goos == 'windows'
+        shell: pwsh
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          $assetVersion = $env:VERSION -replace '^v', ''
+          $asset = Join-Path "dist" "entire-graph_${assetVersion}_windows_$($env:GOARCH).zip"
+          $verifyDir = Join-Path $env:RUNNER_TEMP "entire-graph-clean-path-$($env:GOARCH)"
+          Remove-Item -Path $verifyDir -Recurse -Force -ErrorAction SilentlyContinue
+          Expand-Archive -Path $asset -DestinationPath $verifyDir
+
+          $binary = Join-Path $verifyDir "entire-graph.exe"
+          $originalPath = $env:PATH
+          try {
+            $env:PATH = "$env:SystemRoot\System32;$env:SystemRoot"
+            $actualVersion = (& $binary version | Out-String).Trim()
+            if ($LASTEXITCODE -ne 0) {
+              throw "entire-graph.exe exited with code $LASTEXITCODE on a clean PATH"
+            }
+          } finally {
+            $env:PATH = $originalPath
+          }
+          if ($actualVersion -ne $env:VERSION) {
+            throw "unexpected version: expected $env:VERSION, got $actualVersion"
+          }
       - uses: actions/upload-artifact@v4
         with:
           name: release-${{ matrix.goos }}-${{ matrix.goarch }}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -66,7 +66,15 @@ build_target() {
 	mkdir -p "$work"
 
 	printf 'building %s/%s\n' "$goos" "$goarch" >&2
-	GOOS="$goos" GOARCH="$goarch" CGO_ENABLED="${CGO_ENABLED:-1}" \
+	cgo_ldflags=$(go env CGO_LDFLAGS)
+	if [ "$goos" = "windows" ]; then
+		# Release archives cannot assume a MinGW runtime is installed beside the binary.
+		case " $cgo_ldflags " in
+			*" -static "*) ;;
+			*) cgo_ldflags="${cgo_ldflags:+$cgo_ldflags }-static" ;;
+		esac
+	fi
+	GOOS="$goos" GOARCH="$goarch" CGO_ENABLED="${CGO_ENABLED:-1}" CGO_LDFLAGS="$cgo_ldflags" \
 		go build -trimpath -ldflags "-s -w -X main.version=$version" \
 		-o "$work/$bin" ./cmd/entire-graph
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/71
<!-- entire-trail-link-end -->

## What changed

- Append the exact `-static` linker flag for every Windows release target while preserving effective `CGO_LDFLAGS` from the process environment or GOENV.
- Verify each extracted Windows archive with a PATH containing only the Windows system directories.

## Why

The published Graph v0.3.0 Windows executable imports MinGW runtime DLLs that are not present on a clean Windows machine. It exits with `0xC0000135` until those external DLLs are added to PATH. Release archives should be self-contained.

## Validation

- Built the Windows AMD64 archive on an isolated Azure Windows Server 2022 VM with Go 1.26.6 and GCC 15.2.0.
- Confirmed the candidate imports only `KERNEL32.dll` and `msvcrt.dll`.
- Installed the candidate through Entire CLI 0.10.0 and exercised `version`, `init-agents`, idempotence, and full-profile search with no MinGW or GCC directory on PATH.
- Verified GOENV preservation, process-environment precedence, and idempotent `-static` handling.
- Passed shell syntax, workflow YAML, PowerShell parsing, diff checks, and the graph-directed narrow Go test.

Both native Windows release matrix jobs remain the merge gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 62c51e033e19e950b5731ec3418870407f1c0352. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->