### PR TITLE
release: prepare v0.4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,18 @@ jobs:
         with: { go-version: "1.26.x" }
       - run: go test ./...
 
+  bm25-adapter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --disable-pip-version-check rank-bm25==0.2.2
+      - run: python -m unittest bench.memory.benchmarks.common.test_bm25_client
+
   # The status line is a POSIX shell script with its own shell suite; `go test` never runs it.
   # No windows-latest: the script targets /bin/sh.
   statusline:

--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ entire plugin install graph
 entire graph version
 ```
 
-`entire graph version` printing a release tag (for example `v0.3.0`) is the
-installation check; a plugin built from source prints `dev` instead (see
-[operations](docs/operations.md)). 
+`entire graph version` printing a release tag confirms that a versioned build
+is active.
+The local install helper reports the source checkout's Git description; a raw
+unversioned build prints `dev` (see [operations](docs/operations.md)).
 
 ## Activate it for your agent
 
@@ -58,7 +59,7 @@ Activation is per repository:
 entire graph init-agents --repo .
 ```
 
-The command created or touches the following files:
+The command creates or updates these files:
 
 - `.entire/graph-agent.md`: the agent operating guide. Generated in full and
   regenerated in full on each successful rerun; manual edits there do not
@@ -70,9 +71,9 @@ The command created or touches the following files:
 Review the three files, then commit them together when the instructions should
 apply to your team. Committing also matters for performance: the files are
 indexable Markdown, and while they sit uncommitted the working tree counts as
-dirty, which turns off query cache reuse (more details below). 
+dirty, which turns off query cache reuse (details below).
 
-Finally, start a fresh agent session in the repository. A session that was open 
+Finally, start a fresh agent session in the repository. A session that was open
 during activation has not seen the new instructions.
 
 ## Ask your first question
@@ -218,8 +219,8 @@ the [trust and security](docs/trust-and-security.md) documentation.
 - [Language support](docs/language-support.md)
 - [Benchmark methodology and evidence](docs/benchmarks.md)
 
