### PR TITLE
docs(benchmarks): cite entire-graph version and date behind the 94.74 headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ example is below, after setup.
 
 The Entire Graph retrieval engine ranked first in an eight-system LoCoMo comparison
 (1,540 questions, shared reader and judge, 200-item retrieval budget for every
-arm) while building its index without model calls.
+arm) while building its index without model calls. Measured 2026-08-14, on the
+retrieval path that first shipped in
+[v0.4.0](https://github.com/entireio/entire-graph/releases/tag/v0.4.0)
+([#104](https://github.com/entireio/entire-graph/pull/104)); v0.3.0 and earlier
+score 91.56 on the same benchmark, without it.
 
 | System | LoCoMo | Index-time tokens |
 | --- | --- | --- |

--- a/bench/memory/LOCOMO-COMPARISON.md
+++ b/bench/memory/LOCOMO-COMPARISON.md
@@ -521,6 +521,16 @@ It was caught before it reached this table.
 
 ## 10. Method
 
+- **entire-graph version:** measured 2026-08-14 against the multi-resolution prose retrieval
+  feature branch that later merged to `main` as
+  [#104](https://github.com/entireio/entire-graph/pull/104) on 2026-08-18 and first shipped in
+  [v0.4.0](https://github.com/entireio/entire-graph/releases/tag/v0.4.0). **v0.3.0 (released
+  2026-08-14, before #104 merged) and earlier do not have this feature** and score 91.56
+  (`mrq_base`) on the same benchmark, not 94.74. `sw_eg_mr3`, the run id this document cites for
+  94.74, has no corresponding row in [`RUN-INDEX.md`](RUN-INDEX.md) — the registry this document's
+  own rules require. `plan_f_hyb` (08-14 14:08, `turn+session` ingest granularity) is a **different,
+  non-default** run that happens to score the same 94.74; do not treat the two as
+  interchangeable evidence for the default-granularity claim in §7 until this is resolved.
 - **Answerer and judge:** `gpt-5.6-sol` (Azure AI) for every system, no exceptions.
 - **Retrieval budget:** `top_k = 200` for every system.
 - **Questions:** all 1,540. No subsetting, no per-type headline.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -53,6 +53,12 @@ model, one shared judge model, and a 200-item retrieval budget for every arm. Wh
 comparison above is attested against an unpublished bundle, this one's full methodology, every
 retraction, and every quoted number's provenance are committed in this repository.
 
+Measured 2026-08-14, on the retrieval path that first shipped in
+[v0.4.0](https://github.com/entireio/entire-graph/releases/tag/v0.4.0)
+([#104](https://github.com/entireio/entire-graph/pull/104)) — v0.3.0 and earlier score 91.56 on
+the same benchmark, without it. Full before/after breakdown:
+[`LOCOMO-COMPARISON.md` §3](../bench/memory/LOCOMO-COMPARISON.md#3-the-finding-we-were-structurally-unable-to-spend-the-retrieval-budget).
+
 entire-graph ranks first at **94.74**; the margin over the strongest inference-built competitor
 (mem0 OSS, 93.83) is **+0.91pp** and does not clear statistical significance (McNemar *p* = 0.125).
 The margin over a BM25 lexical baseline built at identical zero cost — **+2.86pp at *p* =


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/79
<!-- entire-trail-link-end -->

## Summary
- Answers "was this measured on v0.3.0 or today's PR": neither cleanly — it requires the
  multi-resolution prose retrieval that merged as #104 (2026-08-18) and first shipped in v0.4.0
  (tagged same day). v0.3.0 (2026-08-14, predates #104) scores **91.56** on the identical
  benchmark, not 94.74. Verified by `git merge-base --is-ancestor` against both tags.
- Adds the version + measurement date to the README table, `docs/benchmarks.md`, and
  `bench/memory/LOCOMO-COMPARISON.md` §10 Method, none of which previously cited either.
- **Also surfaces an open integrity gap**, does not resolve it: the `sw_eg_mr3` run id
  `LOCOMO-COMPARISON.md` cites for 94.74 has no entry in `RUN-INDEX.md` (the registry the doc's
  own methodology requires every run id to resolve against). A different, non-default run
  (`plan_f_hyb`, `turn+session` ingest granularity) scored the identical 94.74 and may be what's
  actually behind the headline. Flagged inline in §10 rather than silently fixed — needs a
  from-source re-verification, tracked separately.

## Test plan
- [x] `git merge-base --is-ancestor <PR#104 merge commit> v0.4.0` → yes
- [x] `git merge-base --is-ancestor <PR#104 merge commit> v0.3.0` → no
- [x] Visual check of rendered markdown in all three files