### PR TITLE
docs(security): add SECURITY.md with a private reporting path and threat model

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,165 @@
+# Security Policy
+
+Entire Graph is a local, no-egress code-intelligence plugin. It parses a Git
+repository on your machine and answers queries about it. That shape determines
+the whole threat model below: **the repository is the untrusted input.**
+
+## Relationship to the organization policy
+
+This policy governs `entireio/entire-graph` and **overrides** the
+organization-wide policy at
+[`entireio/.github`](https://github.com/entireio/.github/blob/main/SECURITY.md)
+wherever the two differ about this repository's local attack surface.
+
+The override is deliberate, because the org policy's routing rule inverts
+itself when applied here. That policy issues advisories only for a
+vulnerability "exploited by a remote or non-local actor", and sends
+local-execution problems — resource exhaustion that "requires local access to
+trigger", and "issues that cannot be exploited without direct access to the
+user's machine" — to public GitHub Issues as ordinary bug reports. It also
+lists "denial of service attacks" as out of scope outright.
+
+Entire Graph has no server and no remote surface. It is a binary you run on
+your own machine, so *every* vulnerability it can have is a local-execution
+vulnerability, and read literally the org rule would route all of them to a
+public tracker. The framing is what is wrong, not the rule: the attacker here
+*is* remote in the way that matters — they wrote the repository you cloned —
+and their payload merely detonates locally, on your machine, at the moment you
+run an ordinary query. So on this repository:
+
+- Report privately, per the section below. The local-execution carve-out does
+  not apply here.
+- Hostile-content denial of service **is** in scope, notwithstanding the org
+  policy's blanket exclusion. A repository that hangs or exhausts the machine
+  of anyone who merely clones and indexes it is an attack, not a slow test.
+
+Everything the org policy covers that is not this attack surface — the `entire`
+CLI proper, Entire's hosted services, org-wide contact and confidentiality
+commitments — applies unchanged.
+
+## Reporting a vulnerability
+
+**Do not open a public issue for a suspected vulnerability**, and do not open
+an issue asking who to contact. GitHub's own guidance suggests that second one
+for repositories with no private reporting channel; it is unnecessary here,
+because the contact is right below.
+
+**Email [security@entire.io](mailto:security@entire.io).** This is the private
+channel that works today, and it is the one to use.
+
+GitHub's **Report a vulnerability** button is not available on this repository.
+That button is gated on the repository's
+[private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository)
+setting, which is currently disabled — a repository setting, which publishing
+this file does not change. If a maintainer enables it later it becomes a second
+private channel of equal standing, and this section should be updated to say
+so. Until then, email is the channel.
+
+Please include: what the bug is, what an attacker gains, a minimal reproduction
+(the repository shape and the exact command matter far more than prose here —
+see below), the affected version from `entire graph version`, and a suggested
+fix if you have one.
+
+## Supported versions
+
+**The most recent tagged release is supported, along with `main`.** Earlier
+tags are not. Fixes ship in the next release cut from `main`; there are no
+backports.
+
+If you are on an older tag, upgrade and re-check before reporting, or tell us
+which tag you tested so we can work out whether the bug survives. Report what
+`entire graph version` prints.
+
+## Threat model: what is in scope
+
+Entire Graph is routinely pointed at repositories the user did not write and
+has not read: a fresh clone, a contributor's branch, a dependency checkout, a
+repository an agent was told to investigate. Merely running `entire graph` over
+a repository must not compromise the machine.
+
+So **repository-controlled content is the primary attacker channel**, and that
+means all of it:
+
+- **File and directory names** — including `..` segments, absolute paths,
+  unicode and encoding tricks, and names that collide after normalization.
+- **File contents** — anything the tree-sitter parsers and the ranking code
+  consume.
+- **Symlinks** — inside the tree, and pointing anywhere outside it.
+- **`.gitignore`, nested `.gitignore`, `.git/info/exclude`, `.graphignore`** —
+  and any path they can cause the tool to resolve.
+- **Git configuration in the repository, including `core.excludesFile`** —
+  repository-controlled config that names paths the tool then reads.
+
+Reports we specifically want, phrased as what you would demonstrate:
+
+- **Writing outside the intended destination.** Any repository content that
+  causes a write outside the cache directory or outside the explicit path the
+  user passed — via traversal, symlink following, or an absolute path. The
+  write surfaces are the cache, `index --report <path>`,
+  `verify --record-baseline <path>`, and `init-agents`. Queries are documented
+  as never modifying repository source files; a case where one does is a bug
+  under this policy.
+- **Reading outside the repository.** Repository-controlled ignore, include,
+  or config paths that pull file contents from elsewhere on disk into output.
+- **Execution the user did not ask for.** Anything in a repository that gets
+  executed by an ordinary query. Note the documented boundary: `search`
+  *suggests* a `VERIFY:` command derived from repository contents and does not
+  run it. A path where that text, or any other repository content, actually
+  executes is in scope.
+- **Any network call.** The built-in analyzer is no-egress by design: no
+  remote fetches, no model or hosted API calls, no grammar downloads, no
+  telemetry. **An observed network call from analysis or query commands is
+  itself a reportable security bug**, no further impact needed. The two
+  documented networked operations are installation
+  (`entire plugin install graph`) and the benchmark harness's clone phase;
+  neither is a finding.
+- **Denial of service from a repository the user merely cloned** — a crash,
+  hang, unbounded memory, or pathological blowup triggered by hostile content
+  rather than by size.
+
+See [docs/trust-and-security.md](docs/trust-and-security.md) for the precise
+read, write, execute, and network surfaces these map onto.
+
+## Out of scope
+
+- **Hostile flags the victim types themselves.** `verify` executes the test
+  command you give it, and `--setup` executes the setup command you give it,
+  both with your privileges — that is the documented contract. Likewise
+  pointing `--cache-dir`, `--report`, or `--record-baseline` at a sensitive
+  path. If the attack requires the user to run a command an attacker wrote,
+  report it upstream to whatever handed them that command.
+- **Anything requiring pre-existing write access to the machine.** If the
+  attacker can already write the cache directory, the config, the `PATH`, or
+  the binary, they did not need this tool.
+- **Resource exhaustion on a repository the user authored.** A large monorepo
+  indexing slowly, or a generated file the parser is slow on, is a performance
+  bug — please file it as a regular issue. Hostile-content DoS (above) is
+  different and is in scope.
+- **Third-party dependency advisories** with no demonstrated impact here.
+  Report those upstream first.
+- Static analysis being incomplete. Missed or unresolved edges from dynamic
+  dispatch, reflection, or generated code are documented limits, not
+  vulnerabilities.
+
+## What to expect
+
+These are the organization policy's published commitments, and they apply here
+unchanged:
+
+- **Acknowledgment within 48 hours** of your report.
+- **Progress updates** while we investigate.
+- **A 90-day resolution target** for confirmed critical issues — usually much
+  sooner for something this small and local.
+- **Confidentiality.** Reports are kept confidential; your information is not
+  shared with third parties without your consent, except as required by law.
+- **Credit for your contribution.** We make every effort to acknowledge
+  reporters.
+
+This repository adds no further commitment on top of those — no bounty, no
+tighter SLA, and no default embargo or coordinated-disclosure agreement. If you
+need a publication date or a disclosure timeline agreed, say so in your first
+email and we will settle it with you explicitly, rather than leave you relying
+on a default that does not exist.
+
+If you are unsure whether what you found counts, report it privately anyway.
+Deciding scope is our job, not yours.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/85
<!-- entire-trail-link-end -->

> **Revised after audit.** An earlier version of this description made three
> factual claims about GitHub behaviour and about the org policy that were
> wrong, and `SECURITY.md` itself carried three further defects. All six are
> corrected below, and each replacement is backed by a command whose output is
> shown. See [What the first version got wrong](#what-the-first-version-got-wrong).

## The bug

This repository has no `SECURITY.md` of its own, so it inherits the
organization default at `entireio/.github` through GitHub's community-health
fallback. **That default is actively wrong for this project**, and that is the
defect being fixed — not the absence of a contact address.

The org policy issues advisories only where a vulnerability is *"exploited by a
remote or non-local actor"*. It routes local-execution problems — resource
exhaustion that *"requires local access to trigger"*, and *"issues that cannot
be exploited without direct access to the user's machine"* — to public GitHub
Issues as *"bug reports rather than security advisories"*, and it lists
*"denial of service attacks"* as out of scope outright:

```console
$ curl -s https://raw.githubusercontent.com/entireio/.github/main/SECURITY.md \
    | sed -n '/^## Security Advisories/,/^Use GitHub Issues/p'
## Security Advisories

Security advisories are issued when a confirmed vulnerability can be exploited by a remote or non-local actor. Because the Entire CLI is primarily used as a local development tool, the following are generally treated as **bug reports rather than security advisories**:

- Regular expression performance issues (ReDoS) that only affect local execution
- Resource exhaustion that requires local access to trigger
- Issues that cannot be exploited without direct access to the user's machine

Use GitHub Issues for the respective repository to report bugs.
```

Entire Graph is a local binary with no server. **Every** vulnerability it can
have is a local-execution vulnerability, so read literally that carve-out
routes 100% of this project's real findings to a public tracker. The framing is
what misfires, not the intent: the attacker here *is* remote in the way that
matters — they wrote the repository you cloned — and the payload merely
detonates locally, on your machine, the moment you run an ordinary query.

## The concrete path this leaves open

Not a bug in the code — a bug in the *routing*, so the exploit is a disclosure
exploit.

`entire graph` is routinely pointed at repositories the user did not write: a
fresh clone, a contributor's branch, a dependency checkout, a repository an
agent was told to investigate. `docs/trust-and-security.md:34-44` documents
four write surfaces (the cache, `index --report <path>`,
`verify --record-baseline <path>`, `init-agents`), and
`docs/trust-and-security.md:23-26` documents that the ignore-stack read
includes repository-controlled git config such as `core.excludesFile`.

So the repo shape and command are ordinary:

```sh
git clone https://github.com/attacker/looks-useful
cd looks-useful
entire graph search --repo . --query "where is auth handled"
```

If any repository-controlled name, symlink, or ignore/config path in that tree
can steer a write outside its intended destination, that is a local
arbitrary-file-write reachable from `git clone` plus one query. Today its
finder reads the inherited policy, sees their finding described as a local
issue that belongs in GitHub Issues, and publishes a working exploit against a
tool whose whole usage pattern is "point it at a repo you have not read", with
no fixed release available.

## The fix

Add `SECURITY.md` at the repo root. Documentation only; one new file, no
existing file touched.

- **The override, stated and justified** (`SECURITY.md:7-38`) — this policy
  overrides the org default for this repository's local attack surface. Two
  concrete consequences: report privately, the local-execution carve-out does
  not apply (`:30-31`); and hostile-content DoS **is** in scope despite the
  org's blanket exclusion (`:32-34`). Everything else the org policy covers —
  the `entire` CLI proper, hosted services, contact and confidentiality —
  applies unchanged (`:36-38`).
- **Reporting, honest about which channel actually works** (`SECURITY.md:40-61`)
  — email `security@entire.io` is named as *the* channel that works today
  (`:47-48`). The doc states plainly that GitHub's **Report a vulnerability**
  button is not available here and explains why (`:50-56`). It also tells
  reporters not to open an issue asking for a contact, which is what GitHub's
  own guidance suggests when a repo has no private channel.
- **Supported versions as a rule, not a table** (`SECURITY.md:63-71`) — the
  most recent tagged release plus `main`, no backports. A hardcoded table would
  self-falsify at the next tag; `main` is already `v0.4.0-10-gcceb4de`.
- **In-scope threat model** (`SECURITY.md:73-121`) — repository-controlled
  content is the attacker channel (`:80-91`): file and directory names, file
  contents, symlinks, `.gitignore`/nested `.gitignore`/`.git/info/exclude`/
  `.graphignore`, and repository git config including `core.excludesFile`. Then
  the reports wanted (`:95-118`): writes outside the intended destination,
  reads outside the repository, execution of repository content, any network
  call, hostile-content DoS.
- **No-egress made reportable** (`SECURITY.md:109-115`) — an observed network
  call from analysis or query commands is itself a security bug, no further
  impact required. Carves out the two genuinely networked operations
  (`entire plugin install graph`, the bench clone phase) per
  `docs/trust-and-security.md:9-14`, so the rule is not trivially false.
- **Out of scope** (`SECURITY.md:123-142`) — hostile flags the victim types at
  their own shell (`verify` and `--setup` execute caller-provided commands by
  design, `docs/trust-and-security.md:58-61`); anything requiring pre-existing
  write access to the machine; resource exhaustion on a repository the user
  authored; third-party advisories with no demonstrated impact; documented
  static-analysis incompleteness.
- **Reporter expectations** (`SECURITY.md:144-162`) — every line traceable to
  the org policy's published text: 48-hour acknowledgment, progress updates,
  90-day resolution target, confidentiality, and *"make every effort to
  acknowledge your contributions"*. Nothing beyond that is claimed. There is no
  credit-in-the-advisory promise and no coordinated-disclosure clause, because
  **the org policy contains neither** — verified:

```console
$ curl -s https://raw.githubusercontent.com/entireio/.github/main/SECURITY.md \
    | grep -ic 'coordinated disclosure\|embargo\|bounty\|release notes'
0
```

  `SECURITY.md:158-162` says so plainly and asks any reporter who needs a
  disclosure timeline to agree one explicitly rather than rely on a default
  that does not exist.

No email address, PGP key, bounty, or SLA is invented.

## What the first version got wrong

The audit refuted three factual claims (1, 2, 4 below) and flagged three
further defects (3, 5, 6). Corrections, with the command behind each:

**1. "No working private channel a reporter can discover from the repo itself."
— FALSE.** The repository's security policy page already resolves anonymously
today and already surfaces `security@entire.io`, served from `entireio/.github`
by GitHub's community-health fallback:

```console
$ curl -s -o /tmp/p.html -w 'HTTP %{http_code}\n' https://github.com/entireio/entire-graph/security/policy
HTTP 200

$ grep -o 'security@entire.io' /tmp/p.html | wc -l
       2
```

So a private channel is discoverable. The real problem is narrower and is what
this PR now argues: the inherited policy tells a reporter that *their specific
class of finding* is a bug report for the public tracker.

**2. "GitHub renders no Report a vulnerability affordance without a security
policy." — WRONG CAUSALITY.** That button is gated on private vulnerability
reporting, not on the presence of a policy. GitHub's docs: *"Private
vulnerability reporting is separate from a repository's `SECURITY.md` file. You
can only report vulnerabilities privately for repositories where this feature
is enabled."* The setting is off here:

```console
$ gh api repos/entireio/entire-graph/private-vulnerability-reporting
{"enabled":false}
```

Note the two facts together: the policy page exists (via fallback) **and** the
button does not render — which is the direct observation that policy presence
is not what gates it.

**3. Consequence for this PR: the preferred channel named in the first draft
was non-functional.** Merging a file does not flip a repository setting, so
after merge the Security-tab button still will not exist. `SECURITY.md` has
therefore been rewritten to name **email as the channel that works**, and to
state that the button is unavailable and why (`:50-56`), rather than to present
a channel that does not exist as "preferred".

**4. The expectations section was described as entirely lifted from the org
policy. It was not** — the org policy has no credit-in-the-advisory commitment
and no coordinated-disclosure clause. Both invented clauses are removed; credit
is now worded to match the org policy's actual language, and the absence of a
disclosure default is stated openly instead of papered over.

**5. Staleness.** The hardcoded `v0.4.0 (current) | Yes` support table
self-falsifies at the next tag — `main` is already `v0.4.0-10-gcceb4de`. It is
replaced by a rule (`SECURITY.md:63-71`).

**6.** Line citations to `docs/trust-and-security.md` were off by one or two
and now land on exactly the cited text: `9-14` (network), `23-26` (ignore stack
including `core.excludesFile`), `34-44` (write surfaces), `58-61`
(`verify`/`--setup` execute caller-provided commands).

## Suggested follow-up, not in this diff

Enabling private vulnerability reporting (**Settings → Advanced Security →
Private vulnerability reporting**) would give the repo a second private channel
and make the Security-tab button real. That is a repository setting, not a file,
so it is out of this PR's reach; `SECURITY.md:54-56` flags that the section
should be updated if it is turned on.

The rest of the repo's security posture also reads as off, which is worth a
separate look:

```console
$ gh api repos/entireio/entire-graph -q .security_and_analysis
{"dependabot_security_updates":{"status":"disabled"},"secret_scanning":{"status":"disabled"},
 "secret_scanning_non_provider_patterns":{"status":"disabled"},
 "secret_scanning_push_protection":{"status":"disabled"},
 "secret_scanning_validity_checks":{"status":"disabled"}}
```

## Why this cannot regress existing behaviour

- One new file, `SECURITY.md`. No existing file is touched — `git show --stat`
  is `1 file changed, 165 insertions(+)`.
- No Go source, no build inputs, no schema. The frozen `1.x` additive-only
  schema contract is untouched; no json tag is added, removed, or renamed.
- No network call is added anywhere; the change adds a *prohibition* on network
  calls, not a call.
- Every claim about tool behaviour is sourced from `docs/trust-and-security.md`
  in this repo, and every claim about the org policy is a verbatim quote from
  `entireio/.github/SECURITY.md`, so the new file cannot drift from behaviour it
  does not describe independently.

## Tests

**No test added, deliberately — there is no code in this change.** A regression
test for a Markdown file would assert its own contents, which cannot fail for
any reason a reader would care about. The failing-first requirement is not
applicable here and was skipped; flagging that explicitly rather than quietly.

The gate was run in full and is clean:

```console
$ gofmt -l .
                      # empty

$ go vet ./...
                      # clean

$ go build ./...
                      # clean

$ go test ./... > /tmp/gotest.log 2>&1; echo "EXIT=$?"
EXIT=0

$ grep -c '^ok' /tmp/gotest.log; grep -c '^FAIL' /tmp/gotest.log
7                     # 7 packages with tests, all ok
0                     # 0 failures  (14 more have no test files)
```

`internal/sem` is the slow one under CGO (`ok ... 49.548s`), as expected.