-Please report problems in [GitHub Issues](https://github.com/entireio/entire-graph/issues) 
-or fork / open a pull request. Thank you! ❤️ 
+Please report problems in [GitHub Issues](https://github.com/entireio/entire-graph/issues)
+or open a pull request. Thank you! ❤️
 
 ## License
 

--- a/bench/memory/README.md
+++ b/bench/memory/README.md
@@ -183,6 +183,8 @@ The defects we found on our own side are listed in `RESULTS.md` §6 and were rem
 | `benchmarks/common/graphify_client.py` | our port of graphify as a benchmark arm |
 | `benchmarks/common/graphify_mem_bridge.py` | prose-memory bridge for the graphify arm |
 | `benchmarks/common/cmm_client.py` | our port of `codebase-memory-mcp` as a benchmark arm |
+| `benchmarks/common/bm25_client.py` | lexical BM25 baseline over raw conversation turns |
+| `benchmarks/common/test_bm25_client.py` | regression coverage for BM25 candidate selection |
 | `benchmarks/common/runmeta.py` | run-provenance capture + the `FAIR_MODE` guard |
 | `patches/0001`–`0004`, `0006` | our diffs against upstream harness files (see `UPSTREAM.md`) |
 | `patches/0005` | the cmm `Section` one-line patch + its regression test — applied to the separate `codebase-memory-mcp` repo, not this harness |

--- a/bench/memory/RUNNING-LOCOMO.md
+++ b/bench/memory/RUNNING-LOCOMO.md
@@ -56,9 +56,13 @@ the result. It is disclosed in the output, not homogenised away.
 ```bash
 git clone https://github.com/entireio/entire-graph.git
 cd entire-graph
-git checkout feat/prose-retrieval-and-benchmarks   # PR #104; after merge, main
+git checkout 212af697863a42a7260ff5bba353db3753d00253
 # everything below lives in bench/memory/
 ```
+
+That commit pins the adapter used for the published results. The 0.4.0 release
+corrects BM25 candidate selection for matches with negative IDF scores, so its
+BM25 adapter is intentionally not byte-identical to the published run.
 
 ### 1. Upstream harness at a pinned commit
 
@@ -81,8 +85,8 @@ for p in <kit>/patches/000[1-4]-*.patch <kit>/patches/0006-*.patch; do git apply
 not this harness, and is applied separately (see §3 below).
 
 Five upstream files are modified: provider timeouts, optional date injection, retry and drop
-accounting, a server-side fix, and `requirements.txt` for the BM25 arm's two pinned dependencies
-(`rank-bm25`, `PyStemmer`; the arm's stopword list is inlined, not an NLTK dependency). Each is
+accounting, a server-side fix, and `requirements.txt` for the BM25 arm's two declared dependencies
+(`rank-bm25`, `PyStemmer`; the arm's stopword list is inlined, not an NLTK dependency). Each patch is
 apply-checked against the pinned commit. Everything else is unmodified upstream code, **including
 the reader and judge prompts**. See [`UPSTREAM.md`](UPSTREAM.md) for the file-level provenance
 manifest.

--- a/bench/memory/UPSTREAM.md
+++ b/bench/memory/UPSTREAM.md
@@ -77,6 +77,8 @@ What each patch does:
   at upstream line 233 / patched-container line 351), plus ingest token-usage metering for the
   cost table and optional Anthropic OAuth-bearer wiring. The metering and OAuth wiring are
   observation-only and gated behind env vars.
+- **0006 `requirements.txt`** adds the `rank-bm25` and `PyStemmer` dependencies used only by the
+  lexical BM25 arm.
 
 ### Not upstream at all — vendored here
 
@@ -84,11 +86,13 @@ Written by us; no upstream code involved.
 
 | file | lines |
 |---|---|
-| `benchmarks/common/entire_client.py` | 693 |
+| `benchmarks/common/entire_client.py` | 696 |
 | `benchmarks/common/graphify_client.py` | 364 |
 | `benchmarks/common/cmm_client.py` | 418 |
 | `benchmarks/common/graphify_mem_bridge.py` | 184 |
 | `benchmarks/common/runmeta.py` | 129 |
+| `benchmarks/common/bm25_client.py` | 369 |
+| `benchmarks/common/test_bm25_client.py` | 40 |
 
 ### Ours but not vendored
 

--- a/bench/memory/benchmarks/common/bm25_client.py
+++ b/bench/memory/benchmarks/common/bm25_client.py
@@ -45,8 +45,8 @@ Fairness contract (identical to the entire / mem0 / cognee / graphify / cmm arms
 
 Ranking is BM25's alone. Nothing here re-orders, rewrites or truncates it, with
 two conventional exceptions, both stated up front and both standard IR practice:
-  1. documents scoring 0 (no query term in common) are not returned -- Lucene
-     never places them in a result set either;
+  1. documents sharing no tokenized query term are not returned -- Lucene never
+     places them in a result set either;
   2. if stopword removal empties the query, the un-stopworded tokens are used,
      so a question like "who is he?" still retrieves.
 
@@ -327,14 +327,19 @@ class Bm25Client:
         tokens = self._tokenize(query)
         scores = await asyncio.to_thread(bm25.get_scores, tokens)
 
-        order = sorted(range(len(units)), key=lambda i: float(scores[i]), reverse=True)
+        # A BM25 score's sign does not indicate lexical overlap. Okapi IDF can
+        # be negative when a term appears in most documents, so valid matches
+        # can rank below the zero assigned to documents with no matching term.
+        # Select candidates by token overlap before ranking and applying top_k.
+        query_terms = frozenset(tokens)
+        candidates = (
+            i for i, frequencies in enumerate(bm25.doc_freqs)
+            if query_terms.intersection(frequencies)
+        )
+        order = sorted(candidates, key=lambda i: float(scores[i]), reverse=True)
         results: list[dict] = []
         for i in order[: int(top_k)]:
             score = float(scores[i])
-            if score <= 0.0:
-                # Conventional BM25 retrieval: a document sharing no query term
-                # is not in the result set (Lucene behaves the same way).
-                break
             u = units[i]
             entry: dict[str, Any] = {
                 "memory": u["text"],

--- a/bench/memory/benchmarks/common/test_bm25_client.py
+++ b/bench/memory/benchmarks/common/test_bm25_client.py
@@ -1,0 +1,40 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from bench.memory.benchmarks.common.bm25_client import Bm25Client
+
+
+class Bm25ClientSearchTest(unittest.IsolatedAsyncioTestCase):
+    async def test_negative_scores_with_lexical_overlap_are_returned(self) -> None:
+        with tempfile.TemporaryDirectory() as state_root, patch.dict(
+            os.environ,
+            {
+                "BM25_STATE_ROOT": state_root,
+                "BM25_STEM": "0",
+                "BM25_STOPWORDS": "0",
+            },
+        ):
+            client = Bm25Client()
+            user_id = "negative-idf"
+            await client.add(
+                [
+                    {"role": "user", "content": "launch code"},
+                    {"role": "user", "content": "launch code"},
+                    {"role": "user", "content": "weather forecast"},
+                ],
+                user_id=user_id,
+            )
+
+            results = await client.search("launch code", user_id=user_id, top_k=2)
+
+            self.assertEqual(2, len(results))
+            self.assertTrue(all(result["score"] < 0 for result in results))
+            self.assertTrue(
+                all(result["memory"] == "user: launch code" for result in results)
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,10 +1,10 @@
 # Agent activation
 
 This page is the reference for `entire graph init-agents`: what it writes, how
-reruns behave, how to verify that a coding agent actually loaded the guide, and
-how to recover when instruction files get into a bad state. Behavior described
-here was verified against the installed v0.3.0 release; run
-`entire graph init-agents --help` for the flags of the version you have.
+reruns behave, how Claude inheritance is handled, how to verify that a coding
+agent loaded the guide, and how to recover from invalid instruction files. The
+behavior described here matches the 0.4.0 release target. Run
+`entire graph init-agents --help` for the flags in your installed version.
 
 ## What `init-agents` writes
 
@@ -14,131 +14,153 @@ Activation is per repository. From the repository root:
 entire graph init-agents --repo .
 ```
 
-The command touches exactly three paths:
+The command manages three repository paths:
 
-- `.entire/graph-agent.md` — the operating guide for coding agents. It is
-  generated in full and regenerated in full on every successful rerun, so
-  manual edits to this file do not survive. Its content is identical to the
-  output of `entire graph agent-guide`.
-- `AGENTS.md` — created if absent; otherwise the command appends or replaces
-  one managed block (see below) and leaves the rest of the file alone.
-- `CLAUDE.md` — same treatment as `AGENTS.md`.
+- `.entire/graph-agent.md`: the complete operating guide for coding agents.
+  It is regenerated on every successful run, so manual edits do not survive.
+  Its content is identical to `entire graph agent-guide` output.
+- `AGENTS.md`: the canonical cross-agent entry point. The command creates the
+  file if absent, appends one managed block if no block exists, or replaces the
+  existing managed block while preserving other content.
+- `CLAUDE.md`: a Claude Code entry point whose managed block is selected from
+  the repository's existing instruction-file topology.
 
-The managed block is delimited by HTML-comment markers and contains a short
-pointer plus an import line:
+The direct managed block contains a pointer to the generated guide. Its
+identifying lines are:
 
 ```markdown
 <!-- entire-graph:begin -->
-This repo has the entire-graph code graph installed. Before exploring code with
-grep/find/whole-file reads, read .entire/graph-agent.md — resolution-first guidance
-for using graph retrieval, focused source inspection, and verification.
+...
 @.entire/graph-agent.md
 <!-- entire-graph:end -->
 ```
 
-The block is written to work two ways. A client that resolves `@`-imports
-(Claude Code does) pulls the guide into context automatically. A client that
-treats the block as plain text still gets an explicit instruction to read
-`.entire/graph-agent.md` before exploring.
+A client that resolves `@` imports loads the guide into context. A client that
+treats the block as plain text still receives an instruction to read
+`.entire/graph-agent.md` before exploring code.
 
-## Rerun behavior
+## Claude inheritance
 
-Verified on v0.3.0:
+`AGENTS.md` always receives the direct guide pointer. The `CLAUDE.md` block
+depends on how that file already reaches `AGENTS.md`:
 
-- When both files contain one intact begin/end pair, a rerun replaces the block
-  content and regenerates `.entire/graph-agent.md`. With no other changes the
-  rerun is byte-idempotent: all three files hash identically before and after.
-- When a file exists but has no markers, a rerun appends one managed block at
-  the end and preserves the existing text.
-- v0.3.0 does not validate markers before writing. If a file contains a stray
-  or incomplete marker — an orphan `<!-- entire-graph:begin -->` with no end,
-  markers in reversed order, or marker text quoted inside an example — a rerun
-  appends a second block instead of replacing the first, leaving duplicate
-  markers in the file. Worse, once an orphan `begin` sits above an appended
-  block, the next rerun treats the orphan as the block start and replaces
-  everything from it to the appended block's end marker, deleting any of your
-  text in between. Keep the marker lines exactly as written and do not quote
-  them elsewhere in the same file.
+- If a distinct `CLAUDE.md` contains a live standalone import whose path
+  resolves to the root `AGENTS.md`, its managed block contains only this notice:
 
-### Recovering from broken markers
+  ```markdown
+  <!-- entire-graph:begin -->
+  <!-- Entire Graph instructions are inherited through AGENTS.md. -->
+  <!-- entire-graph:end -->
+  ```
 
-If `AGENTS.md` or `CLAUDE.md` ends up with duplicate, orphaned, or reordered
-markers:
+  The user's `AGENTS.md` import remains in place, and the guide is not imported
+  directly a second time.
+- If that import is absent or cannot be identified safely, `CLAUDE.md` receives
+  the direct guide pointer. Removing or adding a live `AGENTS.md` import and
+  rerunning `init-agents` switches the managed block accordingly.
+- If `AGENTS.md` and `CLAUDE.md` resolve to the same regular file through a
+  symlink or hard link, the shared file receives the direct block once. The
+  link topology is preserved.
 
-1. Back up both files.
-2. Edit each file so it contains either zero Entire Graph marker lines or
-   exactly one `begin` marker followed by one `end` marker. Marker strings
-   inside code fences or comments count — remove or reword those too.
-3. Keep all of your own text; only the marker lines and the generated block
-   between them belong to `init-agents`.
-4. Rerun `entire graph init-agents --repo .` and confirm each file now has one
-   managed block.
+Import detection recognizes standalone relative or absolute paths that resolve
+to the root `AGENTS.md`. Mentions inside inline code, fenced or indented code,
+HTML comments, or the managed block do not count. Ambiguous Markdown keeps the
+direct pointer rather than assuming inheritance. `init-agents` does not create
+or remove the user-owned `AGENTS.md` import itself.
+
+## Preflight and rerun behavior
+
+Before its first write, `init-agents` inspects both instruction paths, reads
+each distinct file, validates the marker layout, and renders all managed
+content from that validated snapshot.
+
+Each path must be missing or resolve to a regular file. Symlinks and hard links
+to regular files are supported. A directory, named pipe, socket, device, or
+other non-regular target is rejected with its type named in the error. A
+dangling alias between `AGENTS.md` and `CLAUDE.md` is supported; the shared
+target is created and updated once.
+
+Each distinct file must contain either no Entire Graph marker tokens or exactly
+one begin marker followed by one end marker. Marker tokens in examples, code
+fences, or comments still count because they make the replacement range
+ambiguous.
+
+If either path or marker layout fails preflight, the command stops before
+creating or changing `.entire/graph-agent.md`, `AGENTS.md`, or `CLAUDE.md`.
+After preflight succeeds, a rerun:
+
+- regenerates `.entire/graph-agent.md`;
+- appends a block to an unmanaged instruction file;
+- replaces one valid managed block in place;
+- preserves all content outside the managed block; and
+- produces byte-identical files when no inputs have changed.
+
+### Recovering from invalid instruction files
+
+The error names the file and the condition that blocked the run. To recover:
+
+1. Back up `AGENTS.md` and `CLAUDE.md`.
+2. Replace any directory or other non-regular target with a regular file, or
+   move it aside if the instruction file should be created.
+3. In each regular file, keep either zero Entire Graph marker tokens or exactly
+   one complete begin/end pair in that order. Reword marker strings shown in
+   examples or comments.
+4. Preserve user-owned text outside the intended managed block.
+5. Rerun `entire graph init-agents --repo .` and confirm that each independent
+   instruction file contains one managed block.
 
 ## Removal
 
-There is no removal command. To deactivate, delete `.entire/graph-agent.md`
-(and the `.entire/` directory if it is now empty) and remove the managed block,
-including both marker lines, from `AGENTS.md` and `CLAUDE.md`. If either file
-contains only the managed block, delete the file.
+There is no removal command. To deactivate, delete
+`.entire/graph-agent.md` and remove the managed block, including both marker
+lines, from `AGENTS.md` and `CLAUDE.md`. Delete `.entire/` or either instruction
+file only if it is otherwise empty.
 
 ## Commit before you rely on the cache
 
-The three activation files are indexable Markdown. While any of them is
-untracked or modified, the working tree is dirty in a way the query cache
-respects: default (working-tree) queries rebuild the graph instead of reusing
-the cached snapshot. Committing the activation files restores clean-tree cache
-reuse. This is also why activation and a query benchmark should not share one
-uncommitted checkout. Details are in
-[operations — cache](operations.md#cache).
+The three activation files are indexable Markdown. While any is untracked or
+modified, the working tree is dirty in a way the query cache respects. Default
+working-tree queries rebuild the graph instead of reusing a clean snapshot.
+Committing the activation files restores clean-tree cache reuse. Activation and
+a query benchmark should therefore not share one uncommitted checkout. See the
+[operations cache guide](operations.md#what-a-cache-entry-is-keyed-on).
 
 ## Client notes
 
-### Claude Code (tested)
+### Claude Code
 
-Tested with Claude Code 2.1.233 against a fixture repository activated by
-v0.3.0. Claude Code loads the repository's `CLAUDE.md` at session start and
-resolves `@`-imports, so the managed block's `@.entire/graph-agent.md` line
-places the guide in context without an explicit read. In the captured session
-the agent's first tool call was an `entire graph search`, made without first
-opening the guide — the import route, not an on-demand read, delivered the
-instructions.
+Claude Code loads the repository's `CLAUDE.md` at session start and resolves
+live `@` imports. The managed direct pointer loads `.entire/graph-agent.md`.
+When `CLAUDE.md` already imports `AGENTS.md`, the inheritance layout avoids a
+second direct guide pointer.
 
-Two practical consequences:
-
-- A session that was already open during activation does not see the new
-  files. Start a fresh session (or task) in the repository after running
-  `init-agents`.
-- `AGENTS.md` and `CLAUDE.md` both carry the block after a v0.3.0 activation.
-  In the tested layout this did not produce doubled guide content in the
-  session; if you maintain these files by hand, keeping `CLAUDE.md` as a thin
-  pointer to `AGENTS.md` is a reasonable convention, but it is not something
-  v0.3.0 sets up for you.
+A session opened before activation does not see the new files. Start a fresh
+session or task in the repository after running `init-agents`.
 
 ### Other clients
 
-Any agent client that reads a root `AGENTS.md` or `CLAUDE.md` will encounter
-the pointer text. Clients that do not resolve `@`-imports must follow the
-written instruction and read `.entire/graph-agent.md` themselves; whether they
-do depends on the client and model. No client other than Claude Code has been
-verified end to end, so treat integration with other clients as plausible but
-untested, and use the verification steps below.
+Clients that read a root `AGENTS.md` encounter the direct pointer text. Clients
+that do not resolve `@` imports must follow the written instruction and read
+`.entire/graph-agent.md` themselves. Whether they do so depends on the client
+and model, so verify the behavior rather than assuming it.
 
 ## Verifying the activation chain
 
 Each layer has an observable check:
 
 1. **Installation.** `entire version` and `entire graph version` both succeed;
-   the second prints the installed release (for example `v0.3.0`).
-2. **Files.** The three paths above exist, `AGENTS.md` and `CLAUDE.md` each
-   contain exactly one begin/end pair, and
-   `diff <(entire graph agent-guide) .entire/graph-agent.md` is empty.
-3. **Instruction load.** Start a fresh agent session and give it a code-location
-   task. The client-side signal depends on the client; behaviorally, a loaded
-   guide shows up as the next check.
-4. **Adoption.** The session's first code-locating tool call is an
-   `entire graph search …`, before any broad grep/find or whole-file reading.
-   If the agent starts with grep, the instructions did not reach it — check
-   steps 2 and 3.
-5. **Grounding.** The agent's answer cites files and lines it actually opened
-   after the graph query, and any proposed change is checked against focused
-   source or a narrow test.
+   the second prints the installed release, such as `v0.4.0`.
+2. **Files.** The three managed paths exist. Each independent instruction file
+   has exactly one ordered marker pair, and
+   `diff <(entire graph agent-guide) .entire/graph-agent.md` is empty. If
+   `CLAUDE.md` imports `AGENTS.md`, confirm its managed block contains the
+   inheritance notice rather than another direct guide import.
+3. **Instruction load.** Start a fresh agent session and give it a
+   code-location task. The client-side signal depends on the client; behavior
+   is checked in the next step.
+4. **Adoption.** The session's first code-locating tool call is
+   `entire graph search ...`, before broad grep, find, or whole-file reading. If
+   the agent starts elsewhere, the guide may not have loaded or may not have
+   been followed. Check the activation files and the client's instruction view.
+5. **Grounding.** The answer cites files and lines opened after the graph query,
+   and any proposed change is checked against focused source or a narrow test.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,12 +1,11 @@
 # Command reference
 
 Day to day, Entire Graph is driven by a coding agent following the guide that
-`init-agents` installs. The commands below are the same surface used directly —
+`init-agents` installs. The commands below are the same surface used directly
 for manual inspection, debugging a result the agent acted on, or scripting.
 `entire graph help` lists every public command for your installed version, and
 `entire graph <command> --help` is authoritative for flags; this page groups
-the commands by task and records the defaults that matter most, verified
-against v0.3.0.
+the commands by task and records the defaults that matter most.
 
 Pass `--repo .` (or a path) when running outside an Entire session.
 
@@ -16,7 +15,7 @@ Pass `--repo .` (or a path) when running outside an Entire session.
 | --- | --- |
 | `init-agents` | Writes `.entire/graph-agent.md` and managed blocks in `AGENTS.md`/`CLAUDE.md`. See [agent activation](agents.md). |
 | `agent-guide` | Prints the operating guide `init-agents` installs, for inspection or piping elsewhere. |
-| `index` | Prewarms one committed-tree cache variant before a batch of `--head` queries. Defaults to `--profile full`; see [operations — cache](operations.md#cache). |
+| `index` | Prewarms one committed-tree cache variant before a batch of `--head` queries. Defaults to `--profile full`; see the [operations cache guide](operations.md#cache). |
 | `capabilities` | Reports semantic vs inventory-only languages, relation types, profiles, and features as JSON. Feature-detect with this before relying on a relation family. |
 
 ## Inspect
@@ -32,12 +31,15 @@ default**; `--head` switches to the committed tree.
 | `neighbors` | Direct relations of one symbol (`--relation`, `--direction`, `--depth 1\|2`). Ambiguous names return a definition list; disambiguate with `--file`. |
 | `impact` | One-shot blast radius for a symbol: direct and transitive callers (depth ≤ 2), callees, type consumers, data flows, co-change files, siblings. |
 
-Cache visibility differs by command and format: `search` JSON reports
-`stats.index_cache_hit`; `impact` and `neighbors` print an `Index: cache-hit`
-or `cache-miss` header in text and agent formats; `search --format text` and
-`explain` report no cache state. `def` and `explain` also skip the per-user
-fallback cache directory that the other query commands use — details in
-[operations — cache](operations.md#cache).
+Cache visibility differs by command and format. JSON from `search`, `impact`,
+and `neighbors` includes cache fields. Text output from `impact` and
+`neighbors` starts with an `Index: cache-hit` or `cache-miss` header. Agent
+output from `search` and `neighbors` normally uses that header, compacting it
+to `I:hit`/`I:miss` under a tight byte budget and potentially omitting it under
+an extreme cap. `search --format text` and `explain` report no cache state.
+`def` and `explain` also skip the per-user fallback cache directory that the
+other query commands use; details are in the
+[operations cache guide](operations.md#cache).
 
 ## Analyze changes
 
@@ -46,7 +48,7 @@ fallback cache directory that the other query commands use — details in
 | `commit <ref>` | Entity-level change list for a commit vs its first parent, with heuristic dependent counts. |
 | `diff --base A --head B` | The same between two refs. `analyze` is an alias of `diff`. |
 | `checkpoint <id>` | Analyzes the commit behind an Entire-Checkpoint trailer. |
-| `verify` | Runs a caller-provided test command and returns an adjudicated verdict. This executes the command you pass it — see [trust and security](trust-and-security.md). |
+| `verify` | Runs a caller-provided test command and returns an adjudicated verdict. This executes the command you pass it; see [trust and security](trust-and-security.md). |
 
 ## Export
 
@@ -56,7 +58,7 @@ Bulk NDJSON streams. These default to the **committed tree**; pass
 | Command | What it does |
 | --- | --- |
 | `snapshot` | The whole graph: header, files, externals, symbols, relations, summary. Also supports `--format compact-ndjson`. |
-| `symbols` | Symbol records only. No name filter — grep the stream, or use `search`/`def` for a targeted lookup. |
+| `symbols` | Symbol records only. There is no name filter; grep the stream, or use `search`/`def` for a targeted lookup. |
 | `edges` | Relation records, filterable server-side with `--to`, `--from`, `--relation`. |
 | `snapshot-query` | Queries a saved compact snapshot without rebuilding the graph. |
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -12,8 +12,14 @@ entire plugin install graph
 entire graph version
 ```
 
-Updates go through the same command. To install a local development build
-instead, use:
+Update an indexed installation with:
+
+```sh
+entire plugin upgrade graph
+entire graph version
+```
+
+To install a local development build instead, use:
 
 ```sh
 scripts/install-local.sh
@@ -21,17 +27,18 @@ scripts/install-local.sh
 
 The script builds `./entire-graph`, installs it with `entire plugin install
 ./entire-graph --force`, and prints `entire graph version`. It fails before
-writing anything if the parent `entire` CLI is not on `PATH`. A locally built
-binary reports `dev` from `entire graph version`, which distinguishes it from
-an indexed release.
+writing anything if the parent `entire` CLI is not on `PATH`. The helper
+injects `git describe --tags --always --dirty` as the version. A raw `go build`
+without version linker flags reports `dev`.
 
 ## Requirements
 
 - The Entire CLI (0.10.0 or later) must be on `PATH`.
 - Development uses Go 1.26. Tree-sitter bindings require CGO and a working C
   compiler for the target platform.
-- Release archives require `tar` and `shasum`. Signing additionally requires
-  either `cosign` or `gpg` and a configured local key.
+- Local release builds require `tar` for non-Windows archives, `zip` or `7z`
+  for Windows archives, and either `sha256sum` or `shasum`. Signing additionally
+  requires `cosign` or `gpg` and a configured local key.
 
 ## Cache
 
@@ -42,11 +49,11 @@ the cache directory costs a rebuild, nothing else.
 ### Location
 
 The cache root is resolved in order: `--cache-dir`, then
-`ENTIRE_PLUGIN_DATA_DIR`, then — for `search`, `neighbors`, `impact`, and
-`index` — the per-user cache directory (`entire-graph` under the OS user cache
-path). `def` and `explain` stop at `ENTIRE_PLUGIN_DATA_DIR`: with neither the
-flag nor the variable set they rebuild on every run while the other query
-commands quietly share the per-user cache. One directory is shared by every
+`ENTIRE_PLUGIN_DATA_DIR`, then the per-user cache directory (`entire-graph`
+under the OS user cache path). The per-user fallback applies to `search`,
+`neighbors`, `impact`, `index`, `snapshot`, `symbols`, and `edges`. `def` and
+`explain` stop at `ENTIRE_PLUGIN_DATA_DIR`; with neither the flag nor the
+variable set they rebuild on every run. One directory is shared by every
 repository and worktree on the machine; keys, not directories, separate
 entries.
 
@@ -78,15 +85,15 @@ eligible for cache reuse only while the tree is effectively clean:
 
 - Clean tree → the query reuses its cached snapshot (an identical rerun is a
   hit).
-- A dirty or untracked path the graph can index — a supported source
+- A dirty or untracked path the graph can index, such as a supported source
   extension, any extensionless file (it could be a shebang script), or a root
   dependency manifest (`go.mod`, `package.json`, `tsconfig.json`,
-  `pyproject.toml`, `setup.cfg`, `Cargo.toml`, `composer.json`, `pom.xml`) —
+  `pyproject.toml`, `setup.cfg`, `Cargo.toml`, `composer.json`, or `pom.xml`),
   disables reuse for the whole repository until the tree is clean again.
 - Dirty paths with known unsupported extensions that are not manifests (build
   artifacts, archives, editor swap files) do not disable reuse.
-- If the working tree or `HEAD` cannot be inspected — including a repository
-  with no commits — the query fails closed: it builds fresh and caches
+- If the working tree or `HEAD` cannot be inspected, including in a repository
+  with no commits, the query fails closed: it builds fresh and caches
   nothing.
 
 Practical consequence: `init-agents` writes indexable Markdown, so a freshly
@@ -104,7 +111,7 @@ this easy to get wrong: `index` defaults to `--profile full` while `search`
 defaults to `--profile fast`, and `index` cannot warm the default
 working-tree path at all. To prewarm for the installed agent guide's
 committed-tree queries, `index`'s default profile is the right one, but the
-guide's queries are working-tree — they only reuse cache while the tree is
+guide's queries use the working tree, so they only reuse cache while the tree is
 clean, as above.
 
 `index --report <path>` additionally writes a Markdown summary of the built
@@ -113,23 +120,26 @@ graph for human review.
 ### Observing cache state
 
 - `search` (default JSON): `stats.index_cache_hit`.
-- `search --format agent`: header line `Index: cache-hit (…ms) | …`.
-- `impact` and `neighbors` (text and agent formats): leading
-  `Index: cache-hit`/`cache-miss` line, plus JSON fields.
+- `impact --format text` and `neighbors --format text`: leading
+  `Index: cache-hit`/`cache-miss` line.
+- `search --format agent` and `neighbors --format agent`: normally the same
+  `Index:` header. Under a tight byte budget it compacts to `I:hit`/`I:miss`;
+  an extremely small budget can omit the telemetry.
+- JSON output from `search`, `impact`, and `neighbors` includes cache fields.
 - `search --format text` and `explain`: no cache state is reported.
 - `def`: JSON field only.
 
 ## Updating and troubleshooting
 
-Rerunning `entire plugin install graph` installs the current indexed release;
-`entire graph version` confirms what is active. After an upgrade the first
-query per repository is cold — cache entries embed the provider version, so
-old entries simply stop matching and can be deleted at leisure.
+`entire plugin upgrade graph` installs the current indexed release;
+`entire graph version` confirms what is active. After an upgrade, the first
+query per repository is cold because cache entries embed the provider version.
+Old entries simply stop matching and can be deleted at leisure.
 
 If queries rebuild on every run when you expect hits, check in order: a dirty
 or untracked indexable file (`git status`; remember extensionless files and
 root manifests count), a changed `.graphignore`, a profile mismatch between
-runs, and — for `def`/`explain` — a missing `--cache-dir`/
+runs, and, for `def`/`explain`, a missing `--cache-dir`/
 `ENTIRE_PLUGIN_DATA_DIR`, since those two commands do not fall back to the
 per-user cache directory.
 
@@ -145,9 +155,10 @@ renders the single-session variant as a Claude Code status line.
 scripts/release.sh
 ```
 
-The release script writes `dist/release-<version>/` with one `.tar.gz` archive
-per target and a `SHA256SUMS` manifest. `VERSION=<value>` overrides the
-version; otherwise the script uses `git describe --tags --always --dirty`.
+The release script writes `dist/release-<version>/` with one archive per target
+and a `checksums.txt` manifest. Non-Windows targets use `.tar.gz`; Windows
+targets use `.zip`. `VERSION=<value>` overrides the version; otherwise the
+script uses `git describe --tags --always --dirty`.
 
 By default the script builds the current host target. Set
 `ENTIRE_RELEASE_TARGETS` to a space-separated list of `GOOS/GOARCH` targets to
@@ -169,4 +180,6 @@ configured:
 If both signing variables are set and both tools are available, cosign takes
 precedence and the script writes only the `.sig` file.
 
-The script does not publish artifacts.
+The script does not publish artifacts. The GitHub `release` workflow builds and
+verifies six platform archives. A manual workflow run on a branch only validates
+them; pushing a `v*` tag also publishes the GitHub release and `checksums.txt`.

--- a/docs/search.md
+++ b/docs/search.md
@@ -2,13 +2,13 @@
 
 `entire graph search` turns a plain-language task description into ranked
 source regions. This page describes what comes back and how to read it,
-verified against v0.3.0 output. `entire graph search --help` documents the
+verified against current output. `entire graph search --help` documents the
 flags.
 
 ## Ranking
 
 Ranking is hybrid: lexical scoring over bodies, identifiers (camelCase and
-snake_case aware), signatures, and paths, expanded through the code graph —
+snake_case aware), signatures, and paths, expanded through the code graph to
 callers, callees, usage sites, and same-container neighbors of strong lexical
 candidates. Each result carries a `signals` array naming why it ranked (for
 example `path`, `body`, `symbol-name`, `graph:callers`, `complete-symbol`), so
@@ -22,33 +22,33 @@ total (`0` removes the bound). `--top-k` sets the result count.
 
 The default format is JSON, one object per query:
 
-- `results` — ranked hits. Each has `file_path`, `start_line`/`end_line`, a
+- `results`: ranked hits. Each has `file_path`, `start_line`/`end_line`, a
   `focus_line`, the symbol's `kind`, `qualified_name`, and `signature` when the
   hit is a known symbol, the `signals` that ranked it, and a source `snippet`.
-  Trailing entries in `section: "related"` are zero-scored context — callers,
-  siblings, or a covering test adjacent to the real hits.
-- `literal_cluster` — occurrences of a distinctive literal from the top hits
+  Trailing entries in `section: "related"` are zero-scored context, such as
+  callers, siblings, or a covering test adjacent to the real hits.
+- `literal_cluster`: occurrences of a distinctive literal from the top hits
   across the repository, tagged by role (edit site vs consumer).
-- `verify_command` — a suggested check, with the evidence it was derived from
+- `verify_command`: a suggested check, with the evidence it was derived from
   and a `tier`: `narrow` (a focused test), a suite fallback, a build check, or
   a residual floor when nothing narrower can be derived. Text and agent
   formats render it as a `VERIFY:` line. It is a suggestion constructed from
   repository contents; read it before running it (see
   [trust and security](trust-and-security.md)).
-- `stats` — counts, byte accounting, latency, and `index_cache_hit`.
-- `warnings`, `partial_failures`, `completeness` — machine-readable coverage:
+- `stats`: counts, byte accounting, latency, and `index_cache_hit`.
+- `warnings`, `partial_failures`, `completeness`: machine-readable coverage:
   which languages and how many files/symbols/relations backed this answer, and
   what was skipped or failed.
 
 ## Formats
 
-- `json` (default) — everything above; what the installed agent guide's
+- `json` (default): everything above; what the installed agent guide's
   command produces.
-- `ndjson` — the same data as a record stream with a trailing
+- `ndjson`: the same data as a record stream with a trailing
   `search_summary`.
-- `text` — human-readable tiers: full snippets for top hits, terse locators
+- `text`: human-readable tiers with full snippets for top hits, terse locators
   after, then the `VERIFY:` line. Does not report cache state.
-- `agent` — compact ranked output opening with a latency/cache header
+- `agent`: compact ranked output opening with a latency/cache header
   (`Index: cache-hit (…ms) | Query: …ms | …`), degrading gracefully under
   tight byte budgets.
 
@@ -58,4 +58,4 @@ The default format is JSON, one object per query:
 resolution). The installed agent guide asks for `--profile full`, which
 enables the complete relation set and deeper graph expansion. Profile is part
 of the cache key, so mixing profiles across runs builds separate cache
-entries — see [operations — cache](operations.md#cache).
+entries. See the [operations cache guide](operations.md#cache).

--- a/docs/trust-and-security.md
+++ b/docs/trust-and-security.md
@@ -40,8 +40,11 @@ other is installation.
   in `AGENTS.md` and `CLAUDE.md`.
 - `index --report <path>` writes a Markdown graph report to the path you give
   it.
+- `verify --record-baseline <path>` creates parent directories as needed and
+  writes a JSON baseline to the path you give it.
 
-No other command family writes into the repository.
+No other command family writes into the repository unless a caller-provided
+command does so.
 
 ## What it executes
 
@@ -52,9 +55,10 @@ No other command family writes into the repository.
   (test names, build files). It does not run it. Anything that later runs
   that command is executing text influenced by repository contents. Read the
   command first in repositories you do not trust.
-- `entire graph verify` executes exactly the test command the caller provides
-  and adjudicates the result. It runs with your privileges; pass only
-  commands you would run yourself.
+- `entire graph verify` executes the test command the caller provides and
+  adjudicates the result. With `--setup <command>`, it executes that setup
+  command first. Both run with your privileges; pass only commands you would
+  run yourself.
 
 ## Determinism and heuristics
 

--- a/docs/trust-and-security.md
+++ b/docs/trust-and-security.md
@@ -1,17 +1,15 @@
 # Trust and security
 
 This page states what Entire Graph reads, writes, executes, and sends over the
-network, scoped precisely enough to be checked. Statements were verified
-against the v0.3.0 release and the implementation under `internal/`.
+network, scoped precisely enough to be checked. Statements match the 0.4.0
+release target and the implementation under `internal/`.
 
 ## Network
 
 The built-in analyzer is local-only. During analysis it does not fetch remote
 code, download grammars or models, call hosted APIs, resolve embeddings, or
-send telemetry. Tree-sitter grammars are compiled into the binary. Verify
-this on your own machine — `entire graph doctor --json` reports `no_egress:
-true` — rather than take the claim on trust. The benchmark harness's clone
-phase and `entire plugin install graph` are the
+send telemetry. Tree-sitter grammars are compiled into the binary. The
+benchmark harness's clone phase and `entire plugin install graph` are the
 networked operations, and both are explicit: one is a development tool, the
 other is installation.
 
@@ -22,8 +20,9 @@ other is installation.
   `commit`).
 - Bounded local Git history, for co-change relations (`FILE_CHANGES_WITH`) and
   change analysis. History never leaves the machine.
-- The full Git ignore stack — nested `.gitignore` files, `.git/info/exclude`,
-  per-worktree excludes, `core.excludesFile` — plus `.graphignore` and any
+- The full Git ignore stack, including nested `.gitignore` files,
+  `.git/info/exclude`, per-worktree excludes, and `core.excludesFile`, plus
+  `.graphignore` and any
   `--ignore-file`/`--include-file` the caller passes.
 - For `stats` only: local coding-agent session transcripts
   (`~/.claude/projects/<path-slug>/*.jsonl`, or `--sessions-dir`/
@@ -51,9 +50,8 @@ No other command family writes into the repository.
   repository code.
 - `search` **suggests** a `VERIFY:` command derived from repository contents
   (test names, build files). It does not run it. Anything that later runs
-  that command — you, or an agent following the guide — is executing a
-  command whose text was influenced by repository contents, so read it first
-  in repositories you do not trust.
+  that command is executing text influenced by repository contents. Read the
+  command first in repositories you do not trust.
 - `entire graph verify` executes exactly the test command the caller provides
   and adjudicates the result. It runs with your privileges; pass only
   commands you would run yourself.
@@ -68,7 +66,7 @@ Within that determinism, static relations are heuristic. Call, route, event,
 test, and data-flow edges carry `resolution` and `confidence` fields instead
 of a completeness promise; dynamic dispatch, reflection, and generated code
 can produce missing or unresolved edges. Inventory-only languages get file and
-symbol structure with no semantic relations — `capabilities --json` reports
+symbol structure with no semantic relations. `capabilities --json` reports
 which tier a language is in. Files the parser cannot process emit
 machine-readable partial failures rather than disappearing silently.
 
@@ -78,4 +76,4 @@ Interactive queries read the working tree by default and the committed tree
 with `--head`. Bulk streams and ref-based analysis default to committed state
 (`--worktree` opts the streams into the working tree). A result is therefore
 always attributable to one requested repository view; the cache keying that
-preserves this is described in [operations — cache](operations.md#cache).
+preserves this is described in the [operations cache guide](operations.md#cache).

--- a/entire-plugin.yml
+++ b/entire-plugin.yml
@@ -1,2 +1,2 @@
 name: graph
-description: Entity-level checkpoint context for Entire sessions
+description: "Local code intelligence for coding agents: ranked search, relationships, and change impact"


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/76
<!-- entire-trail-link-end -->

## Summary

- update plugin metadata and active documentation for the 0.4.0 release, including current agent activation, indexed upgrades, cache behavior, output formats, release archives, and trust boundaries
- fix the BM25 benchmark adapter so lexical matches with negative Okapi scores are not dropped, with an isolated regression test in CI
- pin the published LoCoMo reproduction instructions to the exact adapter revision used for the published score

## Why

Several active references still described v0.3 activation behavior or gave incorrect commands and archive details. Separately, the BM25 adapter treated a non-positive score as proof of zero lexical overlap. Okapi IDF can be negative for common terms, so that filter discarded valid matches.

## User impact

The release documentation now matches the intended 0.4.0 behavior, including fail-closed agent-file updates and topology-aware Claude inheritance. Existing plugin installations are directed to `entire plugin upgrade graph`. The benchmark arm now keeps all lexical candidates before BM25 ranking, while the published comparison remains reproducible from its pinned revision.

## Validation

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `scripts/entire-graph-statusline_test.sh` (151 passed)
- Python 3.12 BM25 regression with `rank-bm25==0.2.2`
- host release archive extraction, checksum, embedded `v0.4.0` version, and packaged manifest
- YAML parse, Python compile check, and `git diff --check`

No release tag is created and nothing is published by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit dea90af5fc9f4745600a79f7432aebecdb204a37. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->