### PR TITLE
fix: explain high-score confidence warnings

### DIFF
--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -1299,9 +1299,13 @@ func searchLowConfidenceNotices(response sem.SearchResponse) ([]byte, []byte) {
 	if !assessment.Low {
 		return nil, nil
 	}
+	score := fmt.Sprintf("top score %.1f", assessment.TopScore)
+	if ceiling := sem.LowConfidenceScoreCeiling(); assessment.TopScore < ceiling {
+		score += fmt.Sprintf(" (weak, below %.0f)", ceiling)
+	}
 	full := []byte(fmt.Sprintf(
-		"LOW CONFIDENCE: top score %.1f (weak, below %.0f) and %s. This repo may not contain what you asked for; verify before editing.\n",
-		assessment.TopScore, sem.LowConfidenceScoreCeiling(), assessment.Reason,
+		"LOW CONFIDENCE: %s and %s. This repo may not contain what you asked for; verify before editing.\n",
+		score, assessment.Reason,
 	))
 	compact := []byte(fmt.Sprintf("!LOW s=%.1f\n", assessment.TopScore))
 	return full, compact

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -1299,8 +1299,14 @@ func searchLowConfidenceNotices(response sem.SearchResponse) ([]byte, []byte) {
 	if !assessment.Low {
 		return nil, nil
 	}
-	score := fmt.Sprintf("top score %.1f", assessment.TopScore)
-	if ceiling := sem.LowConfidenceScoreCeiling(); assessment.TopScore < ceiling {
+	// Gate the "below" suffix on the score AS DISPLAYED, not the raw value: 11.96 renders
+	// as 12.0, and "top score 12.0 (weak, below 12)" is the contradiction this notice must
+	// never contain. Parsing the rendered string back keeps the two in lockstep even where
+	// %.1f's half-to-even rounding and math.Round disagree.
+	display := fmt.Sprintf("%.1f", assessment.TopScore)
+	score := "top score " + display
+	shown, err := strconv.ParseFloat(display, 64)
+	if ceiling := sem.LowConfidenceScoreCeiling(); err == nil && shown < ceiling {
 		score += fmt.Sprintf(" (weak, below %.0f)", ceiling)
 	}
 	full := []byte(fmt.Sprintf(

--- a/internal/cli/search_confidence_test.go
+++ b/internal/cli/search_confidence_test.go
@@ -123,6 +123,57 @@ func TestAgentSearchLowConfidenceMarker(t *testing.T) {
 	}
 }
 
+func TestSearchLowConfidenceNoticeRetainsWeakScoreThreshold(t *testing.T) {
+	t.Parallel()
+	response := confidenceSearchResponse([]float64{9.6, 8.4, 8.1},
+		[]string{"src/a.go", "src/b.go", "src/c.go"}, "")
+	full, _ := searchLowConfidenceNotices(response)
+	want := "top score 9.6 (weak, below 12) and top results agree on nothing"
+	if !strings.Contains(string(full), want) {
+		t.Fatalf("low-score notice is missing %q:\n%s", want, full)
+	}
+}
+
+func TestSearchLowConfidenceNoticeUsesActualHighScoreReason(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		response   sem.SearchResponse
+		wantReason string
+	}{
+		{
+			name: "near tie",
+			response: confidenceSearchResponse([]float64{27.50, 27.51, 20.0},
+				[]string{"src/a.go", "src/a.go", "src/a.go"}, ""),
+			wantReason: "ranks 1 and 2 are tied (0.0100 apart) - the ranking did not choose",
+		},
+		{
+			name: "documentation wrapper",
+			response: func() sem.SearchResponse {
+				response := confidenceSearchResponse([]float64{27.5, 20.0},
+					[]string{"src/a.go", "src/a.go"}, "")
+				response.Results[0].Snippet = "// Usage notes\n// More usage notes\nfunc wrapper() {}\n"
+				return response
+			}(),
+			wantReason: "top hit is a documentation comment, not an implementation",
+		},
+	}
+	for _, testCase := range cases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			full, _ := searchLowConfidenceNotices(testCase.response)
+			text := string(full)
+			if !strings.Contains(text, testCase.wantReason) {
+				t.Fatalf("high-score notice is missing reason %q:\n%s", testCase.wantReason, text)
+			}
+			if strings.Contains(text, "below 12") {
+				t.Fatalf("high-score notice falsely labels its score as below 12:\n%s", text)
+			}
+		})
+	}
+}
+
 // TestAgentSearchLowConfidenceMarkerNeverBreaksTheByteCap: the marker is a notice, so under
 // a cap too small to hold it the ranking wins and the cap is still honoured exactly.
 func TestAgentSearchLowConfidenceMarkerNeverBreaksTheByteCap(t *testing.T) {

--- a/internal/cli/search_confidence_test.go
+++ b/internal/cli/search_confidence_test.go
@@ -134,6 +134,24 @@ func TestSearchLowConfidenceNoticeRetainsWeakScoreThreshold(t *testing.T) {
 	}
 }
 
+// TestSearchLowConfidenceNoticeRoundedScoreNeverContradictsThreshold: a raw score of 11.96
+// is below the ceiling but DISPLAYS as 12.0, so the "below 12" suffix must stay off — the
+// suffix follows the score the reader sees, not the raw value.
+func TestSearchLowConfidenceNoticeRoundedScoreNeverContradictsThreshold(t *testing.T) {
+	t.Parallel()
+	response := confidenceSearchResponse([]float64{11.96, 10.0, 9.0},
+		[]string{"src/a.go", "src/b.go", "src/c.go"}, "")
+	full, _ := searchLowConfidenceNotices(response)
+	text := string(full)
+	want := "top score 12.0 and top results agree on nothing"
+	if !strings.Contains(text, want) {
+		t.Fatalf("rounded-score notice is missing %q:\n%s", want, text)
+	}
+	if strings.Contains(text, "below 12") {
+		t.Fatalf("notice labels a displayed 12.0 as below 12:\n%s", text)
+	}
+}
+
 func TestSearchLowConfidenceNoticeUsesActualHighScoreReason(t *testing.T) {
 	t.Parallel()
 	cases := []struct {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/72
<!-- entire-trail-link-end -->

## What changed

- Keep the `below 12` explanation only when the top score is actually below the low-score threshold.
- For high-scoring near ties and wrapper-shaped hits, render the assessment reason instead.
- Add focused coverage for low-score, near-tie, and wrapper cases.

## Why

The renderer always described low confidence as `weak, below 12`, even when confidence was low for a different reason and the displayed score was much higher. A Linux onboarding run exposed the contradiction with a score of 27.5.

## Validation

- Focused low-confidence renderer tests passed.
- The broader confidence test set passed.
- `go test ./internal/cli`, `go test ./...`, and `go vet ./...` passed with the repository-pinned Go toolchain.
- `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 62ee5f6f5f563a4ecf7644159b1daa5ce35b34dd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->