### PR TITLE
docs(readme): link benchmark table systems to their real projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ arm) while building its index without model calls.
 | System | LoCoMo | Index-time tokens |
 | --- | --- | --- |
 | **Entire Graph** | **94.74** | **0** |
-| mem0 OSS | 93.83 | 50.85M |
-| cognee | 92.86 | 12.35M |
-| BM25 (lexical baseline) | 91.88 | 0 |
-| cmm | 91.30 | 0 |
-| graphify | 87.34 | 0 |
-| letta | 80.58 | not projectable |
-| supermemory | 77.60 | hosted |
+| [mem0 OSS](https://github.com/mem0ai/mem0) | 93.83 | 50.85M |
+| [cognee](https://github.com/topoteretes/cognee) | 92.86 | 12.35M |
+| [BM25](https://github.com/dorianbrown/rank_bm25) (lexical baseline) | 91.88 | 0 |
+| [codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp) (cmm) | 91.30 | 0 |
+| [graphify](https://github.com/Graphify-Labs/graphify) | 87.34 | 0 |
+| [letta](https://github.com/letta-ai/letta) | 80.58 | not projectable |
+| [supermemory](https://github.com/supermemoryai/supermemory) | 77.60 | hosted |
 
 The margin over the strongest inference-built competitor (mem0 OSS) does not
 clear statistical significance; the margin over the BM25 baseline, built at


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/78
<!-- entire-trail-link-end -->

## Summary
- Ashtom (Slack): "Let's add the actual names linked to the repo? Like cmm is only our abbreviation, not the real name of the project."
- Links each System cell in the root README `## Benchmarks` table to its real GitHub repo: mem0 OSS, cognee, BM25 (→ the `rank_bm25` library the harness actually uses), graphify, letta, supermemory, and `cmm` → its real name `codebase-memory-mcp` (kept `(cmm)` alongside since that's the short name used throughout `docs/benchmarks.md` / `bench/memory/`).
- No number or claim changes — links only. All 7 target repos verified live via the GitHub API before adding.

## Test plan
- [x] Verified all 7 linked repos resolve via `gh api repos/<org>/<repo>`
- [x] Visual check of rendered markdown table