### PR TITLE
docs(readme): restore the LoCoMo table into the root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,30 @@ agent: you ask a code question in plain language, the agent runs graph queries,
 reads the code the graph points at, and answers with citations. A captured
 example is below, after setup.
 
+## Benchmarks
+
 The same retrieval engine ranked first in an eight-system LoCoMo comparison
-while building its index without model calls. See
-[benchmarks](docs/benchmarks.md) for the results, measured costs, methodology,
-and statistical limits.
+(1,540 questions, shared reader and judge, 200-item retrieval budget for every
+arm) while building its index without model calls.
+
+| System | LoCoMo | Index-time tokens |
+| --- | --- | --- |
+| **Entire Graph** | **94.74** | **0** |
+| mem0 OSS | 93.83 | 50.85M |
+| cognee | 92.86 | 12.35M |
+| BM25 (lexical baseline) | 91.88 | 0 |
+| cmm | 91.30 | 0 |
+| graphify | 87.34 | 0 |
+| letta | 80.58 | not projectable |
+| supermemory | 77.60 | hosted |
+
+The margin over the strongest inference-built competitor (mem0 OSS) does not
+clear statistical significance; the margin over the BM25 baseline, built at
+identical zero cost, does (*p* = 5.7×10⁻⁷). Index-time token counts are
+directly metered, not estimated, and are not a one-time charge — an
+inference-built index pays them again on every corpus revision. See
+[benchmarks](docs/benchmarks.md) for full methodology, per-category results,
+retractions, and reproduction steps.
 
 ## Install
 

--- a/docs/readme-plan.md
+++ b/docs/readme-plan.md
@@ -60,8 +60,10 @@ All four are now resolved:
   the v0.3.0 activation files committed before the recorded session.
 - Platforms shown inline: macOS (Homebrew) and Linux (install script), with
   Windows and other channels linked to the Entire CLI installation guide.
-- Quantitative results in the root README: none beyond the generated language
-  counts; benchmark numbers stay in `docs/benchmarks.md`.
+- Quantitative results in the root README: the LoCoMo accuracy/cost table,
+  with its significance caveat and recurring-cost framing kept inline;
+  `docs/benchmarks.md` remains the source for full methodology, per-category
+  results, retractions, and reproduction steps.
 
 ## Guiding principles
 
@@ -298,8 +300,11 @@ than embedding a complete trust matrix in the landing page.
 - Put direct CLI examples and automation in the command and operations references,
   labeled as manual or programmatic alternatives to the agent flow.
 - Keep quantitative methodology, environments, corrections, and reproduction in
-  `docs/benchmarks.md`. Include no root benchmark number unless it survives the
-  claim audit and materially helps a new reader decide whether to continue.
+  `docs/benchmarks.md`. A root benchmark number is included when it survives
+  the claim audit and materially helps a new reader decide whether to
+  continue — the LoCoMo table meets that bar and is inline in the root
+  README; `docs/benchmarks.md` carries what the table cannot: full
+  methodology, per-category results, and every retraction.
 - Include development, issue/support, and license links. Add a security link only
   if a real reporting policy exists.
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/77
<!-- entire-trail-link-end -->

## Summary

#113 (squash-merged) removed the LoCoMo benchmark table from the root
README, per this branch's own `docs/readme-plan.md` rule at the time
("no root benchmark number beyond generated language counts"). That call
is being reversed: the table goes back into `README.md` directly.

- Restores the accuracy/cost table (all eight scores and both token
  figures cross-checked row by row against `bench/memory/LOCOMO-COMPARISON.md`,
  the source of truth)
- `docs/readme-plan.md` updated to describe what actually ships now, rather
  than the rule this reverses
- `docs/benchmarks.md` remains the source for full methodology,
  per-category results, retractions, and reproduction steps -- this table
  is the summary, not a duplicate

This branch is cut fresh from main's current tip (after #111, #112, #113,
#115 all landed) rather than reusing the closed ashtom/readme-refresh
branch, to avoid any risk of reverting already-merged work.

## Validation

- gofmt, go vet, go build, full go test ./... all clean
- All 41 markdown files' local links resolve (scripted check)
- Table numbers verified against bench/memory/LOCOMO-COMPARISON.md row by row