### PR TITLE
docs(benchmarks): add version tested per system to the README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,16 @@ retrieval path that first shipped in
 [v0.4.0](https://github.com/entireio/entire-graph/releases/tag/v0.4.0)
 ([#104](https://github.com/entireio/entire-graph/pull/104))
 
-| System | LoCoMo | Index-time tokens |
-| --- | --- | --- |
-| **entire-graph** | **94.74** | **0** |
-| [mem0](https://github.com/mem0ai/mem0) | 93.83 | 50.85M |
-| [cognee](https://github.com/topoteretes/cognee) | 92.86 | 12.35M |
-| [bm25](https://github.com/dorianbrown/rank_bm25) (lexical baseline) | 91.88 | 0 |
-| [codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp) (cmm) | 91.30 | 0 |
-| [graphify](https://github.com/Graphify-Labs/graphify) | 87.34 | 0 |
-| [letta](https://github.com/letta-ai/letta) | 80.58 | not projectable |
-| [supermemory](https://github.com/supermemoryai/supermemory) | 77.60 | hosted |
+| System | LoCoMo | Index-time tokens | Version tested |
+| --- | --- | --- | --- |
+| **entire-graph** | **94.74** | **0** | [v0.4.0](https://github.com/entireio/entire-graph/releases/tag/v0.4.0) ([#104](https://github.com/entireio/entire-graph/pull/104)) |
+| [mem0](https://github.com/mem0ai/mem0) | 93.83 | 50.85M | commit [`4debc58`](https://github.com/mem0ai/mem0/commit/4debc58a83377b18be81ae1e5969a300736b2fac) |
+| [cognee](https://github.com/topoteretes/cognee) | 92.86 | 12.35M | commit [`38eece5`](https://github.com/topoteretes/cognee/commit/38eece5bbb0cb9f5706fed908abd16dba0f5505e) |
+| [bm25](https://github.com/dorianbrown/rank_bm25) (lexical baseline) | 91.88 | 0 | — |
+| [codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp) (cmm) | 91.30 | 0 | v0.9.0 |
+| [graphify](https://github.com/Graphify-Labs/graphify) | 87.34 | 0 | unpinned commit (see `UPSTREAM.md`) |
+| [letta](https://github.com/letta-ai/letta) | 80.58 | not projectable | [0.16.8](https://github.com/letta-ai/letta/releases/tag/0.16.8) |
+| [supermemory](https://github.com/supermemoryai/supermemory) | 77.60 | hosted | [server-v0.0.7-rc.2](https://github.com/supermemoryai/supermemory/releases/tag/server-v0.0.7-rc.2) |
 
 See [benchmarks](docs/benchmarks.md) for full methodology, per-category results,
 retractions, and reproduction steps.

--- a/bench/memory/UPSTREAM.md
+++ b/bench/memory/UPSTREAM.md
@@ -97,9 +97,11 @@ Written by us; no upstream code involved.
 ### Ours but not vendored
 
 `cognee_client.py`, `letta_client.py`, `graphiti_client.py`, `supermemory_client.py` and their
-workers are also ours, but those arms are not part of the published LoCoMo head-to-head this kit
-reproduces. The empty-buffer guard they carry is described in `README.md` §3.2 and is reproducible
-from that description.
+workers are also ours. `cognee_client.py`, `letta_client.py` and `supermemory_client.py` back
+rows in the published LoCoMo head-to-head this kit reproduces; `graphiti_client.py` does not (its
+run was a 529-question subset, excluded from the table — see `LOCOMO-COMPARISON.md` §2). The
+empty-buffer guard they carry is described in `README.md` §3.2 and is reproducible from that
+description.
 
 ## Third-party components referenced, not vendored
 
@@ -108,3 +110,7 @@ from that description.
 | mem0 (library + OSS server) | `https://github.com/mem0ai/mem0` | `4debc58a83377b18be81ae1e5969a300736b2fac` |
 | cognee | `https://github.com/topoteretes/cognee` | `38eece5bbb0cb9f5706fed908abd16dba0f5505e` |
 | codebase-memory-mcp ("cmm", DeusData) | upstream release | v0.9.0, plus `patches/0005` |
+| graphify | `https://github.com/Graphify-Labs/graphify` | `graphify_client.py` imports the real package (`extractors.markdown.extract_markdown`, `serve._score_query`) from a local checkout at `GRAPHIFY_SOURCE`, default `~/memarms/inputs/repos/graphify` — genuinely runs graphify, not a reimplementation. **Exact commit unpinned**: the same checkout path is used by the separate GraphMark comparison above, which cites commit `c9641bf1caaf41d64ce8a4a421f041939feecca3` — but that hash does not resolve against the public repo (verified via GitHub API, 2026-08-19), so it cannot be cited here as a working pin either. |
+| letta | `https://github.com/letta-ai/letta` | [`0.16.8`](https://github.com/letta-ai/letta/releases/tag/0.16.8) — recovered from an in-repo debugging comment (`run.env`, ENV FIX 2026-08-08) citing `letta/settings.py:314` and `letta/server/db.py:30-31` behavior specific to that release; the live install it describes no longer exists to re-verify against directly |
+| supermemory | `https://github.com/supermemoryai/supermemory` | [`server-v0.0.7-rc.2`](https://github.com/supermemoryai/supermemory/releases/tag/server-v0.0.7-rc.2) — the binary path recorded in the harness config, corroborated independently by `FAIR-CONFIG.md`'s service-state table (§B12) naming the same build |
+| BM25 | `https://github.com/dorianbrown/rank_bm25` | not applicable — generic lexical baseline algorithm, not a versioned product under comparison |

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -53,11 +53,9 @@ model, one shared judge model, and a 200-item retrieval budget for every arm. Wh
 comparison above is attested against an unpublished bundle, this one's full methodology, every
 retraction, and every quoted number's provenance are committed in this repository.
 
-Measured 2026-08-14, on the retrieval path that first shipped in
-[v0.4.0](https://github.com/entireio/entire-graph/releases/tag/v0.4.0)
-([#104](https://github.com/entireio/entire-graph/pull/104)) — v0.3.0 and earlier score 91.56 on
-the same benchmark, without it. Full before/after breakdown:
-[`LOCOMO-COMPARISON.md` §3](../bench/memory/LOCOMO-COMPARISON.md#3-the-finding-we-were-structurally-unable-to-spend-the-retrieval-budget).
+Measured 2026-08-14, entire-graph
+[v0.4.0](https://github.com/entireio/entire-graph/releases/tag/v0.4.0). Per-system versions and
+sources: [`UPSTREAM.md`](../bench/memory/UPSTREAM.md).
 
 entire-graph ranks first at **94.74**; the margin over the strongest inference-built competitor
 (mem0 OSS, 93.83) is **+0.91pp** and does not clear statistical significance (McNemar *p* = 0.125).


### PR DESCRIPTION
## Summary
Adds a "Version tested" column to the README benchmarks table (rebased clean onto main post-#121,
which already dropped the v0.3.0 comparison prose — this PR only adds the version column, nothing
reintroduced).

- **entire-graph**: v0.4.0 / #104
- **mem0, cognee**: pinned commits (already in `UPSTREAM.md`, now surfaced in the table)
- **cmm**: v0.9.0
- **letta**: `0.16.8` — recovered from an in-repo debugging comment referencing
  `letta/settings.py:314` behavior specific to that release, cross-checked against the real tag
- **supermemory**: `server-v0.0.7-rc.2` — recovered from harness config, independently
  corroborated by `FAIR-CONFIG.md`'s own service-state record, cross-checked against the real tag
- **graphify**: `graphify_client.py` genuinely imports and runs the real upstream package — not a
  reimplementation. Exact commit is unpinned: the same checkout's already-published commit
  citation (`docs/benchmarks.md`) doesn't resolve against the public repo, so it isn't repeated
  here — flagged rather than guessed.
- **BM25**: no version cell — it's the baseline algorithm, not a versioned product.

## Test plan
- [x] letta 0.16.8 and supermemory server-v0.0.7-rc.2 confirmed as real tags via `gh api`
- [x] graphify's already-published commit hash confirmed NOT to resolve via `gh api` (422) — excluded rather than repeated
- [x] Visual check of rendered markdown table