### PR TITLE
Version sem.Result for persisted diff/analyze output

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -690,7 +690,7 @@ func runCheckpoint(ctx context.Context, opts Options, args []string) error {
 	if err != nil {
 		return err
 	}
-	return printResult(opts.Stdout, result, flags.JSON)
+	return printResult(opts.Stdout, result, flags.JSON, opts.Version)
 }
 
 func runAnalyze(ctx context.Context, opts Options, args []string) error {
@@ -807,7 +807,7 @@ func analyzeAndPrint(ctx context.Context, opts Options, repo, base, head string,
 	if err != nil {
 		return err
 	}
-	return printResult(opts.Stdout, result, flags.JSON)
+	return printResult(opts.Stdout, result, flags.JSON, opts.Version)
 }
 
 // diffProgressLine renders one --progress event for stderr.
@@ -831,7 +831,12 @@ func diffProgressLine(event sem.AnalyzeProgressEvent) string {
 	return line
 }
 
-func printResult(out io.Writer, result sem.Result, asJSON bool) error {
+func printResult(out io.Writer, result sem.Result, asJSON bool, producerVersion string) error {
+	// ProducerVersion is set here, the one place a Result is rendered, rather
+	// than at each of the two callers — it needs the CLI's build-time version
+	// (Options.Version), which the sem package that builds the rest of the
+	// Result has no access to.
+	result.ProducerVersion = producerVersion
 	if asJSON {
 		encoded, err := json.MarshalIndent(result, "", "  ")
 		if err != nil {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -835,6 +835,55 @@ func TestAnalyzeJSONCommand(t *testing.T) {
 	}
 }
 
+// TestDiffJSONIncludesSchemaVersion pins that `diff --json` output is
+// versioned: downstream consumers are about to persist this payload into
+// checkpoint metadata, so every emission must carry schema_version (and, when
+// the caller has a build version to attribute, producer_version) so a reader
+// years later knows which shape it is holding.
+func TestDiffJSONIncludesSchemaVersion(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	write(t, repo, "auth.py", "def validate_token(token):\n    return bool(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	write(t, repo, "auth.py", "def validate_token(token, issuer=None):\n    return bool(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "update")
+
+	var out bytes.Buffer
+	err := Run(t.Context(), Options{
+		Version: "9.9.9-test",
+		Env:     EntireEnv{RepoRoot: repo},
+		Stdout:  &out,
+		Stderr:  &out,
+	}, []string{"diff", "--json"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), `"schema_version": "1.1"`) {
+		t.Fatalf("diff json missing schema_version:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), `"producer_version": "9.9.9-test"`) {
+		t.Fatalf("diff json missing producer_version:\n%s", out.String())
+	}
+
+	var payload struct {
+		SchemaVersion   string `json:"schema_version"`
+		ProducerVersion string `json:"producer_version"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("diff json invalid:\n%s\n%v", out.String(), err)
+	}
+	if payload.SchemaVersion != "1.1" {
+		t.Fatalf("schema_version = %q, want 1.1", payload.SchemaVersion)
+	}
+	if payload.ProducerVersion != "9.9.9-test" {
+		t.Fatalf("producer_version = %q, want 9.9.9-test", payload.ProducerVersion)
+	}
+}
+
 func TestDiffJSONCommandCoversEverySupportedLanguage(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -77,7 +77,10 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 	}
 	emitProgress("parse", 0, len(changed))
 	parser := TreeSitterParser{}
-	result := Result{Base: base, Head: head}
+	// SchemaVersion is set here, at the one place a content-bearing Result is
+	// constructed; every caller (AnalyzeGitRange, AnalyzeCheckpoint, and the
+	// diff/analyze CLI handlers that call through them) inherits it.
+	result := Result{Base: base, Head: head, SchemaVersion: SchemaVersion}
 	var deltas []*fileDelta
 	for i, file := range changed {
 		if overBudget() {

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -45,6 +45,35 @@ def format_date(value):
 	}
 }
 
+// TestAnalyzeGitRangeSetsSchemaVersion pins that every Result built by the
+// diff/analyze path carries the package SchemaVersion — the field that lets a
+// copy persisted into checkpoint metadata be read back knowing which schema
+// it was written under.
+func TestAnalyzeGitRangeSetsSchemaVersion(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+
+	write(t, repo, "auth.py", "def validate_token(token):\n    return bool(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	base := rev(t, repo, "HEAD")
+
+	write(t, repo, "auth.py", "def validate_token(token, issuer=None):\n    return bool(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "semantic change")
+	head := rev(t, repo, "HEAD")
+
+	result, err := AnalyzeGitRange(context.Background(), repo, base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.SchemaVersion != SchemaVersion {
+		t.Fatalf("schema version = %q, want %q", result.SchemaVersion, SchemaVersion)
+	}
+}
+
 func TestAnalyzeGitRangeSurfacesModuleScopeChange(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")
@@ -572,6 +601,9 @@ func TestAnalyzeCheckpointResolvesAssociatedCommit(t *testing.T) {
 	}
 	if len(result.Files) != 1 {
 		t.Fatalf("files = %#v", result.Files)
+	}
+	if result.SchemaVersion != SchemaVersion {
+		t.Fatalf("schema version = %q, want %q", result.SchemaVersion, SchemaVersion)
 	}
 }
 

--- a/internal/sem/model.go
+++ b/internal/sem/model.go
@@ -85,6 +85,17 @@ type Result struct {
 	Head       string            `json:"head"`
 	Files      []FileChange      `json:"files"`
 	Warnings   []ProviderWarning `json:"warnings,omitempty"`
+	// SchemaVersion pins the shape of this Result so a copy persisted into
+	// checkpoint metadata can be read back knowing which schema it was written
+	// under. Populated centrally from the package SchemaVersion const at the
+	// single place Result is constructed with real content
+	// (AnalyzeGitRangeWithOptions) — every caller (diff, analyze, checkpoint)
+	// funnels through it.
+	SchemaVersion string `json:"schema_version"`
+	// ProducerVersion is the entire-graph binary version that produced this
+	// Result (build-time version threaded from main.go via Options.Version).
+	// Optional/omitted when the caller has no version to attribute.
+	ProducerVersion string `json:"producer_version,omitempty"`
 }
 
 type Parser interface {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/74
<!-- entire-trail-link-end -->

`graph diff --json` output is about to be persisted into checkpoint metadata by entireio/cli and indexed by entireio/entire-brain (the VCS-keystone work), and unversioned persisted data can't evolve safely.

- `sem.Result` gains `schema_version` (stamped from the existing `SchemaVersion` const, "1.1") and `producer_version` (from the existing ldflags build version, omitempty), set centrally in the one constructor all diff/analyze/checkpoint paths share.
- Append-only: no existing field changed; old readers unaffected.
- Tests: `TestAnalyzeGitRangeSetsSchemaVersion`, `TestDiffJSONIncludesSchemaVersion`; full suite + `mise run check` green.

Both downstream consumers tolerate absence of the new fields (old binaries) — verified against their branches.