### PR TITLE
fix(sem): guard the cache-key ignore-file reads against non-regular files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ entire graph search --repo . --query "<the task or bug in one plain sentence>" -
 
 - `--format agent` for compact ranked output with latency telemetry; `json`/`ndjson` for the full schema (completeness, partial failures, diagnostics).
 - `--top-k N` result count; `--max-context-bytes N` byte budget (`0` = unbounded).
-- Working tree by default (clean trees reuse a keyed cache); add `--head` for committed-tree semantics.
+- Working tree by default (always rebuilt and never cached); add `--head` for cached committed-tree semantics.
 - `--profile syntax-only|fast|full` (default `fast`); `--index-all-files` or `--max-indexed-files N` to widen/bound cold-search parsing.
 
 **When:** the start of essentially every task. One good query lands you on the fix area.

--- a/README.md
+++ b/README.md
@@ -91,9 +91,7 @@ The command creates or updates these files:
   is added or replaced. Text outside the markers is preserved.
 
 Review the three files, then commit them together when the instructions should
-apply to your team. Committing also matters for performance: the files are
-indexable Markdown, and while they sit uncommitted the working tree counts as
-dirty, which turns off query cache reuse (details below).
+apply to your team.
 
 Finally, start a fresh agent session in the repository. A session that was open
 during activation has not seen the new instructions.
@@ -140,6 +138,10 @@ Blast radius: 1 caller (1 direct, 0 transitive), 0 callees, 3 type consumers,
 Callers (1 direct, 0 transitive; who breaks if behavior changes):
 - Router.ServeHTTP (mux.go:203, def :188)
 ```
+
+That point-in-time capture predates ADR 0004's security correction. A current
+default working-tree query reports `cache-miss`; committed-tree queries can
+still report `cache-hit` when a matching entry exists.
 
 Only after the graph queries did the agent read source, in narrow line ranges
 around the reported locations. Its answer traced matching through
@@ -189,18 +191,17 @@ Add `--head` to ask about the committed tree instead. Bulk streams
 (`snapshot`, `symbols`, `edges`) and ref-based analysis (`diff`, `commit`)
 default to committed state.
 
-Queries write a derivative local cache; they never modify repository files.
-When the working tree is clean, a repeated query reuses a snapshot keyed to
-the committed tree and the query options. Any indexable dirty file turns reuse
-off for the repository until the tree is clean again. Examples include
-extensionless files and root dependency manifests such as `go.mod` or
-`package.json`. Dirty files the graph cannot index (a `.bin`, say) do not.
-Changing `.graphignore` selects a different cache entry.
+Queries can write a derivative local cache; they never modify repository files.
+Default working-tree queries always build fresh and do not load or store cache
+entries. A `--head` query can reuse a snapshot keyed to the committed tree and
+query options; changing `.graphignore` selects a different committed-tree
+entry.
 
 Cache state is visible where the format reports it: the default `search` JSON
 carries `stats.index_cache_hit`, and `impact`/`neighbors` text output opens
-with an `Index: cache-hit`/`cache-miss` line, as in the capture above.
-`search --format text` does not report cache state.
+with an `Index: cache-hit`/`cache-miss` line. Default working-tree queries
+report a miss; matching `--head` queries may hit. `search --format text` does
+not report cache state.
 
 `entire graph index` prewarms committed-tree (`--head`) queries only, and
 defaults to profile `full` while plain `search` defaults to `fast`. A default

--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ retractions, and reproduction steps.
 
 ## Install
 
-Entire Graph requires Entire CLI 0.10.0 or later on `PATH`. The commands
-below are the official ones from the [Entire CLI installation
+Entire Graph requires Entire CLI 0.10.0 or later and Git 2.36 or later on
+`PATH`. Git 2.36 added the single-session object protocol Entire Graph uses to
+inspect an object's type before reading its contents. The commands below are
+the official ones from the [Entire CLI installation
 guide](https://docs.entire.io/installation), which also covers Windows and
 other channels.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,8 @@ authoritative in `entire graph capabilities --json`.
 | [Benchmarks](benchmarks.md) | Quantitative methodology, results, corrections, and caveats; `bench/README.md` documents the harness layout and flags |
 | [ADR 0001](adr/0001-ga-schema-contract.md) | Accepted `1.x` schema compatibility contract |
 | [ADR 0002](adr/0002-committed-tree-cache-key.md) | Accepted committed-tree cache-key decision; authoritative for committed-tree cache identity |
-| [ADR 0003](adr/0003-working-tree-search-snapshot-cache.md) | Accepted working-tree search-snapshot cache decision; authoritative for working-tree eligibility |
+| [ADR 0003](adr/0003-working-tree-search-snapshot-cache.md) | Superseded clean-tree search-snapshot reuse decision |
+| [ADR 0004](adr/0004-working-tree-cache-security-boundary.md) | Accepted working-tree cache bypass security decision; authoritative for working-tree eligibility |
 
 Completed plans, superseded references, branch diaries, and point-in-time proof
 logs are listed in the [archive](archive/README.md). Archived documents are kept
@@ -47,6 +48,6 @@ revision and will move to the archive when done.
 | Languages, profiles, and relation types | `entire graph capabilities --json` |
 | Provider schema | [ADR 0001](adr/0001-ga-schema-contract.md), [snapshot format](snapshot-format.md), and `internal/sem/provider.go` |
 | Committed-tree cache identity | [ADR 0002](adr/0002-committed-tree-cache-key.md) and the cache implementations under `internal/sem/` |
-| Working-tree cache eligibility | [ADR 0003](adr/0003-working-tree-search-snapshot-cache.md) and `internal/sem/search_cache.go` |
+| Working-tree cache eligibility | [ADR 0004](adr/0004-working-tree-cache-security-boundary.md) and `internal/sem/search_cache.go` |
 | Agent activation behavior | [Agent activation](agents.md), verified against the installed release |
 | Benchmark behavior | [Benchmarks](benchmarks.md), `bench/README.md`, and `cmd/graph-bench` |

--- a/docs/adr/0002-committed-tree-cache-key.md
+++ b/docs/adr/0002-committed-tree-cache-key.md
@@ -1,11 +1,10 @@
 # ADR 0002 — Committed-tree cache key: total over graph-shaping inputs
 
-Status: Accepted; partially superseded by
-[ADR 0003](0003-working-tree-search-snapshot-cache.md) (2026-08-16), which
-replaces only this document's "no change to working-tree mode / stays
-uncached" consequence for the search snapshot cache. The key-totality
-decision below is unchanged, and the working-tree bypass still holds for the
-provider records cache.
+Status: Accepted. [ADR 0003](0003-working-tree-search-snapshot-cache.md)
+temporarily replaced this document's "working-tree mode stays uncached"
+consequence for the search snapshot cache;
+[ADR 0004](0004-working-tree-cache-security-boundary.md) (2026-08-21) restores
+that bypass. The committed-tree key-totality decision below is unchanged.
 Date: 2026-07-28
 
 ## Context
@@ -26,11 +25,13 @@ be served on another, and what does the current keying cost?
 
 Both keys hash the cache version, the **checkout path** (`filepath.Abs(repo)`), the provider
 version, the **HEAD tree hash**, the profile, `MaxParseBytes`, `OnlyFiles`, and the **contents**
-of any `--ignore-file` / `--include-file`. In `--head` mode the file set is otherwise a pure
-function of the tree: `openSource` lists via `gitutil.ListFiles(ctx, repo, committedRevision)`
-and filters with `loadExplicitIgnoreMatcher` (content-hashed) plus a tree-derived
-`headIgnoreMatcher`. `.git/info/exclude` and `core.excludesFile` reach only the working-tree
-path, which is never cached.
+of any `--ignore-file` / `--include-file`. Provider-record entries additionally hash the exact
+commit because their opaque NDJSON header records that commit; the search cache can remain
+tree-keyed because it safely restamps structured commit provenance on a hit. In `--head` mode
+the file set is otherwise a pure function of the tree: `openSource` lists via
+`gitutil.ListFiles(ctx, repo, committedRevision)` and filters with the captured explicit policy
+plus a tree-derived `headIgnoreMatcher`. `.git/info/exclude` and `core.excludesFile` reach only
+the working-tree path, which is never cached.
 
 Measured on a binary built from `cdcb8db`, against an isolated clone with three linked
 worktrees — `wtA`/`wtC` at `cdcb8db`, `wtB` at `6e4bfde`, 3 of 317 tracked files differing:
@@ -138,9 +139,10 @@ correctness fix.
   across worktrees if repository identity is a keyed, validated term, which it now is.
 - **No change to working-tree mode.** It stays uncached; dirty state has no durable key. The
   0-entry rows in the measurement are that policy, not a write failure.
-- **No change to tree-only keying of the parsed graph.** Two commits sharing a tree still share
-  an entry, and `FILE_CHANGES_WITH` co-change edges are still allowed to come from the other
-  commit's history — already documented on `searchSnapshotKey` and unchanged here.
+- **Search snapshots remain tree-keyed.** Two commits sharing a tree still share that structured
+  entry, whose commit provenance is restamped on load. Provider-record streams no longer share
+  across same-tree commits because their serialized header cannot be restamped without decoding
+  and rewriting the stream.
 - **No fix for the linked-worktree `.git/info/exclude` ENOTDIR failure** seen while measuring
   (`read ignore file ".../wtA/.git/info/exclude": not a directory`, exit 1). That is
   working-tree-only, therefore cache-irrelevant, and is owned by a separate change.
@@ -179,3 +181,14 @@ cache**. Two gaps remained and are what this change actually closes:
 Still explicitly NOT done, unchanged from the original decision: cross-worktree sharing (blocked by
 `repoRoot` being overwritten from the cached header) and per-file content-hash incrementality, for
 which a total key is the prerequisite.
+
+## Addendum — immutable cache transactions and exact provenance
+
+The 2026-08-21 transaction hardening captures one bounded ignore policy and carries those same
+bytes through keying, construction, and persistence. Provider-record transactions also capture
+the exact commit, tree, repository key, resolved file cap, and slice options, then reject storage
+when the emitted header does not match the captured commit/tree/repository/provider/profile.
+This closes policy, moving-HEAD, remote-identity, environment, and caller-slice TOCTOU seams.
+
+The final generations are `provider-records-v7` and `search-snapshot-v11`; earlier intermediate
+entries are retired. Working-tree snapshots are never persisted, as recorded by ADR 0004.

--- a/docs/adr/0003-working-tree-search-snapshot-cache.md
+++ b/docs/adr/0003-working-tree-search-snapshot-cache.md
@@ -1,6 +1,9 @@
 # ADR 0003 — Working-tree search-snapshot cache: clean-tree eligibility
 
-Status: Accepted
+Status: Superseded by
+[ADR 0004](0004-working-tree-cache-security-boundary.md) (2026-08-21), which
+removes status-based eligibility and restores unconditional working-tree cache
+bypass. This document remains the historical record of the replaced decision.
 Date: 2026-08-16
 Partially supersedes: [ADR 0002](0002-committed-tree-cache-key.md) — only its
 "working-tree mode stays uncached" consequence. ADR 0002's committed-tree

--- a/docs/adr/0004-working-tree-cache-security-boundary.md
+++ b/docs/adr/0004-working-tree-cache-security-boundary.md
@@ -1,0 +1,48 @@
+# ADR 0004 — Working-tree cache security boundary
+
+Status: Accepted
+Date: 2026-08-21
+Supersedes: [ADR 0003](0003-working-tree-search-snapshot-cache.md). This
+restores ADR 0002's original working-tree bypass for the search snapshot cache;
+ADR 0002's committed-tree key-totality decision remains unchanged.
+
+## Context
+
+ADR 0003 allowed a working-tree query to reuse a `HEAD`-tree-keyed search
+snapshot after `git status` reported that every relevant path matched `HEAD`.
+That probe is not safe at this trust boundary. Git status applies clean and
+long-running process filters selected by repository attributes and config, so
+checking a repository the user has not audited can execute a command chosen by
+that repository.
+
+The comparison is also semantically mismatched: the provider parses raw
+worktree bytes, while Git status compares the index with content after Git's
+configured conversion filters. A status-clean tree therefore does not prove
+that the bytes the provider reads are identical to the committed blobs naming
+the cache entry.
+
+## Decision
+
+Working-tree search snapshots are not cacheable:
+
+1. A query with working-tree options never loads or stores a search-snapshot
+   cache entry. It builds through the existing fresh-worktree path.
+2. Committed-tree (`--head`) cache behavior and key identity are unchanged.
+3. The status-based cleanliness probe and its memoized verdict are removed.
+4. The cache envelope retains its `worktree` discriminator so old entries, and
+   any future safe implementation, cannot collide with committed-tree entries.
+
+Working-tree caching may be reconsidered only with a bounded comparison of raw
+worktree bytes against HEAD/index blobs that contains filesystem traversal and
+does not invoke Git conversion filters or other repository-selected programs.
+
+## Consequences
+
+- A working-tree query always reports a cache miss and repeated interactive
+  queries rebuild the snapshot, including on a clean checkout.
+- `index` prewarms only the committed-tree namespace and therefore benefits
+  later queries only when they use `--head` with the same cache variant.
+- The previous two-second cleanliness-verdict window and explicit invalidation
+  API no longer exist.
+- This accepts a performance regression to keep indexing an unaudited
+  repository from executing its clean/process filter commands.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -132,14 +132,12 @@ There is no removal command. To deactivate, delete
 lines, from `AGENTS.md` and `CLAUDE.md`. Delete `.entire/` or either instruction
 file only if it is otherwise empty.
 
-## Commit before you rely on the cache
+## Working-tree queries bypass the cache
 
-The three activation files are indexable Markdown. While any is untracked or
-modified, the working tree is dirty in a way the query cache respects. Default
-working-tree queries rebuild the graph instead of reusing a clean snapshot.
-Committing the activation files restores clean-tree cache reuse. Activation and
-a query benchmark should therefore not share one uncommitted checkout. See the
-[operations cache guide](operations.md#what-a-cache-entry-is-keyed-on).
+The interactive query family reads the working tree by default and rebuilds its
+snapshot on every query, whether or not the activation files are committed. Use
+`--head` when committed-tree semantics are acceptable and cache reuse matters.
+See the [operations cache guide](operations.md#working-tree-queries).
 
 ## Client notes
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -34,6 +34,8 @@ without version linker flags reports `dev`.
 ## Requirements
 
 - The Entire CLI (0.10.0 or later) must be on `PATH`.
+- Git 2.36 or later must be on `PATH`; committed-tree readers use its
+  single-session `cat-file --batch-command` protocol.
 - Development uses Go 1.26. Tree-sitter bindings require CGO and a working C
   compiler for the target platform.
 - Local release builds require `tar` for non-Windows archives, `zip` or `7z`

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -62,8 +62,8 @@ entries.
 ### Two cache families
 
 - The **search snapshot cache** backs `search`, `neighbors`, `impact`, and
-  `index`. It caches both committed-tree (`--head`) and clean-working-tree
-  queries, in separate entries.
+  `index`. It caches committed-tree (`--head`) queries; working-tree queries
+  always bypass it.
 - The **provider records cache** backs the bulk streams (`snapshot`,
   `symbols`, `edges`). It is committed-tree only; `--worktree` streams always
   bypass it.
@@ -73,35 +73,32 @@ entries.
 A search-snapshot entry is a function of: the cache format version, the
 checkout path, the repository identity (derived from the Git remote), the
 provider version, the committed `HEAD` tree hash, the profile, the parse-size
-and file-count limits, a working-tree marker, any file-subset selection, the
-paths **and contents** of `--ignore-file`/`--include-file` inputs in caller
-order, and the contents of `.graphignore`. Change any of these and the next
-query builds a new entry; matching all of them is what "cache hit" means.
+and file-count limits, any file-subset selection, the paths **and contents** of
+`--ignore-file`/`--include-file` inputs in caller order, and the contents of
+`.graphignore`. Change any of these and the next query builds a new entry;
+matching all of them is what "cache hit" means. A legacy worktree discriminator
+remains in the envelope only to reject retired entries; it is not a current key
+term because working-tree snapshots cannot receive persistent keys.
 [ADR 0002](adr/0002-committed-tree-cache-key.md) records why the key is total
 over graph-shaping inputs.
 
-### Working-tree reuse and dirtiness
+A provider-record entry binds the same graph-shaping inputs plus the exact
+commit and output mode. Exact commit identity is required because the cached
+opaque NDJSON header records it; unlike a structured search snapshot, that
+stream cannot be safely restamped on a same-tree cache hit.
 
-Interactive queries default to the working tree. A working-tree query is
-eligible for cache reuse only while the tree is effectively clean:
+### Working-tree queries
 
-- Clean tree → the query reuses its cached snapshot (an identical rerun is a
-  hit).
-- A dirty or untracked path the graph can index, such as a supported source
-  extension, any extensionless file (it could be a shebang script), or a root
-  dependency manifest (`go.mod`, `package.json`, `tsconfig.json`,
-  `pyproject.toml`, `setup.cfg`, `Cargo.toml`, `composer.json`, or `pom.xml`),
-  disables reuse for the whole repository until the tree is clean again.
-- Dirty paths with known unsupported extensions that are not manifests (build
-  artifacts, archives, editor swap files) do not disable reuse.
-- If the working tree or `HEAD` cannot be inspected, including in a repository
-  with no commits, the query fails closed: it builds fresh and caches
-  nothing.
+Interactive queries default to the working tree and always build a fresh
+snapshot. They neither load nor store search-snapshot cache entries, even when
+the checkout is clean. Git's status/diff machinery cannot establish raw
+worktree equality safely here because it may run repository-selected clean or
+process filters.
 
-Practical consequence: `init-agents` writes indexable Markdown, so a freshly
-activated repository loses clean-tree reuse until the activation files are
-committed. [ADR 0003](adr/0003-working-tree-search-snapshot-cache.md) records
-the working-tree eligibility decision.
+Use `--head` when committed-tree semantics are acceptable and repeated queries
+should reuse a cache entry. [ADR 0004](adr/0004-working-tree-cache-security-boundary.md)
+records the security decision; [ADR 0003](adr/0003-working-tree-search-snapshot-cache.md)
+is the superseded clean-tree reuse design.
 
 ### Prewarming with `index`
 
@@ -113,8 +110,7 @@ this easy to get wrong: `index` defaults to `--profile full` while `search`
 defaults to `--profile fast`, and `index` cannot warm the default
 working-tree path at all. To prewarm for the installed agent guide's
 committed-tree queries, `index`'s default profile is the right one, but the
-guide's queries use the working tree, so they only reuse cache while the tree is
-clean, as above.
+guide's queries use the working tree, so they do not reuse that entry.
 
 `index --report <path>` additionally writes a Markdown summary of the built
 graph for human review.
@@ -138,12 +134,11 @@ graph for human review.
 query per repository is cold because cache entries embed the provider version.
 Old entries simply stop matching and can be deleted at leisure.
 
-If queries rebuild on every run when you expect hits, check in order: a dirty
-or untracked indexable file (`git status`; remember extensionless files and
-root manifests count), a changed `.graphignore`, a profile mismatch between
-runs, and, for `def`/`explain`, a missing `--cache-dir`/
-`ENTIRE_PLUGIN_DATA_DIR`, since those two commands do not fall back to the
-per-user cache directory.
+Working-tree queries always rebuild. If a `--head` query rebuilds when you
+expect a hit, check in order: a changed committed tree or `.graphignore`, a
+profile mismatch between runs, and, for `def`/`explain`, a missing
+`--cache-dir`/`ENTIRE_PLUGIN_DATA_DIR`, since those two commands do not fall
+back to the per-user cache directory.
 
 ## Reports and the status line
 

--- a/docs/readme-plan.md
+++ b/docs/readme-plan.md
@@ -164,9 +164,8 @@ produces four requirements:
 
 - Tell the reader to review the three generated or updated files. Recommend
   committing them as one setup change when the instructions should apply to the
-  team. Make the cache consequence explicit: while any of these indexable
-  Markdown files remains dirty or untracked, default working-tree queries bypass
-  cache reuse for the repository.
+  team. Do not tie that recommendation to cache reuse: default working-tree
+  queries bypass the cache whether those files are committed or uncommitted.
 - Link the guide emitted by `entire graph agent-guide`, but do not imply that every
   client imports the referenced file the same way.
 - Require a fresh client task/session after activation. Use tested client-specific
@@ -206,8 +205,8 @@ produces four requirements:
 
 - Capture the concrete transcript in a clean consuming fixture with no pre-existing
   Entire Graph instructions. Pin the fixture commit and commit the generated
-  activation files before recording so the example is reproducible and does not
-  confound instruction adoption with dirty-tree cache bypass.
+  activation files before recording so the example is reproducible and its
+  instruction inputs stay fixed.
 - Show only visible events: the prompt, instruction-file discovery, the graph
   shell command and abbreviated result, the focused source read, any purposeful
   relation or impact query, and the sourced answer. Do not expose or fabricate
@@ -245,12 +244,10 @@ Follow the table with a short cache explanation:
   `impact`) reads the working tree by default, so current edits are visible.
   Whole-graph streams and ref-based analysis have different defaults; link their
   exact semantics instead of generalizing.
-- Working-tree snapshot reuse is conservative and repository-wide. A dirty path
-  with a supported extension, an extensionless path that could be a shebang
-  script, or a root manifest used for import resolution bypasses reuse for that
-  query. Other dirty paths with known unsupported extensions do not; `.graphignore`
-  content is part of the cache key, and a changed committed tree selects a
-  different entry.
+- Working-tree snapshots always bypass cache reuse because Git's status/diff
+  machinery may execute repository-selected conversion filters. Committed-tree
+  cache keys include `.graphignore` content, and a changed committed tree selects
+  a different entry.
 - Cache writes are derivative local state, so “repository-source-read-only” does
   not mean “writes nothing.”
 - The installed guide's default `search` output is JSON and exposes
@@ -330,8 +327,9 @@ for the same subject.
 | `docs/brain-and-graph-boundaries.md` | Retain and link | Ownership boundary between the repository-local provider and durable Brain/MCP surfaces |
 | `docs/semantic-provider-requirements.md` | Rewrite and narrow | Graph owns repository-local parsing, indexing, queries, cache freshness, and instruction distribution; Brain owns durable and cross-repository state and presentation |
 | `docs/adr/0001-ga-schema-contract.md` | Retain | `1.x` schema compatibility contract |
-| `docs/adr/0002-committed-tree-cache-key.md` | Retain in place; add a reciprocal partial-supersession notice to ADR 0003 without rewriting its decision body | The committed-tree key-totality decision remains accepted; only its working-tree search-snapshot no-cache conclusion is superseded |
-| `docs/adr/0003-working-tree-search-snapshot-cache.md` | Create as Accepted; declare that it partially supersedes ADR 0002 | Working-tree search-snapshot eligibility and isolation; provider-record caching remains committed-tree-only |
+| `docs/adr/0002-committed-tree-cache-key.md` | Retain in place with reciprocal ADR notices | The committed-tree key-totality decision remains accepted and its working-tree bypass is restored by ADR 0004 |
+| `docs/adr/0003-working-tree-search-snapshot-cache.md` | Retain as superseded | Historical clean-tree working-tree reuse decision |
+| `docs/adr/0004-working-tree-cache-security-boundary.md` | Retain as Accepted | Working-tree search-snapshot bypass; authoritative for current eligibility |
 | `docs/archive/` | Retain | Non-normative provenance only |
 
 Historical plans, validation reports, and implemented design records belong in
@@ -357,7 +355,7 @@ Create a small claim ledger during implementation:
 | Claim | Exact scope | Product version or commit | Corpus/environment | Evidence link | Root README? |
 | --- | --- | --- | --- | --- | --- |
 | Local/no-egress analysis | Built-in analyzer only | Pinned release | Not applicable | Implementation, contract, and tests | Yes |
-| Cache reuse and freshness | Clean working tree, dirty supported-extension or extensionless path, dirty resolver manifest, dirty non-manifest path with a known unsupported extension, changed `.graphignore`, and explicit `--head` are distinct cases | Pinned release | Deterministic repository fixture | Cache tests and ADR | Yes |
+| Cache reuse and freshness | Working-tree queries always bypass; changed `.graphignore` and explicit `--head` select committed-tree variants | Pinned release | Deterministic repository fixture | Cache tests and ADR | Yes |
 | Language counts | Semantic versus inventory-only | TBD | Generated capabilities | Language reference | Maybe |
 | Code-query quality | TBD after audit | TBD | TBD | Reproducible result | Maybe |
 | Prose-memory comparison | Public-protocol reimplementation | Pinned | LOCOMO/LongMemEval-S | GraphMark bundle | Docs only by default |
@@ -408,14 +406,13 @@ Rules:
   topology, and visible evidence that the client loaded the guide once.
 - [x] Select a clean consuming fixture, pin its commit, install and commit the
   generated instruction files, and record a source-grounded agent task.
-- [x] Verify cache behavior for a clean working tree; a dirty supported-extension,
-  extensionless, or resolver-manifest path; a dirty non-manifest path with a known
-  unsupported extension; a changed `.graphignore`; explicit `--head`; and
-  committed-tree prewarming with both matching and mismatched profiles and ordered
-  ignore/include inputs. Using isolated cache state for each case, confirm that the
-  matching query reuses the prewarmed entry and that the first query for each
-  mismatched variant misses it. Record the exact cache fields or headers exposed
-  by the formats used in the README and agent guide.
+- [x] Verify that working-tree queries bypass cache reuse regardless of checkout
+  cleanliness; verify changed `.graphignore`, explicit `--head`, and committed-tree
+  prewarming with both matching and mismatched profiles and ordered ignore/include
+  inputs. Using isolated cache state for each case, confirm that only the matching
+  committed-tree query reuses the prewarmed entry and that each mismatched variant
+  misses it. Record the exact cache fields or headers exposed by the formats used
+  in the README and agent guide.
 - [ ] Build the quantitative claim ledger and audit local reads, writes,
   execution, cache, and network boundaries against implementation and tests.
 - [x] Reconcile stale documentation authorities before drafting: repository-agent
@@ -433,17 +430,10 @@ Rules:
 - [x] Rewrite `docs/semantic-provider-requirements.md` so its ownership boundary
   matches the repository-local query, cache, and agent-instruction behavior that
   Entire Graph actually implements.
-- [ ] Create `docs/adr/0003-working-tree-search-snapshot-cache.md` with
-  `Status: Accepted` and reciprocal metadata that partially supersedes ADR 0002
-  only for working-tree search-snapshot eligibility. Document the separate
-  working-tree cache identity and provenance; bypass for dirty supported-extension
-  paths, extensionless paths, or root resolver manifests; continued eligibility
-  for other dirty non-manifest paths with known unsupported extensions;
-  `.graphignore` contents selecting a different cache entry; fail-closed behavior
-  when worktree or HEAD inspection fails, including when no HEAD exists; and the
-  continued working-tree bypass in the provider-record cache. Add the reciprocal
-  notice to ADR 0002, update `docs/README.md` to scope each ADR's authority, and
-  correct the stale `LoadOrBuildProviderSnapshot` source comment.
+- [x] Retain ADR 0003 as the superseded clean-tree reuse decision and add ADR 0004
+  as the authoritative security boundary: working-tree queries always bypass the
+  search-snapshot cache, while committed-tree key identity remains governed by
+  ADR 0002. Keep reciprocal status notices and the documentation index aligned.
 - [ ] Consolidate benchmark content and preserve archived material as explicitly
   non-normative provenance.
 - [x] Reconcile `AGENTS.md`, `CLAUDE.md`, and `.entire/graph-agent.md` together;
@@ -507,18 +497,16 @@ Rules:
   relation or impact query, and a sourced answer.
 - [x] Example output is captured from the pinned binary and fixture, not invented.
 - [x] The README scopes working-tree defaults to the interactive query family and
-  explains clean reuse, repository-wide bypass for dirty supported-extension,
-  extensionless, or resolver-manifest paths, continued cache eligibility for
-  other dirty paths with known unsupported extensions, `.graphignore` keying,
-  derivative cache writes, and the exact observable cache field/header used in
-  the example.
+  explains unconditional working-tree cache bypass, committed-tree
+  `.graphignore` keying, derivative cache writes, and the exact observable cache
+  field/header used in the example.
 - [x] `index` is not presented as warming the default working-tree agent path or
   a committed-tree query with a different profile, cache location, ordered
   ignore/include inputs, or changed `.graphignore`; the default `full`/`fast`
   mismatch is explicit.
-- [x] ADR 0002 and ADR 0003 link to each other, and `docs/README.md` identifies
-  ADR 0002 as authoritative for committed-tree cache identity and ADR 0003 as
-  authoritative for working-tree search-snapshot eligibility.
+- [x] ADR 0002, ADR 0003, and ADR 0004 carry reciprocal status notices, and
+  `docs/README.md` identifies ADR 0002 as authoritative for committed-tree cache
+  identity and ADR 0004 as authoritative for working-tree eligibility.
 - [x] Trust documentation distinguishes built-in analysis, installation network
   activity, derivative cache writes, repository instruction writes, and
   caller-provided command execution.

--- a/internal/cli/callsite.go
+++ b/internal/cli/callsite.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -97,11 +98,16 @@ func openSnapshotLineReader(
 		return newRepoLineReader(snapshot.Header.RepoRoot), nil, nil
 	}
 
+	treePathPrefix, err := gitutil.RepoPrefix(ctx, snapshot.Header.RepoRoot)
+	if err != nil {
+		return nil, nil, err
+	}
 	batch, err := gitutil.NewBatchFileReader(ctx, snapshot.Header.RepoRoot, snapshot.Header.Commit)
 	if err != nil {
 		return nil, nil, err
 	}
 	batch.SetMaxBytes(callSiteMaxFileBytes)
+	limited := gitutil.NewLimitedFileReader(ctx, snapshot.Header.RepoRoot, snapshot.Header.Commit, callSiteMaxFileBytes)
 
 	cache := map[string][]string{}
 	read := func(relPath string) ([]string, bool) {
@@ -117,13 +123,16 @@ func openSnapshotLineReader(
 		var readErr error
 		if !batch.IsPathSafe(relPath) {
 			// The batch protocol is line based, so a newline-bearing Git path
-			// needs the argv-safe one-shot reader. It still reads the same commit;
-			// failure never falls back to the dirty working tree. The ceiling is
+			// needs the shared exact-object bounded reader. It still reads the
+			// same commit; failure never falls back to the dirty working tree. The
+			// ceiling is
 			// passed DOWN rather than applied to the returned string: the sibling
 			// readers refuse an oversized blob before materializing it, and a path
 			// that reaches here can come from an ingested snapshot record, so this
 			// one must not be the exception that allocates first and checks after.
-			result, err := gitutil.ReadFileLimited(ctx, snapshot.Header.RepoRoot, snapshot.Header.Commit, relPath, callSiteMaxFileBytes)
+			// One reader shares its component cache and process allowance across
+			// all source records handled by this command.
+			result, err := limited.ReadFile(treePathPrefix + relPath)
 			readErr = err
 			content = result.Content
 			ok = result.Status == gitutil.LimitedFileContent
@@ -139,7 +148,10 @@ func openSnapshotLineReader(
 		cache[relPath] = lines
 		return lines, true
 	}
-	return read, batch.Close, nil
+	closeReaders := func() error {
+		return errors.Join(batch.Close(), limited.Close())
+	}
+	return read, closeReaders, nil
 }
 
 // openSnapshotLineReaderOrDegrade opens the provenance-correct reader and, when

--- a/internal/cli/callsite.go
+++ b/internal/cli/callsite.go
@@ -115,7 +115,7 @@ func openSnapshotLineReader(
 		var content string
 		var ok bool
 		var readErr error
-		if strings.Contains(relPath, "\n") {
+		if !batch.IsPathSafe(relPath) {
 			// The batch protocol is line based, so a newline-bearing Git path
 			// needs the argv-safe one-shot reader. It still reads the same commit;
 			// failure never falls back to the dirty working tree. The ceiling is
@@ -123,7 +123,10 @@ func openSnapshotLineReader(
 			// readers refuse an oversized blob before materializing it, and a path
 			// that reaches here can come from an ingested snapshot record, so this
 			// one must not be the exception that allocates first and checks after.
-			content, ok, readErr = gitutil.ShowFileLimited(ctx, snapshot.Header.RepoRoot, snapshot.Header.Commit, relPath, callSiteMaxFileBytes)
+			result, err := gitutil.ReadFileLimited(ctx, snapshot.Header.RepoRoot, snapshot.Header.Commit, relPath, callSiteMaxFileBytes)
+			readErr = err
+			content = result.Content
+			ok = result.Status == gitutil.LimitedFileContent
 		} else {
 			content, ok, readErr = batch.ReadFile(relPath)
 		}

--- a/internal/cli/head_source_provenance_test.go
+++ b/internal/cli/head_source_provenance_test.go
@@ -26,6 +26,7 @@ func TestHeadSnapshotLineReaderPreservesCommittedFileContract(t *testing.T) {
 	newlinePaths := runtime.GOOS != "windows"
 	if newlinePaths {
 		write(t, repo, "line\nbreak.go", "committed-newline-path\n")
+		write(t, repo, "trail.go\r", "committed-carriage-path\n")
 	}
 	git(t, repo, "add", ".")
 	git(t, repo, "commit", "-m", "committed reader fixture")
@@ -33,6 +34,7 @@ func TestHeadSnapshotLineReaderPreservesCommittedFileContract(t *testing.T) {
 	write(t, repo, "tracked.go", "dirty\nline\n")
 	if newlinePaths {
 		write(t, repo, "line\nbreak.go", "dirty-newline-path\n")
+		write(t, repo, "trail.go\r", "dirty-carriage-path\n")
 	}
 	write(t, repo, "dirty-only.go", "must not be visible from HEAD\n")
 
@@ -59,6 +61,10 @@ func TestHeadSnapshotLineReaderPreservesCommittedFileContract(t *testing.T) {
 		lines, ok = read("line\nbreak.go")
 		if !ok || strings.Join(lines, "|") != "committed-newline-path|" {
 			t.Fatalf("committed newline-path source = %q, ok=%v", lines, ok)
+		}
+		lines, ok = read("trail.go\r")
+		if !ok || strings.Join(lines, "|") != "committed-carriage-path|" {
+			t.Fatalf("committed trailing-CR path source = %q, ok=%v", lines, ok)
 		}
 	}
 	for _, path := range []string{"dirty-only.go", "contains-nul.go", "oversized.go"} {

--- a/internal/cli/head_source_provenance_test.go
+++ b/internal/cli/head_source_provenance_test.go
@@ -2,11 +2,17 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/entireio/entire-graph/internal/sem"
 )
@@ -19,7 +25,7 @@ func TestHeadSnapshotLineReaderPreservesCommittedFileContract(t *testing.T) {
 	write(t, repo, "tracked.go", "committed\r\nline\r\n")
 	write(t, repo, "contains-nul.go", "before\x00after\n")
 	write(t, repo, "oversized.go", strings.Repeat("x", callSiteMaxFileBytes+1))
-	// A newline in a path is legal in Git and drives the one-shot `git show`
+	// A newline in a path is legal in Git and drives the bounded exact-object
 	// fallback, but Windows cannot create such a file at all. Everything else
 	// this test pins — CRLF, NUL, the size ceiling, worktree isolation — is
 	// cross-platform, so only the newline case is skipped rather than the test.
@@ -76,6 +82,91 @@ func TestHeadSnapshotLineReaderPreservesCommittedFileContract(t *testing.T) {
 		t.Fatalf("close committed reader: %v", err)
 	}
 	closeReader = nil
+}
+
+type deepSnapshotLineFile struct {
+	path    string
+	content string
+}
+
+func importDeepSnapshotLineFiles(t *testing.T, repo string, files []deepSnapshotLineFile) string {
+	t.Helper()
+	var input strings.Builder
+	for i, file := range files {
+		fmt.Fprintf(&input, "blob\nmark :%d\ndata %d\n%s\n", i+1, len(file.content), file.content)
+	}
+	message := "deep snapshot lines"
+	fmt.Fprintf(&input, "commit refs/heads/deep-snapshot-lines\nmark :%d\n", len(files)+1)
+	fmt.Fprint(&input, "committer Test <test@example.com> 1 +0000\n")
+	fmt.Fprintf(&input, "data %d\n%s\n", len(message), message)
+	for i, file := range files {
+		fmt.Fprintf(&input, "M 100644 :%d %s\n", i+1, strconv.Quote("scope/"+file.path))
+	}
+	input.WriteByte('\n')
+
+	cmd := exec.Command("git", "fast-import", "--quiet")
+	cmd.Dir = repo
+	cmd.Stdin = strings.NewReader(input.String())
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git fast-import deep snapshot lines: %v\n%s", err, out)
+	}
+	return rev(t, repo, "refs/heads/deep-snapshot-lines")
+}
+
+func deepSnapshotLinePath(branch int) string {
+	component := strings.Repeat(string(rune('a'+branch)), 200)
+	components := make([]string, 80, 81)
+	for i := range components {
+		components[i] = component
+	}
+	components = append(components, fmt.Sprintf("unsafe\nsource_%d.go", branch))
+	return strings.Join(components, "/")
+}
+
+// TestSnapshotLineReaderSharesDeepUnsafeMetadataAllowance proves the
+// command-lifetime fallback does not reset its component-process allowance per
+// source record. The snapshot root is a repository subdirectory, so the same
+// fixture also pins conversion from caller-relative to tree-root coordinates.
+func TestSnapshotLineReaderSharesDeepUnsafeMetadataAllowance(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	files := make([]deepSnapshotLineFile, 4)
+	for i := range files {
+		files[i] = deepSnapshotLineFile{
+			path:    deepSnapshotLinePath(i),
+			content: fmt.Sprintf("source-%d\n", i),
+		}
+	}
+	head := importDeepSnapshotLineFiles(t, repo, files)
+	subdir := filepath.Join(repo, "scope")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+	read, closeReader, err := openSnapshotLineReader(ctx, sem.ProviderSnapshot{
+		Header: sem.SnapshotHeader{RepoRoot: subdir, Commit: head},
+	}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reads := 0
+	for _, file := range files {
+		lines, ok := read(file.path)
+		if ok && len(lines) > 0 && lines[0]+"\n" == file.content {
+			reads++
+		}
+	}
+	if err := closeReader(); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := reads, 3; got != want {
+		t.Fatalf("snapshot source reads before shared metadata cap = %d, want %d", got, want)
+	}
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("snapshot line reader exceeded safety timeout: %v", err)
+	}
 }
 
 // A committed reader that cannot be opened must cost the answer its source

--- a/internal/cli/head_source_provenance_test.go
+++ b/internal/cli/head_source_provenance_test.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -91,26 +90,58 @@ type deepSnapshotLineFile struct {
 
 func importDeepSnapshotLineFiles(t *testing.T, repo string, files []deepSnapshotLineFile) string {
 	t.Helper()
-	var input strings.Builder
-	for i, file := range files {
-		fmt.Fprintf(&input, "blob\nmark :%d\ndata %d\n%s\n", i+1, len(file.content), file.content)
+	// Construct the tree from single components rather than giving fast-import
+	// each complete 16 KiB path. The latter exceeds Git for Windows' path parser
+	// limit even though the raw Git tree object can represent the fixture.
+	var scopeInput strings.Builder
+	for _, file := range files {
+		components := strings.Split(file.path, "/")
+		blob := gitSnapshotObjectInputOutput(t, repo, file.content, "hash-object", "-w", "--stdin")
+		tree := gitSnapshotObjectInputOutput(
+			t,
+			repo,
+			fmt.Sprintf("100644 blob %s\t%s%c", blob, components[len(components)-1], byte(0)),
+			"mktree", "-z",
+		)
+		for i := len(components) - 2; i >= 1; i-- {
+			tree = gitSnapshotObjectInputOutput(
+				t,
+				repo,
+				fmt.Sprintf("040000 tree %s\t%s%c", tree, components[i], byte(0)),
+				"mktree", "-z",
+			)
+		}
+		fmt.Fprintf(&scopeInput, "040000 tree %s\t%s%c", tree, components[0], byte(0))
 	}
-	message := "deep snapshot lines"
-	fmt.Fprintf(&input, "commit refs/heads/deep-snapshot-lines\nmark :%d\n", len(files)+1)
-	fmt.Fprint(&input, "committer Test <test@example.com> 1 +0000\n")
-	fmt.Fprintf(&input, "data %d\n%s\n", len(message), message)
-	for i, file := range files {
-		fmt.Fprintf(&input, "M 100644 :%d %s\n", i+1, strconv.Quote("scope/"+file.path))
-	}
-	input.WriteByte('\n')
+	scope := gitSnapshotObjectInputOutput(t, repo, scopeInput.String(), "mktree", "-z")
+	root := gitSnapshotObjectInputOutput(
+		t,
+		repo,
+		fmt.Sprintf("040000 tree %s\tscope%c", scope, byte(0)),
+		"mktree", "-z",
+	)
+	commit := gitSnapshotObjectInputOutput(
+		t,
+		repo,
+		"",
+		"-c", "user.name=Entire Graph Test",
+		"-c", "user.email=graph@example.com",
+		"commit-tree", root, "-m", "deep snapshot lines",
+	)
+	git(t, repo, "update-ref", "refs/heads/deep-snapshot-lines", commit)
+	return commit
+}
 
-	cmd := exec.Command("git", "fast-import", "--quiet")
+func gitSnapshotObjectInputOutput(t *testing.T, repo, input string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
 	cmd.Dir = repo
-	cmd.Stdin = strings.NewReader(input.String())
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git fast-import deep snapshot lines: %v\n%s", err, out)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
 	}
-	return rev(t, repo, "refs/heads/deep-snapshot-lines")
+	return strings.TrimSpace(string(out))
 }
 
 func deepSnapshotLinePath(branch int) string {

--- a/internal/cli/neighbors_callsite_test.go
+++ b/internal/cli/neighbors_callsite_test.go
@@ -9,8 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/entireio/entire-graph/internal/sem"
 )
 
 // A section that was never queried must never render as an empty result: an
@@ -261,10 +259,10 @@ func TestCallSiteLocationOmitsRedundantDefinitionLine(t *testing.T) {
 	}
 }
 
-// Relation queries index the whole repository, so the cold cost must be paid at
-// most once for a clean tree: the second query is served from the cache, and a
-// dirty tree still bypasses it.
-func TestRelationQueryReusesIndexForCleanWorktreeOnly(t *testing.T) {
+// Relation queries read the mutable working tree by default. Until raw
+// worktree equality can be established without repository-selected filters,
+// every query must rebuild and no persistent search entry may be written.
+func TestRelationQueryRebuildsWorktreeIndex(t *testing.T) {
 	repo := t.TempDir()
 	runGit := func(args ...string) {
 		t.Helper()
@@ -302,14 +300,13 @@ func TestRelationQueryReusesIndexForCleanWorktreeOnly(t *testing.T) {
 	if first := query(); first.IndexCacheHit {
 		t.Fatal("first query on a cold cache reported a hit")
 	}
-	if second := query(); !second.IndexCacheHit {
-		t.Fatal("second query on a clean worktree did not reuse the index")
+	if second := query(); second.IndexCacheHit {
+		t.Fatal("second query on a clean worktree reused the index")
 	}
 
 	// A dirty working tree must never be served committed-tree content, and the
 	// edit must be visible.
 	write(t, repo, "calls.go", "package calls\n\nfunc Alpha() { Beta() }\nfunc Beta() {}\nfunc Delta() { Beta() }\n")
-	sem.InvalidateWorktreeCleanVerdicts()
 	dirty := query()
 	if dirty.IndexCacheHit {
 		t.Fatal("dirty worktree was served a cached index")
@@ -317,7 +314,9 @@ func TestRelationQueryReusesIndexForCleanWorktreeOnly(t *testing.T) {
 	if len(dirty.Matches) != 1 || len(dirty.Matches[0].Incoming) != 2 {
 		t.Fatalf("dirty worktree edit not visible: %#v", dirty.Matches)
 	}
-	if _, err := os.Stat(filepath.Join(cacheDir, "search")); err != nil {
-		t.Fatalf("cache directory was never written: %v", err)
+	if _, err := os.Stat(filepath.Join(cacheDir, "search")); err == nil {
+		t.Fatal("worktree query wrote a cache entry")
+	} else if !os.IsNotExist(err) {
+		t.Fatal(err)
 	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -314,9 +314,13 @@ func runProviderRecords(ctx context.Context, opts Options, args []string, mode s
 	// parse. Without this the CLI discards the summary and a run that silently
 	// parsed only a fraction of the repo (e.g. a mis-scoped subdir) looks clean.
 	var summary *sem.SnapshotSummary
+	var snapshotHeader sem.SnapshotHeader
 	capture := func(record any) {
-		if s, ok := record.(sem.SnapshotSummary); ok {
-			s := s
+		switch r := record.(type) {
+		case sem.SnapshotHeader:
+			snapshotHeader = r
+		case sem.SnapshotSummary:
+			s := r
 			summary = &s
 		}
 	}
@@ -349,17 +353,22 @@ func runProviderRecords(ctx context.Context, opts Options, args []string, mode s
 		return nil
 	}
 
-	// Whole-graph dump (no targeted filter): serve from the tree-hash record
-	// cache when possible. The cache is keyed on the HEAD tree, the mode, and the
-	// output-affecting options, so a repeat call on an unchanged HEAD skips the
-	// expensive re-index. It is deliberately bypassed for --worktree (the working
-	// tree may differ from HEAD) and, by returning above, for targeted queries.
+	// Whole-graph dump (no targeted filter): serve from the committed-record
+	// cache when possible. The cache is keyed on the exact HEAD commit and tree,
+	// the mode, and output-affecting options, so an unchanged HEAD skips the
+	// expensive re-index. It is deliberately bypassed for --worktree and, by
+	// returning above, for targeted queries.
 	cacheDir := resolveCacheDir(flags.CacheDir, opts.Env.PluginDataDir)
 	useCache := !flags.DisableCache && !flags.Worktree && cacheDir != ""
-	var tree string
+	var commit, tree string
 	if useCache {
-		if t, err := gitutil.RevParse(ctx, repo, "HEAD^{tree}"); err == nil && t != "" {
-			tree = t
+		if c, commitErr := gitutil.RevParse(ctx, repo, "HEAD^{commit}"); commitErr == nil && c != "" {
+			if t, treeErr := gitutil.RevParse(ctx, repo, c+"^{tree}"); treeErr == nil && t != "" {
+				commit = c
+				tree = t
+			} else {
+				useCache = false
+			}
 		} else {
 			useCache = false
 		}
@@ -368,8 +377,22 @@ func runProviderRecords(ctx context.Context, opts Options, args []string, mode s
 	if compact {
 		cacheMode = "snapshot:compact-ndjson-v1"
 	}
+	var recordsCache *sem.ProviderRecordsCacheTransaction
 	if useCache {
-		if records, cachedSummary, hit, err := sem.LoadProviderRecords(ctx, repo, opts.Version, tree, cacheMode, cacheDir, options); err == nil && hit {
+		recordsCache, err = sem.BeginProviderRecordsCache(ctx, repo, opts.Version, commit, tree, cacheMode, cacheDir, options)
+		if err != nil {
+			// Cache setup is optional. The uncached stream below will surface any
+			// policy-input error that also prevents a correct build.
+			useCache = false
+			recordsCache = nil
+		} else {
+			// Pin matcher construction to the exact policy bytes that keyed this
+			// lookup, and carry the same transaction through storage below.
+			options = recordsCache.Options()
+		}
+	}
+	if recordsCache != nil {
+		if records, cachedSummary, hit := recordsCache.Load(); hit {
 			if _, err := opts.Stdout.Write(records); err != nil {
 				return err
 			}
@@ -381,7 +404,7 @@ func runProviderRecords(ctx context.Context, opts Options, args []string, mode s
 	// On a miss, tee the serialized record stream into a buffer so we can persist it after
 	// a successful run without a second pass over the graph.
 	var recordBuf bytes.Buffer
-	if useCache {
+	if recordsCache != nil {
 		encodeRecord = newRecordEncoder(io.MultiWriter(opts.Stdout, &recordBuf))
 	}
 	if err := sem.StreamSnapshot(ctx, repo, opts.Version, options, func(record any) error {
@@ -394,9 +417,9 @@ func runProviderRecords(ctx context.Context, opts Options, args []string, mode s
 		return err
 	}
 	warnIfPartial(opts.Stderr, flags.Worktree, summary)
-	if useCache {
+	if recordsCache != nil {
 		// Best effort: a failed cache write never fails the command.
-		_ = sem.StoreProviderRecords(ctx, repo, opts.Version, tree, cacheMode, cacheDir, options, recordBuf.Bytes(), summary)
+		_ = recordsCache.Store(recordBuf.Bytes(), summary, snapshotHeader)
 	}
 	return nil
 }
@@ -479,7 +502,7 @@ type providerFlags struct {
 	To       string
 	From     string
 	Relation []string
-	// CacheDir/DisableCache control the tree-hash record cache. Empty CacheDir
+	// CacheDir/DisableCache control the committed-record cache. Empty CacheDir
 	// falls back to ENTIRE_PLUGIN_DATA_DIR; --no-cache disables it entirely.
 	CacheDir     string
 	DisableCache bool

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -251,6 +251,50 @@ func TestSnapshotAcceptsWorktree(t *testing.T) {
 	}
 }
 
+func TestProviderRecordsCacheDoesNotReplaySameTreeCommitHeader(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	write(t, repo, "main.go", "package sample\n\nfunc Main() {}\n")
+	git(t, repo, "add", "main.go")
+	git(t, repo, "commit", "-m", "initial")
+	cacheDir := t.TempDir()
+
+	run := func() string {
+		t.Helper()
+		var out bytes.Buffer
+		err := Run(t.Context(), Options{
+			Version: "commit-cache-test",
+			Env:     EntireEnv{RepoRoot: repo},
+			Stdout:  &out,
+			Stderr:  io.Discard,
+		}, []string{"snapshot", "--repo", repo, "--format", "ndjson", "--cache-dir", cacheDir})
+		if err != nil {
+			t.Fatal(err)
+		}
+		line, _, ok := bytes.Cut(out.Bytes(), []byte{'\n'})
+		if !ok {
+			t.Fatalf("snapshot omitted header line: %q", out.Bytes())
+		}
+		var header sem.SnapshotHeader
+		if err := json.Unmarshal(line, &header); err != nil {
+			t.Fatalf("decode snapshot header: %v\n%s", err, line)
+		}
+		return header.Commit
+	}
+
+	first := run()
+	git(t, repo, "commit", "--allow-empty", "-m", "same tree, new provenance")
+	second := run()
+	if want := rev(t, repo, "HEAD^{commit}"); second != want {
+		t.Fatalf("same-tree cache replayed commit %q, want current commit %q (first %q)", second, want, first)
+	}
+	if second == first {
+		t.Fatal("empty commit reused the previous snapshot header")
+	}
+}
+
 func TestSnapshotCompactNDJSONRoundTripsToNativeRecords(t *testing.T) {
 	repo := t.TempDir()
 	write(t, repo, "main.go", "package sample\n\nfunc caller() { callee() }\nfunc callee() {}\n")

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -1804,7 +1804,19 @@ func run(ctx context.Context, dir, name string, args ...string) (string, error) 
 const (
 	rawGitObjectsEnv    = "GIT_NO_REPLACE_OBJECTS=1"
 	noLazyFetchEnv      = "GIT_NO_LAZY_FETCH=1"
-	gitCommandWaitDelay = time.Second
+	// noTransportProtocolEnv is a second, independent no-egress guard.
+	// GIT_NO_LAZY_FETCH only became effective in Git 2.45 (git/git@2c206fc);
+	// this package's floor is Git 2.36 (cat-file --batch-command), so on any
+	// Git between those two versions GIT_NO_LAZY_FETCH is an unrecognized,
+	// silently ignored variable and a partial clone's promisor remote would
+	// still be lazily fetched with no guard at all. GIT_ALLOW_PROTOCOL has
+	// gated every transport since Git 2.11.1; set to empty it whitelists zero
+	// protocols, so any fetch a lazy-fetch would need to make (over http,
+	// https, ssh, or git) fails hard instead of being silently skipped like
+	// GIT_NO_LAZY_FETCH's own guard. This tool never intentionally fetches,
+	// clones, or pushes, so blocking every transport costs it nothing.
+	noTransportProtocolEnv = "GIT_ALLOW_PROTOCOL="
+	gitCommandWaitDelay    = time.Second
 )
 
 // newGitCmdWithCallerLocale builds the two git-grep subprocesses whose
@@ -1824,7 +1836,7 @@ func newGitCmdWithCallerLocale(ctx context.Context, dir string, args ...string) 
 	cmd.WaitDelay = gitCommandWaitDelay
 	// Cmd.Environ observes Dir and updates PWD accordingly. Append after the
 	// inherited environment so a hostile GIT_NO_REPLACE_OBJECTS=0 is overridden.
-	cmd.Env = append(cmd.Environ(), rawGitObjectsEnv, noLazyFetchEnv)
+	cmd.Env = append(cmd.Environ(), rawGitObjectsEnv, noLazyFetchEnv, noTransportProtocolEnv)
 	return cmd
 }
 
@@ -1845,7 +1857,9 @@ func newGitCmdWithCallerLocale(ctx context.Context, dir string, args ...string) 
 // exactly such a command). With lazy fetch disabled, Git reports a missing
 // promised object as a per-entry failure instead of fetching it — ls-tree -l
 // prints its "BAD" sentinel for a blob it cannot size, which callers already
-// classify as LimitedFileUnreadable rather than treating as an error.
+// classify as LimitedFileUnreadable rather than treating as an error. The
+// GIT_ALLOW_PROTOCOL guard alongside it closes the same gap on a Git older
+// than the lazy-fetch guard itself (see noTransportProtocolEnv).
 func newCmd(ctx context.Context, dir, name string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
@@ -1857,7 +1871,7 @@ func newCmd(ctx context.Context, dir, name string, args ...string) *exec.Cmd {
 	// os.Environ would leave child processes with the parent's stale PWD.
 	env := cmd.Environ()
 	if name == "git" {
-		env = append(env, rawGitObjectsEnv, noLazyFetchEnv)
+		env = append(env, rawGitObjectsEnv, noLazyFetchEnv, noTransportProtocolEnv)
 	}
 	cmd.Env = append(env, "LC_ALL=C", "LANG=C")
 	return cmd

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -1531,13 +1531,15 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 	if err != nil {
 		return nil, fmt.Errorf("git ls-tree metadata pipe: %w", err)
 	}
-	if err := cmd.Start(); err != nil {
+	job, err := startPathOutputCommand(cmd)
+	if err != nil {
 		message := strings.TrimSpace(stderr.String())
 		if message == "" {
 			message = err.Error()
 		}
 		return nil, fmt.Errorf("git ls-tree metadata: %s", message)
 	}
+	defer job.close()
 
 	entries := make(map[string]primedLimitedFile, len(paths))
 	outputCount := 0
@@ -1546,7 +1548,7 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 	for {
 		record, readErr := reader.ReadSlice(0)
 		if errors.Is(readErr, bufio.ErrBufferFull) {
-			stopPathOutputCommand(cmd, stdout)
+			stopPathOutputCommand(cmd, stdout, job)
 			return nil, fmt.Errorf(
 				"git ls-tree returned a metadata record longer than %d bytes",
 				literalPathspecBatchBytes+treeMetadataRecordOverheadMax,
@@ -1564,37 +1566,37 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 			return entries, nil
 		}
 		if len(record) == 0 || record[len(record)-1] != 0 {
-			stopPathOutputCommand(cmd, stdout)
+			stopPathOutputCommand(cmd, stdout, job)
 			return nil, errors.New("git ls-tree returned non-NUL-terminated metadata")
 		}
 		record = record[:len(record)-1]
 		tab := bytes.IndexByte(record, '\t')
 		if tab < 0 {
-			stopPathOutputCommand(cmd, stdout)
+			stopPathOutputCommand(cmd, stdout, job)
 			return nil, errors.New("git ls-tree returned malformed metadata")
 		}
 		fields := strings.Fields(string(record[:tab]))
 		if len(fields) != 4 {
-			stopPathOutputCommand(cmd, stdout)
+			stopPathOutputCommand(cmd, stdout, job)
 			return nil, fmt.Errorf("git ls-tree returned malformed metadata header %q", record[:tab])
 		}
 		path := string(record[tab+1:])
 		if _, ok := known[path]; !ok {
-			stopPathOutputCommand(cmd, stdout)
+			stopPathOutputCommand(cmd, stdout, job)
 			return nil, fmt.Errorf("git ls-tree returned unexpected path %q", path)
 		}
 		if _, duplicate := entries[path]; duplicate {
-			stopPathOutputCommand(cmd, stdout)
+			stopPathOutputCommand(cmd, stdout, job)
 			return nil, fmt.Errorf("git ls-tree returned duplicate path %q", path)
 		}
 		outputCount++
 		outputBytes += len(record) + 1
 		if outputCount > len(known) || outputCount > literalPathspecBatchCount {
-			stopPathOutputCommand(cmd, stdout)
+			stopPathOutputCommand(cmd, stdout, job)
 			return nil, fmt.Errorf("git ls-tree returned more than %d metadata records", len(known))
 		}
 		if outputBytes > expectedOutputBytes {
-			stopPathOutputCommand(cmd, stdout)
+			stopPathOutputCommand(cmd, stdout, job)
 			return nil, fmt.Errorf("git ls-tree returned more than %d metadata bytes", expectedOutputBytes)
 		}
 		if fields[1] != "blob" {
@@ -1619,7 +1621,7 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 		}
 		size, err := strconv.ParseInt(fields[3], 10, 64)
 		if err != nil || size < 0 {
-			stopPathOutputCommand(cmd, stdout)
+			stopPathOutputCommand(cmd, stdout, job)
 			return nil, fmt.Errorf("parse git ls-tree blob size %q for %q", fields[3], path)
 		}
 		entries[path] = primedLimitedFile{
@@ -1628,7 +1630,7 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 			objectType: fields[1],
 		}
 		if readErr != nil {
-			stopPathOutputCommand(cmd, stdout)
+			stopPathOutputCommand(cmd, stdout, job)
 			return nil, fmt.Errorf("read git ls-tree metadata: %w", readErr)
 		}
 	}

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -559,59 +559,122 @@ func ShowFile(ctx context.Context, repo, rev, path string) (string, bool, error)
 // could not express that — checking len(content) afterwards bounds the ANSWER
 // once the allocation has already happened. The other bounded readers here do
 // not work that way: the batch reader decides off the size in its header, and
-// the on-disk reader stats before it opens. This asks git for the size first,
-// for the same reason and with the same shape.
+// the on-disk reader stats before it opens. This asks Git for the object type
+// and then its size first, for the same reason and with the same shape.
 //
 // Deciding from the size, rather than reading through an io.LimitReader and
 // stopping git once the ceiling is passed, is deliberate. The reading form
 // deadlocked on Windows: killing git left a grandchild holding the inherited
 // stderr handle, so the copier goroutine never saw EOF and Cmd.Wait blocked in
 // awaitGoroutines forever. Nothing here now depends on process-tree teardown.
-// The extra `cat-file -s` is one small process on a path that is already the
+// The extra `cat-file` probes are small processes on a path that is already the
 // rare fallback for a Git path containing a newline.
 //
-// The size probe cannot make an answer WORSE than ShowFile's: it is best effort,
-// and anything it fails to establish falls through to the read, which keeps its
-// own absent-vs-failed classification.
+// The metadata probe is authoritative only when Git identifies the object. A
+// blob proceeds to the size decision below; a non-blob (notably a gitlink's
+// commit object) is refused before `git show` can render that object's patch.
+// Anything the probe cannot establish falls through to the read, which keeps
+// ShowFile's absent-vs-failed classification.
 func ShowFileLimited(ctx context.Context, repo, rev, path string, maxBytes int64) (string, bool, error) {
 	return showFileLimited(ctx, repo, rev, path, maxBytes, blobSizeAtRev)
 }
 
-// showFileLimited takes the probe as an argument so a test can exercise the
-// no-answer path, which is otherwise unreachable: the probe and the read resolve
-// the same object through the same git, so making one fail while the other
-// succeeds is not something a fixture repository can arrange.
+// LimitedFileStatus classifies the outcome of ReadFileLimited without
+// conflating a missing path, an oversized blob, and a non-blob tree entry.
+type LimitedFileStatus uint8
+
+const (
+	LimitedFileMissing LimitedFileStatus = iota
+	LimitedFileContent
+	LimitedFileOversize
+	LimitedFileNonBlob
+)
+
+// LimitedFileResult is the bounded, typed result for one path at a revision.
+// Content is populated only for LimitedFileContent. Bytes is the exact content
+// size for LimitedFileContent and LimitedFileOversize; the latter comes from
+// Git's object metadata whenever the probe succeeds, so the blob is not read.
+type LimitedFileResult struct {
+	Status  LimitedFileStatus
+	Content string
+	Bytes   int64
+}
+
+// ReadFileLimited is the typed form of ShowFileLimited. Callers that need one
+// coherent snapshot across this metadata probe and other Git operations must
+// pass an already-resolved immutable revision rather than a moving ref name.
+func ReadFileLimited(ctx context.Context, repo, rev, path string, maxBytes int64) (LimitedFileResult, error) {
+	return readFileLimited(ctx, repo, rev, path, maxBytes, blobSizeAtRev)
+}
+
+// showFileLimited preserves the compact historical API for callers that only
+// distinguish returned content from unavailable content.
 func showFileLimited(
 	ctx context.Context,
 	repo, rev, path string,
 	maxBytes int64,
-	probe func(ctx context.Context, repo, rev, path string) (int64, bool),
+	probe func(ctx context.Context, repo, rev, path string) (int64, blobProbeStatus),
 ) (string, bool, error) {
-	if maxBytes <= 0 {
-		return ShowFile(ctx, repo, rev, path)
+	result, err := readFileLimited(ctx, repo, rev, path, maxBytes, probe)
+	if err != nil {
+		return "", false, err
 	}
-	// The probe only ever ADDS an early refusal. Every outcome it cannot speak to
-	// — missing path, bad revision, a git whose diagnostics are worded
-	// differently, a size that will not parse — falls through to ShowFile, which
-	// stays the one place absent-vs-failed is decided. Classifying a second
-	// command's stderr with a matcher written for `git show` would have put that
-	// contract at the mercy of another command's wording.
-	if size, known := probe(ctx, repo, rev, path); known && size > maxBytes {
+	if result.Status != LimitedFileContent {
+		return "", false, nil
+	}
+	return result.Content, true, nil
+}
+
+// readFileLimited takes the probe as an argument so a test can exercise the
+// best-effort no-answer path without relying on a transient Git failure.
+func readFileLimited(
+	ctx context.Context,
+	repo, rev, path string,
+	maxBytes int64,
+	probe func(ctx context.Context, repo, rev, path string) (int64, blobProbeStatus),
+) (LimitedFileResult, error) {
+	if maxBytes <= 0 {
+		content, ok, err := ShowFile(ctx, repo, rev, path)
+		if err != nil {
+			return LimitedFileResult{}, err
+		}
+		if !ok {
+			return LimitedFileResult{Status: LimitedFileMissing}, nil
+		}
+		return LimitedFileResult{Status: LimitedFileContent, Content: content, Bytes: int64(len(content))}, nil
+	}
+	// An identified non-blob is not file content. In particular, `git show` on a
+	// gitlink's small commit object renders the commit's potentially enormous
+	// patch, so trusting only that object's size would defeat the caller's bound.
+	// Unknown outcomes — missing path, bad revision, unexpected diagnostics, or
+	// an unparsable size — still fall through to ShowFile, which remains the one
+	// place absent-vs-failed is decided.
+	size, status := probe(ctx, repo, rev, path)
+	if status == blobProbeNonBlob {
+		return LimitedFileResult{Status: LimitedFileNonBlob}, nil
+	}
+	if status == blobProbeBlob && size > maxBytes {
 		// Refused, not failed: a blob this caller cannot quote, exactly like a
 		// missing one. No content was read to learn this.
-		return "", false, nil
+		return LimitedFileResult{Status: LimitedFileOversize, Bytes: size}, nil
 	}
 	// The commit is immutable, so a size measured above is the size that will be
 	// read — there is no grow-between-calls race to guard against here.
 	content, ok, err := ShowFile(ctx, repo, rev, path)
-	if ok && int64(len(content)) > maxBytes {
+	if err != nil {
+		return LimitedFileResult{}, err
+	}
+	if !ok {
+		return LimitedFileResult{Status: LimitedFileMissing}, nil
+	}
+	if int64(len(content)) > maxBytes {
 		// Only reachable when the probe gave no answer. The bytes are already
 		// allocated, so this cannot restore the memory bound — but it keeps the
 		// ANSWER identical either way, so a caller never receives content it
 		// declared too large to accept.
-		return "", false, nil
+		return LimitedFileResult{Status: LimitedFileOversize, Bytes: int64(len(content))}, nil
 	}
-	return content, ok, err
+	return LimitedFileResult{Status: LimitedFileContent, Content: content, Bytes: int64(len(content))}, nil
 }
 
 // OversizeBlobAtRev reports the size, content hash and line count of the blob at
@@ -668,19 +731,35 @@ func OversizeBlobAtRev(ctx context.Context, repo, rev, path string, maxBytes int
 	return OversizeBlob{Bytes: digest.Bytes, Hash: digest.Hash, Lines: digest.Lines}, true, nil
 }
 
-// blobSizeAtRev reports the size of the blob at rev:path without reading it.
-// It is BEST EFFORT by design: known=false means "no answer", never "absent" or
-// "broken", so a caller can only use it to refuse, not to conclude.
-func blobSizeAtRev(ctx context.Context, repo, rev, path string) (int64, bool) {
-	out, _, err := runWithStderr(ctx, repo, "git", "cat-file", "-s", rev+"^{tree}:"+path)
+type blobProbeStatus uint8
+
+const (
+	blobProbeUnknown blobProbeStatus = iota
+	blobProbeBlob
+	blobProbeNonBlob
+)
+
+// blobSizeAtRev reports the type and, for a blob, the size of rev:path without
+// reading its content. It is best effort: unknown means "no answer", never
+// "absent" or "broken", so a caller can only use it to refuse, not to conclude.
+func blobSizeAtRev(ctx context.Context, repo, rev, path string) (int64, blobProbeStatus) {
+	objectSpec := rev + "^{tree}:" + path
+	typeOut, _, err := runWithStderr(ctx, repo, "git", "cat-file", "-t", objectSpec)
 	if err != nil {
-		return 0, false
+		return 0, blobProbeUnknown
+	}
+	if strings.TrimSpace(typeOut) != "blob" {
+		return 0, blobProbeNonBlob
+	}
+	out, _, err := runWithStderr(ctx, repo, "git", "cat-file", "-s", objectSpec)
+	if err != nil {
+		return 0, blobProbeUnknown
 	}
 	size, parseErr := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
-	if parseErr != nil {
-		return 0, false
+	if parseErr != nil || size < 0 {
+		return 0, blobProbeUnknown
 	}
-	return size, true
+	return size, blobProbeBlob
 }
 
 func isMissingPathDiagnostic(stderr string) bool {

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -890,26 +890,21 @@ func isMissingPathDiagnostic(stderr string) bool {
 			strings.Contains(stderr, "' exists on disk, but not in '"))
 }
 
-// BatchFileReader reads blobs from one revision through persistent
-// `git cat-file --batch-check` metadata and `--batch` content processes. The
-// metadata process prevents non-blobs from entering the content stream; the
-// content process still streams oversized blobs for caller digests. Together
-// they avoid per-file process spawning while preserving HEAD-tree snapshot
-// semantics. Paths are relative to repo; rev represents the repository-root
-// tree when repo is a subdirectory.
+// BatchFileReader reads blobs from one revision through one persistent
+// `git cat-file --batch-command` process. Each read issues `info` first and
+// issues `contents` only for a blob, so a non-blob never enters the content
+// stream. Keeping both commands in one Git process also gives them one snapshot
+// of replace refs; an immutable OID cannot change type between the metadata and
+// content responses. Oversized blobs are still streamed for caller digests.
+// Paths are relative to repo; rev represents the repository-root tree when repo
+// is a subdirectory.
 type BatchFileReader struct {
-	ctx          context.Context
-	repo         string
 	rev          string
 	pathPrefix   string
 	cmd          *exec.Cmd
 	stdin        io.WriteCloser
 	stdout       *bufio.Reader
 	stderr       *bytes.Buffer
-	checkCmd     *exec.Cmd
-	checkStdin   io.WriteCloser
-	checkStdout  *bufio.Reader
-	checkStderr  *bytes.Buffer
 	mu           sync.Mutex
 	closed       bool
 	maxBytes     int64
@@ -966,7 +961,7 @@ func NewBatchFileReader(ctx context.Context, repo, rev string) (*BatchFileReader
 	if err != nil {
 		return nil, err
 	}
-	cmd := newCmd(ctx, repo, "git", "cat-file", "--batch")
+	cmd := newCmd(ctx, repo, "git", "cat-file", "--batch-command")
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, err
@@ -980,23 +975,42 @@ func NewBatchFileReader(ctx context.Context, repo, rev string) (*BatchFileReader
 	cmd.Stderr = &stderr
 	if err := cmd.Start(); err != nil {
 		_ = stdin.Close()
-		return nil, fmt.Errorf("git cat-file --batch: %w", err)
+		return nil, fmt.Errorf("git cat-file --batch-command (requires Git 2.36 or newer): %w", err)
 	}
-	return &BatchFileReader{
-		ctx:        ctx,
-		repo:       repo,
+	reader := &BatchFileReader{
 		rev:        rev,
 		pathPrefix: pathPrefix,
 		cmd:        cmd,
 		stdin:      stdin,
 		stdout:     bufio.NewReader(stdoutPipe),
 		stderr:     &stderr,
-	}, nil
+	}
+	// Start is not enough to feature-detect an option: an older Git starts and
+	// then exits after parsing argv. A metadata-only missing-object request
+	// verifies the protocol without reading an object body. It also establishes
+	// the replace-ref snapshot at reader construction, before caller reads begin.
+	const probeOID = "0000000000000000000000000000000000000000"
+	if _, _, _, found, probeErr := reader.objectInfoLocked(probeOID); probeErr != nil || found {
+		_ = stdin.Close()
+		waitErr := cmd.Wait()
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			if probeErr != nil {
+				msg = probeErr.Error()
+			} else if waitErr != nil {
+				msg = waitErr.Error()
+			} else {
+				msg = "unexpected response to protocol probe"
+			}
+		}
+		return nil, fmt.Errorf("git cat-file --batch-command unavailable (Git 2.36 or newer required): %s", msg)
+	}
+	return reader, nil
 }
 
 // IsBatchPathSafe reports whether path can be embedded in one LF-delimited
-// cat-file --batch request without splitting or normalization. A trailing CR
-// is consumed by Git's line reader; internal CR bytes are preserved.
+// cat-file batch-command request without splitting or normalization. A
+// trailing CR is consumed by Git's line reader; internal CR bytes are preserved.
 func IsBatchPathSafe(path string) bool {
 	return !strings.Contains(path, "\n") && !strings.HasSuffix(path, "\r")
 }
@@ -1026,90 +1040,69 @@ func (r *BatchFileReader) ReadFile(path string) (string, bool, error) {
 func (r *BatchFileReader) readCheckedObjectSpec(objectSpec, oversizeKey string) (string, bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	objectID, objectType, found, err := r.checkObjectSpecLocked(objectSpec)
+	objectID, objectType, objectSize, found, err := r.objectInfoLocked(objectSpec)
 	if err != nil || !found {
 		return "", false, err
 	}
 	if objectType != "blob" {
-		// Never ask the content batch for a non-blob. Its protocol places the
-		// complete object after the header, so declining only after that request
-		// would still have to stream an arbitrarily large tree or commit merely to
-		// reach the next response. The metadata batch has no object body to drain.
+		// Never issue contents for a non-blob. That response places the complete
+		// object after its header, so declining only after the request would still
+		// have to stream an arbitrarily large tree or commit merely to reach the next
+		// response. The info response has no object body to drain.
 		return "", false, nil
 	}
 	// Pin the checked object before asking for content. Besides avoiding a second
 	// path-bearing request, this keeps a moving ref from changing object type
-	// between the metadata and content batches.
-	return r.readObjectSpecLocked(objectID, oversizeKey)
+	// between the metadata and content commands.
+	return r.readObjectContentsLocked(objectID, objectType, objectSize, oversizeKey)
 }
 
-// readKnownBlobObjectID is the content-only path for LimitedFileReader, whose
-// authoritative ls-tree metadata already established that objectID is a blob.
-// The request contains only an immutable OID, never repository path bytes.
+// readKnownBlobObjectID is the exact-OID path for LimitedFileReader, whose
+// ls-tree metadata established that objectID was a blob at metadata time. It
+// still repeats the type check in this SAME batch-command process before asking
+// for contents: a replace ref may have moved between ls-tree and this process's
+// snapshot. The request contains only an immutable OID, never repository path
+// bytes.
 func (r *BatchFileReader) readKnownBlobObjectID(objectID, oversizeKey string) (string, bool, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.readObjectSpecLocked(objectID, oversizeKey)
+	return r.readCheckedObjectSpec(objectID, oversizeKey)
 }
 
-func (r *BatchFileReader) checkObjectSpecLocked(objectSpec string) (string, string, bool, error) {
+func (r *BatchFileReader) objectInfoLocked(objectSpec string) (string, string, int64, bool, error) {
 	if r.closed {
-		return "", "", false, fmt.Errorf("git cat-file batch reader is closed")
+		return "", "", 0, false, fmt.Errorf("git cat-file batch reader is closed")
 	}
-	if r.checkCmd == nil {
-		cmd := newCmd(r.ctx, r.repo, "git", "cat-file", "--batch-check")
-		stdin, err := cmd.StdinPipe()
-		if err != nil {
-			return "", "", false, err
-		}
-		stdoutPipe, err := cmd.StdoutPipe()
-		if err != nil {
-			_ = stdin.Close()
-			return "", "", false, err
-		}
-		stderr := &bytes.Buffer{}
-		cmd.Stderr = stderr
-		if err := cmd.Start(); err != nil {
-			_ = stdin.Close()
-			return "", "", false, fmt.Errorf("git cat-file --batch-check: %w", err)
-		}
-		r.checkCmd = cmd
-		r.checkStdin = stdin
-		r.checkStdout = bufio.NewReader(stdoutPipe)
-		r.checkStderr = stderr
+	if _, err := fmt.Fprintf(r.stdin, "info %s\n", objectSpec); err != nil {
+		return "", "", 0, false, err
 	}
-	if _, err := fmt.Fprintf(r.checkStdin, "%s\n", objectSpec); err != nil {
-		return "", "", false, err
-	}
-	header, err := r.checkStdout.ReadString('\n')
+	header, err := r.stdout.ReadString('\n')
 	if err != nil {
-		return "", "", false, fmt.Errorf("read git cat-file batch-check header: %w", err)
+		return "", "", 0, false, fmt.Errorf("read git cat-file batch-command info header: %w", err)
 	}
 	header = strings.TrimSuffix(header, "\n")
 	if strings.HasSuffix(header, " missing") {
-		return "", "", false, nil
+		return "", "", 0, false, nil
 	}
 	fields := strings.Fields(header)
 	if len(fields) != 3 {
-		return "", "", false, fmt.Errorf("unexpected git cat-file batch-check header %q", header)
+		return "", "", 0, false, fmt.Errorf("unexpected git cat-file batch-command info header %q", header)
 	}
 	size, err := strconv.ParseInt(fields[2], 10, 64)
 	if err != nil || size < 0 {
-		return "", "", false, fmt.Errorf("parse git cat-file batch-check size %q", fields[2])
+		return "", "", 0, false, fmt.Errorf("parse git cat-file batch-command info size %q", fields[2])
 	}
-	return fields[0], fields[1], true, nil
+	return fields[0], fields[1], size, true, nil
 }
 
-func (r *BatchFileReader) readObjectSpecLocked(objectSpec, oversizeKey string) (string, bool, error) {
+func (r *BatchFileReader) readObjectContentsLocked(objectSpec, expectedType string, expectedSize int64, oversizeKey string) (string, bool, error) {
 	if r.closed {
 		return "", false, fmt.Errorf("git cat-file batch reader is closed")
 	}
-	if _, err := fmt.Fprintf(r.stdin, "%s\n", objectSpec); err != nil {
+	if _, err := fmt.Fprintf(r.stdin, "contents %s\n", objectSpec); err != nil {
 		return "", false, err
 	}
 	header, err := r.stdout.ReadString('\n')
 	if err != nil {
-		return "", false, fmt.Errorf("read git cat-file header: %w", err)
+		return "", false, fmt.Errorf("read git cat-file batch-command contents header: %w", err)
 	}
 	header = strings.TrimSuffix(header, "\n")
 	if strings.HasSuffix(header, " missing") {
@@ -1117,17 +1110,23 @@ func (r *BatchFileReader) readObjectSpecLocked(objectSpec, oversizeKey string) (
 	}
 	fields := strings.Fields(header)
 	if len(fields) != 3 {
-		return "", false, fmt.Errorf("unexpected git cat-file header %q", header)
+		return "", false, fmt.Errorf("unexpected git cat-file batch-command contents header %q", header)
 	}
 	size, err := strconv.ParseInt(fields[2], 10, 64)
-	if err != nil {
-		return "", false, fmt.Errorf("parse git cat-file size %q: %w", fields[2], err)
+	if err != nil || size < 0 {
+		return "", false, fmt.Errorf("parse git cat-file size %q", fields[2])
+	}
+	if fields[0] != objectSpec || fields[1] != expectedType || size != expectedSize {
+		// info and contents share one process, so their resolved identity, type and
+		// size must agree. Do not drain an unexpected body merely to salvage the
+		// protocol: that is exactly the unbounded non-blob read this gate prevents.
+		_ = r.cmd.Process.Kill()
+		return "", false, fmt.Errorf("git cat-file batch-command metadata changed between info and contents: info=%s %s %d contents=%s %s %d",
+			objectSpec, expectedType, expectedSize, fields[0], fields[1], size)
 	}
 	if fields[1] != "blob" {
-		if _, err := io.CopyN(io.Discard, r.stdout, size+1); err != nil {
-			return "", false, err
-		}
-		return "", false, nil
+		_ = r.cmd.Process.Kill()
+		return "", false, fmt.Errorf("git cat-file batch-command returned non-blob contents after blob info: %s", fields[1])
 	}
 	if r.maxBytes > 0 && size > r.maxBytes {
 		var src io.Reader = io.LimitReader(r.stdout, size)
@@ -1140,8 +1139,12 @@ func (r *BatchFileReader) readObjectSpecLocked(objectSpec, oversizeKey string) (
 		if err != nil {
 			return "", false, err
 		}
-		if _, err := io.CopyN(io.Discard, r.stdout, 1); err != nil {
+		trailing, err := r.stdout.ReadByte()
+		if err != nil {
 			return "", false, err
+		}
+		if trailing != '\n' {
+			return "", false, fmt.Errorf("git cat-file blob missing trailing newline separator")
 		}
 		if r.oversize == nil {
 			r.oversize = map[string]OversizeBlob{}
@@ -1171,34 +1174,17 @@ func (r *BatchFileReader) Close() error {
 	}
 	r.closed = true
 	stdin := r.stdin
-	checkStdin := r.checkStdin
-	checkCmd := r.checkCmd
-	checkStderr := r.checkStderr
 	r.mu.Unlock()
 	var closeErrors []error
 	if err := stdin.Close(); err != nil {
 		closeErrors = append(closeErrors, err)
-	}
-	if checkStdin != nil {
-		if err := checkStdin.Close(); err != nil {
-			closeErrors = append(closeErrors, err)
-		}
 	}
 	if err := r.cmd.Wait(); err != nil {
 		msg := strings.TrimSpace(r.stderr.String())
 		if msg == "" {
 			msg = err.Error()
 		}
-		closeErrors = append(closeErrors, fmt.Errorf("git cat-file --batch: %s", msg))
-	}
-	if checkCmd != nil {
-		if err := checkCmd.Wait(); err != nil {
-			msg := strings.TrimSpace(checkStderr.String())
-			if msg == "" {
-				msg = err.Error()
-			}
-			closeErrors = append(closeErrors, fmt.Errorf("git cat-file --batch-check: %s", msg))
-		}
+		closeErrors = append(closeErrors, fmt.Errorf("git cat-file --batch-command: %s", msg))
 	}
 	return errors.Join(closeErrors...)
 }

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -1527,11 +1527,16 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 	cmd := newCmd(ctx, repo, "git", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
+	launch, err := preparePathOutputCommand(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("git ls-tree metadata: %w", err)
+	}
+	defer launch.close()
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, fmt.Errorf("git ls-tree metadata pipe: %w", err)
 	}
-	job, err := startPathOutputCommand(cmd)
+	job, err := launch.start(cmd)
 	if err != nil {
 		message := strings.TrimSpace(stderr.String())
 		if message == "" {

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -90,7 +90,13 @@ func repoTreePath(ctx context.Context, repo, path string) (string, error) {
 }
 
 func RevParse(ctx context.Context, repo, rev string) (string, error) {
-	out, err := run(ctx, repo, "git", "rev-parse", rev)
+	// --verify --end-of-options: rev can be a caller-supplied label (e.g. a
+	// diff --base/--head argument). Plain `git rev-parse --end-of-options
+	// <rev>` still just ECHOES an option-shaped arg back on its own output
+	// line instead of rejecting it (rev-parse's parseopt-style passthrough
+	// for shell scripts) -- --verify is what turns "not a revision" into a
+	// hard, single-line failure instead of a silently wrong resolution.
+	out, err := run(ctx, repo, "git", "rev-parse", "--verify", "--end-of-options", rev)
 	if err != nil {
 		return "", err
 	}
@@ -98,7 +104,10 @@ func RevParse(ctx context.Context, repo, rev string) (string, error) {
 }
 
 func FirstParent(ctx context.Context, repo, rev string) (string, error) {
-	out, err := run(ctx, repo, "git", "rev-parse", rev+"^")
+	// --verify --end-of-options: rev is a caller-supplied revision label
+	// (e.g. the `entire commit <rev>` CLI argument); guard it the same way
+	// RevParse does.
+	out, err := run(ctx, repo, "git", "rev-parse", "--verify", "--end-of-options", rev+"^")
 	if err != nil {
 		return "", fmt.Errorf("resolve first parent for %s: %w", rev, err)
 	}

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -822,7 +822,8 @@ func OversizeBlobAtRev(ctx context.Context, repo, rev, path string, maxBytes int
 	if err := cmd.Start(); err != nil {
 		return OversizeBlob{}, false, fmt.Errorf("git cat-file blob: %w", err)
 	}
-	digest, digestErr := filedigest.Stream(stdout)
+	prefix := make([]byte, 0, oversizeBlobPrefixCap)
+	digest, digestErr := filedigest.Stream(io.TeeReader(stdout, prefixCaptureWriter{buf: &prefix}))
 	// Drain anything the digest did not consume before waiting. git blocks on a
 	// full pipe, and Wait would then block on git.
 	_, _ = io.Copy(io.Discard, stdout)
@@ -842,7 +843,7 @@ func OversizeBlobAtRev(ctx context.Context, repo, rev, path string, maxBytes int
 	if digest.Bytes <= maxBytes {
 		return OversizeBlob{}, false, nil
 	}
-	return OversizeBlob{Bytes: digest.Bytes, Hash: digest.Hash, Lines: digest.Lines}, true, nil
+	return OversizeBlob{Bytes: digest.Bytes, Hash: digest.Hash, Lines: digest.Lines, Prefix: string(prefix)}, true, nil
 }
 
 type blobProbeStatus uint8
@@ -920,6 +921,35 @@ type OversizeBlob struct {
 	Bytes int64
 	Hash  string
 	Lines int
+	// Prefix holds up to oversizeBlobPrefixCap leading bytes, captured for
+	// free from the same mandatory streaming pass that computes Hash and
+	// Lines. Git blob reads are all-or-nothing, so a refused blob otherwise
+	// cannot be prefix-sniffed at all (for example, to route an
+	// extensionless committed file by its shebang line) without a second,
+	// unbounded read of the same object.
+	Prefix string
+}
+
+// oversizeBlobPrefixCap bounds OversizeBlob.Prefix. It is comfortably above
+// the largest known prefix consumer (shebang sniffing) while staying a fixed,
+// small cost independent of the blob's real size.
+const oversizeBlobPrefixCap = 4096
+
+// prefixCaptureWriter retains up to oversizeBlobPrefixCap leading bytes
+// written to it and discards the rest, for use as an io.TeeReader sink
+// alongside a digest pass that must consume the whole stream anyway.
+type prefixCaptureWriter struct {
+	buf *[]byte
+}
+
+func (w prefixCaptureWriter) Write(p []byte) (int, error) {
+	if room := oversizeBlobPrefixCap - len(*w.buf); room > 0 {
+		if room > len(p) {
+			room = len(p)
+		}
+		*w.buf = append(*w.buf, p[:room]...)
+	}
+	return len(p), nil
 }
 
 // SetOversizeScanner registers a callback invoked with successive chunks of an OVERSIZE blob as it
@@ -1148,11 +1178,14 @@ func (r *BatchFileReader) readObjectContentsLocked(objectSpec, expectedType stri
 	}
 	if r.maxBytes > 0 && size > r.maxBytes {
 		var src io.Reader = io.LimitReader(r.stdout, size)
+		prefix := make([]byte, 0, oversizeBlobPrefixCap)
+		tee := io.Writer(prefixCaptureWriter{buf: &prefix})
 		if scan := r.oversizeScan; scan != nil {
 			// The same single pass the digest already makes: the scanner sees the bytes on their
 			// way to being discarded, so relevance costs no extra read and no retained memory.
-			src = io.TeeReader(src, oversizeScanWriter{path: oversizeKey, scan: scan})
+			tee = io.MultiWriter(tee, oversizeScanWriter{path: oversizeKey, scan: scan})
 		}
+		src = io.TeeReader(src, tee)
 		digest, err := filedigest.Stream(src)
 		if err != nil {
 			return "", false, r.poisonLocked(fmt.Errorf("stream oversized git blob: %w", err))
@@ -1170,7 +1203,7 @@ func (r *BatchFileReader) readObjectContentsLocked(objectSpec, expectedType stri
 		if r.oversize == nil {
 			r.oversize = map[string]OversizeBlob{}
 		}
-		r.oversize[oversizeKey] = OversizeBlob{Bytes: digest.Bytes, Hash: digest.Hash, Lines: digest.Lines}
+		r.oversize[oversizeKey] = OversizeBlob{Bytes: digest.Bytes, Hash: digest.Hash, Lines: digest.Lines, Prefix: string(prefix)}
 		return "", false, nil
 	}
 	content := make([]byte, size)
@@ -1314,9 +1347,10 @@ func NewLimitedFileReader(ctx context.Context, repo, rev string, maxBytes int64)
 	}
 }
 
-// SetDeadline bounds only the exceptional component-by-component metadata
-// traversal. Ordinary short-path batches remain one process and unchanged.
-// A zero deadline restores the historical no-deadline behavior.
+// SetDeadline bounds the component-by-component metadata traversal, and also
+// stops Prime from starting further metadata batches once elapsed (checked
+// between batches, not mid-batch: one already-started batch still runs to
+// completion). A zero deadline restores the historical no-deadline behavior.
 func (r *LimitedFileReader) SetDeadline(deadline time.Time) {
 	r.mu.Lock()
 	r.deadline = deadline
@@ -1340,6 +1374,20 @@ func (r *LimitedFileReader) Prime(paths []string) error {
 		r.primed = make(map[string]primedLimitedFile, len(paths))
 	}
 	for start := 0; start < len(paths); {
+		// An unbounded candidate list otherwise runs every batch to completion
+		// before the caller's overBudget check ever sees it: SetDeadline only
+		// bounded the exceptional component-by-component path above. Once the
+		// deadline elapses, stop starting new metadata subprocesses and mark
+		// every remaining path unaddressable instead, exactly like the
+		// component traversal's own deadline refusal.
+		if r.deadlineReached() {
+			for _, path := range paths[start:] {
+				if _, already := r.primed[path]; !already {
+					r.primed[path] = unaddressableLimitedFile()
+				}
+			}
+			return nil
+		}
 		// A rare over-limit full path is resolved one tree component at a time.
 		// No command receives the whole path, while the final exact blob OID can
 		// still use the persistent content batch.
@@ -1431,7 +1479,7 @@ func (r *LimitedFileReader) componentEntryMetadata(
 	if metadata, ok := r.componentMetadata[key]; ok {
 		return metadata, true, nil
 	}
-	if r.componentMetadataProcesses >= limitedFileComponentMetadataProcessLimit || r.componentDeadlineReached() {
+	if r.componentMetadataProcesses >= limitedFileComponentMetadataProcessLimit || r.deadlineReached() {
 		return treeComponentMetadataResult{}, false, nil
 	}
 	r.componentMetadataProcesses++
@@ -1448,7 +1496,7 @@ func (r *LimitedFileReader) componentEntryMetadata(
 	return metadata, true, nil
 }
 
-func (r *LimitedFileReader) componentDeadlineReached() bool {
+func (r *LimitedFileReader) deadlineReached() bool {
 	if r.deadline.IsZero() {
 		return false
 	}

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -52,6 +52,26 @@ func RepoRoot(ctx context.Context, cwd string) (string, error) {
 	return strings.TrimSuffix(out, "\n"), nil
 }
 
+// RepoPrefix reports cwd's path from the repository root, including Git's
+// trailing slash when non-empty. Git is authoritative here: linked worktrees,
+// submodules, and unusual path bytes must use the same coordinate system as
+// tree object expressions. Only Git's final LF is removed.
+func RepoPrefix(ctx context.Context, cwd string) (string, error) {
+	out, err := run(ctx, cwd, "git", "rev-parse", "--show-prefix")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(out, "\n"), nil
+}
+
+func repoTreePath(ctx context.Context, repo, path string) (string, error) {
+	prefix, err := RepoPrefix(ctx, repo)
+	if err != nil {
+		return "", err
+	}
+	return prefix + path, nil
+}
+
 func RevParse(ctx context.Context, repo, rev string) (string, error) {
 	out, err := run(ctx, repo, "git", "rev-parse", rev)
 	if err != nil {
@@ -520,6 +540,9 @@ func FileCochanges(ctx context.Context, repo, revision string, maxCommits int) (
 	return pairs, nil
 }
 
+// ShowFile reads path relative to repo from a revision that represents the
+// repository-root tree. When repo is a subdirectory, Git's authoritative cwd
+// prefix is added before resolving the object.
 func ShowFile(ctx context.Context, repo, rev, path string) (string, bool, error) {
 	// Classify against git's stderr only, never the wrapped error that echoes
 	// the argv (which includes rev+":"+path). Matching the full error text made
@@ -528,7 +551,11 @@ func ShowFile(ctx context.Context, repo, rev, path string) (string, bool, error)
 	// Peel the revision to a tree before resolving the path. Without the type
 	// constraint, a missing full object ID or a blob object can produce the
 	// same path-looking diagnostic as a genuinely absent file.
-	objectSpec := rev + "^{tree}:" + path
+	treePath, err := repoTreePath(ctx, repo, path)
+	if err != nil {
+		return "", false, err
+	}
+	objectSpec := rev + "^{tree}:" + treePath
 	out, stderr, err := runWithStderr(ctx, repo, "git", "show", objectSpec)
 	if err != nil {
 		if isMissingPathDiagnostic(stderr) {
@@ -590,6 +617,10 @@ const (
 	LimitedFileContent
 	LimitedFileOversize
 	LimitedFileNonBlob
+	// LimitedFileUnaddressable means a valid tree path cannot fit the bounded
+	// argv used for exact metadata lookup (currently one component exceeds the
+	// whole 15 KiB pathspec budget). No content was read.
+	LimitedFileUnaddressable
 )
 
 // LimitedFileResult is the bounded, typed result for one path at a revision.
@@ -605,6 +636,8 @@ type LimitedFileResult struct {
 // ReadFileLimited is the typed form of ShowFileLimited. Callers that need one
 // coherent snapshot across this metadata probe and other Git operations must
 // pass an already-resolved immutable revision rather than a moving ref name.
+// Like ShowFile, path is relative to repo and rev represents the repository
+// root when repo is a subdirectory.
 func ReadFileLimited(ctx context.Context, repo, rev, path string, maxBytes int64) (LimitedFileResult, error) {
 	return readFileLimited(ctx, repo, rev, path, maxBytes, blobSizeAtRev)
 }
@@ -635,16 +668,6 @@ func readFileLimited(
 	maxBytes int64,
 	probe func(ctx context.Context, repo, rev, path string) (int64, blobProbeStatus),
 ) (LimitedFileResult, error) {
-	if maxBytes <= 0 {
-		content, ok, err := ShowFile(ctx, repo, rev, path)
-		if err != nil {
-			return LimitedFileResult{}, err
-		}
-		if !ok {
-			return LimitedFileResult{Status: LimitedFileMissing}, nil
-		}
-		return LimitedFileResult{Status: LimitedFileContent, Content: content, Bytes: int64(len(content))}, nil
-	}
 	// An identified non-blob is not file content. In particular, `git show` on a
 	// gitlink's small commit object renders the commit's potentially enormous
 	// patch, so trusting only that object's size would defeat the caller's bound.
@@ -655,21 +678,29 @@ func readFileLimited(
 	if status == blobProbeNonBlob {
 		return LimitedFileResult{Status: LimitedFileNonBlob}, nil
 	}
-	if status == blobProbeBlob && size > maxBytes {
+	if status == blobProbeBlob && maxBytes > 0 && size > maxBytes {
 		// Refused, not failed: a blob this caller cannot quote, exactly like a
 		// missing one. No content was read to learn this.
 		return LimitedFileResult{Status: LimitedFileOversize, Bytes: size}, nil
 	}
-	// The commit is immutable, so a size measured above is the size that will be
-	// read — there is no grow-between-calls race to guard against here.
-	content, ok, err := ShowFile(ctx, repo, rev, path)
+	// A positively identified blob can be read with plumbing, avoiding git
+	// show's worktree-path disambiguation and its commit-rendering behavior.
+	// Unknown probes retain ShowFile as the historical missing-vs-error arbiter.
+	var content string
+	var ok bool
+	var err error
+	if status == blobProbeBlob {
+		content, ok, err = readBlobAtRev(ctx, repo, rev, path)
+	} else {
+		content, ok, err = ShowFile(ctx, repo, rev, path)
+	}
 	if err != nil {
 		return LimitedFileResult{}, err
 	}
 	if !ok {
 		return LimitedFileResult{Status: LimitedFileMissing}, nil
 	}
-	if int64(len(content)) > maxBytes {
+	if maxBytes > 0 && int64(len(content)) > maxBytes {
 		// Only reachable when the probe gave no answer. The bytes are already
 		// allocated, so this cannot restore the memory bound — but it keeps the
 		// ANSWER identical either way, so a caller never receives content it
@@ -677,6 +708,26 @@ func readFileLimited(
 		return LimitedFileResult{Status: LimitedFileOversize, Bytes: int64(len(content))}, nil
 	}
 	return LimitedFileResult{Status: LimitedFileContent, Content: content, Bytes: int64(len(content))}, nil
+}
+
+func readBlobAtRev(ctx context.Context, repo, rev, path string) (string, bool, error) {
+	treePath, err := repoTreePath(ctx, repo, path)
+	if err != nil {
+		return "", false, err
+	}
+	objectSpec := rev + "^{tree}:" + treePath
+	out, stderr, err := runWithStderr(ctx, repo, "git", "cat-file", "blob", objectSpec)
+	if err != nil {
+		if isMissingPathDiagnostic(stderr) {
+			return "", false, nil
+		}
+		msg := stderr
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", false, fmt.Errorf("git cat-file blob %s: %s", objectSpec, msg)
+	}
+	return out, true, nil
 }
 
 // OversizeBlobAtRev reports the size, content hash and line count of the blob at
@@ -700,7 +751,11 @@ func OversizeBlobAtRev(ctx context.Context, repo, rev, path string, maxBytes int
 	if maxBytes <= 0 {
 		return OversizeBlob{}, false, nil
 	}
-	cmd := newCmd(ctx, repo, "git", "cat-file", "blob", rev+"^{tree}:"+path)
+	treePath, err := repoTreePath(ctx, repo, path)
+	if err != nil {
+		return OversizeBlob{}, false, err
+	}
+	cmd := newCmd(ctx, repo, "git", "cat-file", "blob", rev+"^{tree}:"+treePath)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	stdout, err := cmd.StdoutPipe()
@@ -745,23 +800,21 @@ const (
 // reading its content. It is best effort: unknown means "no answer", never
 // "absent" or "broken", so a caller can only use it to refuse, not to conclude.
 func blobSizeAtRev(ctx context.Context, repo, rev, path string) (int64, blobProbeStatus) {
-	objectSpec := rev + "^{tree}:" + path
-	typeOut, _, err := runWithStderr(ctx, repo, "git", "cat-file", "-t", objectSpec)
+	treePath, err := repoTreePath(ctx, repo, path)
 	if err != nil {
 		return 0, blobProbeUnknown
 	}
-	if strings.TrimSpace(typeOut) != "blob" {
+	entry, found, err := treeEntryMetadata(ctx, repo, rev, treePath)
+	if err != nil || !found {
+		return 0, blobProbeUnknown
+	}
+	if entry.result.Status == LimitedFileUnaddressable {
+		return 0, blobProbeUnknown
+	}
+	if entry.objectType != "blob" {
 		return 0, blobProbeNonBlob
 	}
-	out, _, err := runWithStderr(ctx, repo, "git", "cat-file", "-s", objectSpec)
-	if err != nil {
-		return 0, blobProbeUnknown
-	}
-	size, parseErr := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
-	if parseErr != nil || size < 0 {
-		return 0, blobProbeUnknown
-	}
-	return size, blobProbeBlob
+	return entry.result.Bytes, blobProbeBlob
 }
 
 func isMissingPathDiagnostic(stderr string) bool {
@@ -775,9 +828,11 @@ func isMissingPathDiagnostic(stderr string) bool {
 
 // BatchFileReader reads blobs from one revision through a persistent
 // `git cat-file --batch` process. It avoids spawning one git process per file
-// while preserving HEAD-tree snapshot semantics.
+// while preserving HEAD-tree snapshot semantics. Paths are relative to repo;
+// rev represents the repository-root tree when repo is a subdirectory.
 type BatchFileReader struct {
 	rev          string
+	pathPrefix   string
 	cmd          *exec.Cmd
 	stdin        io.WriteCloser
 	stdout       *bufio.Reader
@@ -834,6 +889,10 @@ func (r *BatchFileReader) OversizeBlob(path string) (OversizeBlob, bool) {
 }
 
 func NewBatchFileReader(ctx context.Context, repo, rev string) (*BatchFileReader, error) {
+	pathPrefix, err := RepoPrefix(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
 	cmd := newCmd(ctx, repo, "git", "cat-file", "--batch")
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -851,16 +910,34 @@ func NewBatchFileReader(ctx context.Context, repo, rev string) (*BatchFileReader
 		return nil, fmt.Errorf("git cat-file --batch: %w", err)
 	}
 	return &BatchFileReader{
-		rev:    rev,
-		cmd:    cmd,
-		stdin:  stdin,
-		stdout: bufio.NewReader(stdoutPipe),
-		stderr: &stderr,
+		rev:        rev,
+		pathPrefix: pathPrefix,
+		cmd:        cmd,
+		stdin:      stdin,
+		stdout:     bufio.NewReader(stdoutPipe),
+		stderr:     &stderr,
 	}, nil
 }
 
+// IsBatchPathSafe reports whether path can be embedded in one LF-delimited
+// cat-file --batch request without splitting or normalization. A trailing CR
+// is consumed by Git's line reader; internal CR bytes are preserved.
+func IsBatchPathSafe(path string) bool {
+	return !strings.Contains(path, "\n") && !strings.HasSuffix(path, "\r")
+}
+
+// IsPathSafe includes the repository-cwd prefix that ReadFile prepends before
+// writing its request. Git reports embedded newlines in that prefix verbatim,
+// so a plain caller-relative path can still be unsafe in an unusual subdir.
+func (r *BatchFileReader) IsPathSafe(path string) bool {
+	return IsBatchPathSafe(r.rev + ":" + r.pathPrefix + path)
+}
+
 func (r *BatchFileReader) ReadFile(path string) (string, bool, error) {
-	return r.readObjectSpec(r.rev+":"+path, path)
+	if !r.IsPathSafe(path) {
+		return "", false, fmt.Errorf("Git path cannot be represented by cat-file batch protocol")
+	}
+	return r.readObjectSpec(r.rev+":"+r.pathPrefix+path, path)
 }
 
 // readObjectSpec is the shared batch protocol implementation. LimitedFileReader
@@ -972,8 +1049,9 @@ type LimitedFileReader struct {
 }
 
 type primedLimitedFile struct {
-	result   LimitedFileResult
-	objectID string
+	result     LimitedFileResult
+	objectID   string
+	objectType string
 }
 
 const treeMetadataLiteralPrefix = ":(top,literal)"
@@ -1002,10 +1080,18 @@ func (r *LimitedFileReader) Prime(paths []string) error {
 		r.primed = make(map[string]primedLimitedFile, len(paths))
 	}
 	for start := 0; start < len(paths); {
-		// Leave a rare over-limit path unprimed so ReadFile uses the existing
-		// argv-safe one-shot bounded reader instead of exceeding this batch's
-		// command-line budget or rejecting a valid deep Git-tree path.
+		// A rare over-limit full path is resolved one tree component at a time.
+		// No command receives the whole path, while the final exact blob OID can
+		// still use the persistent content batch.
 		if len(treeMetadataLiteralPrefix)+len(paths[start]) > literalPathspecBatchBytes {
+			entry, found, err := treeEntryMetadataByComponents(r.ctx, r.repo, r.rev, paths[start])
+			if err != nil {
+				return err
+			}
+			if !found {
+				entry = primedLimitedFile{result: LimitedFileResult{Status: LimitedFileMissing}}
+			}
+			r.primed[paths[start]] = entry
 			start++
 			continue
 		}
@@ -1023,6 +1109,53 @@ func (r *LimitedFileReader) Prime(paths []string) error {
 		start = end
 	}
 	return nil
+}
+
+func treeEntryMetadata(ctx context.Context, repo, rev, path string) (primedLimitedFile, bool, error) {
+	if len(treeMetadataLiteralPrefix)+len(path) > literalPathspecBatchBytes {
+		return treeEntryMetadataByComponents(ctx, repo, rev, path)
+	}
+	entries, err := treeEntryMetadataBatch(ctx, repo, rev, []string{path})
+	if err != nil {
+		return primedLimitedFile{}, false, err
+	}
+	entry, found := entries[path]
+	return entry, found, nil
+}
+
+// treeEntryMetadataByComponents resolves a deep path without ever placing the
+// full repository-controlled string in argv. Each intermediate entry must be a
+// tree; its immutable OID becomes the root of the next exact one-component
+// lookup. The rare path pays one bounded Git process per component.
+func treeEntryMetadataByComponents(ctx context.Context, repo, rev, path string) (primedLimitedFile, bool, error) {
+	components := strings.Split(path, "/")
+	currentTree := rev
+	for i, component := range components {
+		if component == "" {
+			return primedLimitedFile{}, false, fmt.Errorf("invalid Git tree path %q", path)
+		}
+		if len(treeMetadataLiteralPrefix)+len(component) > literalPathspecBatchBytes {
+			return primedLimitedFile{
+				result: LimitedFileResult{Status: LimitedFileUnaddressable},
+			}, true, nil
+		}
+		entries, err := treeEntryMetadataBatch(ctx, repo, currentTree, []string{component})
+		if err != nil {
+			return primedLimitedFile{}, false, err
+		}
+		entry, found := entries[component]
+		if !found {
+			return primedLimitedFile{}, false, nil
+		}
+		if i == len(components)-1 {
+			return entry, true, nil
+		}
+		if entry.objectType != "tree" {
+			return primedLimitedFile{}, false, nil
+		}
+		currentTree = entry.objectID
+	}
+	return primedLimitedFile{}, false, nil
 }
 
 // treeMetadataBatchEnd keeps each ls-tree invocation prefix-free as well as
@@ -1109,7 +1242,11 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 			return nil, fmt.Errorf("git ls-tree returned duplicate path %q", path)
 		}
 		if fields[1] != "blob" {
-			entries[path] = primedLimitedFile{result: LimitedFileResult{Status: LimitedFileNonBlob}}
+			entries[path] = primedLimitedFile{
+				result:     LimitedFileResult{Status: LimitedFileNonBlob},
+				objectID:   fields[2],
+				objectType: fields[1],
+			}
 			continue
 		}
 		size, err := strconv.ParseInt(fields[3], 10, 64)
@@ -1117,8 +1254,9 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 			return nil, fmt.Errorf("parse git ls-tree blob size %q for %q", fields[3], path)
 		}
 		entries[path] = primedLimitedFile{
-			result:   LimitedFileResult{Status: LimitedFileContent, Bytes: size},
-			objectID: fields[2],
+			result:     LimitedFileResult{Status: LimitedFileContent, Bytes: size},
+			objectID:   fields[2],
+			objectType: fields[1],
 		}
 	}
 	return entries, nil

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -614,6 +614,60 @@ func showFileLimited(
 	return content, ok, err
 }
 
+// OversizeBlobAtRev reports the size, content hash and line count of the blob at
+// rev:path when that blob exceeds maxBytes — the same OversizeBlob the batch
+// reader records for a blob IT refuses, learned the same way, by streaming the
+// blob past a digest and discarding it. The bytes are never held.
+//
+// It is the companion ShowFileLimited owes its callers. The batch reader digests
+// what it declines on the way past, so a caller can still record a file it could
+// not parse; ShowFileLimited only refuses, so a caller taking that fallback — a
+// Git path containing a newline, which `cat-file --batch` cannot carry — would
+// otherwise lose the file entirely because of how it is NAMED.
+//
+// The second return means "this blob exists and is over maxBytes", not merely
+// "found": false is also the answer for a blob at or under the ceiling, so a
+// caller that refused for some other reason cannot record it as oversized. A
+// missing path is (false, nil); a read that broke is (false, err).
+//
+// maxBytes <= 0 means no ceiling, so nothing is oversized and no git runs.
+func OversizeBlobAtRev(ctx context.Context, repo, rev, path string, maxBytes int64) (OversizeBlob, bool, error) {
+	if maxBytes <= 0 {
+		return OversizeBlob{}, false, nil
+	}
+	cmd := newCmd(ctx, repo, "git", "cat-file", "blob", rev+"^{tree}:"+path)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return OversizeBlob{}, false, err
+	}
+	if err := cmd.Start(); err != nil {
+		return OversizeBlob{}, false, fmt.Errorf("git cat-file blob: %w", err)
+	}
+	digest, digestErr := filedigest.Stream(stdout)
+	// Drain anything the digest did not consume before waiting. git blocks on a
+	// full pipe, and Wait would then block on git.
+	_, _ = io.Copy(io.Discard, stdout)
+	if waitErr := cmd.Wait(); waitErr != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if isMissingPathDiagnostic(msg) {
+			return OversizeBlob{}, false, nil
+		}
+		if msg == "" {
+			msg = waitErr.Error()
+		}
+		return OversizeBlob{}, false, fmt.Errorf("git cat-file blob %s:%s: %s", rev, path, msg)
+	}
+	if digestErr != nil {
+		return OversizeBlob{}, false, digestErr
+	}
+	if digest.Bytes <= maxBytes {
+		return OversizeBlob{}, false, nil
+	}
+	return OversizeBlob{Bytes: digest.Bytes, Hash: digest.Hash, Lines: digest.Lines}, true, nil
+}
+
 // blobSizeAtRev reports the size of the blob at rev:path without reading it.
 // It is BEST EFFORT by design: known=false means "no answer", never "absent" or
 // "broken", so a caller can only use it to refuse, not to conclude.

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -976,6 +976,8 @@ type primedLimitedFile struct {
 	objectID string
 }
 
+const treeMetadataLiteralPrefix = ":(top,literal)"
+
 // NewLimitedFileReader creates a lazy reader. No Git process starts until Prime
 // or ReadFile, so an empty or extension-filtered range costs no subprocesses.
 // rev must be immutable when metadata and content consistency matters.
@@ -1000,16 +1002,14 @@ func (r *LimitedFileReader) Prime(paths []string) error {
 		r.primed = make(map[string]primedLimitedFile, len(paths))
 	}
 	for start := 0; start < len(paths); {
-		// literalPathspecBatchEnd deliberately admits one over-limit first
-		// path so its callers always make progress. This reader can do better:
-		// leave that rare path unprimed and let ReadFile use the existing
+		// Leave a rare over-limit path unprimed so ReadFile uses the existing
 		// argv-safe one-shot bounded reader instead of exceeding this batch's
 		// command-line budget or rejecting a valid deep Git-tree path.
-		if len(":(literal)")+len(paths[start]) > literalPathspecBatchBytes {
+		if len(treeMetadataLiteralPrefix)+len(paths[start]) > literalPathspecBatchBytes {
 			start++
 			continue
 		}
-		end := literalPathspecBatchEnd(paths, start)
+		end := treeMetadataBatchEnd(paths, start)
 		entries, err := treeEntryMetadataBatch(r.ctx, r.repo, r.rev, paths[start:end])
 		if err != nil {
 			return err
@@ -1025,6 +1025,41 @@ func (r *LimitedFileReader) Prime(paths []string) error {
 	return nil
 }
 
+// treeMetadataBatchEnd keeps each ls-tree invocation prefix-free as well as
+// count- and argv-bounded. Combining an ancestor tree path with one of its
+// descendants makes ls-tree recursively expand the ancestor; splitting them
+// preserves the command's one-record-per-exact-path memory bound.
+func treeMetadataBatchEnd(paths []string, start int) int {
+	end := start
+	pathspecBytes := 0
+	for end < len(paths) && end-start < literalPathspecBatchCount {
+		next := paths[end]
+		nextBytes := len(treeMetadataLiteralPrefix) + len(next)
+		if end > start && pathspecBytes+nextBytes > literalPathspecBatchBytes {
+			break
+		}
+		conflicts := false
+		for _, batched := range paths[start:end] {
+			if treePathsOverlap(batched, next) {
+				conflicts = true
+				break
+			}
+		}
+		if conflicts {
+			break
+		}
+		pathspecBytes += nextBytes
+		end++
+	}
+	return end
+}
+
+func treePathsOverlap(left, right string) bool {
+	return left == right ||
+		strings.HasPrefix(left, right+"/") ||
+		strings.HasPrefix(right, left+"/")
+}
+
 func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []string) (map[string]primedLimitedFile, error) {
 	if rev == "" || strings.HasPrefix(rev, "-") || strings.ContainsRune(rev, 0) {
 		return nil, fmt.Errorf("invalid treeish %q", rev)
@@ -1032,18 +1067,18 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 	if len(paths) > literalPathspecBatchCount {
 		return nil, fmt.Errorf("git tree metadata input exceeds %d paths", literalPathspecBatchCount)
 	}
-	args := []string{"ls-tree", "-z", "-l", rev, "--"}
+	args := []string{"ls-tree", "-z", "-l", "--full-name", rev, "--"}
 	known := make(map[string]struct{}, len(paths))
 	pathspecBytes := 0
 	for _, path := range paths {
 		if path == "" || strings.ContainsRune(path, 0) {
 			return nil, fmt.Errorf("invalid Git tree path %q", path)
 		}
-		pathspecBytes += len(":(literal)") + len(path)
+		pathspecBytes += len(treeMetadataLiteralPrefix) + len(path)
 		if pathspecBytes > literalPathspecBatchBytes {
 			return nil, fmt.Errorf("git tree metadata pathspecs exceed %d bytes", literalPathspecBatchBytes)
 		}
-		args = append(args, ":(literal)"+path)
+		args = append(args, treeMetadataLiteralPrefix+path)
 		known[path] = struct{}{}
 	}
 	out, err := run(ctx, repo, "git", args...)

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -329,6 +329,13 @@ func grepTreePaths(ctx context.Context, repo, treeish string, patterns []string,
 		}
 		return nil, fmt.Errorf("git %s: %s", strings.Join(args, " "), message)
 	}
+	if stderr.Len() > 0 {
+		message := strings.TrimSpace(stderr.String())
+		if message == "" {
+			message = "unexpected stderr output"
+		}
+		return nil, fmt.Errorf("git %s: %s", strings.Join(args, " "), message)
+	}
 	prefix := ""
 	if treeish != "" {
 		prefix = treeish + ":"
@@ -387,6 +394,13 @@ func grepFixedStringMatches(ctx context.Context, repo, treeish string, patterns 
 		message := strings.TrimSpace(stderr.String())
 		if message == "" {
 			message = err.Error()
+		}
+		return nil, fmt.Errorf("git %s: %s", strings.Join(args, " "), message)
+	}
+	if stderr.Len() > 0 {
+		message := strings.TrimSpace(stderr.String())
+		if message == "" {
+			message = "unexpected stderr output"
 		}
 		return nil, fmt.Errorf("git %s: %s", strings.Join(args, " "), message)
 	}

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -1862,8 +1862,8 @@ func run(ctx context.Context, dir, name string, args ...string) (string, error) 
 }
 
 const (
-	rawGitObjectsEnv    = "GIT_NO_REPLACE_OBJECTS=1"
-	noLazyFetchEnv      = "GIT_NO_LAZY_FETCH=1"
+	rawGitObjectsEnv = "GIT_NO_REPLACE_OBJECTS=1"
+	noLazyFetchEnv   = "GIT_NO_LAZY_FETCH=1"
 	// noTransportProtocolEnv is a second, independent no-egress guard.
 	// GIT_NO_LAZY_FETCH only became effective in Git 2.45 (git/git@2c206fc);
 	// this package's floor is Git 2.36 (cat-file --batch-command), so on any

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/entireio/entire-graph/internal/filedigest"
 )
@@ -62,6 +63,22 @@ func RepoPrefix(ctx context.Context, cwd string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSuffix(out, "\n"), nil
+}
+
+// RepoCommandRoot returns a cwd from which tree-root-relative paths keep the
+// same coordinates. A worktree subdirectory is normalized to Git's top level;
+// a worktree root or bare repository already has an empty prefix and is kept as
+// provided. This matters when rev itself is a subtree OID: running tree commands
+// from the original subdirectory would apply that prefix a second time.
+func RepoCommandRoot(ctx context.Context, cwd string) (string, error) {
+	prefix, err := RepoPrefix(ctx, cwd)
+	if err != nil {
+		return "", err
+	}
+	if prefix == "" {
+		return cwd, nil
+	}
+	return RepoRoot(ctx, cwd)
 }
 
 func repoTreePath(ctx context.Context, repo, path string) (string, error) {
@@ -594,10 +611,10 @@ func ShowFile(ctx context.Context, repo, rev, path string) (string, bool, error)
 // deadlocked on Windows: killing git left a grandchild holding the inherited
 // stderr handle, so the copier goroutine never saw EOF and Cmd.Wait blocked in
 // awaitGoroutines forever. Nothing here now depends on process-tree teardown.
-// This one-shot helper pays for separate `cat-file` probes. Callers scanning a
-// range of ordinary paths should use LimitedFileReader, which batches metadata
-// and sends exact blob OIDs (never repository paths) to its persistent content
-// batch. An unprimed LimitedFileReader path falls back here.
+// This one-shot helper pays for separate metadata probes. Callers scanning a
+// range of paths should use LimitedFileReader, which batches metadata, shares
+// exceptional component traversal, and sends exact blob OIDs (never repository
+// paths) to its persistent content batch.
 //
 // The metadata probe is authoritative only when Git identifies the object. A
 // blob proceeds to the size decision below; a non-blob (notably a gitlink's
@@ -617,9 +634,10 @@ const (
 	LimitedFileContent
 	LimitedFileOversize
 	LimitedFileNonBlob
-	// LimitedFileUnaddressable means a valid tree path cannot fit the bounded
-	// argv used for exact metadata lookup (currently one component exceeds the
-	// whole 15 KiB pathspec budget). No content was read.
+	// LimitedFileUnaddressable means a valid tree path could not be resolved
+	// within the bounded exact-metadata traversal: a component exceeded the
+	// argv ceiling, the component-process allowance was exhausted, or the
+	// caller's traversal deadline elapsed. No content was read.
 	LimitedFileUnaddressable
 )
 
@@ -637,7 +655,9 @@ type LimitedFileResult struct {
 // coherent snapshot across this metadata probe and other Git operations must
 // pass an already-resolved immutable revision rather than a moving ref name.
 // Like ShowFile, path is relative to repo and rev represents the repository
-// root when repo is a subdirectory.
+// root when repo is a subdirectory. Path must be canonical and file-like: it
+// cannot be empty or NUL-bearing and cannot contain empty, ".", or ".."
+// components. Invalid paths fail before Git runs.
 func ReadFileLimited(ctx context.Context, repo, rev, path string, maxBytes int64) (LimitedFileResult, error) {
 	return readFileLimited(ctx, repo, rev, path, maxBytes, blobSizeAtRev)
 }
@@ -668,6 +688,13 @@ func readFileLimited(
 	maxBytes int64,
 	probe func(ctx context.Context, repo, rev, path string) (int64, blobProbeStatus),
 ) (LimitedFileResult, error) {
+	// A file read must never let git-show reinterpret an empty/trailing-slash
+	// path as a request to render a tree. Validate before the best-effort probe:
+	// otherwise its validation error becomes "unknown" and the fallback can
+	// materialize an unbounded repository-controlled directory listing.
+	if err := validateLimitedFilePath(path); err != nil {
+		return LimitedFileResult{}, err
+	}
 	// An identified non-blob is not file content. In particular, `git show` on a
 	// gitlink's small commit object renders the commit's potentially enormous
 	// patch, so trusting only that object's size would defeat the caller's bound.
@@ -677,6 +704,9 @@ func readFileLimited(
 	size, status := probe(ctx, repo, rev, path)
 	if status == blobProbeNonBlob {
 		return LimitedFileResult{Status: LimitedFileNonBlob}, nil
+	}
+	if status == blobProbeUnaddressable {
+		return LimitedFileResult{Status: LimitedFileUnaddressable}, nil
 	}
 	if status == blobProbeBlob && maxBytes > 0 && size > maxBytes {
 		// Refused, not failed: a blob this caller cannot quote, exactly like a
@@ -708,6 +738,18 @@ func readFileLimited(
 		return LimitedFileResult{Status: LimitedFileOversize, Bytes: int64(len(content))}, nil
 	}
 	return LimitedFileResult{Status: LimitedFileContent, Content: content, Bytes: int64(len(content))}, nil
+}
+
+func validateLimitedFilePath(path string) error {
+	if path == "" || strings.ContainsRune(path, 0) {
+		return fmt.Errorf("invalid Git tree path %q", path)
+	}
+	for _, component := range strings.Split(path, "/") {
+		if component == "" || component == "." || component == ".." {
+			return fmt.Errorf("invalid Git tree path %q", path)
+		}
+	}
+	return nil
 }
 
 func readBlobAtRev(ctx context.Context, repo, rev, path string) (string, bool, error) {
@@ -794,6 +836,7 @@ const (
 	blobProbeUnknown blobProbeStatus = iota
 	blobProbeBlob
 	blobProbeNonBlob
+	blobProbeUnaddressable
 )
 
 // blobSizeAtRev reports the type and, for a blob, the size of rev:path without
@@ -809,7 +852,7 @@ func blobSizeAtRev(ctx context.Context, repo, rev, path string) (int64, blobProb
 		return 0, blobProbeUnknown
 	}
 	if entry.result.Status == LimitedFileUnaddressable {
-		return 0, blobProbeUnknown
+		return 0, blobProbeUnaddressable
 	}
 	if entry.objectType != "blob" {
 		return 0, blobProbeNonBlob
@@ -1035,7 +1078,7 @@ func (r *BatchFileReader) Close() error {
 // ReadFile then asks a persistent content batch for the exact blob OIDs at or
 // below the ceiling. Repository paths never enter that line-oriented protocol,
 // so newline-bearing and trailing-carriage-return names cannot split or
-// normalize a request. An unprimed path uses the argv-safe one-shot fallback.
+// normalize a request. An unprimed path resolves the same metadata lazily.
 type LimitedFileReader struct {
 	ctx      context.Context
 	repo     string
@@ -1046,6 +1089,12 @@ type LimitedFileReader struct {
 	content *BatchFileReader
 	primed  map[string]primedLimitedFile
 	closed  bool
+
+	componentMetadata          map[treeComponentMetadataKey]treeComponentMetadataResult
+	componentMetadataProcesses int
+	componentMetadataLookup    treeMetadataLookup
+	deadline                   time.Time
+	now                        func() time.Time
 }
 
 type primedLimitedFile struct {
@@ -1056,11 +1105,51 @@ type primedLimitedFile struct {
 
 const treeMetadataLiteralPrefix = ":(top,literal)"
 
+// Normal paths use count- and argv-bounded metadata batches. Only a path too
+// large for those batches enters component traversal. 256 leaves ample room
+// for the existing 80-component compatibility case while bounding one
+// adversarial reader (and therefore both sides of an Analyze call)
+// independently of path depth/count.
+const limitedFileComponentMetadataProcessLimit = 256
+
+type treeComponentMetadataKey struct {
+	treeOID   string
+	component string
+}
+
+type treeComponentMetadataResult struct {
+	entry primedLimitedFile
+	found bool
+}
+
+type treeMetadataLookup func(
+	context.Context,
+	string,
+	string,
+	[]string,
+) (map[string]primedLimitedFile, error)
+
 // NewLimitedFileReader creates a lazy reader. No Git process starts until Prime
 // or ReadFile, so an empty or extension-filtered range costs no subprocesses.
 // rev must be immutable when metadata and content consistency matters.
 func NewLimitedFileReader(ctx context.Context, repo, rev string, maxBytes int64) *LimitedFileReader {
-	return &LimitedFileReader{ctx: ctx, repo: repo, rev: rev, maxBytes: maxBytes}
+	return &LimitedFileReader{
+		ctx:                     ctx,
+		repo:                    repo,
+		rev:                     rev,
+		maxBytes:                maxBytes,
+		componentMetadataLookup: treeEntryMetadataBatch,
+		now:                     time.Now,
+	}
+}
+
+// SetDeadline bounds only the exceptional component-by-component metadata
+// traversal. Ordinary short-path batches remain one process and unchanged.
+// A zero deadline restores the historical no-deadline behavior.
+func (r *LimitedFileReader) SetDeadline(deadline time.Time) {
+	r.mu.Lock()
+	r.deadline = deadline
+	r.mu.Unlock()
 }
 
 // Prime resolves exact tree-entry metadata for a bounded group of paths. Unlike
@@ -1084,7 +1173,7 @@ func (r *LimitedFileReader) Prime(paths []string) error {
 		// No command receives the whole path, while the final exact blob OID can
 		// still use the persistent content batch.
 		if len(treeMetadataLiteralPrefix)+len(paths[start]) > literalPathspecBatchBytes {
-			entry, found, err := treeEntryMetadataByComponents(r.ctx, r.repo, r.rev, paths[start])
+			entry, found, err := r.treeEntryMetadataByComponents(paths[start])
 			if err != nil {
 				return err
 			}
@@ -1112,10 +1201,15 @@ func (r *LimitedFileReader) Prime(paths []string) error {
 }
 
 func treeEntryMetadata(ctx context.Context, repo, rev, path string) (primedLimitedFile, bool, error) {
+	reader := NewLimitedFileReader(ctx, repo, rev, 0)
+	return reader.treeEntryMetadata(path)
+}
+
+func (r *LimitedFileReader) treeEntryMetadata(path string) (primedLimitedFile, bool, error) {
 	if len(treeMetadataLiteralPrefix)+len(path) > literalPathspecBatchBytes {
-		return treeEntryMetadataByComponents(ctx, repo, rev, path)
+		return r.treeEntryMetadataByComponents(path)
 	}
-	entries, err := treeEntryMetadataBatch(ctx, repo, rev, []string{path})
+	entries, err := treeEntryMetadataBatch(r.ctx, r.repo, r.rev, []string{path})
 	if err != nil {
 		return primedLimitedFile{}, false, err
 	}
@@ -1126,36 +1220,76 @@ func treeEntryMetadata(ctx context.Context, repo, rev, path string) (primedLimit
 // treeEntryMetadataByComponents resolves a deep path without ever placing the
 // full repository-controlled string in argv. Each intermediate entry must be a
 // tree; its immutable OID becomes the root of the next exact one-component
-// lookup. The rare path pays one bounded Git process per component.
-func treeEntryMetadataByComponents(ctx context.Context, repo, rev, path string) (primedLimitedFile, bool, error) {
+// lookup. Resolved (tree OID, component) pairs are cached across paths, and
+// uncached lookups stop at the reader's process allowance or deadline.
+func (r *LimitedFileReader) treeEntryMetadataByComponents(path string) (primedLimitedFile, bool, error) {
+	if err := validateLimitedFilePath(path); err != nil {
+		return primedLimitedFile{}, false, err
+	}
 	components := strings.Split(path, "/")
-	currentTree := rev
+	currentTree := r.rev
 	for i, component := range components {
-		if component == "" {
-			return primedLimitedFile{}, false, fmt.Errorf("invalid Git tree path %q", path)
-		}
 		if len(treeMetadataLiteralPrefix)+len(component) > literalPathspecBatchBytes {
-			return primedLimitedFile{
-				result: LimitedFileResult{Status: LimitedFileUnaddressable},
-			}, true, nil
+			return unaddressableLimitedFile(), true, nil
 		}
-		entries, err := treeEntryMetadataBatch(ctx, repo, currentTree, []string{component})
+		metadata, addressable, err := r.componentEntryMetadata(currentTree, component)
 		if err != nil {
 			return primedLimitedFile{}, false, err
 		}
-		entry, found := entries[component]
-		if !found {
+		if !addressable {
+			return unaddressableLimitedFile(), true, nil
+		}
+		if !metadata.found {
 			return primedLimitedFile{}, false, nil
 		}
 		if i == len(components)-1 {
-			return entry, true, nil
+			return metadata.entry, true, nil
 		}
-		if entry.objectType != "tree" {
+		if metadata.entry.objectType != "tree" {
 			return primedLimitedFile{}, false, nil
 		}
-		currentTree = entry.objectID
+		currentTree = metadata.entry.objectID
 	}
 	return primedLimitedFile{}, false, nil
+}
+
+func (r *LimitedFileReader) componentEntryMetadata(
+	treeOID, component string,
+) (treeComponentMetadataResult, bool, error) {
+	key := treeComponentMetadataKey{treeOID: treeOID, component: component}
+	if metadata, ok := r.componentMetadata[key]; ok {
+		return metadata, true, nil
+	}
+	if r.componentMetadataProcesses >= limitedFileComponentMetadataProcessLimit || r.componentDeadlineReached() {
+		return treeComponentMetadataResult{}, false, nil
+	}
+	r.componentMetadataProcesses++
+	entries, err := r.componentMetadataLookup(r.ctx, r.repo, treeOID, []string{component})
+	if err != nil {
+		return treeComponentMetadataResult{}, false, err
+	}
+	entry, found := entries[component]
+	metadata := treeComponentMetadataResult{entry: entry, found: found}
+	if r.componentMetadata == nil {
+		r.componentMetadata = make(map[treeComponentMetadataKey]treeComponentMetadataResult)
+	}
+	r.componentMetadata[key] = metadata
+	return metadata, true, nil
+}
+
+func (r *LimitedFileReader) componentDeadlineReached() bool {
+	if r.deadline.IsZero() {
+		return false
+	}
+	now := r.now
+	if now == nil {
+		now = time.Now
+	}
+	return !now().Before(r.deadline)
+}
+
+func unaddressableLimitedFile() primedLimitedFile {
+	return primedLimitedFile{result: LimitedFileResult{Status: LimitedFileUnaddressable}}
 }
 
 // treeMetadataBatchEnd keeps each ls-tree invocation prefix-free as well as
@@ -1204,8 +1338,8 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 	known := make(map[string]struct{}, len(paths))
 	pathspecBytes := 0
 	for _, path := range paths {
-		if path == "" || strings.HasSuffix(path, "/") || strings.ContainsRune(path, 0) {
-			return nil, fmt.Errorf("invalid Git tree path %q", path)
+		if err := validateLimitedFilePath(path); err != nil {
+			return nil, err
 		}
 		pathspecBytes += len(treeMetadataLiteralPrefix) + len(path)
 		if pathspecBytes > literalPathspecBatchBytes {
@@ -1272,7 +1406,19 @@ func (r *LimitedFileReader) ReadFile(path string) (LimitedFileResult, error) {
 	}
 	entry, primed := r.primed[path]
 	if !primed {
-		return ReadFileLimited(r.ctx, r.repo, r.rev, path, r.maxBytes)
+		var found bool
+		var err error
+		entry, found, err = r.treeEntryMetadata(path)
+		if err != nil {
+			return LimitedFileResult{}, err
+		}
+		if !found {
+			entry = primedLimitedFile{result: LimitedFileResult{Status: LimitedFileMissing}}
+		}
+		if r.primed == nil {
+			r.primed = make(map[string]primedLimitedFile)
+		}
+		r.primed[path] = entry
 	}
 	result := entry.result
 	if result.Status != LimitedFileContent {

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -1755,6 +1755,7 @@ func run(ctx context.Context, dir, name string, args ...string) (string, error) 
 
 const (
 	rawGitObjectsEnv    = "GIT_NO_REPLACE_OBJECTS=1"
+	noLazyFetchEnv      = "GIT_NO_LAZY_FETCH=1"
 	gitCommandWaitDelay = time.Second
 )
 
@@ -1762,6 +1763,10 @@ const (
 // case-folding must retain the caller's locale. Like every other production Git
 // subprocess in this package, it disables replace refs: exact tree/object IDs
 // are the immutable snapshot boundary, regardless of later refs/replace edits.
+// It also disables lazy fetching, for the same reason newCmd does below: this
+// provider promises no-egress execution, and without this a partial clone
+// would have Git silently reach out to the promisor remote for any object a
+// command here touches.
 func newGitCmdWithCallerLocale(ctx context.Context, dir string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
@@ -1771,7 +1776,7 @@ func newGitCmdWithCallerLocale(ctx context.Context, dir string, args ...string) 
 	cmd.WaitDelay = gitCommandWaitDelay
 	// Cmd.Environ observes Dir and updates PWD accordingly. Append after the
 	// inherited environment so a hostile GIT_NO_REPLACE_OBJECTS=0 is overridden.
-	cmd.Env = append(cmd.Environ(), rawGitObjectsEnv)
+	cmd.Env = append(cmd.Environ(), rawGitObjectsEnv, noLazyFetchEnv)
 	return cmd
 }
 
@@ -1784,6 +1789,15 @@ func newGitCmdWithCallerLocale(ctx context.Context, dir string, args ...string) 
 // tree or object ID keeps raw-object semantics across separate subprocesses.
 // The git-grep paths above preserve caller locale while applying the same raw
 // object rule.
+//
+// It also disables lazy fetching for every Git command: this provider
+// advertises no-egress execution, but a partial clone with a promisor remote
+// configured will otherwise have Git silently contact that remote to fill in
+// any object a command here asks about (ls-tree -l's per-blob size lookup is
+// exactly such a command). With lazy fetch disabled, Git reports a missing
+// promised object as a per-entry failure instead of fetching it — ls-tree -l
+// prints its "BAD" sentinel for a blob it cannot size, which callers already
+// classify as LimitedFileUnreadable rather than treating as an error.
 func newCmd(ctx context.Context, dir, name string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
@@ -1795,7 +1809,7 @@ func newCmd(ctx context.Context, dir, name string, args ...string) *exec.Cmd {
 	// os.Environ would leave child processes with the parent's stale PWD.
 	env := cmd.Environ()
 	if name == "git" {
-		env = append(env, rawGitObjectsEnv)
+		env = append(env, rawGitObjectsEnv, noLazyFetchEnv)
 	}
 	cmd.Env = append(env, "LC_ALL=C", "LANG=C")
 	return cmd

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -313,8 +313,7 @@ func grepTreePaths(ctx context.Context, repo, treeish string, patterns []string,
 		args = append(args, treeish)
 	}
 	args = append(args, "--")
-	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Dir = repo
+	cmd := newGitCmdWithCallerLocale(ctx, repo, args...)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -374,8 +373,7 @@ func grepFixedStringMatches(ctx context.Context, repo, treeish string, patterns 
 	// Preserve the caller's locale here. Unlike the other git commands in this
 	// package, `git grep -i` uses LC_CTYPE for non-ASCII case folding; forcing
 	// the C locale would make Unicode matches disappear.
-	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Dir = repo
+	cmd := newGitCmdWithCallerLocale(ctx, repo, args...)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -893,9 +891,10 @@ func isMissingPathDiagnostic(stderr string) bool {
 // BatchFileReader reads blobs from one revision through one persistent
 // `git cat-file --batch-command` process. Each read issues `info` first and
 // issues `contents` only for a blob, so a non-blob never enters the content
-// stream. Keeping both commands in one Git process also gives them one snapshot
-// of replace refs; an immutable OID cannot change type between the metadata and
-// content responses. Oversized blobs are still streamed for caller digests.
+// stream. All production Git commands ignore replace refs, and keeping both
+// commands in one process ensures an immutable raw OID cannot change type
+// between the metadata and content responses. Oversized blobs are still
+// streamed for caller digests.
 // Paths are relative to repo; rev represents the repository-root tree when repo
 // is a subdirectory.
 type BatchFileReader struct {
@@ -907,6 +906,7 @@ type BatchFileReader struct {
 	stderr       *bytes.Buffer
 	mu           sync.Mutex
 	closed       bool
+	poison       error
 	maxBytes     int64
 	oversize     map[string]OversizeBlob
 	oversizeScan func(path string, chunk []byte)
@@ -987,8 +987,8 @@ func NewBatchFileReader(ctx context.Context, repo, rev string) (*BatchFileReader
 	}
 	// Start is not enough to feature-detect an option: an older Git starts and
 	// then exits after parsing argv. A metadata-only missing-object request
-	// verifies the protocol without reading an object body. It also establishes
-	// the replace-ref snapshot at reader construction, before caller reads begin.
+	// verifies the protocol without reading an object body. The process already
+	// has raw-object semantics through GIT_NO_REPLACE_OBJECTS.
 	const probeOID = "0000000000000000000000000000000000000000"
 	if _, _, _, found, probeErr := reader.objectInfoLocked(probeOID); probeErr != nil || found {
 		_ = stdin.Close()
@@ -1023,6 +1023,14 @@ func (r *BatchFileReader) IsPathSafe(path string) bool {
 }
 
 func (r *BatchFileReader) ReadFile(path string) (string, bool, error) {
+	// Once framing failed, even a path rejected locally must not obscure the
+	// session's original cause. More importantly, no later call may reach stdin.
+	r.mu.Lock()
+	poison := r.poison
+	r.mu.Unlock()
+	if poison != nil {
+		return "", false, poison
+	}
 	// Reject path forms Git interprets relative to the worktree before they enter
 	// the persistent protocol. In particular, `rev:../file` terminates cat-file
 	// with an "outside repository" error and would poison every later read on the
@@ -1060,73 +1068,83 @@ func (r *BatchFileReader) readCheckedObjectSpec(objectSpec, oversizeKey string) 
 // readKnownBlobObjectID is the exact-OID path for LimitedFileReader, whose
 // ls-tree metadata established that objectID was a blob at metadata time. It
 // still repeats the type check in this SAME batch-command process before asking
-// for contents: a replace ref may have moved between ls-tree and this process's
-// snapshot. The request contains only an immutable OID, never repository path
-// bytes.
+// for contents, defending against missing/corrupt objects without ever sending
+// a non-blob body request. The request contains only an immutable raw OID, never
+// repository path bytes.
 func (r *BatchFileReader) readKnownBlobObjectID(objectID, oversizeKey string) (string, bool, error) {
 	return r.readCheckedObjectSpec(objectID, oversizeKey)
 }
 
 func (r *BatchFileReader) objectInfoLocked(objectSpec string) (string, string, int64, bool, error) {
+	if r.poison != nil {
+		return "", "", 0, false, r.poison
+	}
 	if r.closed {
 		return "", "", 0, false, fmt.Errorf("git cat-file batch reader is closed")
 	}
 	if _, err := fmt.Fprintf(r.stdin, "info %s\n", objectSpec); err != nil {
-		return "", "", 0, false, err
+		return "", "", 0, false, r.poisonLocked(fmt.Errorf("write git cat-file batch-command info request: %w", err))
 	}
 	header, err := r.stdout.ReadString('\n')
 	if err != nil {
-		return "", "", 0, false, fmt.Errorf("read git cat-file batch-command info header: %w", err)
+		return "", "", 0, false, r.poisonLocked(fmt.Errorf("read git cat-file batch-command info header: %w", err))
 	}
 	header = strings.TrimSuffix(header, "\n")
 	if strings.HasSuffix(header, " missing") {
+		if header != objectSpec+" missing" {
+			return "", "", 0, false, r.poisonLocked(fmt.Errorf("unexpected git cat-file batch-command info missing header %q", header))
+		}
 		return "", "", 0, false, nil
 	}
 	fields := strings.Fields(header)
 	if len(fields) != 3 {
-		return "", "", 0, false, fmt.Errorf("unexpected git cat-file batch-command info header %q", header)
+		return "", "", 0, false, r.poisonLocked(fmt.Errorf("unexpected git cat-file batch-command info header %q", header))
 	}
 	size, err := strconv.ParseInt(fields[2], 10, 64)
 	if err != nil || size < 0 {
-		return "", "", 0, false, fmt.Errorf("parse git cat-file batch-command info size %q", fields[2])
+		return "", "", 0, false, r.poisonLocked(fmt.Errorf("parse git cat-file batch-command info size %q", fields[2]))
 	}
 	return fields[0], fields[1], size, true, nil
 }
 
 func (r *BatchFileReader) readObjectContentsLocked(objectSpec, expectedType string, expectedSize int64, oversizeKey string) (string, bool, error) {
+	if r.poison != nil {
+		return "", false, r.poison
+	}
 	if r.closed {
 		return "", false, fmt.Errorf("git cat-file batch reader is closed")
 	}
 	if _, err := fmt.Fprintf(r.stdin, "contents %s\n", objectSpec); err != nil {
-		return "", false, err
+		return "", false, r.poisonLocked(fmt.Errorf("write git cat-file batch-command contents request: %w", err))
 	}
 	header, err := r.stdout.ReadString('\n')
 	if err != nil {
-		return "", false, fmt.Errorf("read git cat-file batch-command contents header: %w", err)
+		return "", false, r.poisonLocked(fmt.Errorf("read git cat-file batch-command contents header: %w", err))
 	}
 	header = strings.TrimSuffix(header, "\n")
 	if strings.HasSuffix(header, " missing") {
+		if header != objectSpec+" missing" {
+			return "", false, r.poisonLocked(fmt.Errorf("unexpected git cat-file batch-command contents missing header %q", header))
+		}
 		return "", false, nil
 	}
 	fields := strings.Fields(header)
 	if len(fields) != 3 {
-		return "", false, fmt.Errorf("unexpected git cat-file batch-command contents header %q", header)
+		return "", false, r.poisonLocked(fmt.Errorf("unexpected git cat-file batch-command contents header %q", header))
 	}
 	size, err := strconv.ParseInt(fields[2], 10, 64)
 	if err != nil || size < 0 {
-		return "", false, fmt.Errorf("parse git cat-file size %q", fields[2])
+		return "", false, r.poisonLocked(fmt.Errorf("parse git cat-file size %q", fields[2]))
 	}
 	if fields[0] != objectSpec || fields[1] != expectedType || size != expectedSize {
 		// info and contents share one process, so their resolved identity, type and
 		// size must agree. Do not drain an unexpected body merely to salvage the
 		// protocol: that is exactly the unbounded non-blob read this gate prevents.
-		_ = r.cmd.Process.Kill()
-		return "", false, fmt.Errorf("git cat-file batch-command metadata changed between info and contents: info=%s %s %d contents=%s %s %d",
-			objectSpec, expectedType, expectedSize, fields[0], fields[1], size)
+		return "", false, r.poisonLocked(fmt.Errorf("git cat-file batch-command metadata changed between info and contents: info=%s %s %d contents=%s %s %d",
+			objectSpec, expectedType, expectedSize, fields[0], fields[1], size))
 	}
 	if fields[1] != "blob" {
-		_ = r.cmd.Process.Kill()
-		return "", false, fmt.Errorf("git cat-file batch-command returned non-blob contents after blob info: %s", fields[1])
+		return "", false, r.poisonLocked(fmt.Errorf("git cat-file batch-command returned non-blob contents after blob info: %s", fields[1]))
 	}
 	if r.maxBytes > 0 && size > r.maxBytes {
 		var src io.Reader = io.LimitReader(r.stdout, size)
@@ -1137,14 +1155,17 @@ func (r *BatchFileReader) readObjectContentsLocked(objectSpec, expectedType stri
 		}
 		digest, err := filedigest.Stream(src)
 		if err != nil {
-			return "", false, err
+			return "", false, r.poisonLocked(fmt.Errorf("stream oversized git blob: %w", err))
+		}
+		if digest.Bytes != size {
+			return "", false, r.poisonLocked(fmt.Errorf("git cat-file blob body length %d, want %d", digest.Bytes, size))
 		}
 		trailing, err := r.stdout.ReadByte()
 		if err != nil {
-			return "", false, err
+			return "", false, r.poisonLocked(fmt.Errorf("read git cat-file blob separator: %w", err))
 		}
 		if trailing != '\n' {
-			return "", false, fmt.Errorf("git cat-file blob missing trailing newline separator")
+			return "", false, r.poisonLocked(fmt.Errorf("git cat-file blob missing trailing newline separator"))
 		}
 		if r.oversize == nil {
 			r.oversize = map[string]OversizeBlob{}
@@ -1154,45 +1175,72 @@ func (r *BatchFileReader) readObjectContentsLocked(objectSpec, expectedType stri
 	}
 	content := make([]byte, size)
 	if _, err := io.ReadFull(r.stdout, content); err != nil {
-		return "", false, err
+		return "", false, r.poisonLocked(fmt.Errorf("read git cat-file blob body: %w", err))
 	}
 	trailing, err := r.stdout.ReadByte()
 	if err != nil {
-		return "", false, err
+		return "", false, r.poisonLocked(fmt.Errorf("read git cat-file blob separator: %w", err))
 	}
 	if trailing != '\n' {
-		return "", false, fmt.Errorf("git cat-file blob missing trailing newline separator")
+		return "", false, r.poisonLocked(fmt.Errorf("git cat-file blob missing trailing newline separator"))
 	}
 	return string(content), true, nil
+}
+
+// poisonLocked retires a batch-command session whose request/response boundary
+// is no longer trustworthy. It preserves the first protocol error as the
+// reader's stable result; later reads never write into a dead or desynchronized
+// stream, and Close reaps the killed child while returning this original cause.
+// r.mu must be held.
+func (r *BatchFileReader) poisonLocked(err error) error {
+	if r.poison != nil {
+		return r.poison
+	}
+	r.poison = err
+	if r.cmd.Process != nil {
+		_ = r.cmd.Process.Kill()
+	}
+	return err
 }
 
 func (r *BatchFileReader) Close() error {
 	r.mu.Lock()
 	if r.closed {
+		poison := r.poison
 		r.mu.Unlock()
-		return nil
+		return poison
 	}
 	r.closed = true
 	stdin := r.stdin
+	poison := r.poison
 	r.mu.Unlock()
 	var closeErrors []error
 	if err := stdin.Close(); err != nil {
 		closeErrors = append(closeErrors, err)
 	}
 	if err := r.cmd.Wait(); err != nil {
+		if poison != nil {
+			// poisonLocked deliberately killed this child. The protocol cause is
+			// actionable; "signal: killed" is only the cleanup mechanism.
+			return poison
+		}
 		msg := strings.TrimSpace(r.stderr.String())
 		if msg == "" {
 			msg = err.Error()
 		}
 		closeErrors = append(closeErrors, fmt.Errorf("git cat-file --batch-command: %s", msg))
 	}
+	if poison != nil {
+		return poison
+	}
 	return errors.Join(closeErrors...)
 }
 
-// LimitedFileReader performs repeated bounded reads from one immutable Git
-// tree without spawning probes per file. Prime batches exact ls-tree metadata;
-// ReadFile then asks a persistent content batch for the exact blob OIDs at or
-// below the ceiling. Repository paths never enter that line-oriented protocol,
+// LimitedFileReader performs repeated bounded reads from one immutable raw Git
+// tree without spawning probes per file. Replace refs are ignored. Prime
+// batches exact ls-tree metadata; ReadFile then asks a persistent content batch
+// for the exact blob OIDs at or below the ceiling. Repository paths never enter
+// that line-oriented protocol,
 // so newline-bearing and trailing-carriage-return names cannot split or
 // normalize a request. An unprimed path resolves the same metadata lazily.
 type LimitedFileReader struct {
@@ -1219,7 +1267,14 @@ type primedLimitedFile struct {
 	objectType string
 }
 
-const treeMetadataLiteralPrefix = ":(top,literal)"
+const (
+	treeMetadataLiteralPrefix = ":(top,literal)"
+	// ls-tree formats mode, type, object ID, and decimal size (or BAD) before
+	// each path. SHA-256 object IDs need at most 64 bytes; 128 bytes leaves
+	// generous room for every fixed field while putting a hard bound on a
+	// malformed record before its path is retained.
+	treeMetadataRecordOverheadMax = 128
+)
 
 // Normal paths use count- and argv-bounded metadata batches. Only a path too
 // large for those batches enters component traversal. 256 leaves ample room
@@ -1450,9 +1505,13 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 	if len(paths) > literalPathspecBatchCount {
 		return nil, fmt.Errorf("git tree metadata input exceeds %d paths", literalPathspecBatchCount)
 	}
+	if len(paths) == 0 {
+		return map[string]primedLimitedFile{}, nil
+	}
 	args := []string{"ls-tree", "-z", "-l", "--full-name", rev, "--"}
 	known := make(map[string]struct{}, len(paths))
 	pathspecBytes := 0
+	expectedOutputBytes := 0
 	for _, path := range paths {
 		if err := validateLimitedFilePath(path); err != nil {
 			return nil, err
@@ -1463,33 +1522,80 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 		}
 		args = append(args, treeMetadataLiteralPrefix+path)
 		known[path] = struct{}{}
+		expectedOutputBytes += len(path) + treeMetadataRecordOverheadMax
 	}
-	out, err := run(ctx, repo, "git", args...)
+	cmd := newCmd(ctx, repo, "git", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("git ls-tree metadata pipe: %w", err)
 	}
-	if len(out) > 0 && out[len(out)-1] != 0 {
-		return nil, errors.New("git ls-tree returned non-NUL-terminated metadata")
-	}
-	entries := make(map[string]primedLimitedFile, len(paths))
-	for _, record := range bytes.Split([]byte(out), []byte{0}) {
-		if len(record) == 0 {
-			continue
+	if err := cmd.Start(); err != nil {
+		message := strings.TrimSpace(stderr.String())
+		if message == "" {
+			message = err.Error()
 		}
+		return nil, fmt.Errorf("git ls-tree metadata: %s", message)
+	}
+
+	entries := make(map[string]primedLimitedFile, len(paths))
+	outputCount := 0
+	outputBytes := 0
+	reader := bufio.NewReaderSize(stdout, literalPathspecBatchBytes+treeMetadataRecordOverheadMax)
+	for {
+		record, readErr := reader.ReadSlice(0)
+		if errors.Is(readErr, bufio.ErrBufferFull) {
+			stopPathOutputCommand(cmd)
+			return nil, fmt.Errorf(
+				"git ls-tree returned a metadata record longer than %d bytes",
+				literalPathspecBatchBytes+treeMetadataRecordOverheadMax,
+			)
+		}
+		if len(record) == 0 && errors.Is(readErr, io.EOF) {
+			waitErr := cmd.Wait()
+			if waitErr != nil {
+				message := strings.TrimSpace(stderr.String())
+				if message == "" {
+					message = waitErr.Error()
+				}
+				return nil, fmt.Errorf("git ls-tree metadata: %s", message)
+			}
+			return entries, nil
+		}
+		if len(record) == 0 || record[len(record)-1] != 0 {
+			stopPathOutputCommand(cmd)
+			return nil, errors.New("git ls-tree returned non-NUL-terminated metadata")
+		}
+		record = record[:len(record)-1]
 		tab := bytes.IndexByte(record, '\t')
 		if tab < 0 {
+			stopPathOutputCommand(cmd)
 			return nil, errors.New("git ls-tree returned malformed metadata")
 		}
 		fields := strings.Fields(string(record[:tab]))
 		if len(fields) != 4 {
+			stopPathOutputCommand(cmd)
 			return nil, fmt.Errorf("git ls-tree returned malformed metadata header %q", record[:tab])
 		}
 		path := string(record[tab+1:])
 		if _, ok := known[path]; !ok {
+			stopPathOutputCommand(cmd)
 			return nil, fmt.Errorf("git ls-tree returned unexpected path %q", path)
 		}
 		if _, duplicate := entries[path]; duplicate {
+			stopPathOutputCommand(cmd)
 			return nil, fmt.Errorf("git ls-tree returned duplicate path %q", path)
+		}
+		outputCount++
+		outputBytes += len(record) + 1
+		if outputCount > len(known) || outputCount > literalPathspecBatchCount {
+			stopPathOutputCommand(cmd)
+			return nil, fmt.Errorf("git ls-tree returned more than %d metadata records", len(known))
+		}
+		if outputBytes > expectedOutputBytes {
+			stopPathOutputCommand(cmd)
+			return nil, fmt.Errorf("git ls-tree returned more than %d metadata bytes", expectedOutputBytes)
 		}
 		if fields[1] != "blob" {
 			entries[path] = primedLimitedFile{
@@ -1513,6 +1619,7 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 		}
 		size, err := strconv.ParseInt(fields[3], 10, 64)
 		if err != nil || size < 0 {
+			stopPathOutputCommand(cmd)
 			return nil, fmt.Errorf("parse git ls-tree blob size %q for %q", fields[3], path)
 		}
 		entries[path] = primedLimitedFile{
@@ -1520,8 +1627,11 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 			objectID:   fields[2],
 			objectType: fields[1],
 		}
+		if readErr != nil {
+			stopPathOutputCommand(cmd)
+			return nil, fmt.Errorf("read git ls-tree metadata: %w", readErr)
+		}
 	}
-	return entries, nil
 }
 
 // ReadFile returns one typed bounded result. Oversized blobs are answered from
@@ -1636,19 +1746,40 @@ func run(ctx context.Context, dir, name string, args ...string) (string, error) 
 	return stdout, nil
 }
 
+const rawGitObjectsEnv = "GIT_NO_REPLACE_OBJECTS=1"
+
+// newGitCmdWithCallerLocale builds the two git-grep subprocesses whose
+// case-folding must retain the caller's locale. Like every other production Git
+// subprocess in this package, it disables replace refs: exact tree/object IDs
+// are the immutable snapshot boundary, regardless of later refs/replace edits.
+func newGitCmdWithCallerLocale(ctx context.Context, dir string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	// Cmd.Environ observes Dir and updates PWD accordingly. Append after the
+	// inherited environment so a hostile GIT_NO_REPLACE_OBJECTS=0 is overridden.
+	cmd.Env = append(cmd.Environ(), rawGitObjectsEnv)
+	return cmd
+}
+
 // newCmd builds the exec.Cmd used by subprocesses whose diagnostics must be
 // stable. It pins the subprocess locale to C (LC_ALL=C overrides LANG and any
 // LC_*; LANG=C is set as a belt-and-braces default) so git's stderr messages
 // are always the English ones our error classification matches — e.g.
 // ShowFile's absent-file detection would otherwise break under a non-English
-// git locale. GrepIndexMatches intentionally bypasses this helper and keeps
-// the caller's locale because git grep uses LC_CTYPE for case folding.
+// git locale. It also disables replace refs for every Git command, so an exact
+// tree or object ID keeps raw-object semantics across separate subprocesses.
+// The git-grep paths above preserve caller locale while applying the same raw
+// object rule.
 func newCmd(ctx context.Context, dir, name string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
 	// Cmd.Environ observes Dir and updates PWD accordingly. Starting from
 	// os.Environ would leave child processes with the parent's stale PWD.
-	cmd.Env = append(cmd.Environ(), "LC_ALL=C", "LANG=C")
+	env := cmd.Environ()
+	if name == "git" {
+		env = append(env, rawGitObjectsEnv)
+	}
+	cmd.Env = append(env, "LC_ALL=C", "LANG=C")
 	return cmd
 }
 

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -1546,7 +1546,7 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 	for {
 		record, readErr := reader.ReadSlice(0)
 		if errors.Is(readErr, bufio.ErrBufferFull) {
-			stopPathOutputCommand(cmd)
+			stopPathOutputCommand(cmd, stdout)
 			return nil, fmt.Errorf(
 				"git ls-tree returned a metadata record longer than %d bytes",
 				literalPathspecBatchBytes+treeMetadataRecordOverheadMax,
@@ -1564,37 +1564,37 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 			return entries, nil
 		}
 		if len(record) == 0 || record[len(record)-1] != 0 {
-			stopPathOutputCommand(cmd)
+			stopPathOutputCommand(cmd, stdout)
 			return nil, errors.New("git ls-tree returned non-NUL-terminated metadata")
 		}
 		record = record[:len(record)-1]
 		tab := bytes.IndexByte(record, '\t')
 		if tab < 0 {
-			stopPathOutputCommand(cmd)
+			stopPathOutputCommand(cmd, stdout)
 			return nil, errors.New("git ls-tree returned malformed metadata")
 		}
 		fields := strings.Fields(string(record[:tab]))
 		if len(fields) != 4 {
-			stopPathOutputCommand(cmd)
+			stopPathOutputCommand(cmd, stdout)
 			return nil, fmt.Errorf("git ls-tree returned malformed metadata header %q", record[:tab])
 		}
 		path := string(record[tab+1:])
 		if _, ok := known[path]; !ok {
-			stopPathOutputCommand(cmd)
+			stopPathOutputCommand(cmd, stdout)
 			return nil, fmt.Errorf("git ls-tree returned unexpected path %q", path)
 		}
 		if _, duplicate := entries[path]; duplicate {
-			stopPathOutputCommand(cmd)
+			stopPathOutputCommand(cmd, stdout)
 			return nil, fmt.Errorf("git ls-tree returned duplicate path %q", path)
 		}
 		outputCount++
 		outputBytes += len(record) + 1
 		if outputCount > len(known) || outputCount > literalPathspecBatchCount {
-			stopPathOutputCommand(cmd)
+			stopPathOutputCommand(cmd, stdout)
 			return nil, fmt.Errorf("git ls-tree returned more than %d metadata records", len(known))
 		}
 		if outputBytes > expectedOutputBytes {
-			stopPathOutputCommand(cmd)
+			stopPathOutputCommand(cmd, stdout)
 			return nil, fmt.Errorf("git ls-tree returned more than %d metadata bytes", expectedOutputBytes)
 		}
 		if fields[1] != "blob" {
@@ -1619,7 +1619,7 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 		}
 		size, err := strconv.ParseInt(fields[3], 10, 64)
 		if err != nil || size < 0 {
-			stopPathOutputCommand(cmd)
+			stopPathOutputCommand(cmd, stdout)
 			return nil, fmt.Errorf("parse git ls-tree blob size %q for %q", fields[3], path)
 		}
 		entries[path] = primedLimitedFile{
@@ -1628,7 +1628,7 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 			objectType: fields[1],
 		}
 		if readErr != nil {
-			stopPathOutputCommand(cmd)
+			stopPathOutputCommand(cmd, stdout)
 			return nil, fmt.Errorf("read git ls-tree metadata: %w", readErr)
 		}
 	}
@@ -1746,7 +1746,10 @@ func run(ctx context.Context, dir, name string, args ...string) (string, error) 
 	return stdout, nil
 }
 
-const rawGitObjectsEnv = "GIT_NO_REPLACE_OBJECTS=1"
+const (
+	rawGitObjectsEnv    = "GIT_NO_REPLACE_OBJECTS=1"
+	gitCommandWaitDelay = time.Second
+)
 
 // newGitCmdWithCallerLocale builds the two git-grep subprocesses whose
 // case-folding must retain the caller's locale. Like every other production Git
@@ -1755,6 +1758,10 @@ const rawGitObjectsEnv = "GIT_NO_REPLACE_OBJECTS=1"
 func newGitCmdWithCallerLocale(ctx context.Context, dir string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
+	// Bound Wait when Git exits but a child process inherited one of the pipes.
+	// This matters especially on Windows, where killing Git does not necessarily
+	// close an orphan-held stderr handle promptly.
+	cmd.WaitDelay = gitCommandWaitDelay
 	// Cmd.Environ observes Dir and updates PWD accordingly. Append after the
 	// inherited environment so a hostile GIT_NO_REPLACE_OBJECTS=0 is overridden.
 	cmd.Env = append(cmd.Environ(), rawGitObjectsEnv)
@@ -1773,6 +1780,10 @@ func newGitCmdWithCallerLocale(ctx context.Context, dir string, args ...string) 
 func newCmd(ctx context.Context, dir, name string, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
+	// Bound Wait after cancellation or process exit when a descendant retains a
+	// subprocess pipe. All production Git commands are constructed here or by
+	// newGitCmdWithCallerLocale, so malformed-output retirement cannot hang.
+	cmd.WaitDelay = gitCommandWaitDelay
 	// Cmd.Environ observes Dir and updates PWD accordingly. Starting from
 	// os.Environ would leave child processes with the parent's stale PWD.
 	env := cmd.Environ()

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -1000,6 +1000,15 @@ func (r *LimitedFileReader) Prime(paths []string) error {
 		r.primed = make(map[string]primedLimitedFile, len(paths))
 	}
 	for start := 0; start < len(paths); {
+		// literalPathspecBatchEnd deliberately admits one over-limit first
+		// path so its callers always make progress. This reader can do better:
+		// leave that rare path unprimed and let ReadFile use the existing
+		// argv-safe one-shot bounded reader instead of exceeding this batch's
+		// command-line budget or rejecting a valid deep Git-tree path.
+		if len(":(literal)")+len(paths[start]) > literalPathspecBatchBytes {
+			start++
+			continue
+		}
 		end := literalPathspecBatchEnd(paths, start)
 		entries, err := treeEntryMetadataBatch(r.ctx, r.repo, r.rev, paths[start:end])
 		if err != nil {
@@ -1029,9 +1038,6 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 	for _, path := range paths {
 		if path == "" || strings.ContainsRune(path, 0) {
 			return nil, fmt.Errorf("invalid Git tree path %q", path)
-		}
-		if len(path) > literalPathOutputMaxPathBytes {
-			return nil, fmt.Errorf("git tree metadata input path exceeds %d bytes", literalPathOutputMaxPathBytes)
 		}
 		pathspecBytes += len(":(literal)") + len(path)
 		if pathspecBytes > literalPathspecBatchBytes {

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -567,8 +567,10 @@ func ShowFile(ctx context.Context, repo, rev, path string) (string, bool, error)
 // deadlocked on Windows: killing git left a grandchild holding the inherited
 // stderr handle, so the copier goroutine never saw EOF and Cmd.Wait blocked in
 // awaitGoroutines forever. Nothing here now depends on process-tree teardown.
-// The extra `cat-file` probes are small processes on a path that is already the
-// rare fallback for a Git path containing a newline.
+// This one-shot helper pays for separate `cat-file` probes. Callers scanning a
+// range of ordinary paths should use LimitedFileReader, which batches metadata
+// and sends exact blob OIDs (never repository paths) to its persistent content
+// batch. An unprimed LimitedFileReader path falls back here.
 //
 // The metadata probe is authoritative only when Git identifies the object. A
 // blob proceeds to the size decision below; a non-blob (notably a gitlink's
@@ -858,12 +860,19 @@ func NewBatchFileReader(ctx context.Context, repo, rev string) (*BatchFileReader
 }
 
 func (r *BatchFileReader) ReadFile(path string) (string, bool, error) {
+	return r.readObjectSpec(r.rev+":"+path, path)
+}
+
+// readObjectSpec is the shared batch protocol implementation. LimitedFileReader
+// passes a hex blob OID here, so repository-controlled path bytes never enter
+// the line-oriented request; ordinary callers retain rev:path behavior.
+func (r *BatchFileReader) readObjectSpec(objectSpec, oversizeKey string) (string, bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.closed {
 		return "", false, fmt.Errorf("git cat-file batch reader is closed")
 	}
-	if _, err := fmt.Fprintf(r.stdin, "%s:%s\n", r.rev, path); err != nil {
+	if _, err := fmt.Fprintf(r.stdin, "%s\n", objectSpec); err != nil {
 		return "", false, err
 	}
 	header, err := r.stdout.ReadString('\n')
@@ -893,7 +902,7 @@ func (r *BatchFileReader) ReadFile(path string) (string, bool, error) {
 		if scan := r.oversizeScan; scan != nil {
 			// The same single pass the digest already makes: the scanner sees the bytes on their
 			// way to being discarded, so relevance costs no extra read and no retained memory.
-			src = io.TeeReader(src, oversizeScanWriter{path: path, scan: scan})
+			src = io.TeeReader(src, oversizeScanWriter{path: oversizeKey, scan: scan})
 		}
 		digest, err := filedigest.Stream(src)
 		if err != nil {
@@ -905,7 +914,7 @@ func (r *BatchFileReader) ReadFile(path string) (string, bool, error) {
 		if r.oversize == nil {
 			r.oversize = map[string]OversizeBlob{}
 		}
-		r.oversize[path] = OversizeBlob{Bytes: digest.Bytes, Hash: digest.Hash, Lines: digest.Lines}
+		r.oversize[oversizeKey] = OversizeBlob{Bytes: digest.Bytes, Hash: digest.Hash, Lines: digest.Lines}
 		return "", false, nil
 	}
 	content := make([]byte, size)
@@ -940,6 +949,195 @@ func (r *BatchFileReader) Close() error {
 			msg = err.Error()
 		}
 		return fmt.Errorf("git cat-file --batch: %s", msg)
+	}
+	return nil
+}
+
+// LimitedFileReader performs repeated bounded reads from one immutable Git
+// tree without spawning probes per file. Prime batches exact ls-tree metadata;
+// ReadFile then asks a persistent content batch for the exact blob OIDs at or
+// below the ceiling. Repository paths never enter that line-oriented protocol,
+// so newline-bearing and trailing-carriage-return names cannot split or
+// normalize a request. An unprimed path uses the argv-safe one-shot fallback.
+type LimitedFileReader struct {
+	ctx      context.Context
+	repo     string
+	rev      string
+	maxBytes int64
+
+	mu      sync.Mutex
+	content *BatchFileReader
+	primed  map[string]primedLimitedFile
+	closed  bool
+}
+
+type primedLimitedFile struct {
+	result   LimitedFileResult
+	objectID string
+}
+
+// NewLimitedFileReader creates a lazy reader. No Git process starts until Prime
+// or ReadFile, so an empty or extension-filtered range costs no subprocesses.
+// rev must be immutable when metadata and content consistency matters.
+func NewLimitedFileReader(ctx context.Context, repo, rev string, maxBytes int64) *LimitedFileReader {
+	return &LimitedFileReader{ctx: ctx, repo: repo, rev: rev, maxBytes: maxBytes}
+}
+
+// Prime resolves exact tree-entry metadata for a bounded group of paths. Unlike
+// cat-file, ls-tree identifies a gitlink from its tree mode even when the
+// referenced commit object is absent from the superproject object database.
+// Literal pathspec batches keep unusual names inert and bound argv size.
+func (r *LimitedFileReader) Prime(paths []string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return errors.New("limited Git file reader is closed")
+	}
+	if len(paths) == 0 {
+		return nil
+	}
+	if r.primed == nil {
+		r.primed = make(map[string]primedLimitedFile, len(paths))
+	}
+	for start := 0; start < len(paths); {
+		end := literalPathspecBatchEnd(paths, start)
+		entries, err := treeEntryMetadataBatch(r.ctx, r.repo, r.rev, paths[start:end])
+		if err != nil {
+			return err
+		}
+		for _, path := range paths[start:end] {
+			r.primed[path] = primedLimitedFile{result: LimitedFileResult{Status: LimitedFileMissing}}
+		}
+		for path, entry := range entries {
+			r.primed[path] = entry
+		}
+		start = end
+	}
+	return nil
+}
+
+func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []string) (map[string]primedLimitedFile, error) {
+	if rev == "" || strings.HasPrefix(rev, "-") || strings.ContainsRune(rev, 0) {
+		return nil, fmt.Errorf("invalid treeish %q", rev)
+	}
+	if len(paths) > literalPathspecBatchCount {
+		return nil, fmt.Errorf("git tree metadata input exceeds %d paths", literalPathspecBatchCount)
+	}
+	args := []string{"ls-tree", "-z", "-l", rev, "--"}
+	known := make(map[string]struct{}, len(paths))
+	pathspecBytes := 0
+	for _, path := range paths {
+		if path == "" || strings.ContainsRune(path, 0) {
+			return nil, fmt.Errorf("invalid Git tree path %q", path)
+		}
+		if len(path) > literalPathOutputMaxPathBytes {
+			return nil, fmt.Errorf("git tree metadata input path exceeds %d bytes", literalPathOutputMaxPathBytes)
+		}
+		pathspecBytes += len(":(literal)") + len(path)
+		if pathspecBytes > literalPathspecBatchBytes {
+			return nil, fmt.Errorf("git tree metadata pathspecs exceed %d bytes", literalPathspecBatchBytes)
+		}
+		args = append(args, ":(literal)"+path)
+		known[path] = struct{}{}
+	}
+	out, err := run(ctx, repo, "git", args...)
+	if err != nil {
+		return nil, err
+	}
+	if len(out) > 0 && out[len(out)-1] != 0 {
+		return nil, errors.New("git ls-tree returned non-NUL-terminated metadata")
+	}
+	entries := make(map[string]primedLimitedFile, len(paths))
+	for _, record := range bytes.Split([]byte(out), []byte{0}) {
+		if len(record) == 0 {
+			continue
+		}
+		tab := bytes.IndexByte(record, '\t')
+		if tab < 0 {
+			return nil, errors.New("git ls-tree returned malformed metadata")
+		}
+		fields := strings.Fields(string(record[:tab]))
+		if len(fields) != 4 {
+			return nil, fmt.Errorf("git ls-tree returned malformed metadata header %q", record[:tab])
+		}
+		path := string(record[tab+1:])
+		if _, ok := known[path]; !ok {
+			return nil, fmt.Errorf("git ls-tree returned unexpected path %q", path)
+		}
+		if _, duplicate := entries[path]; duplicate {
+			return nil, fmt.Errorf("git ls-tree returned duplicate path %q", path)
+		}
+		if fields[1] != "blob" {
+			entries[path] = primedLimitedFile{result: LimitedFileResult{Status: LimitedFileNonBlob}}
+			continue
+		}
+		size, err := strconv.ParseInt(fields[3], 10, 64)
+		if err != nil || size < 0 {
+			return nil, fmt.Errorf("parse git ls-tree blob size %q for %q", fields[3], path)
+		}
+		entries[path] = primedLimitedFile{
+			result:   LimitedFileResult{Status: LimitedFileContent, Bytes: size},
+			objectID: fields[2],
+		}
+	}
+	return entries, nil
+}
+
+// ReadFile returns one typed bounded result. Oversized blobs are answered from
+// metadata and are never sent to the content batch.
+func (r *LimitedFileReader) ReadFile(path string) (LimitedFileResult, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return LimitedFileResult{}, errors.New("limited Git file reader is closed")
+	}
+	entry, primed := r.primed[path]
+	if !primed {
+		return ReadFileLimited(r.ctx, r.repo, r.rev, path, r.maxBytes)
+	}
+	result := entry.result
+	if result.Status != LimitedFileContent {
+		return result, nil
+	}
+	if r.maxBytes > 0 && result.Bytes > r.maxBytes {
+		result.Status = LimitedFileOversize
+		return result, nil
+	}
+	if r.content == nil {
+		content, err := NewBatchFileReader(r.ctx, r.repo, r.rev)
+		if err != nil {
+			return LimitedFileResult{}, err
+		}
+		content.SetMaxBytes(r.maxBytes)
+		r.content = content
+	}
+	content, ok, err := r.content.readObjectSpec(entry.objectID, path)
+	if err != nil {
+		return LimitedFileResult{}, err
+	}
+	if !ok {
+		if oversize, exists := r.content.OversizeBlob(path); exists {
+			return LimitedFileResult{Status: LimitedFileOversize, Bytes: oversize.Bytes}, nil
+		}
+		return LimitedFileResult{Status: LimitedFileMissing}, nil
+	}
+	result.Content = content
+	result.Bytes = int64(len(content))
+	return result, nil
+}
+
+// Close stops any lazy batches that were started.
+func (r *LimitedFileReader) Close() error {
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return nil
+	}
+	r.closed = true
+	content := r.content
+	r.mu.Unlock()
+	if content != nil {
+		return content.Close()
 	}
 	return nil
 }

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -634,6 +634,11 @@ const (
 	LimitedFileContent
 	LimitedFileOversize
 	LimitedFileNonBlob
+	// LimitedFileUnreadable means the tree entry exists and identifies a blob,
+	// but Git could not read that blob's object metadata. This is distinct from
+	// LimitedFileMissing (no tree entry) and from the bounded traversal refusal
+	// below; callers can report one bad object as a recoverable file-read failure.
+	LimitedFileUnreadable
 	// LimitedFileUnaddressable means a valid tree path could not be resolved
 	// within the bounded exact-metadata traversal: a component exceeded the
 	// argv ceiling, the component-process allowance was exhausted, or the
@@ -705,6 +710,9 @@ func readFileLimited(
 	if status == blobProbeNonBlob {
 		return LimitedFileResult{Status: LimitedFileNonBlob}, nil
 	}
+	if status == blobProbeUnreadable {
+		return LimitedFileResult{Status: LimitedFileUnreadable}, nil
+	}
 	if status == blobProbeUnaddressable {
 		return LimitedFileResult{Status: LimitedFileUnaddressable}, nil
 	}
@@ -750,6 +758,15 @@ func validateLimitedFilePath(path string) error {
 		}
 	}
 	return nil
+}
+
+// IsCanonicalGitTreePath reports whether path has the file-like, slash-separated
+// form accepted by the bounded object readers. Raw Git trees can contain "." or
+// ".." entries that cannot be represented safely by rev:path plumbing; callers
+// enumerating such trees use this predicate to turn one entry into a partial
+// read failure without poisoning a shared Git process.
+func IsCanonicalGitTreePath(path string) bool {
+	return validateLimitedFilePath(path) == nil
 }
 
 func readBlobAtRev(ctx context.Context, repo, rev, path string) (string, bool, error) {
@@ -836,6 +853,7 @@ const (
 	blobProbeUnknown blobProbeStatus = iota
 	blobProbeBlob
 	blobProbeNonBlob
+	blobProbeUnreadable
 	blobProbeUnaddressable
 )
 
@@ -854,6 +872,9 @@ func blobSizeAtRev(ctx context.Context, repo, rev, path string) (int64, blobProb
 	if entry.result.Status == LimitedFileUnaddressable {
 		return 0, blobProbeUnaddressable
 	}
+	if entry.result.Status == LimitedFileUnreadable {
+		return 0, blobProbeUnreadable
+	}
 	if entry.objectType != "blob" {
 		return 0, blobProbeNonBlob
 	}
@@ -869,17 +890,26 @@ func isMissingPathDiagnostic(stderr string) bool {
 			strings.Contains(stderr, "' exists on disk, but not in '"))
 }
 
-// BatchFileReader reads blobs from one revision through a persistent
-// `git cat-file --batch` process. It avoids spawning one git process per file
-// while preserving HEAD-tree snapshot semantics. Paths are relative to repo;
-// rev represents the repository-root tree when repo is a subdirectory.
+// BatchFileReader reads blobs from one revision through persistent
+// `git cat-file --batch-check` metadata and `--batch` content processes. The
+// metadata process prevents non-blobs from entering the content stream; the
+// content process still streams oversized blobs for caller digests. Together
+// they avoid per-file process spawning while preserving HEAD-tree snapshot
+// semantics. Paths are relative to repo; rev represents the repository-root
+// tree when repo is a subdirectory.
 type BatchFileReader struct {
+	ctx          context.Context
+	repo         string
 	rev          string
 	pathPrefix   string
 	cmd          *exec.Cmd
 	stdin        io.WriteCloser
 	stdout       *bufio.Reader
 	stderr       *bytes.Buffer
+	checkCmd     *exec.Cmd
+	checkStdin   io.WriteCloser
+	checkStdout  *bufio.Reader
+	checkStderr  *bytes.Buffer
 	mu           sync.Mutex
 	closed       bool
 	maxBytes     int64
@@ -953,6 +983,8 @@ func NewBatchFileReader(ctx context.Context, repo, rev string) (*BatchFileReader
 		return nil, fmt.Errorf("git cat-file --batch: %w", err)
 	}
 	return &BatchFileReader{
+		ctx:        ctx,
+		repo:       repo,
 		rev:        rev,
 		pathPrefix: pathPrefix,
 		cmd:        cmd,
@@ -977,18 +1009,98 @@ func (r *BatchFileReader) IsPathSafe(path string) bool {
 }
 
 func (r *BatchFileReader) ReadFile(path string) (string, bool, error) {
+	// Reject path forms Git interprets relative to the worktree before they enter
+	// the persistent protocol. In particular, `rev:../file` terminates cat-file
+	// with an "outside repository" error and would poison every later read on the
+	// shared process. Repository tree listings can contain such raw components
+	// even though a filesystem checkout cannot.
+	if err := validateLimitedFilePath(path); err != nil {
+		return "", false, err
+	}
 	if !r.IsPathSafe(path) {
 		return "", false, fmt.Errorf("Git path cannot be represented by cat-file batch protocol")
 	}
-	return r.readObjectSpec(r.rev+":"+r.pathPrefix+path, path)
+	return r.readCheckedObjectSpec(r.rev+":"+r.pathPrefix+path, path)
 }
 
-// readObjectSpec is the shared batch protocol implementation. LimitedFileReader
-// passes a hex blob OID here, so repository-controlled path bytes never enter
-// the line-oriented request; ordinary callers retain rev:path behavior.
-func (r *BatchFileReader) readObjectSpec(objectSpec, oversizeKey string) (string, bool, error) {
+func (r *BatchFileReader) readCheckedObjectSpec(objectSpec, oversizeKey string) (string, bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	objectID, objectType, found, err := r.checkObjectSpecLocked(objectSpec)
+	if err != nil || !found {
+		return "", false, err
+	}
+	if objectType != "blob" {
+		// Never ask the content batch for a non-blob. Its protocol places the
+		// complete object after the header, so declining only after that request
+		// would still have to stream an arbitrarily large tree or commit merely to
+		// reach the next response. The metadata batch has no object body to drain.
+		return "", false, nil
+	}
+	// Pin the checked object before asking for content. Besides avoiding a second
+	// path-bearing request, this keeps a moving ref from changing object type
+	// between the metadata and content batches.
+	return r.readObjectSpecLocked(objectID, oversizeKey)
+}
+
+// readKnownBlobObjectID is the content-only path for LimitedFileReader, whose
+// authoritative ls-tree metadata already established that objectID is a blob.
+// The request contains only an immutable OID, never repository path bytes.
+func (r *BatchFileReader) readKnownBlobObjectID(objectID, oversizeKey string) (string, bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.readObjectSpecLocked(objectID, oversizeKey)
+}
+
+func (r *BatchFileReader) checkObjectSpecLocked(objectSpec string) (string, string, bool, error) {
+	if r.closed {
+		return "", "", false, fmt.Errorf("git cat-file batch reader is closed")
+	}
+	if r.checkCmd == nil {
+		cmd := newCmd(r.ctx, r.repo, "git", "cat-file", "--batch-check")
+		stdin, err := cmd.StdinPipe()
+		if err != nil {
+			return "", "", false, err
+		}
+		stdoutPipe, err := cmd.StdoutPipe()
+		if err != nil {
+			_ = stdin.Close()
+			return "", "", false, err
+		}
+		stderr := &bytes.Buffer{}
+		cmd.Stderr = stderr
+		if err := cmd.Start(); err != nil {
+			_ = stdin.Close()
+			return "", "", false, fmt.Errorf("git cat-file --batch-check: %w", err)
+		}
+		r.checkCmd = cmd
+		r.checkStdin = stdin
+		r.checkStdout = bufio.NewReader(stdoutPipe)
+		r.checkStderr = stderr
+	}
+	if _, err := fmt.Fprintf(r.checkStdin, "%s\n", objectSpec); err != nil {
+		return "", "", false, err
+	}
+	header, err := r.checkStdout.ReadString('\n')
+	if err != nil {
+		return "", "", false, fmt.Errorf("read git cat-file batch-check header: %w", err)
+	}
+	header = strings.TrimSuffix(header, "\n")
+	if strings.HasSuffix(header, " missing") {
+		return "", "", false, nil
+	}
+	fields := strings.Fields(header)
+	if len(fields) != 3 {
+		return "", "", false, fmt.Errorf("unexpected git cat-file batch-check header %q", header)
+	}
+	size, err := strconv.ParseInt(fields[2], 10, 64)
+	if err != nil || size < 0 {
+		return "", "", false, fmt.Errorf("parse git cat-file batch-check size %q", fields[2])
+	}
+	return fields[0], fields[1], true, nil
+}
+
+func (r *BatchFileReader) readObjectSpecLocked(objectSpec, oversizeKey string) (string, bool, error) {
 	if r.closed {
 		return "", false, fmt.Errorf("git cat-file batch reader is closed")
 	}
@@ -1059,18 +1171,36 @@ func (r *BatchFileReader) Close() error {
 	}
 	r.closed = true
 	stdin := r.stdin
+	checkStdin := r.checkStdin
+	checkCmd := r.checkCmd
+	checkStderr := r.checkStderr
 	r.mu.Unlock()
+	var closeErrors []error
 	if err := stdin.Close(); err != nil {
-		return err
+		closeErrors = append(closeErrors, err)
+	}
+	if checkStdin != nil {
+		if err := checkStdin.Close(); err != nil {
+			closeErrors = append(closeErrors, err)
+		}
 	}
 	if err := r.cmd.Wait(); err != nil {
 		msg := strings.TrimSpace(r.stderr.String())
 		if msg == "" {
 			msg = err.Error()
 		}
-		return fmt.Errorf("git cat-file --batch: %s", msg)
+		closeErrors = append(closeErrors, fmt.Errorf("git cat-file --batch: %s", msg))
 	}
-	return nil
+	if checkCmd != nil {
+		if err := checkCmd.Wait(); err != nil {
+			msg := strings.TrimSpace(checkStderr.String())
+			if msg == "" {
+				msg = err.Error()
+			}
+			closeErrors = append(closeErrors, fmt.Errorf("git cat-file --batch-check: %s", msg))
+		}
+	}
+	return errors.Join(closeErrors...)
 }
 
 // LimitedFileReader performs repeated bounded reads from one immutable Git
@@ -1383,6 +1513,18 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 			}
 			continue
 		}
+		// With -l, Git uses the exact sentinel BAD when a listed blob object
+		// cannot be inspected (for example, a tree references a missing object).
+		// The tree entry is still authoritative and recoverable as one unreadable
+		// file. Keep every other unexpected size a hard protocol error.
+		if fields[3] == "BAD" {
+			entries[path] = primedLimitedFile{
+				result:     LimitedFileResult{Status: LimitedFileUnreadable},
+				objectID:   fields[2],
+				objectType: fields[1],
+			}
+			continue
+		}
 		size, err := strconv.ParseInt(fields[3], 10, 64)
 		if err != nil || size < 0 {
 			return nil, fmt.Errorf("parse git ls-tree blob size %q for %q", fields[3], path)
@@ -1436,7 +1578,7 @@ func (r *LimitedFileReader) ReadFile(path string) (LimitedFileResult, error) {
 		content.SetMaxBytes(r.maxBytes)
 		r.content = content
 	}
-	content, ok, err := r.content.readObjectSpec(entry.objectID, path)
+	content, ok, err := r.content.readKnownBlobObjectID(entry.objectID, path)
 	if err != nil {
 		return LimitedFileResult{}, err
 	}
@@ -1444,7 +1586,10 @@ func (r *LimitedFileReader) ReadFile(path string) (LimitedFileResult, error) {
 		if oversize, exists := r.content.OversizeBlob(path); exists {
 			return LimitedFileResult{Status: LimitedFileOversize, Bytes: oversize.Bytes}, nil
 		}
-		return LimitedFileResult{Status: LimitedFileMissing}, nil
+		// Metadata already established an exact blob entry. A missing exact OID
+		// therefore means its object became unavailable, not that the tree path
+		// was absent.
+		return LimitedFileResult{Status: LimitedFileUnreadable}, nil
 	}
 	result.Content = content
 	result.Bytes = int64(len(content))

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -1071,7 +1071,7 @@ func treeEntryMetadataBatch(ctx context.Context, repo, rev string, paths []strin
 	known := make(map[string]struct{}, len(paths))
 	pathspecBytes := 0
 	for _, path := range paths {
-		if path == "" || strings.ContainsRune(path, 0) {
+		if path == "" || strings.HasSuffix(path, "/") || strings.ContainsRune(path, 0) {
 			return nil, fmt.Errorf("invalid Git tree path %q", path)
 		}
 		pathspecBytes += len(treeMetadataLiteralPrefix) + len(path)

--- a/internal/gitutil/git.go
+++ b/internal/gitutil/git.go
@@ -804,7 +804,8 @@ func readBlobAtRev(ctx context.Context, repo, rev, path string) (string, bool, e
 // OversizeBlobAtRev reports the size, content hash and line count of the blob at
 // rev:path when that blob exceeds maxBytes — the same OversizeBlob the batch
 // reader records for a blob IT refuses, learned the same way, by streaming the
-// blob past a digest and discarding it. The bytes are never held.
+// blob past a digest and discarding it. The complete content is never held;
+// only the bounded leading Prefix is retained.
 //
 // It is the companion ShowFileLimited owes its callers. The batch reader digests
 // what it declines on the way past, so a caller can still record a file it could
@@ -913,18 +914,19 @@ func isMissingPathDiagnostic(stderr string) bool {
 // Paths are relative to repo; rev represents the repository-root tree when repo
 // is a subdirectory.
 type BatchFileReader struct {
-	rev          string
-	pathPrefix   string
-	cmd          *exec.Cmd
-	stdin        io.WriteCloser
-	stdout       *bufio.Reader
-	stderr       *bytes.Buffer
-	mu           sync.Mutex
-	closed       bool
-	poison       error
-	maxBytes     int64
-	oversize     map[string]OversizeBlob
-	oversizeScan func(path string, chunk []byte)
+	rev            string
+	pathPrefix     string
+	cmd            *exec.Cmd
+	stdin          io.WriteCloser
+	stdout         *bufio.Reader
+	stderr         *bytes.Buffer
+	mu             sync.Mutex
+	closed         bool
+	poison         error
+	maxBytes       int64
+	oversize       map[string]OversizeBlob
+	oversizeScan   func(path string, chunk []byte)
+	oversizePrefix func(path string) bool
 }
 
 // OversizeBlob describes a blob ReadFile refused to materialize because it
@@ -935,12 +937,11 @@ type OversizeBlob struct {
 	Bytes int64
 	Hash  string
 	Lines int
-	// Prefix holds up to oversizeBlobPrefixCap leading bytes, captured for
-	// free from the same mandatory streaming pass that computes Hash and
-	// Lines. Git blob reads are all-or-nothing, so a refused blob otherwise
-	// cannot be prefix-sniffed at all (for example, to route an
-	// extensionless committed file by its shebang line) without a second,
-	// unbounded read of the same object.
+	// Prefix holds up to oversizeBlobPrefixCap leading bytes. Batch readers
+	// populate it only for paths admitted by SetOversizePrefixSelector; the
+	// one-shot OversizeBlobAtRev result also populates it because it retains no
+	// aggregate registry. The bytes come from the same mandatory streaming pass
+	// that computes Hash and Lines.
 	Prefix string
 }
 
@@ -978,6 +979,17 @@ func (r *BatchFileReader) SetOversizeScanner(scan func(path string, chunk []byte
 	r.oversizeScan = scan
 }
 
+// SetOversizePrefixSelector opts selected oversized paths into retaining a
+// bounded leading prefix alongside their digest. The default retains none:
+// even a small per-blob prefix becomes unbounded aggregate memory when a tree
+// contains many oversized blobs. The selector runs while the reader lock is
+// held and must not call back into the reader.
+func (r *BatchFileReader) SetOversizePrefixSelector(selectPath func(path string) bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.oversizePrefix = selectPath
+}
+
 // SetMaxBytes caps the blob size ReadFile will materialize. A larger blob is
 // streamed past the reader into a digest and discarded: ReadFile reports it as
 // unavailable and OversizeBlob then returns its size, content hash and line
@@ -998,6 +1010,26 @@ func (r *BatchFileReader) OversizeBlob(path string) (OversizeBlob, bool) {
 	defer r.mu.Unlock()
 	blob, ok := r.oversize[path]
 	return blob, ok
+}
+
+// TakeOversizeBlob returns an oversized record while consuming its optional
+// retained Prefix. Size, hash, and line metadata remain available through
+// OversizeBlob, but repeated calls return an empty Prefix. Prefix consumers use
+// this form so aggregate retained prefix memory is bounded by active workers
+// rather than by the number of oversized paths in the tree.
+func (r *BatchFileReader) TakeOversizeBlob(path string) (OversizeBlob, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	blob, ok := r.oversize[path]
+	if !ok {
+		return OversizeBlob{}, false
+	}
+	if blob.Prefix != "" {
+		stored := blob
+		stored.Prefix = ""
+		r.oversize[path] = stored
+	}
+	return blob, true
 }
 
 func NewBatchFileReader(ctx context.Context, repo, rev string) (*BatchFileReader, error) {
@@ -1192,14 +1224,20 @@ func (r *BatchFileReader) readObjectContentsLocked(objectSpec, expectedType stri
 	}
 	if r.maxBytes > 0 && size > r.maxBytes {
 		var src io.Reader = io.LimitReader(r.stdout, size)
-		prefix := make([]byte, 0, oversizeBlobPrefixCap)
-		tee := io.Writer(prefixCaptureWriter{buf: &prefix})
+		var prefix []byte
+		writers := make([]io.Writer, 0, 2)
+		if selectPath := r.oversizePrefix; selectPath != nil && selectPath(oversizeKey) {
+			prefix = make([]byte, 0, oversizeBlobPrefixCap)
+			writers = append(writers, prefixCaptureWriter{buf: &prefix})
+		}
 		if scan := r.oversizeScan; scan != nil {
 			// The same single pass the digest already makes: the scanner sees the bytes on their
 			// way to being discarded, so relevance costs no extra read and no retained memory.
-			tee = io.MultiWriter(tee, oversizeScanWriter{path: oversizeKey, scan: scan})
+			writers = append(writers, oversizeScanWriter{path: oversizeKey, scan: scan})
 		}
-		src = io.TeeReader(src, tee)
+		if len(writers) > 0 {
+			src = io.TeeReader(src, io.MultiWriter(writers...))
+		}
 		digest, err := filedigest.Stream(src)
 		if err != nil {
 			return "", false, r.poisonLocked(fmt.Errorf("stream oversized git blob: %w", err))
@@ -1383,6 +1421,14 @@ func (r *LimitedFileReader) Prime(paths []string) error {
 	}
 	if len(paths) == 0 {
 		return nil
+	}
+	// Argument validity is independent of the traversal budget. Validate the
+	// complete batch before an elapsed deadline can classify untouched input as
+	// merely unaddressable and thereby change the API's fail-fast contract.
+	for _, path := range paths {
+		if err := validateLimitedFilePath(path); err != nil {
+			return err
+		}
 	}
 	if r.primed == nil {
 		r.primed = make(map[string]primedLimitedFile, len(paths))

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -2435,3 +2435,58 @@ func TestOversizeBlobAtRevNeverMaterializesTheBlob(t *testing.T) {
 		t.Fatalf("allocated %d bytes reading a %d-byte blob; it must never be held", allocated, blobSize)
 	}
 }
+
+// TestRevParseRejectsAnOptionShapedRevisionInsteadOfPassingItThrough
+// reproduces the trail finding: RevParse fed a caller-supplied label straight
+// to `git rev-parse <label>` with no `--end-of-options` guard. A label
+// spelled like a flag (starting with "-") is not rejected as a bad revision —
+// git rev-parse's documented behavior for a flag it does not itself
+// recognize is to echo it back verbatim (exit 0), which is silent wrong
+// resolution, not a resolved OID. `--end-of-options` forces every remaining
+// argument to be treated as a revision, so an option-shaped label now fails
+// loudly instead of round-tripping through unresolved.
+func TestRevParseRejectsAnOptionShapedRevisionInsteadOfPassingItThrough(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	write(t, repo, "a.txt", "hi\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "init")
+
+	if _, err := RevParse(t.Context(), repo, "--upload-pack=/bin/true"); err == nil {
+		t.Fatal("RevParse(\"--upload-pack=/bin/true\") returned nil error, want a rejection: " +
+			"an option-shaped label must not be silently passed through as if it were a revision")
+	}
+
+	// Control: an ordinary revision still resolves.
+	if _, err := RevParse(t.Context(), repo, "HEAD"); err != nil {
+		t.Fatalf("RevParse(\"HEAD\") = %v, want a resolved commit OID", err)
+	}
+}
+
+// TestFirstParentRejectsAnOptionShapedRevision pins the same guard on
+// FirstParent, used directly with a CLI-supplied revision by `entire commit
+// <rev>` (internal/cli/root.go's runCommit).
+func TestFirstParentRejectsAnOptionShapedRevision(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	write(t, repo, "a.txt", "hi\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "init")
+	write(t, repo, "a.txt", "hi again\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "second")
+
+	if _, err := FirstParent(t.Context(), repo, "--upload-pack=/bin/true"); err == nil {
+		t.Fatal("FirstParent(\"--upload-pack=/bin/true\") returned nil error, want a rejection")
+	}
+
+	if _, err := FirstParent(t.Context(), repo, "HEAD"); err != nil {
+		t.Fatalf("FirstParent(\"HEAD\") = %v, want a resolved parent OID", err)
+	}
+}

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -1029,14 +1029,11 @@ func TestBlobSizeAtRevProbeSucceedsFromARepoSubdirectory(t *testing.T) {
 	subdir := filepath.Join(repo, "scope")
 
 	for _, path := range []string{"big.txt", "nested/big.txt"} {
-		detailed, err := ReadFileLimited(t.Context(), subdir, "HEAD", path, ceiling)
-		if err != nil {
-			t.Fatalf("ReadFileLimited(%q): %v", path, err)
-		}
-		if detailed.Status != LimitedFileOversize || detailed.Bytes != ceiling+1 || detailed.Content != "" {
-			t.Fatalf("ReadFileLimited(subdir, HEAD, %q, %d) = %#v, want oversize status with %d bytes and"+
-				" no content read: a double-prefixed pathspec would miss the tree entry entirely and this"+
-				" falls back to materializing the whole oversized blob", path, ceiling, detailed, ceiling+1)
+		bytes, status := blobSizeAtRev(t.Context(), subdir, "HEAD", path)
+		if status != blobProbeBlob || bytes != ceiling+1 {
+			t.Fatalf("blobSizeAtRev(subdir, HEAD, %q) = (%d, %v), want (%d, blobProbeBlob): a"+
+				" double-prefixed pathspec must fail this probe directly instead of being hidden by"+
+				" ReadFileLimited's content fallback", path, bytes, status, ceiling+1)
 		}
 	}
 }

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -950,6 +950,53 @@ func TestGitObjectReadersUseRepoSubdirectoryPrefix(t *testing.T) {
 	}
 }
 
+// TestBlobSizeAtRevProbeSucceedsFromARepoSubdirectory is an adversarial check
+// against the trail finding claiming treeEntryMetadata's ls-tree, run with a
+// subdirectory `repo` as its cwd, re-applies repoTreePath's already-prefixed
+// treePath a second time (e.g. "scope/scope/file"). ls-tree's pathspec here
+// carries the `:(top,literal)` magic (treeMetadataLiteralPrefix), which
+// anchors a literal pathspec to the REPOSITORY ROOT regardless of the
+// process's cwd -- verified independently with a bare `git ls-tree` from a
+// subdirectory. If the claimed double-prefix bug were real, the probe would
+// silently return blobProbeUnknown for the second-level path below, and
+// ReadFileLimited would fall through to materializing the oversized blob
+// with `git show` -- exactly the memory-bound violation the finding warns
+// about. This asserts the PROBE succeeds (LimitedFileOversize with the exact
+// size, no content read) rather than merely that some result comes back.
+func TestBlobSizeAtRevProbeSucceedsFromARepoSubdirectory(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	git(t, repo, "config", "commit.gpgsign", "false")
+	if err := os.MkdirAll(filepath.Join(repo, "scope", "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const ceiling = 1 << 10
+	oversized := strings.Repeat("x", ceiling+1)
+	if err := os.WriteFile(filepath.Join(repo, "scope", "big.txt"), []byte(oversized), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "scope", "nested", "big.txt"), []byte(oversized), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "subdirectory oversize fixture")
+	subdir := filepath.Join(repo, "scope")
+
+	for _, path := range []string{"big.txt", "nested/big.txt"} {
+		detailed, err := ReadFileLimited(t.Context(), subdir, "HEAD", path, ceiling)
+		if err != nil {
+			t.Fatalf("ReadFileLimited(%q): %v", path, err)
+		}
+		if detailed.Status != LimitedFileOversize || detailed.Bytes != ceiling+1 || detailed.Content != "" {
+			t.Fatalf("ReadFileLimited(subdir, HEAD, %q, %d) = %#v, want oversize status with %d bytes and"+
+				" no content read: a double-prefixed pathspec would miss the tree entry entirely and this"+
+				" falls back to materializing the whole oversized blob", path, ceiling, detailed, ceiling+1)
+		}
+	}
+}
+
 func TestBatchFileReaderRejectsLineUnsafePathsWithoutDesync(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows filenames cannot contain newlines or carriage returns")

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -1564,7 +1564,9 @@ func TestLimitedFileReaderStreamsAndRejectsDuplicateTreeMetadata(t *testing.T) {
 	runtime.GC()
 	var before, after runtime.MemStats
 	runtime.ReadMemStats(&before)
-	reader := NewLimitedFileReader(t.Context(), repo, tree, 1024)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	reader := NewLimitedFileReader(ctx, repo, tree, 1024)
 	err := reader.Prime([]string{"file.go"})
 	runtime.ReadMemStats(&after)
 	if err == nil || !strings.Contains(err.Error(), `duplicate path "file.go"`) {
@@ -1576,6 +1578,15 @@ func TestLimitedFileReaderStreamsAndRejectsDuplicateTreeMetadata(t *testing.T) {
 	const allocationBudget = 4 << 20
 	if allocated := after.TotalAlloc - before.TotalAlloc; allocated > allocationBudget {
 		t.Fatalf("duplicate metadata probe allocated %d bytes, want under %d", allocated, allocationBudget)
+	}
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("duplicate metadata probe did not retire Git before its deadline: %v", err)
+	}
+	// A prompt Wait is not enough on Windows if the killed Git launcher leaves
+	// its worker behind with the repository as its current directory. Require
+	// the complete repository to be removable as soon as Prime returns.
+	if err := os.RemoveAll(repo); err != nil {
+		t.Fatalf("duplicate metadata probe left a Git process holding the repository: %v", err)
 	}
 }
 
@@ -1972,6 +1983,9 @@ func TestNewCmdPinsSubprocessLocaleToC(t *testing.T) {
 	t.Setenv("GIT_NO_REPLACE_OBJECTS", "0")
 	dir := t.TempDir()
 	cmd := newCmd(context.Background(), dir, "git", "version")
+	if cmd.WaitDelay != gitCommandWaitDelay || cmd.WaitDelay == 0 {
+		t.Fatalf("stable-locale command WaitDelay = %v, want %v", cmd.WaitDelay, gitCommandWaitDelay)
+	}
 	lcAll, lang, pwd, noReplace := "", "", "", ""
 	for _, kv := range cmd.Env {
 		if v, ok := strings.CutPrefix(kv, "LC_ALL="); ok {
@@ -1998,6 +2012,9 @@ func TestNewCmdPinsSubprocessLocaleToC(t *testing.T) {
 	}
 
 	grepCmd := newGitCmdWithCallerLocale(context.Background(), dir, "version")
+	if grepCmd.WaitDelay != gitCommandWaitDelay || grepCmd.WaitDelay == 0 {
+		t.Fatalf("caller-locale command WaitDelay = %v, want %v", grepCmd.WaitDelay, gitCommandWaitDelay)
+	}
 	lcAll, pwd, noReplace = "", "", ""
 	for _, kv := range grepCmd.Env {
 		if v, ok := strings.CutPrefix(kv, "LC_ALL="); ok {

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -472,6 +472,106 @@ func TestBatchFileReaderReadsMultipleFilesFromHead(t *testing.T) {
 	}
 }
 
+func TestGitObjectReadersUseRepoSubdirectoryPrefix(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	if err := os.MkdirAll(filepath.Join(repo, "scope"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const content = "package scope\n"
+	if err := os.WriteFile(filepath.Join(repo, "scope", "file.go"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "subdirectory object fixture")
+	subdir := filepath.Join(repo, "scope")
+
+	prefix, err := RepoPrefix(t.Context(), subdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prefix != "scope/" {
+		t.Fatalf("repository prefix = %q, want scope/", prefix)
+	}
+	shown, ok, err := ShowFile(t.Context(), subdir, "HEAD", "file.go")
+	if err != nil || !ok || shown != content {
+		t.Fatalf("subdirectory ShowFile = (%q, %v, %v), want exact content", shown, ok, err)
+	}
+	limited, err := ReadFileLimited(t.Context(), subdir, "HEAD", "file.go", 1024)
+	if err != nil || limited.Status != LimitedFileContent || limited.Content != content {
+		t.Fatalf("subdirectory ReadFileLimited = (%#v, %v), want exact content", limited, err)
+	}
+	batch, err := NewBatchFileReader(t.Context(), subdir, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = batch.Close() })
+	batched, ok, err := batch.ReadFile("file.go")
+	if err != nil || !ok || batched != content {
+		t.Fatalf("subdirectory batch read = (%q, %v, %v), want exact content", batched, ok, err)
+	}
+}
+
+func TestBatchFileReaderRejectsLineUnsafePathsWithoutDesync(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows filenames cannot contain newlines or carriage returns")
+	}
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	files := map[string]string{
+		"name.go":       "package plain\n",
+		"name.go\r":     "package carriage\n",
+		"line\nname.go": "package newline\n",
+	}
+	for path, content := range files {
+		if err := os.WriteFile(filepath.Join(repo, path), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "line protocol fixture")
+
+	batch, err := NewBatchFileReader(t.Context(), repo, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = batch.Close() })
+	for _, path := range []string{"name.go\r", "line\nname.go"} {
+		if content, ok, err := batch.ReadFile(path); err == nil || ok || content != "" {
+			t.Fatalf("unsafe batch read %q = (%q, %v, %v), want pre-write error", path, content, ok, err)
+		}
+	}
+	plain, ok, err := batch.ReadFile("name.go")
+	if err != nil || !ok || plain != files["name.go"] {
+		t.Fatalf("plain sibling after unsafe reads = (%q, %v, %v), want exact content", plain, ok, err)
+	}
+
+	carriage, err := ReadFileLimited(t.Context(), repo, "HEAD", "name.go\r", 1024)
+	if err != nil || carriage.Status != LimitedFileContent || carriage.Content != files["name.go\r"] || carriage.Bytes != int64(len(files["name.go\r"])) {
+		t.Fatalf("typed trailing-CR read = (%#v, %v), want exact content and size", carriage, err)
+	}
+	carriage, err = ReadFileLimited(t.Context(), repo, "HEAD", "name.go\r", int64(len(files["name.go\r"])-1))
+	if err != nil || carriage.Status != LimitedFileOversize || carriage.Bytes != int64(len(files["name.go\r"])) {
+		t.Fatalf("capped trailing-CR read = (%#v, %v), want metadata-only oversize", carriage, err)
+	}
+
+	unsafeRevision, err := NewBatchFileReader(t.Context(), repo, "HEAD\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = unsafeRevision.Close() })
+	if unsafeRevision.IsPathSafe("name.go") {
+		t.Fatal("revision newline was not included in batch request safety check")
+	}
+	if _, _, err := unsafeRevision.ReadFile("name.go"); err == nil {
+		t.Fatal("batch accepted a revision newline before writing its request")
+	}
+}
+
 func TestShowFileClassifiesErrorsByStderrNotPath(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")
@@ -714,6 +814,43 @@ func TestShowFileLimitedRejectsGitlinkBeforeRenderingCommit(t *testing.T) {
 	}
 	if detailed.Status != LimitedFileNonBlob || detailed.Content != "" || detailed.Bytes != 0 {
 		t.Errorf("typed gitlink result = %#v, want non-blob with no content", detailed)
+	}
+}
+
+func TestReadFileLimitedClassifiesGitlinksWithoutCeiling(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	if err := os.WriteFile(filepath.Join(repo, "seed.txt"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", "seed.txt")
+	git(t, repo, "commit", "-m", "reachable target")
+	target := gitOutput(t, repo, "rev-parse", "HEAD")
+	git(t, repo, "update-index", "--add", "--cacheinfo", "160000", target, "reachable")
+	git(t, repo, "commit", "-m", "reachable gitlink")
+
+	reachable, err := ReadFileLimited(t.Context(), repo, "HEAD", "reachable", 0)
+	if err != nil || reachable.Status != LimitedFileNonBlob {
+		t.Fatalf("reachable unbounded gitlink = (%#v, %v), want non-blob", reachable, err)
+	}
+	oidLength := 40
+	if gitOutput(t, repo, "rev-parse", "--show-object-format") == "sha256" {
+		oidLength = 64
+	}
+	danglingTree := gitInputOutput(
+		t,
+		repo,
+		fmt.Sprintf("160000 commit %s\tdangling%c", strings.Repeat("1", oidLength), byte(0)),
+		"mktree", "-z", "--missing",
+	)
+	dangling, err := ReadFileLimited(t.Context(), repo, danglingTree, "dangling", 0)
+	if err != nil || dangling.Status != LimitedFileNonBlob {
+		t.Fatalf("dangling unbounded gitlink = (%#v, %v), want non-blob", dangling, err)
+	}
+	if content, ok, err := ShowFileLimited(t.Context(), repo, danglingTree, "dangling", 0); err != nil || ok || content != "" {
+		t.Fatalf("compact dangling gitlink = (%q, %v, %v), want refused non-blob", content, ok, err)
 	}
 }
 
@@ -992,11 +1129,9 @@ func TestLimitedFileReaderPrimesDeepGitTreePath(t *testing.T) {
 	}
 }
 
-func TestLimitedFileReaderFallsBackForPathBeyondBatchArgvBound(t *testing.T) {
+func TestLimitedFileReaderPrimesPathBeyondBatchArgvBound(t *testing.T) {
 	repo := t.TempDir()
-	// A bare repository avoids git show's pre-existing worktree-path stat for
-	// very long revision arguments and isolates the reader's fallback behavior.
-	git(t, repo, "init", "--bare")
+	git(t, repo, "init")
 	tree, path := nestedGitTree(t, repo, "package fallback\n", 80)
 	if len(treeMetadataLiteralPrefix)+len(path) <= literalPathspecBatchBytes {
 		t.Fatalf("fixture path length = %d, want beyond batch argv bound", len(path))
@@ -1007,18 +1142,43 @@ func TestLimitedFileReaderFallsBackForPathBeyondBatchArgvBound(t *testing.T) {
 	if err := reader.Prime([]string{path}); err != nil {
 		t.Fatal(err)
 	}
-	if _, primed := reader.primed[path]; primed {
-		t.Fatal("over-bound path unexpectedly entered metadata batch")
+	if _, primed := reader.primed[path]; !primed {
+		t.Fatal("over-bound path was not resolved by bounded component traversal")
 	}
 	result, err := reader.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if result.Status != LimitedFileContent || result.Content != "package fallback\n" {
-		t.Fatalf("one-shot deep Git-tree file = %#v, want exact content", result)
+		t.Fatalf("component-resolved deep Git-tree file = %#v, want exact content", result)
+	}
+	if reader.content == nil {
+		t.Fatal("component-resolved path did not use exact-OID content batch")
+	}
+}
+
+func TestLimitedFileReaderClassifiesSingleComponentBeyondArgvBound(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	blob := gitInputOutput(t, repo, "package leaf\n", "hash-object", "-w", "--stdin")
+	leafTree := gitInputOutput(t, repo, fmt.Sprintf("100644 blob %s\tfile.go%c", blob, byte(0)), "mktree", "-z")
+	component := strings.Repeat("x", literalPathspecBatchBytes+1)
+	tree := gitInputOutput(t, repo, fmt.Sprintf("040000 tree %s\t%s%c", leafTree, component, byte(0)), "mktree", "-z")
+	path := component + "/file.go"
+
+	reader := NewLimitedFileReader(t.Context(), repo, tree, 1024)
+	if err := reader.Prime([]string{path}); err != nil {
+		t.Fatal(err)
+	}
+	result, err := reader.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != LimitedFileUnaddressable {
+		t.Fatalf("over-bound component result = %#v, want bounded unaddressable classification", result)
 	}
 	if reader.content != nil {
-		t.Fatal("over-bound path started persistent content batch instead of one-shot fallback")
+		t.Fatal("unaddressable component started a content batch")
 	}
 }
 

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -1668,6 +1668,70 @@ func TestLimitedFileReaderPrimesPathBeyondBatchArgvBound(t *testing.T) {
 	}
 }
 
+// TestLimitedFileReaderPrimeStopsOrdinaryBatchesAtDeadline reproduces the
+// trail finding on Prime: the ordinary short-path batch loop ran every batch
+// to completion regardless of SetDeadline, so a candidate list long enough to
+// need several literalPathspecBatchCount-sized batches could keep starting
+// new Git subprocesses long after the caller's wall-clock budget elapsed.
+func TestLimitedFileReaderPrimeStopsOrdinaryBatchesAtDeadline(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	// More than one literalPathspecBatchCount-sized group, so Prime must issue
+	// at least two ordinary metadata batches to resolve every path.
+	const total = literalPathspecBatchCount + 10
+	paths := make([]string, total)
+	for i := range paths {
+		path := fmt.Sprintf("file%03d.go", i)
+		paths[i] = path
+		if err := os.WriteFile(filepath.Join(repo, path), []byte("package p\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "many short paths")
+	head := gitOutput(t, repo, "rev-parse", "HEAD")
+
+	reader := NewLimitedFileReader(t.Context(), repo, head, 1024)
+	t.Cleanup(func() { _ = reader.Close() })
+	deadline := time.Unix(100, 0)
+	checks := 0
+	reader.now = func() time.Time {
+		checks++
+		if checks == 1 {
+			// Let the first batch attempt proceed, so this test exercises a
+			// deadline that elapses mid-Prime, not one already elapsed
+			// before the first Git subprocess ever ran.
+			return deadline.Add(-time.Second)
+		}
+		return deadline
+	}
+	reader.SetDeadline(deadline)
+
+	if err := reader.Prime(paths); err != nil {
+		t.Fatal(err)
+	}
+	if checks < 2 {
+		t.Fatalf("Prime checked the deadline %d times, want at least 2 (once per batch attempt)", checks)
+	}
+	resolved, unaddressable := 0, 0
+	for _, path := range paths {
+		switch reader.primed[path].result.Status {
+		case LimitedFileUnaddressable:
+			unaddressable++
+		default:
+			resolved++
+		}
+	}
+	if unaddressable == 0 {
+		t.Fatalf("Prime resolved every path despite an elapsed deadline: %d resolved, 0 unaddressable", resolved)
+	}
+	if resolved == 0 {
+		t.Fatal("Prime marked every path unaddressable; want the already-started first batch to still complete")
+	}
+}
+
 func TestLimitedFileReaderCachesAndCapsComponentMetadata(t *testing.T) {
 	const (
 		depth  = 80

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -2045,12 +2045,13 @@ func TestNewCmdPinsSubprocessLocaleToC(t *testing.T) {
 	t.Setenv("LC_ALL", "fr_FR.UTF-8")
 	t.Setenv("LANG", "fr_FR.UTF-8")
 	t.Setenv("GIT_NO_REPLACE_OBJECTS", "0")
+	t.Setenv("GIT_ALLOW_PROTOCOL", "https")
 	dir := t.TempDir()
 	cmd := newCmd(context.Background(), dir, "git", "version")
 	if cmd.WaitDelay != gitCommandWaitDelay || cmd.WaitDelay == 0 {
 		t.Fatalf("stable-locale command WaitDelay = %v, want %v", cmd.WaitDelay, gitCommandWaitDelay)
 	}
-	lcAll, lang, pwd, noReplace, noLazyFetch := "", "", "", "", ""
+	lcAll, lang, pwd, noReplace, noLazyFetch, allowProtocol := "", "", "", "", "", "unset"
 	for _, kv := range cmd.Env {
 		if v, ok := strings.CutPrefix(kv, "LC_ALL="); ok {
 			lcAll = v
@@ -2067,6 +2068,9 @@ func TestNewCmdPinsSubprocessLocaleToC(t *testing.T) {
 		if v, ok := strings.CutPrefix(kv, "GIT_NO_LAZY_FETCH="); ok {
 			noLazyFetch = v
 		}
+		if v, ok := strings.CutPrefix(kv, "GIT_ALLOW_PROTOCOL="); ok {
+			allowProtocol = v
+		}
 	}
 	if lcAll != "C" || lang != "C" {
 		t.Fatalf("effective subprocess locale LC_ALL=%q LANG=%q, want both \"C\"", lcAll, lang)
@@ -2080,12 +2084,16 @@ func TestNewCmdPinsSubprocessLocaleToC(t *testing.T) {
 	if noLazyFetch != "1" {
 		t.Fatalf("effective GIT_NO_LAZY_FETCH=%q, want 1: a partial clone's promisor remote must never be contacted by this no-egress provider", noLazyFetch)
 	}
+	if allowProtocol != "" {
+		t.Fatalf("effective GIT_ALLOW_PROTOCOL=%q, want empty: GIT_NO_LAZY_FETCH is unrecognized before Git 2.45,"+
+			" so every transport must independently be denied regardless of the inherited environment", allowProtocol)
+	}
 
 	grepCmd := newGitCmdWithCallerLocale(context.Background(), dir, "version")
 	if grepCmd.WaitDelay != gitCommandWaitDelay || grepCmd.WaitDelay == 0 {
 		t.Fatalf("caller-locale command WaitDelay = %v, want %v", grepCmd.WaitDelay, gitCommandWaitDelay)
 	}
-	lcAll, pwd, noReplace, noLazyFetch = "", "", "", ""
+	lcAll, pwd, noReplace, noLazyFetch, allowProtocol = "", "", "", "", "unset"
 	for _, kv := range grepCmd.Env {
 		if v, ok := strings.CutPrefix(kv, "LC_ALL="); ok {
 			lcAll = v
@@ -2099,6 +2107,9 @@ func TestNewCmdPinsSubprocessLocaleToC(t *testing.T) {
 		if v, ok := strings.CutPrefix(kv, "GIT_NO_LAZY_FETCH="); ok {
 			noLazyFetch = v
 		}
+		if v, ok := strings.CutPrefix(kv, "GIT_ALLOW_PROTOCOL="); ok {
+			allowProtocol = v
+		}
 	}
 	if lcAll != "fr_FR.UTF-8" {
 		t.Fatalf("caller-locale git command LC_ALL=%q, want inherited locale", lcAll)
@@ -2111,6 +2122,40 @@ func TestNewCmdPinsSubprocessLocaleToC(t *testing.T) {
 	}
 	if noLazyFetch != "1" {
 		t.Fatalf("caller-locale git command GIT_NO_LAZY_FETCH=%q, want 1", noLazyFetch)
+	}
+	if allowProtocol != "" {
+		t.Fatalf("caller-locale git command GIT_ALLOW_PROTOCOL=%q, want empty", allowProtocol)
+	}
+}
+
+// TestGitAllowProtocolBlocksALazyFetchGitVersionIndependently pins the
+// property the trail finding asked for directly: even if a caller's own
+// GIT_NO_LAZY_FETCH were somehow ineffective (as it silently is on any Git
+// older than 2.45, since the variable did not exist yet), a fetch attempt
+// still cannot reach the network, because newCmd's GIT_ALLOW_PROTOCOL=
+// denies every transport unconditionally.
+func TestGitAllowProtocolBlocksALazyFetchGitVersionIndependently(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	if err := os.WriteFile(filepath.Join(repo, "a.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+
+	// GIT_NO_LAZY_FETCH unset here (unlike newCmd's own environment) stands
+	// in for a Git binary old enough that the variable does nothing, so a
+	// pass only because of that guard would go undetected by this test.
+	cmd := exec.Command("git", "-C", repo, "fetch", "file:///nonexistent-does-not-exist")
+	cmd.Env = append(os.Environ(), noTransportProtocolEnv)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("git fetch under GIT_ALLOW_PROTOCOL= succeeded, want every transport denied: %s", out)
+	}
+	if !strings.Contains(string(out), "not allowed") {
+		t.Fatalf("git fetch under GIT_ALLOW_PROTOCOL= failed for an unexpected reason (want a transport-denial error): %s", out)
 	}
 }
 

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -475,12 +475,60 @@ func TestBatchFileReaderReadsMultipleFilesFromHead(t *testing.T) {
 
 type countingWriteCloser struct {
 	io.WriteCloser
-	writes int
+	commands    []string
+	beforeWrite func(string)
 }
 
 func (w *countingWriteCloser) Write(p []byte) (int, error) {
-	w.writes++
+	command := string(p)
+	if w.beforeWrite != nil {
+		w.beforeWrite(command)
+	}
+	w.commands = append(w.commands, command)
 	return w.WriteCloser.Write(p)
+}
+
+func (w *countingWriteCloser) countCommands(prefix string) int {
+	count := 0
+	for _, command := range w.commands {
+		if strings.HasPrefix(command, prefix) {
+			count++
+		}
+	}
+	return count
+}
+
+func TestNewBatchFileReaderReportsUnsupportedBatchCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX shell shim")
+	}
+	binDir := t.TempDir()
+	fakeGit := filepath.Join(binDir, "git")
+	const script = `#!/bin/sh
+if [ "$1" = "rev-parse" ] && [ "$2" = "--show-prefix" ]; then
+	printf '\n'
+	exit 0
+fi
+if [ "$1" = "cat-file" ] && [ "$2" = "--batch-command" ]; then
+	printf '%s\n' 'error: unknown option batch-command' >&2
+	exit 129
+fi
+exit 2
+`
+	if err := os.WriteFile(fakeGit, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+
+	reader, err := NewBatchFileReader(t.Context(), t.TempDir(), "HEAD")
+	if reader != nil {
+		_ = reader.Close()
+		t.Fatal("unsupported batch-command returned a reader")
+	}
+	if err == nil || !strings.Contains(err.Error(), "Git 2.36 or newer required") ||
+		!strings.Contains(err.Error(), "unknown option batch-command") {
+		t.Fatalf("unsupported batch-command error = %v, want version requirement and Git diagnostic", err)
+	}
 }
 
 func TestBatchFileReaderRejectsNonBlobBeforeRequestingContent(t *testing.T) {
@@ -509,11 +557,11 @@ func TestBatchFileReaderRejectsNonBlobBeforeRequestingContent(t *testing.T) {
 	if content, ok, err := reader.ReadFile("module.py"); err != nil || ok || content != "" {
 		t.Fatalf("gitlink batch read = (%q, %v, %v), want metadata-only refusal", content, ok, err)
 	}
-	if contentWrites.writes != 0 {
-		t.Fatalf("gitlink issued %d content requests, want none", contentWrites.writes)
+	if got := contentWrites.countCommands("contents "); got != 0 {
+		t.Fatalf("gitlink issued %d content requests, want none: %#v", got, contentWrites.commands)
 	}
-	if reader.checkCmd == nil {
-		t.Fatal("gitlink read did not use the metadata batch")
+	if got := contentWrites.countCommands("info "); got != 1 {
+		t.Fatalf("gitlink issued %d metadata requests, want one: %#v", got, contentWrites.commands)
 	}
 
 	// A real blob still reaches the content batch. The one-byte ceiling makes it
@@ -521,12 +569,159 @@ func TestBatchFileReaderRejectsNonBlobBeforeRequestingContent(t *testing.T) {
 	if content, ok, err := reader.ReadFile("plain.py"); err != nil || ok || content != "" {
 		t.Fatalf("oversized blob batch read = (%q, %v, %v), want refusal", content, ok, err)
 	}
-	if contentWrites.writes != 1 {
-		t.Fatalf("blob issued %d content requests, want one", contentWrites.writes)
+	if got := contentWrites.countCommands("contents "); got != 1 {
+		t.Fatalf("blob issued %d content requests, want one: %#v", got, contentWrites.commands)
 	}
 	if _, ok := reader.OversizeBlob("plain.py"); !ok {
 		t.Fatal("blob preflight bypassed the existing oversize digest registry")
 	}
+}
+
+func TestBatchFileReaderPinsReplaceRefsAcrossInfoAndContents(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	const content = "package pinned\n"
+	if err := os.WriteFile(filepath.Join(repo, "file.go"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", "file.go")
+	git(t, repo, "commit", "-m", "replace-race fixture")
+	originalOID := gitOutput(t, repo, "rev-parse", "HEAD:file.go")
+	replacementLeaf := gitInputOutput(t, repo, "replacement\n", "hash-object", "-w", "--stdin")
+	replacementTree := gitInputOutput(
+		t,
+		repo,
+		fmt.Sprintf("100644 blob %s\tleaf%c", replacementLeaf, byte(0)),
+		"mktree", "-z",
+	)
+
+	reader, err := NewBatchFileReader(t.Context(), repo, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = reader.Close() })
+	writes := &countingWriteCloser{WriteCloser: reader.stdin}
+	reader.stdin = writes
+	moved := false
+	writes.beforeWrite = func(command string) {
+		if moved || !strings.HasPrefix(command, "contents ") {
+			return
+		}
+		moved = true
+		// This runs after the info response but before contents reaches Git. With
+		// separate metadata/content processes, the content process sees this new
+		// replacement and returns a tree body for an object checked as a blob.
+		git(t, repo, "update-ref", "refs/replace/"+originalOID, replacementTree)
+	}
+
+	got, ok, err := reader.ReadFile("file.go")
+	if err != nil || !ok || got != content {
+		t.Fatalf("read across moving replacement = (%q, %v, %v), want original blob", got, ok, err)
+	}
+	if !moved {
+		t.Fatal("fixture did not move the replacement between info and contents")
+	}
+	if got := writes.countCommands("info "); got != 1 {
+		t.Fatalf("metadata commands = %d, want one: %#v", got, writes.commands)
+	}
+	if got := writes.countCommands("contents "); got != 1 {
+		t.Fatalf("content commands = %d, want one original-blob request: %#v", got, writes.commands)
+	}
+	// The replacement target was a tree. Returning the original bytes and keeping
+	// the session usable proves that no non-blob body entered or desynchronized it.
+	again, ok, err := reader.ReadFile("file.go")
+	if err != nil || !ok || again != content {
+		t.Fatalf("read after moving replacement = (%q, %v, %v), want synchronized original blob", again, ok, err)
+	}
+}
+
+func TestLimitedFileReaderRechecksKnownOIDInContentSession(t *testing.T) {
+	t.Run("replacement becomes nonblob", func(t *testing.T) {
+		repo := t.TempDir()
+		git(t, repo, "init")
+		originalOID := gitInputOutput(t, repo, "package original\n", "hash-object", "-w", "--stdin")
+		rootTree := gitInputOutput(t, repo, fmt.Sprintf("100644 blob %s\tfile.go%c", originalOID, byte(0)), "mktree", "-z")
+		replacementLeaf := gitInputOutput(t, repo, "leaf\n", "hash-object", "-w", "--stdin")
+		replacementTree := gitInputOutput(t, repo, fmt.Sprintf("100644 blob %s\tleaf%c", replacementLeaf, byte(0)), "mktree", "-z")
+
+		reader := NewLimitedFileReader(t.Context(), repo, rootTree, 1024)
+		t.Cleanup(func() { _ = reader.Close() })
+		if err := reader.Prime([]string{"file.go"}); err != nil {
+			t.Fatal(err)
+		}
+		git(t, repo, "update-ref", "refs/replace/"+originalOID, replacementTree)
+		content, err := NewBatchFileReader(t.Context(), repo, rootTree)
+		if err != nil {
+			t.Fatal(err)
+		}
+		content.SetMaxBytes(1024)
+		writes := &countingWriteCloser{WriteCloser: content.stdin}
+		content.stdin = writes
+		reader.content = content
+
+		result, err := reader.ReadFile("file.go")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Status != LimitedFileUnreadable {
+			t.Fatalf("known OID replaced by tree = %#v, want unreadable without a body request", result)
+		}
+		if got := writes.countCommands("info "); got != 1 {
+			t.Fatalf("known-OID metadata commands = %d, want one: %#v", got, writes.commands)
+		}
+		if got := writes.countCommands("contents "); got != 0 {
+			t.Fatalf("known OID replaced by tree issued %d content commands, want zero: %#v", got, writes.commands)
+		}
+	})
+
+	t.Run("replacement becomes oversized blob", func(t *testing.T) {
+		repo := t.TempDir()
+		git(t, repo, "init")
+		originalOID := gitInputOutput(t, repo, "small\n", "hash-object", "-w", "--stdin")
+		rootTree := gitInputOutput(t, repo, fmt.Sprintf("100644 blob %s\tfile.go%c", originalOID, byte(0)), "mktree", "-z")
+		oversizedContent := strings.Repeat("replacement line\n", 64)
+		replacementOID := gitInputOutput(t, repo, oversizedContent, "hash-object", "-w", "--stdin")
+		const ceiling = int64(32)
+
+		reader := NewLimitedFileReader(t.Context(), repo, rootTree, ceiling)
+		t.Cleanup(func() { _ = reader.Close() })
+		if err := reader.Prime([]string{"file.go"}); err != nil {
+			t.Fatal(err)
+		}
+		git(t, repo, "update-ref", "refs/replace/"+originalOID, replacementOID)
+		content, err := NewBatchFileReader(t.Context(), repo, rootTree)
+		if err != nil {
+			t.Fatal(err)
+		}
+		content.SetMaxBytes(ceiling)
+		writes := &countingWriteCloser{WriteCloser: content.stdin}
+		content.stdin = writes
+		reader.content = content
+
+		result, err := reader.ReadFile("file.go")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Status != LimitedFileOversize || result.Bytes != int64(len(oversizedContent)) {
+			t.Fatalf("known OID replaced by oversized blob = %#v, want exact oversize result", result)
+		}
+		digest, ok := content.OversizeBlob("file.go")
+		if !ok {
+			t.Fatal("replacement oversize blob had no digest")
+		}
+		wantHash := sha256.Sum256([]byte(oversizedContent))
+		if digest.Bytes != int64(len(oversizedContent)) || digest.Hash != hex.EncodeToString(wantHash[:]) || digest.Lines != 64 {
+			t.Fatalf("replacement oversize digest = %#v, want exact bytes/hash/lines", digest)
+		}
+		if got := writes.countCommands("info "); got != 1 {
+			t.Fatalf("oversize known-OID metadata commands = %d, want one: %#v", got, writes.commands)
+		}
+		if got := writes.countCommands("contents "); got != 1 {
+			t.Fatalf("oversize known-OID content commands = %d, want one digest stream: %#v", got, writes.commands)
+		}
+	})
 }
 
 func TestBatchFileReaderRejectsInvalidPathWithoutDesync(t *testing.T) {

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -731,8 +731,25 @@ func TestBatchFileReaderRejectsNonBlobBeforeRequestingContent(t *testing.T) {
 	if got := contentWrites.countCommands("contents "); got != 1 {
 		t.Fatalf("blob issued %d content requests, want one: %#v", got, contentWrites.commands)
 	}
-	if _, ok := reader.OversizeBlob("plain.py"); !ok {
+	if blob, ok := reader.OversizeBlob("plain.py"); !ok {
 		t.Fatal("blob preflight bypassed the existing oversize digest registry")
+	} else if blob.Prefix != "" {
+		t.Fatalf("ordinary oversized blob retained %d prefix bytes without an opt-in consumer", len(blob.Prefix))
+	}
+
+	reader.SetOversizePrefixSelector(func(path string) bool { return path == "plain.py" })
+	if content, ok, err := reader.ReadFile("plain.py"); err != nil || ok || content != "" {
+		t.Fatalf("opted-in oversized blob read = (%q, %v, %v), want refusal", content, ok, err)
+	}
+	if blob, ok := reader.TakeOversizeBlob("plain.py"); !ok {
+		t.Fatal("opted-in oversized blob missing from digest registry")
+	} else if !strings.HasPrefix(blob.Prefix, "def plain") {
+		t.Fatalf("opted-in oversized blob prefix = %q, want leading source bytes", blob.Prefix)
+	}
+	if blob, ok := reader.OversizeBlob("plain.py"); !ok {
+		t.Fatal("consuming prefix removed oversized blob metadata")
+	} else if blob.Prefix != "" || blob.Bytes == 0 || blob.Hash == "" {
+		t.Fatalf("stored oversized blob after prefix consumption = %#v, want metadata with empty Prefix", blob)
 	}
 }
 
@@ -1803,6 +1820,20 @@ func TestLimitedFileReaderPrimeStopsOrdinaryBatchesAtDeadline(t *testing.T) {
 	}
 	if resolved == 0 {
 		t.Fatal("Prime marked every path unaddressable; want the already-started first batch to still complete")
+	}
+}
+
+func TestLimitedFileReaderPrimeValidatesPathsBeforeExpiredDeadline(t *testing.T) {
+	reader := NewLimitedFileReader(t.Context(), t.TempDir(), "HEAD", 1024)
+	deadline := time.Unix(100, 0)
+	reader.now = func() time.Time { return deadline }
+	reader.SetDeadline(deadline)
+
+	if err := reader.Prime([]string{"bad/"}); err == nil || !strings.Contains(err.Error(), `invalid Git tree path "bad/"`) {
+		t.Fatalf("Prime invalid path after elapsed deadline = %v, want the established path-validation error", err)
+	}
+	if len(reader.primed) != 0 {
+		t.Fatalf("Prime retained invalid path metadata after validation failure: %#v", reader.primed)
 	}
 }
 

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -187,6 +187,33 @@ func TestGrepTreePathsMatchesTextAPIAndHandlesUnusualPaths(t *testing.T) {
 	}
 }
 
+func TestGitGrepRejectsSuccessfulStderr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the Git wrapper is a POSIX shell script")
+	}
+	wrapperDir := t.TempDir()
+	wrapper := filepath.Join(wrapperDir, "git")
+	script := `#!/bin/sh
+case " $* " in
+	*" -o "*) printf 'HEAD:auth.py\000Foo\n' ;;
+	*) printf 'HEAD:auth.py\000' ;;
+esac
+printf '%s\n' "error: 'HEAD:caller.py': unable to read promised blob" >&2
+exit 0
+`
+	if err := os.WriteFile(wrapper, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if paths, err := GrepTreePathsIncludingBinary(t.Context(), t.TempDir(), "HEAD", []string{"Foo"}); err == nil {
+		t.Fatalf("path-only Git grep accepted successful stderr and returned %#v", paths)
+	}
+	if matches, err := grepFixedStringMatches(t.Context(), t.TempDir(), "HEAD", []string{"Foo"}, 1); err == nil {
+		t.Fatalf("matched-text Git grep accepted successful stderr and returned %#v", matches)
+	}
+}
+
 // TestGrepTreePathsIncludingBinaryFindsFilesGrepTreePathsExcludes pins the
 // only behavioral difference between the two functions: a blob Git itself
 // classifies as binary because of an early embedded NUL byte. GrepTreePaths

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"math"
 	"os"
 	"os/exec"
@@ -713,6 +714,213 @@ func TestShowFileLimitedRejectsGitlinkBeforeRenderingCommit(t *testing.T) {
 	}
 	if detailed.Status != LimitedFileNonBlob || detailed.Content != "" || detailed.Bytes != 0 {
 		t.Errorf("typed gitlink result = %#v, want non-blob with no content", detailed)
+	}
+}
+
+func TestLimitedFileReaderReusesBatchesAndRefusesByMetadata(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	git(t, repo, "config", "commit.gpgsign", "false")
+
+	if err := os.WriteFile(filepath.Join(repo, "seed.txt"), []byte("target\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", "seed.txt")
+	git(t, repo, "commit", "-m", "gitlink target")
+	target := gitOutput(t, repo, "rev-parse", "HEAD")
+
+	if err := os.MkdirAll(filepath.Join(repo, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const fileCount = 32
+	for i := range fileCount {
+		path := filepath.Join(repo, "src", fmt.Sprintf("file%02d.go", i))
+		if err := os.WriteFile(path, []byte(fmt.Sprintf("package src\n// file %d\n", i)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	const ceiling = int64(64)
+	if err := os.WriteFile(filepath.Join(repo, "large.go"), []byte(strings.Repeat("x", int(ceiling)+1)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "update-index", "--add", "--cacheinfo", "160000", target, "vendor/module.go")
+	git(t, repo, "commit", "-m", "reader fixture")
+
+	reader := NewLimitedFileReader(t.Context(), repo, "HEAD", ceiling)
+	t.Cleanup(func() { _ = reader.Close() })
+	primePaths := make([]string, 0, fileCount+3)
+	for i := range fileCount {
+		primePaths = append(primePaths, fmt.Sprintf("src/file%02d.go", i))
+	}
+	primePaths = append(primePaths, "large.go", "vendor/module.go", "missing.go")
+	if err := reader.Prime(primePaths); err != nil {
+		t.Fatal(err)
+	}
+	if reader.content != nil {
+		t.Fatal("metadata priming should not start the persistent content batch")
+	}
+	var contentCmd *exec.Cmd
+	for i := range fileCount {
+		path := fmt.Sprintf("src/file%02d.go", i)
+		result, err := reader.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Status != LimitedFileContent || !strings.Contains(result.Content, fmt.Sprintf("file %d", i)) {
+			t.Fatalf("%s = %#v, want its content", path, result)
+		}
+		if i == 0 {
+			contentCmd = reader.content.cmd
+		} else if reader.content.cmd != contentCmd {
+			t.Fatal("limited reader started new Git processes instead of reusing its content batch")
+		}
+	}
+
+	large, err := reader.ReadFile("large.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if large.Status != LimitedFileOversize || large.Bytes != ceiling+1 || large.Content != "" {
+		t.Fatalf("large blob = %#v, want metadata-only oversize refusal", large)
+	}
+	if _, streamed := reader.content.OversizeBlob("large.go"); streamed {
+		t.Fatal("oversized blob entered the content batch and was streamed merely to advance it")
+	}
+	if reader.content.cmd != contentCmd {
+		t.Fatal("oversize probe replaced a persistent batch process")
+	}
+
+	gitlink, err := reader.ReadFile("vendor/module.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gitlink.Status != LimitedFileNonBlob {
+		t.Fatalf("gitlink = %#v, want non-blob", gitlink)
+	}
+	missing, err := reader.ReadFile("missing.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if missing.Status != LimitedFileMissing {
+		t.Fatalf("missing path = %#v, want missing", missing)
+	}
+}
+
+func TestLimitedFileReaderUsesObjectIDsForLineTerminators(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows filenames cannot contain newlines or carriage returns")
+	}
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	git(t, repo, "config", "commit.gpgsign", "false")
+
+	plainPath := "name.go"
+	carriagePath := "name.go\r"
+	newlinePath := "line\nname.go"
+	plainContent := "package plain\n"
+	carriageContent := "package carriage\n"
+	newlineContent := "package newline\n"
+	if err := os.WriteFile(filepath.Join(repo, plainPath), []byte(plainContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, carriagePath), []byte(carriageContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, newlinePath), []byte(newlineContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "carriage return siblings")
+
+	reader := NewLimitedFileReader(t.Context(), repo, "HEAD", 1024)
+	t.Cleanup(func() { _ = reader.Close() })
+	if err := reader.Prime([]string{plainPath, carriagePath, newlinePath}); err != nil {
+		t.Fatal(err)
+	}
+	newlineResult, err := reader.ReadFile(newlinePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newlineResult.Status != LimitedFileContent || newlineResult.Content != newlineContent {
+		t.Fatalf("newline path = %#v, want its own content %q", newlineResult, newlineContent)
+	}
+	if reader.content == nil {
+		t.Fatal("newline path did not start the exact-object content batch")
+	}
+	contentCmd := reader.content.cmd
+
+	carriageResult, err := reader.ReadFile(carriagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if carriageResult.Status != LimitedFileContent || carriageResult.Content != carriageContent {
+		t.Fatalf("trailing-CR path = %#v, want its own content %q", carriageResult, carriageContent)
+	}
+	if reader.content.cmd != contentCmd {
+		t.Fatal("line-terminator paths did not reuse the exact-object content batch")
+	}
+
+	plain, err := reader.ReadFile(plainPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plain.Status != LimitedFileContent || plain.Content != plainContent {
+		t.Fatalf("plain sibling = %#v, want %q", plain, plainContent)
+	}
+	if reader.content.cmd != contentCmd {
+		t.Fatal("plain sibling did not reuse the exact-object content batch")
+	}
+}
+
+func TestLimitedFileReaderKeepsRepoSubdirectoryPathsRelative(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	git(t, repo, "config", "commit.gpgsign", "false")
+
+	const content = "package scope\n"
+	if err := os.MkdirAll(filepath.Join(repo, "scope"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "scope", "file.go"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "subdirectory fixture")
+
+	reader := NewLimitedFileReader(t.Context(), filepath.Join(repo, "scope"), "HEAD", 1024)
+	t.Cleanup(func() { _ = reader.Close() })
+	if err := reader.Prime([]string{"file.go", "missing.go"}); err != nil {
+		t.Fatal(err)
+	}
+	result, err := reader.ReadFile("file.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != LimitedFileContent || result.Content != content {
+		t.Fatalf("subdirectory file = %#v, want cwd-relative content %q", result, content)
+	}
+	missing, err := reader.ReadFile("missing.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if missing.Status != LimitedFileMissing {
+		t.Fatalf("subdirectory missing path = %#v, want missing", missing)
+	}
+}
+
+func TestLimitedFileReaderBoundsMetadataPathspecs(t *testing.T) {
+	reader := NewLimitedFileReader(t.Context(), t.TempDir(), "HEAD", 1024)
+	path := strings.Repeat("x", literalPathOutputMaxPathBytes+1)
+	err := reader.Prime([]string{path})
+	if err == nil || !strings.Contains(err.Error(), "input path exceeds") {
+		t.Fatalf("oversized metadata path error = %v, want bounded-input rejection", err)
 	}
 }
 

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -281,6 +281,37 @@ func TestGrepIndexMatchesPreservesUnicodeCaseFoldingLocale(t *testing.T) {
 	}
 }
 
+func TestTreeGrepsIgnoreReplaceRefsAndOverrideHostileEnvironment(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	originalOID := gitInputOutput(t, repo, "OriginalNeedle\n", "hash-object", "-w", "--stdin")
+	replacementOID := gitInputOutput(t, repo, "replacement without it\n", "hash-object", "-w", "--stdin")
+	tree := gitInputOutput(t, repo, fmt.Sprintf("100644 blob %s\tfile.go%c", originalOID, byte(0)), "mktree", "-z")
+	git(t, repo, "update-ref", "refs/replace/"+originalOID, replacementOID)
+	// Preserve a hostile inherited assignment and prove production commands
+	// append their canonical raw-object override after it. The control below
+	// removes the variable entirely so Git demonstrably honors the replacement.
+	t.Setenv("GIT_NO_REPLACE_OBJECTS", "0")
+	if got := gitOutputHonoringReplaceRefs(t, repo, "cat-file", "-p", originalOID); got != "replacement without it" {
+		t.Fatalf("control Git replacement view = %q, want replacement content", got)
+	}
+
+	paths, err := GrepTreePaths(t.Context(), repo, tree, []string{"OriginalNeedle"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(paths, []string{"file.go"}) {
+		t.Fatalf("raw tree grep paths = %#v, want file.go despite replacement", paths)
+	}
+	matches, err := GrepTreeMatches(t.Context(), repo, tree, []string{"OriginalNeedle"}, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 || matches[0].Path != "file.go" || matches[0].Text != "OriginalNeedle" {
+		t.Fatalf("raw tree grep matches = %#v, want original blob match", matches)
+	}
+}
+
 func TestChangedFilesHandlesNewlinesAndTabsInPaths(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows filenames cannot contain newlines")
@@ -531,6 +562,107 @@ exit 2
 	}
 }
 
+func TestBatchFileReaderProtocolFailureIsStickyAndRetiresProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX shell protocol shim")
+	}
+	for _, test := range []struct {
+		name      string
+		mode      string
+		maxBytes  int64
+		wantError string
+	}{
+		{name: "wrong separator", mode: "separator", wantError: "missing trailing newline separator"},
+		{name: "short oversized body", mode: "partial", maxBytes: 1, wantError: "blob body length 2, want 5"},
+		{name: "mismatched info missing header", mode: "info-missing", wantError: `info missing header "other missing"`},
+		{name: "mismatched contents missing header", mode: "contents-missing", wantError: `contents missing header "other missing"`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			binDir := t.TempDir()
+			requestLog := filepath.Join(t.TempDir(), "requests.log")
+			fakeGit := filepath.Join(binDir, "git")
+			const objectID = "1111111111111111111111111111111111111111"
+			const script = `#!/bin/sh
+if [ "$1" = "rev-parse" ] && [ "$2" = "--show-prefix" ]; then
+	printf '\n'
+	exit 0
+fi
+if [ "$1" = "cat-file" ] && [ "$2" = "--batch-command" ]; then
+	while IFS= read -r line; do
+		printf '%s\n' "$line" >> "$ENTIRE_GRAPH_BATCH_REQUEST_LOG"
+		case "$line" in
+			"info 0000000000000000000000000000000000000000")
+				printf '%s missing\n' '0000000000000000000000000000000000000000'
+				;;
+			info\ *)
+				if [ "$ENTIRE_GRAPH_BATCH_MODE" = "info-missing" ]; then
+					printf 'other missing\n'
+				elif [ "$ENTIRE_GRAPH_BATCH_MODE" = "partial" ]; then
+					printf '%s blob 5\n' '1111111111111111111111111111111111111111'
+				else
+					printf '%s blob 3\n' '1111111111111111111111111111111111111111'
+				fi
+				;;
+			contents\ *)
+				if [ "$ENTIRE_GRAPH_BATCH_MODE" = "contents-missing" ]; then
+					printf 'other missing\n'
+				elif [ "$ENTIRE_GRAPH_BATCH_MODE" = "partial" ]; then
+					printf '%s blob 5\nab' '1111111111111111111111111111111111111111'
+					exit 0
+				fi
+				printf '%s blob 3\nabc!' '1111111111111111111111111111111111111111'
+				;;
+		esac
+	done
+	exit 0
+fi
+exit 2
+`
+			if err := os.WriteFile(fakeGit, []byte(script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv("PATH", binDir)
+			t.Setenv("ENTIRE_GRAPH_BATCH_REQUEST_LOG", requestLog)
+			t.Setenv("ENTIRE_GRAPH_BATCH_MODE", test.mode)
+
+			reader, err := NewBatchFileReader(t.Context(), t.TempDir(), "HEAD")
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = reader.Close() })
+			reader.SetMaxBytes(test.maxBytes)
+			if _, ok, firstErr := reader.ReadFile("file.go"); firstErr == nil || ok ||
+				!strings.Contains(firstErr.Error(), test.wantError) {
+				t.Fatalf("first malformed response = (ok %v, err %v), want %q", ok, firstErr, test.wantError)
+			} else {
+				// Even a locally invalid path must return the sticky protocol cause after
+				// poisoning, rather than hiding it or reaching stdin.
+				if _, ok, secondErr := reader.ReadFile("../file.go"); secondErr == nil || ok || secondErr.Error() != firstErr.Error() {
+					t.Fatalf("second read = (ok %v, err %v), want original poison %q", ok, secondErr, firstErr)
+				}
+				if closeErr := reader.Close(); closeErr == nil || closeErr.Error() != firstErr.Error() {
+					t.Fatalf("close after poison = %v, want original protocol error %q", closeErr, firstErr)
+				}
+			}
+			logged, err := os.ReadFile(requestLog)
+			if err != nil {
+				t.Fatal(err)
+			}
+			commands := strings.Split(strings.TrimSpace(string(logged)), "\n")
+			want := []string{
+				"info 0000000000000000000000000000000000000000",
+				"info HEAD:file.go",
+			}
+			if test.mode != "info-missing" {
+				want = append(want, "contents "+objectID)
+			}
+			if !reflect.DeepEqual(commands, want) {
+				t.Fatalf("protocol commands after poison = %#v, want exactly %#v and no second request", commands, want)
+			}
+		})
+	}
+}
+
 func TestBatchFileReaderRejectsNonBlobBeforeRequestingContent(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")
@@ -577,7 +709,7 @@ func TestBatchFileReaderRejectsNonBlobBeforeRequestingContent(t *testing.T) {
 	}
 }
 
-func TestBatchFileReaderPinsReplaceRefsAcrossInfoAndContents(t *testing.T) {
+func TestBatchFileReaderIgnoresReplaceRefMovedAcrossInfoAndContents(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")
 	git(t, repo, "config", "user.name", "Entire Graph Test")
@@ -596,6 +728,7 @@ func TestBatchFileReaderPinsReplaceRefsAcrossInfoAndContents(t *testing.T) {
 		fmt.Sprintf("100644 blob %s\tleaf%c", replacementLeaf, byte(0)),
 		"mktree", "-z",
 	)
+	t.Setenv("GIT_NO_REPLACE_OBJECTS", "0")
 
 	reader, err := NewBatchFileReader(t.Context(), repo, "HEAD")
 	if err != nil {
@@ -605,15 +738,17 @@ func TestBatchFileReaderPinsReplaceRefsAcrossInfoAndContents(t *testing.T) {
 	writes := &countingWriteCloser{WriteCloser: reader.stdin}
 	reader.stdin = writes
 	moved := false
+	controlType := ""
 	writes.beforeWrite = func(command string) {
 		if moved || !strings.HasPrefix(command, "contents ") {
 			return
 		}
 		moved = true
-		// This runs after the info response but before contents reaches Git. With
-		// separate metadata/content processes, the content process sees this new
-		// replacement and returns a tree body for an object checked as a blob.
+		// This runs after the info response but before contents reaches Git. Every
+		// production Git process has raw-object semantics, so the new replacement
+		// cannot turn this exact blob OID into a tree body.
 		git(t, repo, "update-ref", "refs/replace/"+originalOID, replacementTree)
+		controlType = gitOutputHonoringReplaceRefs(t, repo, "cat-file", "-t", originalOID)
 	}
 
 	got, ok, err := reader.ReadFile("file.go")
@@ -622,6 +757,9 @@ func TestBatchFileReaderPinsReplaceRefsAcrossInfoAndContents(t *testing.T) {
 	}
 	if !moved {
 		t.Fatal("fixture did not move the replacement between info and contents")
+	}
+	if controlType != "tree" {
+		t.Fatalf("control Git replacement type = %q, want tree", controlType)
 	}
 	if got := writes.countCommands("info "); got != 1 {
 		t.Fatalf("metadata commands = %d, want one: %#v", got, writes.commands)
@@ -637,14 +775,15 @@ func TestBatchFileReaderPinsReplaceRefsAcrossInfoAndContents(t *testing.T) {
 	}
 }
 
-func TestLimitedFileReaderRechecksKnownOIDInContentSession(t *testing.T) {
-	t.Run("replacement becomes nonblob", func(t *testing.T) {
+func TestLimitedFileReaderUsesRawKnownOIDDespiteReplaceRefs(t *testing.T) {
+	t.Run("nonblob replacement is ignored", func(t *testing.T) {
 		repo := t.TempDir()
 		git(t, repo, "init")
 		originalOID := gitInputOutput(t, repo, "package original\n", "hash-object", "-w", "--stdin")
 		rootTree := gitInputOutput(t, repo, fmt.Sprintf("100644 blob %s\tfile.go%c", originalOID, byte(0)), "mktree", "-z")
 		replacementLeaf := gitInputOutput(t, repo, "leaf\n", "hash-object", "-w", "--stdin")
 		replacementTree := gitInputOutput(t, repo, fmt.Sprintf("100644 blob %s\tleaf%c", replacementLeaf, byte(0)), "mktree", "-z")
+		t.Setenv("GIT_NO_REPLACE_OBJECTS", "0")
 
 		reader := NewLimitedFileReader(t.Context(), repo, rootTree, 1024)
 		t.Cleanup(func() { _ = reader.Close() })
@@ -652,6 +791,9 @@ func TestLimitedFileReaderRechecksKnownOIDInContentSession(t *testing.T) {
 			t.Fatal(err)
 		}
 		git(t, repo, "update-ref", "refs/replace/"+originalOID, replacementTree)
+		if got := gitOutputHonoringReplaceRefs(t, repo, "cat-file", "-t", originalOID); got != "tree" {
+			t.Fatalf("control Git replacement type = %q, want tree", got)
+		}
 		content, err := NewBatchFileReader(t.Context(), repo, rootTree)
 		if err != nil {
 			t.Fatal(err)
@@ -665,18 +807,18 @@ func TestLimitedFileReaderRechecksKnownOIDInContentSession(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if result.Status != LimitedFileUnreadable {
-			t.Fatalf("known OID replaced by tree = %#v, want unreadable without a body request", result)
+		if result.Status != LimitedFileContent || result.Content != "package original\n" {
+			t.Fatalf("known OID with tree replacement = %#v, want original raw blob", result)
 		}
 		if got := writes.countCommands("info "); got != 1 {
 			t.Fatalf("known-OID metadata commands = %d, want one: %#v", got, writes.commands)
 		}
-		if got := writes.countCommands("contents "); got != 0 {
-			t.Fatalf("known OID replaced by tree issued %d content commands, want zero: %#v", got, writes.commands)
+		if got := writes.countCommands("contents "); got != 1 {
+			t.Fatalf("raw known OID issued %d content commands, want one original-blob request: %#v", got, writes.commands)
 		}
 	})
 
-	t.Run("replacement becomes oversized blob", func(t *testing.T) {
+	t.Run("oversized blob replacement is ignored", func(t *testing.T) {
 		repo := t.TempDir()
 		git(t, repo, "init")
 		originalOID := gitInputOutput(t, repo, "small\n", "hash-object", "-w", "--stdin")
@@ -684,6 +826,7 @@ func TestLimitedFileReaderRechecksKnownOIDInContentSession(t *testing.T) {
 		oversizedContent := strings.Repeat("replacement line\n", 64)
 		replacementOID := gitInputOutput(t, repo, oversizedContent, "hash-object", "-w", "--stdin")
 		const ceiling = int64(32)
+		t.Setenv("GIT_NO_REPLACE_OBJECTS", "0")
 
 		reader := NewLimitedFileReader(t.Context(), repo, rootTree, ceiling)
 		t.Cleanup(func() { _ = reader.Close() })
@@ -691,6 +834,9 @@ func TestLimitedFileReaderRechecksKnownOIDInContentSession(t *testing.T) {
 			t.Fatal(err)
 		}
 		git(t, repo, "update-ref", "refs/replace/"+originalOID, replacementOID)
+		if got := gitOutputHonoringReplaceRefs(t, repo, "cat-file", "-s", originalOID); got != strconv.Itoa(len(oversizedContent)) {
+			t.Fatalf("control Git replacement size = %q, want %d", got, len(oversizedContent))
+		}
 		content, err := NewBatchFileReader(t.Context(), repo, rootTree)
 		if err != nil {
 			t.Fatal(err)
@@ -704,22 +850,17 @@ func TestLimitedFileReaderRechecksKnownOIDInContentSession(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if result.Status != LimitedFileOversize || result.Bytes != int64(len(oversizedContent)) {
-			t.Fatalf("known OID replaced by oversized blob = %#v, want exact oversize result", result)
+		if result.Status != LimitedFileContent || result.Content != "small\n" || result.Bytes != int64(len("small\n")) {
+			t.Fatalf("known OID with oversized replacement = %#v, want original small raw blob", result)
 		}
-		digest, ok := content.OversizeBlob("file.go")
-		if !ok {
-			t.Fatal("replacement oversize blob had no digest")
-		}
-		wantHash := sha256.Sum256([]byte(oversizedContent))
-		if digest.Bytes != int64(len(oversizedContent)) || digest.Hash != hex.EncodeToString(wantHash[:]) || digest.Lines != 64 {
-			t.Fatalf("replacement oversize digest = %#v, want exact bytes/hash/lines", digest)
+		if digest, ok := content.OversizeBlob("file.go"); ok {
+			t.Fatalf("ignored replacement produced an oversize digest: %#v", digest)
 		}
 		if got := writes.countCommands("info "); got != 1 {
-			t.Fatalf("oversize known-OID metadata commands = %d, want one: %#v", got, writes.commands)
+			t.Fatalf("raw known-OID metadata commands = %d, want one: %#v", got, writes.commands)
 		}
 		if got := writes.countCommands("contents "); got != 1 {
-			t.Fatalf("oversize known-OID content commands = %d, want one digest stream: %#v", got, writes.commands)
+			t.Fatalf("raw known-OID content commands = %d, want one original-blob read: %#v", got, writes.commands)
 		}
 	})
 }
@@ -1401,6 +1542,43 @@ func TestLimitedFileReaderSplitsAncestorAndDescendantPathspecs(t *testing.T) {
 	}
 }
 
+// An exact literal pathspec does not imply one ls-tree record when a raw tree
+// contains duplicate names. Keep the adversarial output proportional to the
+// requested path set: the reader must reject the second record and retire Git,
+// rather than buffering every duplicate before discovering the malformed tree.
+func TestLimitedFileReaderStreamsAndRejectsDuplicateTreeMetadata(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	blob := gitInputOutput(t, repo, "package duplicate\n", "hash-object", "-w", "--stdin")
+
+	const duplicateEntries = 100_000
+	tree := func() string {
+		var input strings.Builder
+		input.Grow(duplicateEntries * (len(blob) + len("100644 blob \tfile.go\x00")))
+		for range duplicateEntries {
+			fmt.Fprintf(&input, "100644 blob %s\tfile.go%c", blob, byte(0))
+		}
+		return gitInputOutput(t, repo, input.String(), "mktree", "-z")
+	}()
+
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	reader := NewLimitedFileReader(t.Context(), repo, tree, 1024)
+	err := reader.Prime([]string{"file.go"})
+	runtime.ReadMemStats(&after)
+	if err == nil || !strings.Contains(err.Error(), `duplicate path "file.go"`) {
+		t.Fatalf("duplicate-tree Prime error = %v, want immediate duplicate-path rejection", err)
+	}
+	// The old whole-output run path allocated the complete ~6.9 MiB listing,
+	// then copied and split it. This generous bound permits subprocess plumbing
+	// while proving the duplicate stream is stopped after its second record.
+	const allocationBudget = 4 << 20
+	if allocated := after.TotalAlloc - before.TotalAlloc; allocated > allocationBudget {
+		t.Fatalf("duplicate metadata probe allocated %d bytes, want under %d", allocated, allocationBudget)
+	}
+}
+
 func TestLimitedFileReaderRejectsTrailingSlashBeforeGit(t *testing.T) {
 	// The directory need not be a repository: validation must happen before
 	// ls-tree, because a single literal path ending in slash expands every
@@ -1791,9 +1969,10 @@ func TestNewCmdPinsSubprocessLocaleToC(t *testing.T) {
 	// after the inherited environment so it overrides LC_ALL/LANG/LC_MESSAGES.
 	t.Setenv("LC_ALL", "fr_FR.UTF-8")
 	t.Setenv("LANG", "fr_FR.UTF-8")
+	t.Setenv("GIT_NO_REPLACE_OBJECTS", "0")
 	dir := t.TempDir()
 	cmd := newCmd(context.Background(), dir, "git", "version")
-	lcAll, lang, pwd := "", "", ""
+	lcAll, lang, pwd, noReplace := "", "", "", ""
 	for _, kv := range cmd.Env {
 		if v, ok := strings.CutPrefix(kv, "LC_ALL="); ok {
 			lcAll = v
@@ -1804,12 +1983,41 @@ func TestNewCmdPinsSubprocessLocaleToC(t *testing.T) {
 		if v, ok := strings.CutPrefix(kv, "PWD="); ok {
 			pwd = v
 		}
+		if v, ok := strings.CutPrefix(kv, "GIT_NO_REPLACE_OBJECTS="); ok {
+			noReplace = v
+		}
 	}
 	if lcAll != "C" || lang != "C" {
 		t.Fatalf("effective subprocess locale LC_ALL=%q LANG=%q, want both \"C\"", lcAll, lang)
 	}
 	if runtime.GOOS != "windows" && filepath.Clean(pwd) != filepath.Clean(dir) {
 		t.Fatalf("subprocess PWD=%q, want command directory %q", pwd, dir)
+	}
+	if noReplace != "1" {
+		t.Fatalf("effective GIT_NO_REPLACE_OBJECTS=%q, want 1", noReplace)
+	}
+
+	grepCmd := newGitCmdWithCallerLocale(context.Background(), dir, "version")
+	lcAll, pwd, noReplace = "", "", ""
+	for _, kv := range grepCmd.Env {
+		if v, ok := strings.CutPrefix(kv, "LC_ALL="); ok {
+			lcAll = v
+		}
+		if v, ok := strings.CutPrefix(kv, "PWD="); ok {
+			pwd = v
+		}
+		if v, ok := strings.CutPrefix(kv, "GIT_NO_REPLACE_OBJECTS="); ok {
+			noReplace = v
+		}
+	}
+	if lcAll != "fr_FR.UTF-8" {
+		t.Fatalf("caller-locale git command LC_ALL=%q, want inherited locale", lcAll)
+	}
+	if runtime.GOOS != "windows" && filepath.Clean(pwd) != filepath.Clean(dir) {
+		t.Fatalf("caller-locale git command PWD=%q, want command directory %q", pwd, dir)
+	}
+	if noReplace != "1" {
+		t.Fatalf("caller-locale git command GIT_NO_REPLACE_OBJECTS=%q, want 1", noReplace)
 	}
 }
 
@@ -1830,6 +2038,28 @@ func gitOutput(t *testing.T, repo string, args ...string) string {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// gitOutputHonoringReplaceRefs is a test control, never a production command.
+// GIT_NO_REPLACE_OBJECTS disables replacements whenever it is present, even
+// when its value is "0", so remove every inherited occurrence explicitly.
+func gitOutputHonoringReplaceRefs(t *testing.T, repo string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo
+	env := cmd.Environ()
+	filtered := env[:0]
+	for _, entry := range env {
+		if !strings.HasPrefix(entry, "GIT_NO_REPLACE_OBJECTS=") {
+			filtered = append(filtered, entry)
+		}
+	}
+	cmd.Env = filtered
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git honoring replacements %v: %v\n%s", args, err, out)
 	}
 	return strings.TrimSpace(string(out))
 }

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -3,6 +3,8 @@ package gitutil
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"math"
 	"os"
 	"os/exec"
@@ -812,5 +814,113 @@ func TestGrepTreePathsCaseSensitiveIncludingBinary(t *testing.T) {
 	want := []string{"dollar.js", "exact.py", "substring.py"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("case-sensitive grep = %#v, want %#v", got, want)
+	}
+}
+
+// TestOversizeBlobAtRevAnswersOnlyForOversizedBlobs pins the contract that lets
+// a caller of ShowFileLimited record a file it was refused. The "found" return
+// means "exists AND is over the ceiling", never merely "exists": a caller whose
+// read failed for some other reason must not be able to report that file as too
+// large, because it would then carry a size, hash and line count nothing
+// established.
+func TestOversizeBlobAtRevAnswersOnlyForOversizedBlobs(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	git(t, repo, "config", "commit.gpgsign", "false")
+
+	const ceiling = 1 << 10
+	over := strings.Repeat("x\n", ceiling) // 2*ceiling bytes, ceiling lines
+	if err := os.WriteFile(filepath.Join(repo, "over.txt"), []byte(over), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "exact.txt"), []byte(strings.Repeat("y", ceiling)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repo, "dir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "dir", "leaf.txt"), []byte("leaf\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "size fixture")
+
+	blob, found, err := OversizeBlobAtRev(t.Context(), repo, "HEAD", "over.txt", ceiling)
+	if err != nil || !found {
+		t.Fatalf("oversized blob = (found %v, err %v), want (true, nil)", found, err)
+	}
+	sum := sha256.Sum256([]byte(over))
+	if blob.Bytes != int64(len(over)) || blob.Lines != ceiling || blob.Hash != hex.EncodeToString(sum[:]) {
+		t.Errorf(
+			"blob = {Bytes:%d Lines:%d Hash:%s}, want {Bytes:%d Lines:%d Hash:%s}",
+			blob.Bytes, blob.Lines, blob.Hash, len(over), ceiling, hex.EncodeToString(sum[:]),
+		)
+	}
+
+	// A blob exactly at the ceiling is not oversized: ShowFileLimited returns it,
+	// so nothing here is owed a record.
+	if _, found, err := OversizeBlobAtRev(t.Context(), repo, "HEAD", "exact.txt", ceiling); err != nil || found {
+		t.Errorf("blob at the ceiling = (found %v, err %v), want (false, nil)", found, err)
+	}
+	// Absent is refused, not broken -- the same distinction the readers keep.
+	if _, found, err := OversizeBlobAtRev(t.Context(), repo, "HEAD", "absent.txt", ceiling); err != nil || found {
+		t.Errorf("absent path = (found %v, err %v), want (false, nil)", found, err)
+	}
+	// No ceiling means nothing is oversized, and no git runs.
+	if _, found, err := OversizeBlobAtRev(t.Context(), repo, "HEAD", "over.txt", 0); err != nil || found {
+		t.Errorf("disabled ceiling = (found %v, err %v), want (false, nil)", found, err)
+	}
+	// A tree is not a blob: git cannot cat it, and that is a failure to report,
+	// not an absence -- the caller must not silently record a directory.
+	if _, found, err := OversizeBlobAtRev(t.Context(), repo, "HEAD", "dir", ceiling); err == nil || found {
+		t.Errorf("a tree path = (found %v, err %v), want (false, error)", found, err)
+	}
+}
+
+// TestOversizeBlobAtRevNeverMaterializesTheBlob is the reason the function
+// exists rather than callers reading the file and measuring it. The digest is
+// computed while the blob streams past and is discarded, so learning a 32 MiB
+// file's identity costs a bounded buffer, not 32 MiB.
+func TestOversizeBlobAtRevNeverMaterializesTheBlob(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	git(t, repo, "config", "commit.gpgsign", "false")
+
+	const blobSize = 32 << 20
+	const ceiling = 1 << 10
+	// Incompressible, so git really does stream 32 MiB past the digest.
+	blob := make([]byte, blobSize)
+	if _, err := rand.Read(blob); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "huge.bin"), blob, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "huge fixture")
+
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	record, found, err := OversizeBlobAtRev(t.Context(), repo, "HEAD", "huge.bin", ceiling)
+	if err != nil || !found {
+		t.Fatalf("OversizeBlobAtRev = (found %v, err %v), want (true, nil)", found, err)
+	}
+	if record.Bytes != blobSize {
+		t.Fatalf("Bytes = %d, want %d", record.Bytes, blobSize)
+	}
+
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	allocated := after.TotalAlloc - before.TotalAlloc
+	// Generous: the point is that the bound is a buffer, not the blob. A version
+	// that held the content would allocate at least blobSize.
+	if allocated > blobSize/4 {
+		t.Fatalf("allocated %d bytes reading a %d-byte blob; it must never be held", allocated, blobSize)
 	}
 }

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -1986,7 +1986,7 @@ func TestNewCmdPinsSubprocessLocaleToC(t *testing.T) {
 	if cmd.WaitDelay != gitCommandWaitDelay || cmd.WaitDelay == 0 {
 		t.Fatalf("stable-locale command WaitDelay = %v, want %v", cmd.WaitDelay, gitCommandWaitDelay)
 	}
-	lcAll, lang, pwd, noReplace := "", "", "", ""
+	lcAll, lang, pwd, noReplace, noLazyFetch := "", "", "", "", ""
 	for _, kv := range cmd.Env {
 		if v, ok := strings.CutPrefix(kv, "LC_ALL="); ok {
 			lcAll = v
@@ -2000,6 +2000,9 @@ func TestNewCmdPinsSubprocessLocaleToC(t *testing.T) {
 		if v, ok := strings.CutPrefix(kv, "GIT_NO_REPLACE_OBJECTS="); ok {
 			noReplace = v
 		}
+		if v, ok := strings.CutPrefix(kv, "GIT_NO_LAZY_FETCH="); ok {
+			noLazyFetch = v
+		}
 	}
 	if lcAll != "C" || lang != "C" {
 		t.Fatalf("effective subprocess locale LC_ALL=%q LANG=%q, want both \"C\"", lcAll, lang)
@@ -2010,12 +2013,15 @@ func TestNewCmdPinsSubprocessLocaleToC(t *testing.T) {
 	if noReplace != "1" {
 		t.Fatalf("effective GIT_NO_REPLACE_OBJECTS=%q, want 1", noReplace)
 	}
+	if noLazyFetch != "1" {
+		t.Fatalf("effective GIT_NO_LAZY_FETCH=%q, want 1: a partial clone's promisor remote must never be contacted by this no-egress provider", noLazyFetch)
+	}
 
 	grepCmd := newGitCmdWithCallerLocale(context.Background(), dir, "version")
 	if grepCmd.WaitDelay != gitCommandWaitDelay || grepCmd.WaitDelay == 0 {
 		t.Fatalf("caller-locale command WaitDelay = %v, want %v", grepCmd.WaitDelay, gitCommandWaitDelay)
 	}
-	lcAll, pwd, noReplace = "", "", ""
+	lcAll, pwd, noReplace, noLazyFetch = "", "", "", ""
 	for _, kv := range grepCmd.Env {
 		if v, ok := strings.CutPrefix(kv, "LC_ALL="); ok {
 			lcAll = v
@@ -2026,6 +2032,9 @@ func TestNewCmdPinsSubprocessLocaleToC(t *testing.T) {
 		if v, ok := strings.CutPrefix(kv, "GIT_NO_REPLACE_OBJECTS="); ok {
 			noReplace = v
 		}
+		if v, ok := strings.CutPrefix(kv, "GIT_NO_LAZY_FETCH="); ok {
+			noLazyFetch = v
+		}
 	}
 	if lcAll != "fr_FR.UTF-8" {
 		t.Fatalf("caller-locale git command LC_ALL=%q, want inherited locale", lcAll)
@@ -2035,6 +2044,9 @@ func TestNewCmdPinsSubprocessLocaleToC(t *testing.T) {
 	}
 	if noReplace != "1" {
 		t.Fatalf("caller-locale git command GIT_NO_REPLACE_OBJECTS=%q, want 1", noReplace)
+	}
+	if noLazyFetch != "1" {
+		t.Fatalf("caller-locale git command GIT_NO_LAZY_FETCH=%q, want 1", noLazyFetch)
 	}
 }
 

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -915,13 +915,72 @@ func TestLimitedFileReaderKeepsRepoSubdirectoryPathsRelative(t *testing.T) {
 	}
 }
 
-func TestLimitedFileReaderBoundsMetadataPathspecs(t *testing.T) {
-	reader := NewLimitedFileReader(t.Context(), t.TempDir(), "HEAD", 1024)
-	path := strings.Repeat("x", literalPathOutputMaxPathBytes+1)
-	err := reader.Prime([]string{path})
-	if err == nil || !strings.Contains(err.Error(), "input path exceeds") {
-		t.Fatalf("oversized metadata path error = %v, want bounded-input rejection", err)
+func TestLimitedFileReaderPrimesDeepGitTreePath(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	tree, path := nestedGitTree(t, repo, "package deep\n", 25)
+	if len(path) <= literalPathOutputMaxPathBytes || len(":(literal)")+len(path) >= literalPathspecBatchBytes {
+		t.Fatalf("fixture path length = %d, want between output and batch limits", len(path))
 	}
+
+	reader := NewLimitedFileReader(t.Context(), repo, tree, 1024)
+	t.Cleanup(func() { _ = reader.Close() })
+	if err := reader.Prime([]string{path}); err != nil {
+		t.Fatal(err)
+	}
+	if _, primed := reader.primed[path]; !primed {
+		t.Fatal("valid deep Git-tree path was not metadata-primed")
+	}
+	result, err := reader.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != LimitedFileContent || result.Content != "package deep\n" {
+		t.Fatalf("deep Git-tree file = %#v, want exact content", result)
+	}
+}
+
+func TestLimitedFileReaderFallsBackForPathBeyondBatchArgvBound(t *testing.T) {
+	repo := t.TempDir()
+	// A bare repository avoids git show's pre-existing worktree-path stat for
+	// very long revision arguments and isolates the reader's fallback behavior.
+	git(t, repo, "init", "--bare")
+	tree, path := nestedGitTree(t, repo, "package fallback\n", 80)
+	if len(":(literal)")+len(path) <= literalPathspecBatchBytes {
+		t.Fatalf("fixture path length = %d, want beyond batch argv bound", len(path))
+	}
+
+	reader := NewLimitedFileReader(t.Context(), repo, tree, 1024)
+	t.Cleanup(func() { _ = reader.Close() })
+	if err := reader.Prime([]string{path}); err != nil {
+		t.Fatal(err)
+	}
+	if _, primed := reader.primed[path]; primed {
+		t.Fatal("over-bound path unexpectedly entered metadata batch")
+	}
+	result, err := reader.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != LimitedFileContent || result.Content != "package fallback\n" {
+		t.Fatalf("one-shot deep Git-tree file = %#v, want exact content", result)
+	}
+	if reader.content != nil {
+		t.Fatal("over-bound path started persistent content batch instead of one-shot fallback")
+	}
+}
+
+func nestedGitTree(t *testing.T, repo, content string, depth int) (tree, path string) {
+	t.Helper()
+	blob := gitInputOutput(t, repo, content, "hash-object", "-w", "--stdin")
+	tree = gitInputOutput(t, repo, fmt.Sprintf("100644 blob %s\tfile.go%c", blob, byte(0)), "mktree", "-z")
+	path = "file.go"
+	component := strings.Repeat("a", 200)
+	for range depth {
+		tree = gitInputOutput(t, repo, fmt.Sprintf("040000 tree %s\t%s%c", tree, component, byte(0)), "mktree", "-z")
+		path = component + "/" + path
+	}
+	return tree, path
 }
 
 // A ceiling no blob can reach must behave as no ceiling. This once guarded an

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -956,6 +956,17 @@ func TestLimitedFileReaderSplitsAncestorAndDescendantPathspecs(t *testing.T) {
 	}
 }
 
+func TestLimitedFileReaderRejectsTrailingSlashBeforeGit(t *testing.T) {
+	// The directory need not be a repository: validation must happen before
+	// ls-tree, because a single literal path ending in slash expands every
+	// immediate child instead of returning one exact tree entry.
+	reader := NewLimitedFileReader(t.Context(), t.TempDir(), "HEAD", 1024)
+	err := reader.Prime([]string{"dir/"})
+	if err == nil || !strings.Contains(err.Error(), `invalid Git tree path "dir/"`) {
+		t.Fatalf("trailing-slash Prime error = %v, want pre-Git invalid-path rejection", err)
+	}
+}
+
 func TestLimitedFileReaderPrimesDeepGitTreePath(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -2233,34 +2233,24 @@ func TestNewCmdPinsSubprocessLocaleToC(t *testing.T) {
 	}
 }
 
-// TestGitAllowProtocolBlocksALazyFetchGitVersionIndependently pins the
-// property the trail finding asked for directly: even if a caller's own
-// GIT_NO_LAZY_FETCH were somehow ineffective (as it silently is on any Git
-// older than 2.45, since the variable did not exist yet), a fetch attempt
-// still cannot reach the network, because newCmd's GIT_ALLOW_PROTOCOL=
-// denies every transport unconditionally.
-func TestGitAllowProtocolBlocksALazyFetchGitVersionIndependently(t *testing.T) {
-	repo := t.TempDir()
-	git(t, repo, "init")
-	git(t, repo, "config", "user.name", "Entire Graph Test")
-	git(t, repo, "config", "user.email", "graph@example.com")
-	if err := os.WriteFile(filepath.Join(repo, "a.txt"), []byte("hello\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	git(t, repo, "add", ".")
-	git(t, repo, "commit", "-m", "initial")
+func TestNewCmdDisablesEveryGitTransport(t *testing.T) {
+	source := t.TempDir()
+	target := t.TempDir()
+	git(t, source, "init", "--bare")
+	git(t, target, "init")
 
-	// GIT_NO_LAZY_FETCH unset here (unlike newCmd's own environment) stands
-	// in for a Git binary old enough that the variable does nothing, so a
-	// pass only because of that guard would go undetected by this test.
-	cmd := exec.Command("git", "-C", repo, "fetch", "file:///nonexistent-does-not-exist")
-	cmd.Env = append(os.Environ(), noTransportProtocolEnv)
+	// A caller-provided allowlist and locale must not reopen a transport or make
+	// the denial assertion depend on localized Git diagnostics.
+	t.Setenv("GIT_ALLOW_PROTOCOL", "file:https:ssh")
+	t.Setenv("LC_ALL", "de_DE.UTF-8")
+	t.Setenv("LANG", "de_DE.UTF-8")
+	cmd := newCmd(t.Context(), target, "git", "fetch", source)
 	out, err := cmd.CombinedOutput()
 	if err == nil {
-		t.Fatalf("git fetch under GIT_ALLOW_PROTOCOL= succeeded, want every transport denied: %s", out)
+		t.Fatalf("Git fetch unexpectedly succeeded despite the no-egress transport boundary")
 	}
-	if !strings.Contains(string(out), "not allowed") {
-		t.Fatalf("git fetch under GIT_ALLOW_PROTOCOL= failed for an unexpected reason (want a transport-denial error): %s", out)
+	if !strings.Contains(string(out), "transport 'file' not allowed") {
+		t.Fatalf("Git fetch failure = %q, want C-locale disabled file transport", out)
 	}
 }
 

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -1002,11 +1002,9 @@ func TestGitObjectReadersUseRepoSubdirectoryPrefix(t *testing.T) {
 // anchors a literal pathspec to the REPOSITORY ROOT regardless of the
 // process's cwd -- verified independently with a bare `git ls-tree` from a
 // subdirectory. If the claimed double-prefix bug were real, the probe would
-// silently return blobProbeUnknown for the second-level path below, and
-// ReadFileLimited would fall through to materializing the oversized blob
-// with `git show` -- exactly the memory-bound violation the finding warns
-// about. This asserts the PROBE succeeds (LimitedFileOversize with the exact
-// size, no content read) rather than merely that some result comes back.
+// silently return blobProbeUnknown for the second-level path below. Calling
+// blobSizeAtRev directly and requiring blobProbeBlob with the exact size keeps
+// a higher-level content fallback from masking that failure.
 func TestBlobSizeAtRevProbeSucceedsFromARepoSubdirectory(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -877,7 +877,7 @@ func TestLimitedFileReaderUsesObjectIDsForLineTerminators(t *testing.T) {
 	}
 }
 
-func TestLimitedFileReaderKeepsRepoSubdirectoryPathsRelative(t *testing.T) {
+func TestLimitedFileReaderKeepsRootPathsExactFromRepoSubdirectory(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")
 	git(t, repo, "config", "user.name", "Entire Graph Test")
@@ -896,17 +896,17 @@ func TestLimitedFileReaderKeepsRepoSubdirectoryPathsRelative(t *testing.T) {
 
 	reader := NewLimitedFileReader(t.Context(), filepath.Join(repo, "scope"), "HEAD", 1024)
 	t.Cleanup(func() { _ = reader.Close() })
-	if err := reader.Prime([]string{"file.go", "missing.go"}); err != nil {
+	if err := reader.Prime([]string{"scope/file.go", "scope/missing.go"}); err != nil {
 		t.Fatal(err)
 	}
-	result, err := reader.ReadFile("file.go")
+	result, err := reader.ReadFile("scope/file.go")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if result.Status != LimitedFileContent || result.Content != content {
-		t.Fatalf("subdirectory file = %#v, want cwd-relative content %q", result, content)
+		t.Fatalf("subdirectory file = %#v, want root-relative content %q", result, content)
 	}
-	missing, err := reader.ReadFile("missing.go")
+	missing, err := reader.ReadFile("scope/missing.go")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -915,11 +915,52 @@ func TestLimitedFileReaderKeepsRepoSubdirectoryPathsRelative(t *testing.T) {
 	}
 }
 
+func TestLimitedFileReaderSplitsAncestorAndDescendantPathspecs(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	if err := os.MkdirAll(filepath.Join(repo, "dir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "dir", "file.go"), []byte("package dir\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "overlapping path fixture")
+
+	paths := []string{"dir", "dir/file.go"}
+	if end := treeMetadataBatchEnd(paths, 0); end != 1 {
+		t.Fatalf("first prefix-free batch ended at %d, want 1", end)
+	}
+	reader := NewLimitedFileReader(t.Context(), repo, "HEAD", 1024)
+	t.Cleanup(func() { _ = reader.Close() })
+	if err := reader.Prime(paths); err != nil {
+		t.Fatal(err)
+	}
+	if len(reader.primed) != 2 {
+		t.Fatalf("primed entries = %#v, want exactly ancestor and descendant", reader.primed)
+	}
+	if got := reader.primed["dir"].result.Status; got != LimitedFileNonBlob {
+		t.Fatalf("ancestor status = %v, want non-blob tree", got)
+	}
+	if got := reader.primed["dir/file.go"].result.Status; got != LimitedFileContent {
+		t.Fatalf("descendant status = %v, want blob content", got)
+	}
+	result, err := reader.ReadFile("dir/file.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != LimitedFileContent || result.Content != "package dir\n" {
+		t.Fatalf("descendant read = %#v, want exact content", result)
+	}
+}
+
 func TestLimitedFileReaderPrimesDeepGitTreePath(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")
 	tree, path := nestedGitTree(t, repo, "package deep\n", 25)
-	if len(path) <= literalPathOutputMaxPathBytes || len(":(literal)")+len(path) >= literalPathspecBatchBytes {
+	if len(path) <= literalPathOutputMaxPathBytes || len(treeMetadataLiteralPrefix)+len(path) >= literalPathspecBatchBytes {
 		t.Fatalf("fixture path length = %d, want between output and batch limits", len(path))
 	}
 
@@ -946,7 +987,7 @@ func TestLimitedFileReaderFallsBackForPathBeyondBatchArgvBound(t *testing.T) {
 	// very long revision arguments and isolates the reader's fallback behavior.
 	git(t, repo, "init", "--bare")
 	tree, path := nestedGitTree(t, repo, "package fallback\n", 80)
-	if len(":(literal)")+len(path) <= literalPathspecBatchBytes {
+	if len(treeMetadataLiteralPrefix)+len(path) <= literalPathspecBatchBytes {
 		t.Fatalf("fixture path length = %d, want beyond batch argv bound", len(path))
 	}
 

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -495,6 +495,21 @@ func TestGitObjectReadersUseRepoSubdirectoryPrefix(t *testing.T) {
 	if prefix != "scope/" {
 		t.Fatalf("repository prefix = %q, want scope/", prefix)
 	}
+	commandRoot, err := RepoCommandRoot(t.Context(), subdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commandRootInfo, err := os.Stat(commandRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoInfo, err := os.Stat(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(commandRootInfo, repoInfo) {
+		t.Fatalf("repository command root = %q, want same directory as %q", commandRoot, repo)
+	}
 	shown, ok, err := ShowFile(t.Context(), subdir, "HEAD", "file.go")
 	if err != nil || !ok || shown != content {
 		t.Fatalf("subdirectory ShowFile = (%q, %v, %v), want exact content", shown, ok, err)
@@ -1050,6 +1065,19 @@ func TestLimitedFileReaderKeepsRootPathsExactFromRepoSubdirectory(t *testing.T) 
 	if missing.Status != LimitedFileMissing {
 		t.Fatalf("subdirectory missing path = %#v, want missing", missing)
 	}
+
+	// ReadFile without an explicit Prime must use the same tree-root coordinate,
+	// rather than delegating to the repo-relative one-shot API and prepending
+	// scope/ a second time.
+	lazy := NewLimitedFileReader(t.Context(), filepath.Join(repo, "scope"), "HEAD", 1024)
+	t.Cleanup(func() { _ = lazy.Close() })
+	lazyResult, err := lazy.ReadFile("scope/file.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lazyResult.Status != LimitedFileContent || lazyResult.Content != content {
+		t.Fatalf("lazy subdirectory file = %#v, want root-relative content %q", lazyResult, content)
+	}
 }
 
 func TestLimitedFileReaderSplitsAncestorAndDescendantPathspecs(t *testing.T) {
@@ -1101,6 +1129,20 @@ func TestLimitedFileReaderRejectsTrailingSlashBeforeGit(t *testing.T) {
 	err := reader.Prime([]string{"dir/"})
 	if err == nil || !strings.Contains(err.Error(), `invalid Git tree path "dir/"`) {
 		t.Fatalf("trailing-slash Prime error = %v, want pre-Git invalid-path rejection", err)
+	}
+	if _, err := reader.ReadFile("dir/"); err == nil || !strings.Contains(err.Error(), `invalid Git tree path "dir/"`) {
+		t.Fatalf("trailing-slash lazy read error = %v, want pre-Git invalid-path rejection", err)
+	}
+	for _, path := range []string{"", ".", "./file", "dir/../file", "/file", "dir//file", "dir/", "nul\x00path"} {
+		if _, err := reader.ReadFile(path); err == nil || !strings.Contains(err.Error(), "invalid Git tree path") {
+			t.Fatalf("lazy invalid path %q error = %v, want pre-Git validation", path, err)
+		}
+		if _, err := ReadFileLimited(t.Context(), t.TempDir(), "HEAD", path, 0); err == nil || !strings.Contains(err.Error(), "invalid Git tree path") {
+			t.Fatalf("one-shot invalid path %q error = %v, want pre-Git validation", path, err)
+		}
+		if _, _, err := ShowFileLimited(t.Context(), t.TempDir(), "HEAD", path, 0); err == nil || !strings.Contains(err.Error(), "invalid Git tree path") {
+			t.Fatalf("compatibility invalid path %q error = %v, want pre-Git validation", path, err)
+		}
 	}
 }
 
@@ -1157,6 +1199,136 @@ func TestLimitedFileReaderPrimesPathBeyondBatchArgvBound(t *testing.T) {
 	}
 }
 
+func TestLimitedFileReaderCachesAndCapsComponentMetadata(t *testing.T) {
+	const (
+		depth  = 80
+		leaves = 200
+	)
+	component := strings.Repeat("a", 200)
+	prefix := strings.Repeat(component+"/", depth)
+	paths := make([]string, 0, leaves)
+	for index := range leaves {
+		paths = append(paths, prefix+fmt.Sprintf("file%03d.go", index))
+	}
+	if len(paths[0])+len(treeMetadataLiteralPrefix) <= literalPathspecBatchBytes {
+		t.Fatalf("fixture path length = %d, want component traversal", len(paths[0]))
+	}
+
+	reader := NewLimitedFileReader(t.Context(), "unused", "tree-0", 1024)
+	lookups := 0
+	reader.componentMetadataLookup = func(
+		_ context.Context,
+		_, treeOID string,
+		components []string,
+	) (map[string]primedLimitedFile, error) {
+		lookups++
+		if len(components) != 1 {
+			t.Fatalf("component lookup paths = %#v, want one", components)
+		}
+		componentPath := components[0]
+		treeIndex, err := strconv.Atoi(strings.TrimPrefix(treeOID, "tree-"))
+		if err != nil {
+			t.Fatalf("fake tree OID %q: %v", treeOID, err)
+		}
+		if treeIndex < depth && componentPath == component {
+			return map[string]primedLimitedFile{
+				componentPath: {
+					result:     LimitedFileResult{Status: LimitedFileNonBlob},
+					objectID:   fmt.Sprintf("tree-%d", treeIndex+1),
+					objectType: "tree",
+				},
+			}, nil
+		}
+		if treeIndex == depth && strings.HasPrefix(componentPath, "file") {
+			return map[string]primedLimitedFile{
+				componentPath: {
+					result:     LimitedFileResult{Status: LimitedFileContent, Bytes: 1},
+					objectID:   "blob-" + componentPath,
+					objectType: "blob",
+				},
+			}, nil
+		}
+		return map[string]primedLimitedFile{}, nil
+	}
+
+	if err := reader.Prime(paths); err != nil {
+		t.Fatal(err)
+	}
+	if lookups != limitedFileComponentMetadataProcessLimit ||
+		reader.componentMetadataProcesses != limitedFileComponentMetadataProcessLimit {
+		t.Fatalf("component metadata lookups = %d/%d, want cap %d",
+			lookups, reader.componentMetadataProcesses, limitedFileComponentMetadataProcessLimit)
+	}
+	// The shared 80-entry prefix is looked up once, leaving the rest of the
+	// process allowance for distinct leaves. Without the (tree, component)
+	// cache, only a few paths would resolve before hitting the same cap.
+	wantContent := limitedFileComponentMetadataProcessLimit - depth
+	for index, path := range paths {
+		want := LimitedFileUnaddressable
+		if index < wantContent {
+			want = LimitedFileContent
+		}
+		if got := reader.primed[path].result.Status; got != want {
+			t.Fatalf("path %d status = %v, want %v", index, got, want)
+		}
+	}
+	if len(reader.componentMetadata) != limitedFileComponentMetadataProcessLimit {
+		t.Fatalf("component cache entries = %d, want %d", len(reader.componentMetadata), limitedFileComponentMetadataProcessLimit)
+	}
+	if err := reader.Prime(paths); err != nil {
+		t.Fatal(err)
+	}
+	if lookups != limitedFileComponentMetadataProcessLimit {
+		t.Fatalf("repeat Prime launched %d component lookups, want cached %d", lookups, limitedFileComponentMetadataProcessLimit)
+	}
+}
+
+func TestLimitedFileReaderStopsComponentMetadataAtDeadline(t *testing.T) {
+	const depth = 80
+	component := strings.Repeat("a", 200)
+	prefix := strings.Repeat(component+"/", depth)
+	reader := NewLimitedFileReader(t.Context(), "unused", "tree-0", 1024)
+	lookups := 0
+	reader.componentMetadataLookup = func(
+		_ context.Context,
+		_, treeOID string,
+		components []string,
+	) (map[string]primedLimitedFile, error) {
+		lookups++
+		treeIndex, err := strconv.Atoi(strings.TrimPrefix(treeOID, "tree-"))
+		if err != nil {
+			return nil, err
+		}
+		return map[string]primedLimitedFile{
+			components[0]: {
+				result:     LimitedFileResult{Status: LimitedFileNonBlob},
+				objectID:   fmt.Sprintf("tree-%d", treeIndex+1),
+				objectType: "tree",
+			},
+		}, nil
+	}
+	deadline := time.Unix(100, 0)
+	reader.now = func() time.Time {
+		if reader.componentMetadataProcesses < 3 {
+			return deadline.Add(-time.Second)
+		}
+		return deadline
+	}
+	reader.SetDeadline(deadline)
+	paths := []string{prefix + "first.go", prefix + "second.go"}
+	if err := reader.Prime(paths); err != nil {
+		t.Fatal(err)
+	}
+	if lookups != 3 || reader.componentMetadataProcesses != 3 {
+		t.Fatalf("deadline component lookups = %d/%d, want 3", lookups, reader.componentMetadataProcesses)
+	}
+	for _, path := range paths {
+		if got := reader.primed[path].result.Status; got != LimitedFileUnaddressable {
+			t.Fatalf("deadline result for %q = %v, want unaddressable", path, got)
+		}
+	}
+}
+
 func TestLimitedFileReaderClassifiesSingleComponentBeyondArgvBound(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")
@@ -1176,6 +1348,13 @@ func TestLimitedFileReaderClassifiesSingleComponentBeyondArgvBound(t *testing.T)
 	}
 	if result.Status != LimitedFileUnaddressable {
 		t.Fatalf("over-bound component result = %#v, want bounded unaddressable classification", result)
+	}
+	oneShot, err := ReadFileLimited(t.Context(), repo, tree, path, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oneShot.Status != LimitedFileUnaddressable {
+		t.Fatalf("one-shot over-bound component = %#v, want bounded unaddressable classification", oneShot)
 	}
 	if reader.content != nil {
 		t.Fatal("unaddressable component started a content batch")

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"os/exec"
@@ -469,6 +470,90 @@ func TestBatchFileReaderReadsMultipleFilesFromHead(t *testing.T) {
 	}
 	if _, ok, err := reader.ReadFile("missing.go"); err != nil || ok {
 		t.Fatalf("missing read ok=%v err=%v, want ok=false err=nil", ok, err)
+	}
+}
+
+type countingWriteCloser struct {
+	io.WriteCloser
+	writes int
+}
+
+func (w *countingWriteCloser) Write(p []byte) (int, error) {
+	w.writes++
+	return w.WriteCloser.Write(p)
+}
+
+func TestBatchFileReaderRejectsNonBlobBeforeRequestingContent(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	if err := os.WriteFile(filepath.Join(repo, "plain.py"), []byte("def plain():\n    return True\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", "plain.py")
+	git(t, repo, "commit", "-m", "gitlink target")
+	target := gitOutput(t, repo, "rev-parse", "HEAD")
+	git(t, repo, "update-index", "--add", "--cacheinfo", "160000", target, "module.py")
+	git(t, repo, "commit", "-m", "record gitlink")
+
+	reader, err := NewBatchFileReader(t.Context(), repo, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = reader.Close() })
+	contentWrites := &countingWriteCloser{WriteCloser: reader.stdin}
+	reader.stdin = contentWrites
+	reader.SetMaxBytes(1)
+
+	if content, ok, err := reader.ReadFile("module.py"); err != nil || ok || content != "" {
+		t.Fatalf("gitlink batch read = (%q, %v, %v), want metadata-only refusal", content, ok, err)
+	}
+	if contentWrites.writes != 0 {
+		t.Fatalf("gitlink issued %d content requests, want none", contentWrites.writes)
+	}
+	if reader.checkCmd == nil {
+		t.Fatal("gitlink read did not use the metadata batch")
+	}
+
+	// A real blob still reaches the content batch. The one-byte ceiling makes it
+	// stream through the existing oversize digest path rather than materializing.
+	if content, ok, err := reader.ReadFile("plain.py"); err != nil || ok || content != "" {
+		t.Fatalf("oversized blob batch read = (%q, %v, %v), want refusal", content, ok, err)
+	}
+	if contentWrites.writes != 1 {
+		t.Fatalf("blob issued %d content requests, want one", contentWrites.writes)
+	}
+	if _, ok := reader.OversizeBlob("plain.py"); !ok {
+		t.Fatal("blob preflight bypassed the existing oversize digest registry")
+	}
+}
+
+func TestBatchFileReaderRejectsInvalidPathWithoutDesync(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	const content = "package plain\n"
+	if err := os.WriteFile(filepath.Join(repo, "plain.go"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", "plain.go")
+	git(t, repo, "commit", "-m", "plain file")
+
+	reader, err := NewBatchFileReader(t.Context(), repo, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = reader.Close() })
+	for _, path := range []string{"", ".", "./plain.go", "../plain.go", "/plain.go", "dir//plain.go", "dir/../plain.go", "dir/"} {
+		if got, ok, err := reader.ReadFile(path); err == nil || ok || got != "" {
+			t.Fatalf("invalid batch path %q = (%q, %v, %v), want pre-write error", path, got, ok, err)
+		}
+	}
+	got, ok, err := reader.ReadFile("plain.go")
+	if err != nil || !ok || got != content {
+		t.Fatalf("plain read after invalid paths = (%q, %v, %v), want exact content", got, ok, err)
 	}
 }
 
@@ -1358,6 +1443,43 @@ func TestLimitedFileReaderClassifiesSingleComponentBeyondArgvBound(t *testing.T)
 	}
 	if reader.content != nil {
 		t.Fatal("unaddressable component started a content batch")
+	}
+}
+
+func TestLimitedFileReaderClassifiesMissingBlobObjectAsUnreadable(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	knownBlob := gitInputOutput(t, repo, "package known\n", "hash-object", "-w", "--stdin")
+	missingOID := strings.Repeat("1", len(knownBlob))
+	tree := gitInputOutput(
+		t,
+		repo,
+		fmt.Sprintf("100644 blob %s\tmissing.go%c", missingOID, byte(0)),
+		"mktree", "-z", "--missing",
+	)
+
+	reader := NewLimitedFileReader(t.Context(), repo, tree, 1024)
+	t.Cleanup(func() { _ = reader.Close() })
+	if err := reader.Prime([]string{"missing.go"}); err != nil {
+		t.Fatalf("prime missing-object entry: %v", err)
+	}
+	result, err := reader.ReadFile("missing.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != LimitedFileUnreadable {
+		t.Fatalf("missing-object result = %#v, want unreadable", result)
+	}
+	if reader.content != nil {
+		t.Fatal("unreadable metadata started a content batch")
+	}
+
+	oneShot, err := ReadFileLimited(t.Context(), repo, tree, "missing.go", 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oneShot.Status != LimitedFileUnreadable {
+		t.Fatalf("one-shot missing-object result = %#v, want unreadable", oneShot)
 	}
 }
 

--- a/internal/gitutil/git_test.go
+++ b/internal/gitutil/git_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -573,16 +574,37 @@ func TestShowFileLimitedBoundsTheReadNotTheAnswer(t *testing.T) {
 	if out, ok, err := ShowFileLimited(t.Context(), repo, "HEAD", oversizedPath, ceiling); err != nil || ok || out != "" {
 		t.Errorf("oversized blob = (%d bytes, ok %v, err %v), want (\"\", false, nil)", len(out), ok, err)
 	}
+	detailed, err := ReadFileLimited(t.Context(), repo, "HEAD", oversizedPath, ceiling)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detailed.Status != LimitedFileOversize || detailed.Bytes != ceiling+1 || detailed.Content != "" {
+		t.Errorf("typed oversized blob = %#v, want status oversize, %d bytes, and no content", detailed, ceiling+1)
+	}
 	// The ceiling is inclusive, so the boundary blob is still an answer. This is
 	// what distinguishes a bounded read from an off-by-one refusal.
 	if out, ok, err := ShowFileLimited(t.Context(), repo, "HEAD", "exact.txt", ceiling); err != nil || !ok || out != files["exact.txt"] {
 		t.Errorf("blob at the ceiling = (%d bytes, ok %v, err %v), want (%d bytes, true, nil)", len(out), ok, err, ceiling)
+	}
+	detailed, err = ReadFileLimited(t.Context(), repo, "HEAD", "exact.txt", ceiling)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detailed.Status != LimitedFileContent || detailed.Bytes != ceiling || detailed.Content != files["exact.txt"] {
+		t.Errorf("typed blob at ceiling = %#v, want content status with %d bytes", detailed, ceiling)
 	}
 	if out, ok, err := ShowFileLimited(t.Context(), repo, "HEAD", "small.txt", ceiling); err != nil || !ok || out != files["small.txt"] {
 		t.Errorf("small blob = (%q, ok %v, err %v), want (%q, true, nil)", out, ok, err, files["small.txt"])
 	}
 	if out, ok, err := ShowFileLimited(t.Context(), repo, "HEAD", "does-not-exist.txt", ceiling); err != nil || ok || out != "" {
 		t.Errorf("missing path = (%q, ok %v, err %v), want (\"\", false, nil)", out, ok, err)
+	}
+	detailed, err = ReadFileLimited(t.Context(), repo, "HEAD", "does-not-exist.txt", ceiling)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detailed.Status != LimitedFileMissing || detailed.Bytes != 0 || detailed.Content != "" {
+		t.Errorf("typed missing path = %#v, want missing with no content", detailed)
 	}
 	// Same stderr-only classification as ShowFile: a bad revision is a failure,
 	// not an absent file, even though the argv echoes a path.
@@ -637,6 +659,60 @@ func TestShowFileLimitedNeverMaterializesAnOversizedBlob(t *testing.T) {
 	if allocated := after.TotalAlloc - before.TotalAlloc; allocated > budget {
 		t.Errorf("reading a %d-byte blob under a %d-byte ceiling allocated %d bytes, want under %d: the blob was materialized before the ceiling was applied",
 			blobSize, ceiling, allocated, budget)
+	}
+}
+
+// A gitlink resolves to a commit object, not a blob. `cat-file -s` alone can
+// make that object look safe because the commit itself is tiny, while `git
+// show` renders the commit's entire patch. The bounded file reader must reject
+// the type before invoking that renderer.
+func TestShowFileLimitedRejectsGitlinkBeforeRenderingCommit(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	git(t, repo, "config", "commit.gpgsign", "false")
+
+	const renderedPatchBytes = 16 << 20
+	const ceiling = int64(4 << 10)
+	large := strings.Repeat("a line large enough to render in the commit patch\n", renderedPatchBytes/48+1)
+	if err := os.WriteFile(filepath.Join(repo, "large.txt"), []byte(large), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", "large.txt")
+	git(t, repo, "commit", "-m", "large gitlink target")
+	target := gitOutput(t, repo, "rev-parse", "HEAD")
+	targetSize, err := strconv.ParseInt(gitOutput(t, repo, "cat-file", "-s", target), 10, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if targetSize >= ceiling {
+		t.Fatalf("target commit object is %d bytes, want below the %d-byte ceiling", targetSize, ceiling)
+	}
+
+	git(t, repo, "rm", "large.txt")
+	git(t, repo, "update-index", "--add", "--cacheinfo", "160000", target, "vendor/module")
+	git(t, repo, "commit", "-m", "record gitlink")
+	large = ""
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	out, ok, err := ShowFileLimited(t.Context(), repo, "HEAD", "vendor/module", ceiling)
+	runtime.ReadMemStats(&after)
+	if err != nil || ok || out != "" {
+		t.Fatalf("gitlink = (%d bytes, ok %v, err %v), want (\"\", false, nil)", len(out), ok, err)
+	}
+	const allocationBudget = 4 << 20
+	if allocated := after.TotalAlloc - before.TotalAlloc; allocated > allocationBudget {
+		t.Errorf("refusing a gitlink allocated %d bytes, want under %d: git show rendered the target commit's patch", allocated, allocationBudget)
+	}
+	detailed, err := ReadFileLimited(t.Context(), repo, "HEAD", "vendor/module", ceiling)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detailed.Status != LimitedFileNonBlob || detailed.Content != "" || detailed.Bytes != 0 {
+		t.Errorf("typed gitlink result = %#v, want non-blob with no content", detailed)
 	}
 }
 
@@ -713,7 +789,9 @@ func TestShowFileLimitedRefusesOversizedBlobWhenTheProbeIsSilent(t *testing.T) {
 	git(t, repo, "add", ".")
 	git(t, repo, "commit", "-m", "probe fixture")
 
-	silent := func(context.Context, string, string, string) (int64, bool) { return 0, false }
+	silent := func(context.Context, string, string, string) (int64, blobProbeStatus) {
+		return 0, blobProbeUnknown
+	}
 
 	if out, ok, err := showFileLimited(t.Context(), repo, "HEAD", "over.txt", ceiling, silent); err != nil || ok || out != "" {
 		t.Errorf("oversized blob with a silent probe = (%d bytes, ok %v, err %v), want (\"\", false, nil)", len(out), ok, err)

--- a/internal/gitutil/process_descendants_notwindows.go
+++ b/internal/gitutil/process_descendants_notwindows.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package gitutil
+
+import (
+	"os/exec"
+	"time"
+)
+
+type pathOutputDescendants struct{}
+
+func capturePathOutputDescendants(*exec.Cmd) pathOutputDescendants {
+	return pathOutputDescendants{}
+}
+
+func (pathOutputDescendants) terminateAndWait(time.Duration) {}
+
+func (pathOutputDescendants) close() {}

--- a/internal/gitutil/process_descendants_windows.go
+++ b/internal/gitutil/process_descendants_windows.go
@@ -1,0 +1,136 @@
+//go:build windows
+
+package gitutil
+
+import (
+	"os/exec"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+const (
+	maxPathOutputProcessSnapshotEntries = 65_536
+	maxPathOutputDescendants            = 64
+)
+
+type pathOutputProcessRelation struct {
+	pid    uint32
+	parent uint32
+}
+
+type pathOutputDescendant struct {
+	handle syscall.Handle
+	depth  int
+}
+
+type pathOutputDescendants struct {
+	processes []pathOutputDescendant
+}
+
+// capturePathOutputDescendants snapshots and opens stable handles while Git is
+// still alive and producing output. A PID-only cleanup after killing Git's
+// launcher can race PID reuse and loses the worker's parent relationship.
+func capturePathOutputDescendants(cmd *exec.Cmd) pathOutputDescendants {
+	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
+		return pathOutputDescendants{}
+	}
+	snapshot, err := syscall.CreateToolhelp32Snapshot(syscall.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return pathOutputDescendants{}
+	}
+	defer syscall.CloseHandle(snapshot)
+
+	relations := make([]pathOutputProcessRelation, 0, 256)
+	var entry syscall.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	if err := syscall.Process32First(snapshot, &entry); err != nil {
+		return pathOutputDescendants{}
+	}
+	for len(relations) < maxPathOutputProcessSnapshotEntries {
+		relations = append(relations, pathOutputProcessRelation{
+			pid:    entry.ProcessID,
+			parent: entry.ParentProcessID,
+		})
+		entry.Size = uint32(unsafe.Sizeof(entry))
+		if err := syscall.Process32Next(snapshot, &entry); err != nil {
+			break
+		}
+	}
+
+	type queuedProcess struct {
+		pid   uint32
+		depth int
+	}
+	rootPID := uint32(cmd.Process.Pid)
+	queue := []queuedProcess{{pid: rootPID}}
+	seen := map[uint32]struct{}{rootPID: {}}
+	result := pathOutputDescendants{
+		processes: make([]pathOutputDescendant, 0, 2),
+	}
+	for len(queue) > 0 && len(result.processes) < maxPathOutputDescendants {
+		parent := queue[0]
+		queue = queue[1:]
+		for _, relation := range relations {
+			if relation.parent != parent.pid || relation.pid == 0 {
+				continue
+			}
+			if _, duplicate := seen[relation.pid]; duplicate {
+				continue
+			}
+			seen[relation.pid] = struct{}{}
+			child := queuedProcess{pid: relation.pid, depth: parent.depth + 1}
+			queue = append(queue, child)
+			handle, err := syscall.OpenProcess(
+				syscall.SYNCHRONIZE|syscall.PROCESS_TERMINATE,
+				false,
+				relation.pid,
+			)
+			if err != nil {
+				continue
+			}
+			result.processes = append(result.processes, pathOutputDescendant{
+				handle: handle,
+				depth:  child.depth,
+			})
+			if len(result.processes) >= maxPathOutputDescendants {
+				break
+			}
+		}
+	}
+	return result
+}
+
+// terminateAndWait retires deepest descendants first, then waits against one
+// shared deadline. Stable handles prevent PID reuse from redirecting cleanup at
+// an unrelated process, and the fixed capture cap plus shared deadline keep the
+// malformed-output path bounded.
+func (descendants pathOutputDescendants) terminateAndWait(timeout time.Duration) {
+	for depth := maxPathOutputDescendants; depth > 0; depth-- {
+		for _, process := range descendants.processes {
+			if process.depth != depth {
+				continue
+			}
+			state, err := syscall.WaitForSingleObject(process.handle, 0)
+			if err == nil && state == syscall.WAIT_TIMEOUT {
+				_ = syscall.TerminateProcess(process.handle, 1)
+			}
+		}
+	}
+
+	deadline := time.Now().Add(timeout)
+	for i := len(descendants.processes) - 1; i >= 0; i-- {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return
+		}
+		milliseconds := uint32((remaining + time.Millisecond - 1) / time.Millisecond)
+		_, _ = syscall.WaitForSingleObject(descendants.processes[i].handle, milliseconds)
+	}
+}
+
+func (descendants pathOutputDescendants) close() {
+	for _, process := range descendants.processes {
+		_ = syscall.CloseHandle(process.handle)
+	}
+}

--- a/internal/gitutil/process_descendants_windows_test.go
+++ b/internal/gitutil/process_descendants_windows_test.go
@@ -1,0 +1,81 @@
+//go:build windows
+
+package gitutil
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+const pathOutputDescendantHelperEnv = "ENTIRE_GRAPH_PATH_OUTPUT_DESCENDANT_HELPER"
+
+func TestStopPathOutputCommandTerminatesWindowsDescendants(t *testing.T) {
+	switch os.Getenv(pathOutputDescendantHelperEnv) {
+	case "parent":
+		child := exec.Command(os.Args[0], "-test.run=^TestStopPathOutputCommandTerminatesWindowsDescendants$")
+		child.Env = append(os.Environ(), pathOutputDescendantHelperEnv+"=child")
+		child.Stdout = os.Stdout
+		child.Stderr = os.Stderr
+		_ = child.Run()
+		return
+	case "child":
+		fmt.Fprintln(os.Stdout, os.Getpid())
+		time.Sleep(time.Hour)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	cmd := newCmd(ctx, "", os.Args[0], "-test.run=^TestStopPathOutputCommandTerminatesWindowsDescendants$")
+	cmd.Env = append(cmd.Env, pathOutputDescendantHelperEnv+"=parent")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	line, err := bufio.NewReader(stdout).ReadString('\n')
+	if err != nil {
+		t.Fatalf("read descendant PID: %v; stderr: %s", err, stderr.String())
+	}
+	pid, err := strconv.ParseUint(strings.TrimSpace(line), 10, 32)
+	if err != nil {
+		t.Fatalf("parse descendant PID %q: %v", line, err)
+	}
+	child, err := syscall.OpenProcess(syscall.SYNCHRONIZE, false, uint32(pid))
+	if err != nil {
+		t.Fatalf("open descendant process %d: %v", pid, err)
+	}
+	defer syscall.CloseHandle(child)
+
+	started := time.Now()
+	stopPathOutputCommand(cmd, stdout)
+	if elapsed := time.Since(started); elapsed >= 5*time.Second {
+		t.Fatalf("descendant cleanup took %s, want under 5s", elapsed)
+	}
+	if cmd.ProcessState == nil {
+		t.Fatal("root helper was not reaped")
+	}
+	state, err := syscall.WaitForSingleObject(child, 0)
+	if err != nil {
+		t.Fatalf("query descendant process %d: %v", pid, err)
+	}
+	if state != syscall.WAIT_OBJECT_0 {
+		t.Fatalf("descendant process %d remains active after cleanup (wait state %#x)", pid, state)
+	}
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("descendant cleanup exceeded its context: %v", err)
+	}
+}

--- a/internal/gitutil/process_descendants_windows_test.go
+++ b/internal/gitutil/process_descendants_windows_test.go
@@ -39,11 +39,16 @@ func TestStopPathOutputCommandTerminatesWindowsDescendants(t *testing.T) {
 	cmd.Env = append(cmd.Env, pathOutputDescendantHelperEnv+"=parent")
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
+	launch, err := preparePathOutputCommand(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer launch.close()
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		t.Fatal(err)
 	}
-	job, err := startPathOutputCommand(cmd)
+	job, err := launch.start(cmd)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/gitutil/process_descendants_windows_test.go
+++ b/internal/gitutil/process_descendants_windows_test.go
@@ -43,9 +43,11 @@ func TestStopPathOutputCommandTerminatesWindowsDescendants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := cmd.Start(); err != nil {
+	job, err := startPathOutputCommand(cmd)
+	if err != nil {
 		t.Fatal(err)
 	}
+	defer job.close()
 	line, err := bufio.NewReader(stdout).ReadString('\n')
 	if err != nil {
 		t.Fatalf("read descendant PID: %v; stderr: %s", err, stderr.String())
@@ -61,7 +63,7 @@ func TestStopPathOutputCommandTerminatesWindowsDescendants(t *testing.T) {
 	defer syscall.CloseHandle(child)
 
 	started := time.Now()
-	stopPathOutputCommand(cmd, stdout)
+	stopPathOutputCommand(cmd, stdout, job)
 	if elapsed := time.Since(started); elapsed >= 5*time.Second {
 		t.Fatalf("descendant cleanup took %s, want under 5s", elapsed)
 	}

--- a/internal/gitutil/process_descendants_windows_test.go
+++ b/internal/gitutil/process_descendants_windows_test.go
@@ -48,6 +48,12 @@ func TestStopPathOutputCommandTerminatesWindowsDescendants(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer job.close()
+	if job.handle == 0 {
+		t.Fatal("startPathOutputCommand returned a zero job handle")
+	}
+	if contained, err := job.contains(cmd); err != nil || !contained {
+		t.Fatalf("root helper job membership = (%v, %v), want true", contained, err)
+	}
 	line, err := bufio.NewReader(stdout).ReadString('\n')
 	if err != nil {
 		t.Fatalf("read descendant PID: %v; stderr: %s", err, stderr.String())
@@ -61,6 +67,9 @@ func TestStopPathOutputCommandTerminatesWindowsDescendants(t *testing.T) {
 		t.Fatalf("open descendant process %d: %v", pid, err)
 	}
 	defer syscall.CloseHandle(child)
+	if contained, err := job.containsPID(uint32(pid)); err != nil || !contained {
+		t.Fatalf("descendant helper job membership = (%v, %v), want true", contained, err)
+	}
 
 	started := time.Now()
 	stopPathOutputCommand(cmd, stdout, job)

--- a/internal/gitutil/process_job_notwindows.go
+++ b/internal/gitutil/process_job_notwindows.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package gitutil
+
+import "os/exec"
+
+type pathOutputJob struct{}
+
+func startPathOutputCommand(cmd *exec.Cmd) (pathOutputJob, error) {
+	if err := cmd.Start(); err != nil {
+		return pathOutputJob{}, err
+	}
+	return pathOutputJob{}, nil
+}
+
+func (pathOutputJob) terminate() {}
+
+func (pathOutputJob) close() {}

--- a/internal/gitutil/process_job_notwindows.go
+++ b/internal/gitutil/process_job_notwindows.go
@@ -2,16 +2,30 @@
 
 package gitutil
 
-import "os/exec"
+import (
+	"errors"
+	"os/exec"
+)
 
 type pathOutputJob struct{}
 
-func startPathOutputCommand(cmd *exec.Cmd) (pathOutputJob, error) {
+type pathOutputLaunch struct{}
+
+func preparePathOutputCommand(cmd *exec.Cmd) (pathOutputLaunch, error) {
+	if cmd == nil {
+		return pathOutputLaunch{}, errors.New("prepare path-output command: nil command")
+	}
+	return pathOutputLaunch{}, nil
+}
+
+func (*pathOutputLaunch) start(cmd *exec.Cmd) (pathOutputJob, error) {
 	if err := cmd.Start(); err != nil {
 		return pathOutputJob{}, err
 	}
 	return pathOutputJob{}, nil
 }
+
+func (*pathOutputLaunch) close() {}
 
 func (pathOutputJob) terminate() {}
 

--- a/internal/gitutil/process_job_notwindows.go
+++ b/internal/gitutil/process_job_notwindows.go
@@ -27,6 +27,6 @@ func (*pathOutputLaunch) start(cmd *exec.Cmd) (pathOutputJob, error) {
 
 func (*pathOutputLaunch) close() {}
 
-func (pathOutputJob) terminate() {}
+func (pathOutputJob) terminate() error { return nil }
 
 func (pathOutputJob) close() {}

--- a/internal/gitutil/process_job_windows.go
+++ b/internal/gitutil/process_job_windows.go
@@ -19,31 +19,6 @@ const (
 	processQueryLimitedInformation         = 0x00001000
 )
 
-// jobObjectBasicLimitInformation mirrors JOBOBJECT_BASIC_LIMIT_INFORMATION.
-// Only LimitFlags is populated; the rest keep their zero value, which Windows
-// treats as "no limit" for each field.
-type jobObjectBasicLimitInformation struct {
-	PerProcessUserTimeLimit int64
-	PerJobUserTimeLimit     int64
-	LimitFlags              uint32
-	MinimumWorkingSetSize   uintptr
-	MaximumWorkingSetSize   uintptr
-	ActiveProcessLimit      uint32
-	Affinity                uintptr
-	PriorityClass           uint32
-	SchedulingClass         uint32
-}
-
-// jobObjectExtendedLimitInformation mirrors JOBOBJECT_EXTENDED_LIMIT_INFORMATION.
-type jobObjectExtendedLimitInformation struct {
-	BasicLimitInformation jobObjectBasicLimitInformation
-	IoInfo                [6]uint64
-	ProcessMemoryLimit    uintptr
-	JobMemoryLimit        uintptr
-	PeakProcessMemoryUsed uintptr
-	PeakJobMemoryUsed     uintptr
-}
-
 var (
 	modkernel32Job               = syscall.NewLazyDLL("kernel32.dll")
 	procCreateJobObjectW         = modkernel32Job.NewProc("CreateJobObjectW")
@@ -64,28 +39,34 @@ type pathOutputJob struct {
 	creationParentPID uint32
 }
 
-// startPathOutputCommand establishes containment before cmd can execute. A
-// CREATE_SUSPENDED surrogate is assigned to a KILL_ON_JOB_CLOSE job, then used
-// as cmd's creation parent. The surrogate never executes user code and is
-// retired immediately after cmd.Start returns.
+// pathOutputLaunch establishes containment before callers create os/exec pipe
+// handles. A CREATE_SUSPENDED surrogate is assigned to a KILL_ON_JOB_CLOSE job,
+// then used as cmd's creation parent. The surrogate never executes user code
+// and is retired immediately after start returns.
 //
 // Containment setup is mandatory on Windows. Returning a nil job after starting
 // the command would silently restore the launcher/assignment race this helper
 // exists to close, so any setup failure prevents the command and is returned to
 // the caller.
-func startPathOutputCommand(cmd *exec.Cmd) (pathOutputJob, error) {
+type pathOutputLaunch struct {
+	job              pathOutputJob
+	creationParent   *pathOutputCreationParent
+	originalProcAttr *syscall.SysProcAttr
+}
+
+func preparePathOutputCommand(cmd *exec.Cmd) (pathOutputLaunch, error) {
 	if cmd == nil {
-		return pathOutputJob{}, errors.New("start path-output command: nil command")
+		return pathOutputLaunch{}, errors.New("prepare path-output command: nil command")
 	}
 	originalSysProcAttr := cmd.SysProcAttr
 	if originalSysProcAttr != nil && originalSysProcAttr.ParentProcess != 0 {
-		return pathOutputJob{}, errors.New("start path-output command: caller-supplied Windows parent process is incompatible with job containment")
+		return pathOutputLaunch{}, errors.New("prepare path-output command: caller-supplied Windows parent process is incompatible with job containment")
 	}
 	childAttrs := pathOutputChildSysProcAttr(originalSysProcAttr, 0)
 
 	job, err := createPathOutputJob()
 	if err != nil {
-		return pathOutputJob{}, err
+		return pathOutputLaunch{}, err
 	}
 	creationParent, err := newPathOutputCreationParent(
 		job,
@@ -93,20 +74,43 @@ func startPathOutputCommand(cmd *exec.Cmd) (pathOutputJob, error) {
 	)
 	if err != nil {
 		job.close()
-		return pathOutputJob{}, err
+		return pathOutputLaunch{}, err
 	}
-	defer creationParent.close()
+	return pathOutputLaunch{
+		job:              job,
+		creationParent:   creationParent,
+		originalProcAttr: originalSysProcAttr,
+	}, nil
+}
 
-	childAttrs = pathOutputChildSysProcAttr(originalSysProcAttr, creationParent.process)
+func (launch *pathOutputLaunch) start(cmd *exec.Cmd) (pathOutputJob, error) {
+	if launch == nil || cmd == nil || launch.job.handle == 0 || launch.creationParent == nil {
+		return pathOutputJob{}, errors.New("start path-output command: containment is unavailable")
+	}
+	childAttrs := pathOutputChildSysProcAttr(launch.originalProcAttr, launch.creationParent.process)
 	cmd.SysProcAttr = &childAttrs
 	startErr := cmd.Start()
-	cmd.SysProcAttr = originalSysProcAttr
+	cmd.SysProcAttr = launch.originalProcAttr
 	if startErr != nil {
-		job.close()
+		launch.close()
 		return pathOutputJob{}, startErr
 	}
-	job.creationParentPID = creationParent.pid
+	job := launch.job
+	job.creationParentPID = launch.creationParent.pid
+	launch.creationParent.close()
+	launch.creationParent = nil
+	launch.job = pathOutputJob{}
 	return job, nil
+}
+
+func (launch *pathOutputLaunch) close() {
+	if launch == nil {
+		return
+	}
+	launch.creationParent.close()
+	launch.creationParent = nil
+	launch.job.close()
+	launch.job = pathOutputJob{}
 }
 
 func pathOutputChildSysProcAttr(original *syscall.SysProcAttr, parent syscall.Handle) syscall.SysProcAttr {

--- a/internal/gitutil/process_job_windows.go
+++ b/internal/gitutil/process_job_windows.go
@@ -3,19 +3,20 @@
 package gitutil
 
 import (
+	"errors"
+	"fmt"
+	"os"
 	"os/exec"
 	"syscall"
 	"unsafe"
 )
 
-// processSetQuota is PROCESS_SET_QUOTA. It is not exposed by the standard
-// syscall package for windows, unlike the PROCESS_TERMINATE and SYNCHRONIZE
-// rights used elsewhere in this file.
-const processSetQuota = 0x0100
-
 const (
 	jobObjectExtendedLimitInformationClass = 9
 	jobObjectLimitKillOnJobClose           = 0x00002000
+	createSuspended                        = 0x00000004
+	createNoWindow                         = 0x08000000
+	processQueryLimitedInformation         = 0x00001000
 )
 
 // jobObjectBasicLimitInformation mirrors JOBOBJECT_BASIC_LIMIT_INFORMATION.
@@ -49,91 +50,202 @@ var (
 	procAssignProcessToJobObject = modkernel32Job.NewProc("AssignProcessToJobObject")
 	procSetInformationJobObject  = modkernel32Job.NewProc("SetInformationJobObject")
 	procTerminateJobObject       = modkernel32Job.NewProc("TerminateJobObject")
+	procIsProcessInJob           = modkernel32Job.NewProc("IsProcessInJob")
 )
 
 // pathOutputJob is a Windows Job Object that contains a launched process and
-// every descendant it spawns for as long as the job handle stays open. Unlike
-// a point-in-time process-tree snapshot (pathOutputDescendants), a job closes
-// the race a snapshot has against a descendant spawned after the snapshot was
-// taken: Windows places a new child process into its parent's job
-// automatically whenever the parent is itself a job member, so a
-// launcher/worker pair spawned after cleanup begins is still caught.
+// every descendant it spawns for as long as the job handle stays open. The
+// actual command is created with a suspended member of this job as its
+// PROC_THREAD_ATTRIBUTE_PARENT_PROCESS. Windows inherits the designated
+// parent's job membership while creating the child, so there is no interval in
+// which a fast launcher can create an uncontained worker.
 type pathOutputJob struct {
-	handle syscall.Handle
+	handle            syscall.Handle
+	creationParentPID uint32
 }
 
-// startPathOutputCommand starts cmd and, best-effort, contains it (and its
-// future descendants) in a job object established immediately after start --
-// before the process has had a chance to do anything beyond being created.
-// Job creation or assignment failure is not fatal: it only means cleanup
-// falls back to the pre-existing point-in-time descendant snapshot taken by
-// stopPathOutputCommand.
+// startPathOutputCommand establishes containment before cmd can execute. A
+// CREATE_SUSPENDED surrogate is assigned to a KILL_ON_JOB_CLOSE job, then used
+// as cmd's creation parent. The surrogate never executes user code and is
+// retired immediately after cmd.Start returns.
+//
+// Containment setup is mandatory on Windows. Returning a nil job after starting
+// the command would silently restore the launcher/assignment race this helper
+// exists to close, so any setup failure prevents the command and is returned to
+// the caller.
 func startPathOutputCommand(cmd *exec.Cmd) (pathOutputJob, error) {
-	if err := cmd.Start(); err != nil {
+	if cmd == nil {
+		return pathOutputJob{}, errors.New("start path-output command: nil command")
+	}
+	originalSysProcAttr := cmd.SysProcAttr
+	if originalSysProcAttr != nil && originalSysProcAttr.ParentProcess != 0 {
+		return pathOutputJob{}, errors.New("start path-output command: caller-supplied Windows parent process is incompatible with job containment")
+	}
+	childAttrs := pathOutputChildSysProcAttr(originalSysProcAttr, 0)
+
+	job, err := createPathOutputJob()
+	if err != nil {
 		return pathOutputJob{}, err
 	}
-	return newPathOutputJob(cmd), nil
+	creationParent, err := newPathOutputCreationParent(
+		job,
+		len(childAttrs.AdditionalInheritedHandles) > 0 && !childAttrs.NoInheritHandles,
+	)
+	if err != nil {
+		job.close()
+		return pathOutputJob{}, err
+	}
+	defer creationParent.close()
+
+	childAttrs = pathOutputChildSysProcAttr(originalSysProcAttr, creationParent.process)
+	cmd.SysProcAttr = &childAttrs
+	startErr := cmd.Start()
+	cmd.SysProcAttr = originalSysProcAttr
+	if startErr != nil {
+		job.close()
+		return pathOutputJob{}, startErr
+	}
+	job.creationParentPID = creationParent.pid
+	return job, nil
 }
 
-func newPathOutputJob(cmd *exec.Cmd) pathOutputJob {
-	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
-		return pathOutputJob{}
+func pathOutputChildSysProcAttr(original *syscall.SysProcAttr, parent syscall.Handle) syscall.SysProcAttr {
+	attributes := syscall.SysProcAttr{}
+	if original != nil {
+		attributes = *original
 	}
-	handle, _, _ := procCreateJobObjectW.Call(0, 0)
+	attributes.ParentProcess = parent
+	return attributes
+}
+
+func createPathOutputJob() (pathOutputJob, error) {
+	handle, _, callErr := procCreateJobObjectW.Call(0, 0)
 	if handle == 0 {
-		return pathOutputJob{}
+		return pathOutputJob{}, windowsJobCallError("CreateJobObjectW", callErr)
 	}
-	jobHandle := syscall.Handle(handle)
+	job := pathOutputJob{handle: syscall.Handle(handle)}
 	info := jobObjectExtendedLimitInformation{
 		BasicLimitInformation: jobObjectBasicLimitInformation{
 			LimitFlags: jobObjectLimitKillOnJobClose,
 		},
 	}
-	ret, _, _ := procSetInformationJobObject.Call(
-		uintptr(jobHandle),
+	ret, _, callErr := procSetInformationJobObject.Call(
+		uintptr(job.handle),
 		jobObjectExtendedLimitInformationClass,
 		uintptr(unsafe.Pointer(&info)),
 		unsafe.Sizeof(info),
 	)
 	if ret == 0 {
-		_ = syscall.CloseHandle(jobHandle)
-		return pathOutputJob{}
-	}
-	job := pathOutputJob{handle: jobHandle}
-	if !job.assign(cmd) {
 		job.close()
-		return pathOutputJob{}
+		return pathOutputJob{}, windowsJobCallError("SetInformationJobObject", callErr)
 	}
-	return job
+	return job, nil
 }
 
-// assign places the already-started process into the job. This runs as the
-// very next step after cmd.Start() returns in startPathOutputCommand, so the
-// window in which a fast-forking launcher could spawn a worker outside the
-// job's containment is a scheduling quantum, not however long the command
-// runs before something goes wrong and cleanup begins.
-func (job pathOutputJob) assign(cmd *exec.Cmd) bool {
-	if job.handle == 0 || cmd == nil || cmd.Process == nil {
-		return false
-	}
-	processHandle, err := syscall.OpenProcess(
-		syscall.PROCESS_TERMINATE|processSetQuota,
-		false,
-		uint32(cmd.Process.Pid),
-	)
+type pathOutputCreationParent struct {
+	process syscall.Handle
+	thread  syscall.Handle
+	pid     uint32
+}
+
+func newPathOutputCreationParent(job pathOutputJob, inheritHandles bool) (*pathOutputCreationParent, error) {
+	executable, err := os.Executable()
 	if err != nil {
-		return false
+		return nil, fmt.Errorf("resolve path-output creation parent executable: %w", err)
 	}
-	defer syscall.CloseHandle(processHandle)
-	ret, _, _ := procAssignProcessToJobObject.Call(uintptr(job.handle), uintptr(processHandle))
-	return ret != 0
+	application, err := syscall.UTF16PtrFromString(executable)
+	if err != nil {
+		return nil, fmt.Errorf("encode path-output creation parent executable: %w", err)
+	}
+	startup := syscall.StartupInfo{Cb: uint32(unsafe.Sizeof(syscall.StartupInfo{}))}
+	var process syscall.ProcessInformation
+	// SysProcAttr requires AdditionalInheritedHandles to exist in ParentProcess.
+	// Windows handle inheritance preserves their numeric values, so let the
+	// suspended surrogate inherit them before Go supplies the exact handle list
+	// for the real child. The surrogate executes no instructions, and the real
+	// child still inherits only the handles os.StartProcess explicitly lists.
+	if err := syscall.CreateProcess(
+		application,
+		nil,
+		nil,
+		nil,
+		inheritHandles,
+		createSuspended|createNoWindow,
+		nil,
+		nil,
+		&startup,
+		&process,
+	); err != nil {
+		return nil, fmt.Errorf("create suspended path-output parent: %w", err)
+	}
+	parent := &pathOutputCreationParent{
+		process: process.Process,
+		thread:  process.Thread,
+		pid:     process.ProcessId,
+	}
+	ret, _, callErr := procAssignProcessToJobObject.Call(uintptr(job.handle), uintptr(parent.process))
+	if ret == 0 {
+		parent.close()
+		return nil, windowsJobCallError("AssignProcessToJobObject", callErr)
+	}
+	return parent, nil
+}
+
+func (parent *pathOutputCreationParent) close() {
+	if parent == nil {
+		return
+	}
+	if parent.process != 0 {
+		_ = syscall.TerminateProcess(parent.process, 1)
+		_, _ = syscall.WaitForSingleObject(parent.process, 5_000)
+	}
+	if parent.thread != 0 {
+		_ = syscall.CloseHandle(parent.thread)
+		parent.thread = 0
+	}
+	if parent.process != 0 {
+		_ = syscall.CloseHandle(parent.process)
+		parent.process = 0
+	}
+}
+
+func (job pathOutputJob) contains(cmd *exec.Cmd) (bool, error) {
+	if job.handle == 0 || cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
+		return false, errors.New("job or process is unavailable")
+	}
+	return job.containsPID(uint32(cmd.Process.Pid))
+}
+
+func (job pathOutputJob) containsPID(pid uint32) (bool, error) {
+	if job.handle == 0 || pid == 0 {
+		return false, errors.New("job or process is unavailable")
+	}
+	process, err := syscall.OpenProcess(processQueryLimitedInformation, false, pid)
+	if err != nil {
+		return false, err
+	}
+	defer syscall.CloseHandle(process)
+	var contained int32
+	ret, _, callErr := procIsProcessInJob.Call(
+		uintptr(process),
+		uintptr(job.handle),
+		uintptr(unsafe.Pointer(&contained)),
+	)
+	if ret == 0 {
+		return false, windowsJobCallError("IsProcessInJob", callErr)
+	}
+	return contained != 0, nil
+}
+
+func windowsJobCallError(name string, err error) error {
+	if err == nil || errors.Is(err, syscall.Errno(0)) {
+		return fmt.Errorf("%s failed", name)
+	}
+	return fmt.Errorf("%s: %w", name, err)
 }
 
 // terminate kills every process still in the job: current members and any
-// descendant spawned after the job was created, including ones that spawned
-// after the point-in-time snapshot capturePathOutputDescendants takes as a
-// fallback for descendants that already existed when a job could not be
-// created.
+// descendant spawned after the point-in-time snapshot capture fallback.
 func (job pathOutputJob) terminate() {
 	if job.handle == 0 {
 		return

--- a/internal/gitutil/process_job_windows.go
+++ b/internal/gitutil/process_job_windows.go
@@ -1,0 +1,149 @@
+//go:build windows
+
+package gitutil
+
+import (
+	"os/exec"
+	"syscall"
+	"unsafe"
+)
+
+// processSetQuota is PROCESS_SET_QUOTA. It is not exposed by the standard
+// syscall package for windows, unlike the PROCESS_TERMINATE and SYNCHRONIZE
+// rights used elsewhere in this file.
+const processSetQuota = 0x0100
+
+const (
+	jobObjectExtendedLimitInformationClass = 9
+	jobObjectLimitKillOnJobClose           = 0x00002000
+)
+
+// jobObjectBasicLimitInformation mirrors JOBOBJECT_BASIC_LIMIT_INFORMATION.
+// Only LimitFlags is populated; the rest keep their zero value, which Windows
+// treats as "no limit" for each field.
+type jobObjectBasicLimitInformation struct {
+	PerProcessUserTimeLimit int64
+	PerJobUserTimeLimit     int64
+	LimitFlags              uint32
+	MinimumWorkingSetSize   uintptr
+	MaximumWorkingSetSize   uintptr
+	ActiveProcessLimit      uint32
+	Affinity                uintptr
+	PriorityClass           uint32
+	SchedulingClass         uint32
+}
+
+// jobObjectExtendedLimitInformation mirrors JOBOBJECT_EXTENDED_LIMIT_INFORMATION.
+type jobObjectExtendedLimitInformation struct {
+	BasicLimitInformation jobObjectBasicLimitInformation
+	IoInfo                [6]uint64
+	ProcessMemoryLimit    uintptr
+	JobMemoryLimit        uintptr
+	PeakProcessMemoryUsed uintptr
+	PeakJobMemoryUsed     uintptr
+}
+
+var (
+	modkernel32Job               = syscall.NewLazyDLL("kernel32.dll")
+	procCreateJobObjectW         = modkernel32Job.NewProc("CreateJobObjectW")
+	procAssignProcessToJobObject = modkernel32Job.NewProc("AssignProcessToJobObject")
+	procSetInformationJobObject  = modkernel32Job.NewProc("SetInformationJobObject")
+	procTerminateJobObject       = modkernel32Job.NewProc("TerminateJobObject")
+)
+
+// pathOutputJob is a Windows Job Object that contains a launched process and
+// every descendant it spawns for as long as the job handle stays open. Unlike
+// a point-in-time process-tree snapshot (pathOutputDescendants), a job closes
+// the race a snapshot has against a descendant spawned after the snapshot was
+// taken: Windows places a new child process into its parent's job
+// automatically whenever the parent is itself a job member, so a
+// launcher/worker pair spawned after cleanup begins is still caught.
+type pathOutputJob struct {
+	handle syscall.Handle
+}
+
+// startPathOutputCommand starts cmd and, best-effort, contains it (and its
+// future descendants) in a job object established immediately after start --
+// before the process has had a chance to do anything beyond being created.
+// Job creation or assignment failure is not fatal: it only means cleanup
+// falls back to the pre-existing point-in-time descendant snapshot taken by
+// stopPathOutputCommand.
+func startPathOutputCommand(cmd *exec.Cmd) (pathOutputJob, error) {
+	if err := cmd.Start(); err != nil {
+		return pathOutputJob{}, err
+	}
+	return newPathOutputJob(cmd), nil
+}
+
+func newPathOutputJob(cmd *exec.Cmd) pathOutputJob {
+	if cmd == nil || cmd.Process == nil || cmd.Process.Pid <= 0 {
+		return pathOutputJob{}
+	}
+	handle, _, _ := procCreateJobObjectW.Call(0, 0)
+	if handle == 0 {
+		return pathOutputJob{}
+	}
+	jobHandle := syscall.Handle(handle)
+	info := jobObjectExtendedLimitInformation{
+		BasicLimitInformation: jobObjectBasicLimitInformation{
+			LimitFlags: jobObjectLimitKillOnJobClose,
+		},
+	}
+	ret, _, _ := procSetInformationJobObject.Call(
+		uintptr(jobHandle),
+		jobObjectExtendedLimitInformationClass,
+		uintptr(unsafe.Pointer(&info)),
+		unsafe.Sizeof(info),
+	)
+	if ret == 0 {
+		_ = syscall.CloseHandle(jobHandle)
+		return pathOutputJob{}
+	}
+	job := pathOutputJob{handle: jobHandle}
+	if !job.assign(cmd) {
+		job.close()
+		return pathOutputJob{}
+	}
+	return job
+}
+
+// assign places the already-started process into the job. This runs as the
+// very next step after cmd.Start() returns in startPathOutputCommand, so the
+// window in which a fast-forking launcher could spawn a worker outside the
+// job's containment is a scheduling quantum, not however long the command
+// runs before something goes wrong and cleanup begins.
+func (job pathOutputJob) assign(cmd *exec.Cmd) bool {
+	if job.handle == 0 || cmd == nil || cmd.Process == nil {
+		return false
+	}
+	processHandle, err := syscall.OpenProcess(
+		syscall.PROCESS_TERMINATE|processSetQuota,
+		false,
+		uint32(cmd.Process.Pid),
+	)
+	if err != nil {
+		return false
+	}
+	defer syscall.CloseHandle(processHandle)
+	ret, _, _ := procAssignProcessToJobObject.Call(uintptr(job.handle), uintptr(processHandle))
+	return ret != 0
+}
+
+// terminate kills every process still in the job: current members and any
+// descendant spawned after the job was created, including ones that spawned
+// after the point-in-time snapshot capturePathOutputDescendants takes as a
+// fallback for descendants that already existed when a job could not be
+// created.
+func (job pathOutputJob) terminate() {
+	if job.handle == 0 {
+		return
+	}
+	_, _, _ = procTerminateJobObject.Call(uintptr(job.handle), 1)
+}
+
+func (job pathOutputJob) close() {
+	if job.handle == 0 {
+		return
+	}
+	_ = syscall.CloseHandle(job.handle)
+}

--- a/internal/gitutil/process_job_windows.go
+++ b/internal/gitutil/process_job_windows.go
@@ -104,11 +104,21 @@ func (launch *pathOutputLaunch) start(cmd *exec.Cmd) (pathOutputJob, error) {
 	// is reading to notice the cancellation in the first place.
 	job := launch.job
 	cmd.Cancel = func() error {
-		job.terminate()
-		if cmd.Process != nil {
-			return cmd.Process.Kill()
+		jobErr := job.terminate()
+		if jobErr == nil {
+			// Returning nil tells os/exec that cancellation succeeded. If the
+			// launcher already exited 0, Wait will then still return the context
+			// error instead of accepting the deliberately truncated output.
+			return nil
 		}
-		return nil
+		if cmd.Process == nil {
+			return jobErr
+		}
+		killErr := cmd.Process.Kill()
+		if killErr == nil || errors.Is(killErr, os.ErrProcessDone) {
+			return jobErr
+		}
+		return errors.Join(jobErr, killErr)
 	}
 	startErr := cmd.Start()
 	cmd.SysProcAttr = launch.originalProcAttr
@@ -270,11 +280,15 @@ func windowsJobCallError(name string, err error) error {
 
 // terminate kills every process still in the job: current members and any
 // descendant spawned after the point-in-time snapshot capture fallback.
-func (job pathOutputJob) terminate() {
+func (job pathOutputJob) terminate() error {
 	if job.handle == 0 {
-		return
+		return errors.New("terminate Windows job: handle is unavailable")
 	}
-	_, _, _ = procTerminateJobObject.Call(uintptr(job.handle), 1)
+	ret, _, callErr := procTerminateJobObject.Call(uintptr(job.handle), 1)
+	if ret == 0 {
+		return windowsJobCallError("TerminateJobObject", callErr)
+	}
+	return nil
 }
 
 func (job pathOutputJob) close() {

--- a/internal/gitutil/process_job_windows.go
+++ b/internal/gitutil/process_job_windows.go
@@ -89,13 +89,33 @@ func (launch *pathOutputLaunch) start(cmd *exec.Cmd) (pathOutputJob, error) {
 	}
 	childAttrs := pathOutputChildSysProcAttr(launch.originalProcAttr, launch.creationParent.process)
 	cmd.SysProcAttr = &childAttrs
+	// The job's handle is already valid (createPathOutputJob ran inside
+	// preparePathOutputCommand, before this method was ever called), so it can
+	// be captured here and installed as cmd.Cancel BEFORE Start. That matters
+	// because os/exec's context-cancellation watchdog is armed INSIDE Start
+	// when cmd is built with CommandContext, and every streaming caller in
+	// this package blocks reading cmd's stdout pipe before it ever calls
+	// Wait — so WaitDelay's own forced pipe-close, which runs only once Wait
+	// executes, never gets a chance to fire. Without this, a canceled context
+	// killed only cmd.Process (the default Cancel) while a descendant Git
+	// spawned inside this job kept the pipe's write end open, and the blocked
+	// reader hung until whatever later, explicit stopPathOutputCommand call
+	// happened to run — which never happens on this exact path, since nothing
+	// is reading to notice the cancellation in the first place.
+	job := launch.job
+	cmd.Cancel = func() error {
+		job.terminate()
+		if cmd.Process != nil {
+			return cmd.Process.Kill()
+		}
+		return nil
+	}
 	startErr := cmd.Start()
 	cmd.SysProcAttr = launch.originalProcAttr
 	if startErr != nil {
 		launch.close()
 		return pathOutputJob{}, startErr
 	}
-	job := launch.job
 	job.creationParentPID = launch.creationParent.pid
 	launch.creationParent.close()
 	launch.creationParent = nil

--- a/internal/gitutil/process_job_windows_386.go
+++ b/internal/gitutil/process_job_windows_386.go
@@ -1,0 +1,40 @@
+//go:build windows && 386
+
+package gitutil
+
+import "unsafe"
+
+// jobObjectBasicLimitInformation mirrors JOBOBJECT_BASIC_LIMIT_INFORMATION.
+// Win32 gives LARGE_INTEGER eight-byte ABI alignment even though Go aligns an
+// int64 to four bytes on 386, so the explicit tail padding is load-bearing for
+// the following IO_COUNTERS field in JOBOBJECT_EXTENDED_LIMIT_INFORMATION.
+// Only LimitFlags is populated; Windows treats every other zero as no limit.
+type jobObjectBasicLimitInformation struct {
+	PerProcessUserTimeLimit int64
+	PerJobUserTimeLimit     int64
+	LimitFlags              uint32
+	MinimumWorkingSetSize   uintptr
+	MaximumWorkingSetSize   uintptr
+	ActiveProcessLimit      uint32
+	Affinity                uintptr
+	PriorityClass           uint32
+	SchedulingClass         uint32
+	_                       uint32
+}
+
+// jobObjectExtendedLimitInformation mirrors JOBOBJECT_EXTENDED_LIMIT_INFORMATION.
+type jobObjectExtendedLimitInformation struct {
+	BasicLimitInformation jobObjectBasicLimitInformation
+	IoInfo                [6]uint64
+	ProcessMemoryLimit    uintptr
+	JobMemoryLimit        uintptr
+	PeakProcessMemoryUsed uintptr
+	PeakJobMemoryUsed     uintptr
+}
+
+var (
+	_ [48 - unsafe.Sizeof(jobObjectBasicLimitInformation{})]byte
+	_ [unsafe.Sizeof(jobObjectBasicLimitInformation{}) - 48]byte
+	_ [112 - unsafe.Sizeof(jobObjectExtendedLimitInformation{})]byte
+	_ [unsafe.Sizeof(jobObjectExtendedLimitInformation{}) - 112]byte
+)

--- a/internal/gitutil/process_job_windows_64.go
+++ b/internal/gitutil/process_job_windows_64.go
@@ -1,0 +1,36 @@
+//go:build windows && (amd64 || arm64)
+
+package gitutil
+
+import "unsafe"
+
+// jobObjectBasicLimitInformation mirrors JOBOBJECT_BASIC_LIMIT_INFORMATION.
+// Only LimitFlags is populated; Windows treats every other zero as no limit.
+type jobObjectBasicLimitInformation struct {
+	PerProcessUserTimeLimit int64
+	PerJobUserTimeLimit     int64
+	LimitFlags              uint32
+	MinimumWorkingSetSize   uintptr
+	MaximumWorkingSetSize   uintptr
+	ActiveProcessLimit      uint32
+	Affinity                uintptr
+	PriorityClass           uint32
+	SchedulingClass         uint32
+}
+
+// jobObjectExtendedLimitInformation mirrors JOBOBJECT_EXTENDED_LIMIT_INFORMATION.
+type jobObjectExtendedLimitInformation struct {
+	BasicLimitInformation jobObjectBasicLimitInformation
+	IoInfo                [6]uint64
+	ProcessMemoryLimit    uintptr
+	JobMemoryLimit        uintptr
+	PeakProcessMemoryUsed uintptr
+	PeakJobMemoryUsed     uintptr
+}
+
+var (
+	_ [64 - unsafe.Sizeof(jobObjectBasicLimitInformation{})]byte
+	_ [unsafe.Sizeof(jobObjectBasicLimitInformation{}) - 64]byte
+	_ [144 - unsafe.Sizeof(jobObjectExtendedLimitInformation{})]byte
+	_ [unsafe.Sizeof(jobObjectExtendedLimitInformation{}) - 144]byte
+)

--- a/internal/gitutil/process_job_windows_test.go
+++ b/internal/gitutil/process_job_windows_test.go
@@ -5,6 +5,7 @@ package gitutil
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -201,13 +202,30 @@ func TestPathOutputCommandCancelTerminatesDescendantsHoldingTheStdoutPipe(t *tes
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer job.close()
-	t.Cleanup(job.terminate)
+	defer func() {
+		_ = job.terminate()
+		if cmd.ProcessState == nil {
+			_ = cmd.Wait()
+		}
+		job.close()
+	}()
 
 	reader := bufio.NewReader(stdout)
 	line, err := reader.ReadString('\n')
 	if err != nil || strings.TrimSpace(line) != "stdout-ready" {
 		t.Fatalf("read grandchild readiness line: line=%q err=%v", line, err)
+	}
+	launcher, err := syscall.OpenProcess(syscall.SYNCHRONIZE, false, uint32(cmd.Process.Pid))
+	if err != nil {
+		t.Fatalf("open launcher process %d: %v", cmd.Process.Pid, err)
+	}
+	defer syscall.CloseHandle(launcher)
+	state, err := syscall.WaitForSingleObject(launcher, 5_000)
+	if err != nil {
+		t.Fatalf("wait for launcher exit: %v", err)
+	}
+	if state != syscall.WAIT_OBJECT_0 {
+		t.Fatalf("launcher process %d did not exit before cancellation (wait state %#x)", cmd.Process.Pid, state)
 	}
 
 	cancel()
@@ -223,6 +241,9 @@ func TestPathOutputCommandCancelTerminatesDescendantsHoldingTheStdoutPipe(t *tes
 		t.Fatal("read from the stdout pipe did not unblock within 10s of context cancellation:" +
 			" cmd.Cancel must terminate the whole job, not only cmd.Process, to free a descendant" +
 			" that is holding the pipe open when cmd.Process itself has already exited")
+	}
+	if waitErr := cmd.Wait(); !errors.Is(waitErr, context.Canceled) {
+		t.Fatalf("Wait after whole-job cancellation = %v, want context.Canceled so truncated output cannot be accepted", waitErr)
 	}
 }
 

--- a/internal/gitutil/process_job_windows_test.go
+++ b/internal/gitutil/process_job_windows_test.go
@@ -152,6 +152,80 @@ func TestPathOutputCommandIsBornInJobAndDirectTerminationWorks(t *testing.T) {
 	}
 }
 
+// TestPathOutputCommandCancelTerminatesDescendantsHoldingTheStdoutPipe
+// reproduces the trail finding: a canceled context must free a caller
+// blocked reading cmd's stdout pipe even when the descendant STILL HOLDING
+// the pipe's write end is not cmd.Process itself. The "launcher" helper
+// starts a "child" grandchild inheriting its own stdout and then exits
+// immediately, exactly the launcher/worker shape a real Git subprocess tree
+// can take; killing only cmd.Process (the default Cancel, or a job
+// terminated solely at an explicit stop point after the blocked read
+// returns) leaves the grandchild running and the pipe open.
+func TestPathOutputCommandCancelTerminatesDescendantsHoldingTheStdoutPipe(t *testing.T) {
+	switch os.Getenv(pathOutputJobHelperEnv) {
+	case "launcher":
+		grandchild := exec.Command(os.Args[0], "-test.run=^TestPathOutputCommandCancelTerminatesDescendantsHoldingTheStdoutPipe$")
+		grandchild.Env = append(os.Environ(), pathOutputJobHelperEnv+"=child")
+		grandchild.Stdout = os.Stdout
+		grandchild.Stderr = os.Stderr
+		if err := grandchild.Start(); err != nil {
+			fmt.Fprintln(os.Stderr, "launcher: start grandchild:", err)
+			os.Exit(1)
+		}
+		// Exit well before the grandchild does, so cmd.Process (this
+		// launcher) is already gone by the time the context is canceled and
+		// only the grandchild is left holding the pipe — the shape that
+		// defeats a fix which kills cmd.Process alone.
+		os.Exit(0)
+	case "child":
+		fmt.Fprintln(os.Stdout, "stdout-ready")
+		time.Sleep(time.Hour)
+		return
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestPathOutputCommandCancelTerminatesDescendantsHoldingTheStdoutPipe$")
+	cmd.Env = append(os.Environ(), pathOutputJobHelperEnv+"=launcher")
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: createNoWindow}
+	launch, err := preparePathOutputCommand(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer launch.close()
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	job, err := launch.start(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer job.close()
+	t.Cleanup(job.terminate)
+
+	reader := bufio.NewReader(stdout)
+	line, err := reader.ReadString('\n')
+	if err != nil || strings.TrimSpace(line) != "stdout-ready" {
+		t.Fatalf("read grandchild readiness line: line=%q err=%v", line, err)
+	}
+
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = reader.ReadByte()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("read from the stdout pipe did not unblock within 10s of context cancellation:" +
+			" cmd.Cancel must terminate the whole job, not only cmd.Process, to free a descendant" +
+			" that is holding the pipe open when cmd.Process itself has already exited")
+	}
+}
+
 func TestPathOutputCommandRejectsCallerSuppliedCreationParent(t *testing.T) {
 	current, err := syscall.GetCurrentProcess()
 	if err != nil {

--- a/internal/gitutil/process_job_windows_test.go
+++ b/internal/gitutil/process_job_windows_test.go
@@ -1,0 +1,173 @@
+//go:build windows
+
+package gitutil
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+const pathOutputJobHelperEnv = "ENTIRE_GRAPH_PATH_OUTPUT_JOB_HELPER"
+
+func TestPathOutputChildSysProcAttrPreservesEveryCallerField(t *testing.T) {
+	processSecurity := &syscall.SecurityAttributes{Length: 11, InheritHandle: 1}
+	threadSecurity := &syscall.SecurityAttributes{Length: 22, InheritHandle: 1}
+	original := &syscall.SysProcAttr{
+		HideWindow:                 true,
+		CmdLine:                    `custom command line`,
+		CreationFlags:              0x12345678,
+		Token:                      syscall.Token(41),
+		ProcessAttributes:          processSecurity,
+		ThreadAttributes:           threadSecurity,
+		NoInheritHandles:           true,
+		AdditionalInheritedHandles: []syscall.Handle{51, 52},
+	}
+	parent := syscall.Handle(61)
+	want := *original
+	want.ParentProcess = parent
+	if got := pathOutputChildSysProcAttr(original, parent); !reflect.DeepEqual(got, want) {
+		t.Fatalf("child SysProcAttr = %#v, want exact caller copy plus parent %#v", got, want)
+	}
+	if original.ParentProcess != 0 {
+		t.Fatalf("caller SysProcAttr was mutated: %#v", original)
+	}
+}
+
+func TestPathOutputCommandIsBornInJobAndDirectTerminationWorks(t *testing.T) {
+	if os.Getenv(pathOutputJobHelperEnv) == "child" {
+		fmt.Fprintln(os.Stdout, "stdout-ready")
+		fmt.Fprintln(os.Stderr, "stderr-ready")
+		time.Sleep(time.Hour)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestPathOutputCommandIsBornInJobAndDirectTerminationWorks$")
+	cmd.Env = append(os.Environ(), pathOutputJobHelperEnv+"=child")
+	originalAttrs := &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: createNoWindow,
+	}
+	cmd.SysProcAttr = originalAttrs
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	job, err := startPathOutputCommand(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleaned := false
+	t.Cleanup(func() {
+		job.terminate()
+		job.close()
+		if !cleaned {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
+	if job.handle == 0 {
+		t.Fatal("startPathOutputCommand returned a zero job handle")
+	}
+	if job.creationParentPID == 0 {
+		t.Fatal("startPathOutputCommand did not record its creation parent")
+	}
+	if cmd.SysProcAttr != originalAttrs || !cmd.SysProcAttr.HideWindow || cmd.SysProcAttr.CreationFlags != createNoWindow || cmd.SysProcAttr.ParentProcess != 0 {
+		t.Fatalf("command SysProcAttr was not preserved: %#v", cmd.SysProcAttr)
+	}
+
+	contained, err := job.contains(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contained {
+		t.Fatal("actual command is not a member of its returned job")
+	}
+	parentPID, err := windowsProcessParentPID(uint32(cmd.Process.Pid))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parentPID != job.creationParentPID {
+		t.Fatalf("actual command parent PID = %d, want suspended job member %d", parentPID, job.creationParentPID)
+	}
+
+	stdoutLine, err := bufio.NewReader(stdout).ReadString('\n')
+	if err != nil {
+		t.Fatalf("read child stdout: %v", err)
+	}
+	stderrLine, err := bufio.NewReader(stderr).ReadString('\n')
+	if err != nil {
+		t.Fatalf("read child stderr: %v", err)
+	}
+	if strings.TrimSpace(stdoutLine) != "stdout-ready" || strings.TrimSpace(stderrLine) != "stderr-ready" {
+		t.Fatalf("child standard handles = (%q, %q), want readiness lines", stdoutLine, stderrLine)
+	}
+
+	done := make(chan error, 1)
+	job.terminate()
+	go func() { done <- cmd.Wait() }()
+	select {
+	case <-done:
+		cleaned = true
+	case <-time.After(5 * time.Second):
+		t.Fatal("direct TerminateJobObject did not retire the actual command")
+	}
+	if cmd.ProcessState == nil {
+		t.Fatal("direct job termination did not reap the actual command")
+	}
+}
+
+func TestPathOutputCommandRejectsCallerSuppliedCreationParent(t *testing.T) {
+	current, err := syscall.GetCurrentProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	attrs := &syscall.SysProcAttr{ParentProcess: current, HideWindow: true}
+	cmd := exec.Command(os.Args[0], "-test.run=^$")
+	cmd.SysProcAttr = attrs
+	job, err := startPathOutputCommand(cmd)
+	if err == nil || !strings.Contains(err.Error(), "caller-supplied Windows parent process") {
+		t.Fatalf("startPathOutputCommand = (%#v, %v), want explicit parent-process refusal", job, err)
+	}
+	if job.handle != 0 || cmd.Process != nil || cmd.SysProcAttr != attrs {
+		t.Fatalf("refused command mutated or started: job=%#v process=%#v attrs=%#v", job, cmd.Process, cmd.SysProcAttr)
+	}
+}
+
+func windowsProcessParentPID(pid uint32) (uint32, error) {
+	snapshot, err := syscall.CreateToolhelp32Snapshot(syscall.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return 0, err
+	}
+	defer syscall.CloseHandle(snapshot)
+
+	var entry syscall.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	if err := syscall.Process32First(snapshot, &entry); err != nil {
+		return 0, err
+	}
+	for {
+		if entry.ProcessID == pid {
+			return entry.ParentProcessID, nil
+		}
+		entry.Size = uint32(unsafe.Sizeof(entry))
+		if err := syscall.Process32Next(snapshot, &entry); err != nil {
+			return 0, fmt.Errorf("find process %d in Windows snapshot: %w", pid, err)
+		}
+	}
+}

--- a/internal/gitutil/process_job_windows_test.go
+++ b/internal/gitutil/process_job_windows_test.go
@@ -18,6 +18,21 @@ import (
 
 const pathOutputJobHelperEnv = "ENTIRE_GRAPH_PATH_OUTPUT_JOB_HELPER"
 
+func TestWindowsJobObjectInformationABILayout(t *testing.T) {
+	wantBasic := uintptr(64)
+	wantExtended := uintptr(144)
+	if unsafe.Sizeof(uintptr(0)) == 4 {
+		wantBasic = 48
+		wantExtended = 112
+	}
+	if got := unsafe.Sizeof(jobObjectBasicLimitInformation{}); got != wantBasic {
+		t.Fatalf("JOBOBJECT_BASIC_LIMIT_INFORMATION size = %d, want %d", got, wantBasic)
+	}
+	if got := unsafe.Sizeof(jobObjectExtendedLimitInformation{}); got != wantExtended {
+		t.Fatalf("JOBOBJECT_EXTENDED_LIMIT_INFORMATION size = %d, want %d", got, wantExtended)
+	}
+}
+
 func TestPathOutputChildSysProcAttrPreservesEveryCallerField(t *testing.T) {
 	processSecurity := &syscall.SecurityAttributes{Length: 11, InheritHandle: 1}
 	threadSecurity := &syscall.SecurityAttributes{Length: 22, InheritHandle: 1}
@@ -59,6 +74,11 @@ func TestPathOutputCommandIsBornInJobAndDirectTerminationWorks(t *testing.T) {
 		CreationFlags: createNoWindow,
 	}
 	cmd.SysProcAttr = originalAttrs
+	launch, err := preparePathOutputCommand(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer launch.close()
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		t.Fatal(err)
@@ -68,7 +88,7 @@ func TestPathOutputCommandIsBornInJobAndDirectTerminationWorks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	job, err := startPathOutputCommand(cmd)
+	job, err := launch.start(cmd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,12 +160,12 @@ func TestPathOutputCommandRejectsCallerSuppliedCreationParent(t *testing.T) {
 	attrs := &syscall.SysProcAttr{ParentProcess: current, HideWindow: true}
 	cmd := exec.Command(os.Args[0], "-test.run=^$")
 	cmd.SysProcAttr = attrs
-	job, err := startPathOutputCommand(cmd)
+	launch, err := preparePathOutputCommand(cmd)
 	if err == nil || !strings.Contains(err.Error(), "caller-supplied Windows parent process") {
-		t.Fatalf("startPathOutputCommand = (%#v, %v), want explicit parent-process refusal", job, err)
+		t.Fatalf("preparePathOutputCommand = (%#v, %v), want explicit parent-process refusal", launch, err)
 	}
-	if job.handle != 0 || cmd.Process != nil || cmd.SysProcAttr != attrs {
-		t.Fatalf("refused command mutated or started: job=%#v process=%#v attrs=%#v", job, cmd.Process, cmd.SysProcAttr)
+	if launch.job.handle != 0 || cmd.Process != nil || cmd.SysProcAttr != attrs {
+		t.Fatalf("refused command mutated or started: launch=%#v process=%#v attrs=%#v", launch, cmd.Process, cmd.SysProcAttr)
 	}
 }
 

--- a/internal/gitutil/worktree_paths.go
+++ b/internal/gitutil/worktree_paths.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 const (
@@ -246,19 +247,16 @@ func visitBoundedNULPaths(cmd *exec.Cmd, visit func(string) bool) error {
 	for {
 		record, readErr := reader.ReadSlice(0)
 		if errors.Is(readErr, bufio.ErrBufferFull) {
-			_ = cmd.Process.Kill()
-			_ = cmd.Wait()
+			stopPathOutputCommand(cmd, stdout)
 			return fmt.Errorf("git returned a path longer than %d bytes", nestedIgnorePathMaxBytes)
 		}
 		if len(record) > 0 {
 			if record[len(record)-1] != 0 {
-				_ = cmd.Process.Kill()
-				_ = cmd.Wait()
+				stopPathOutputCommand(cmd, stdout)
 				return errors.New("git returned a non-NUL-terminated path")
 			}
 			if !visit(string(record[:len(record)-1])) {
-				_ = cmd.Process.Kill()
-				_ = cmd.Wait()
+				stopPathOutputCommand(cmd, stdout)
 				return nil
 			}
 		}
@@ -266,7 +264,7 @@ func visitBoundedNULPaths(cmd *exec.Cmd, visit func(string) bool) error {
 			continue
 		}
 		if !errors.Is(readErr, io.EOF) {
-			stopPathOutputCommand(cmd)
+			stopPathOutputCommand(cmd, stdout)
 			return readErr
 		}
 		waitErr := cmd.Wait()
@@ -389,7 +387,7 @@ func runBoundedPathOutput(
 	for {
 		record, readErr := reader.ReadSlice(0)
 		if errors.Is(readErr, bufio.ErrBufferFull) {
-			stopPathOutputCommand(cmd)
+			stopPathOutputCommand(cmd, stdout)
 			return nil, fmt.Errorf(
 				"git returned a path longer than %d bytes",
 				literalPathOutputMaxPathBytes,
@@ -397,33 +395,33 @@ func runBoundedPathOutput(
 		}
 		if len(record) > 0 {
 			if record[len(record)-1] != 0 {
-				stopPathOutputCommand(cmd)
+				stopPathOutputCommand(cmd, stdout)
 				return nil, errors.New("git returned a non-NUL-terminated path")
 			}
 			if len(record) == 1 {
-				stopPathOutputCommand(cmd)
+				stopPathOutputCommand(cmd, stdout)
 				return nil, errors.New("git returned an empty path")
 			}
 			path := string(record[:len(record)-1])
 			if _, ok := known[path]; !ok {
-				stopPathOutputCommand(cmd)
+				stopPathOutputCommand(cmd, stdout)
 				return nil, fmt.Errorf("git returned unexpected path %q", path)
 			}
 			if _, duplicate := result[path]; duplicate {
-				stopPathOutputCommand(cmd)
+				stopPathOutputCommand(cmd, stdout)
 				return nil, fmt.Errorf("git returned duplicate path %q", path)
 			}
 			outputCount++
 			outputBytes += len(record)
 			if outputCount > len(known) || outputCount > literalPathspecBatchCount {
-				stopPathOutputCommand(cmd)
+				stopPathOutputCommand(cmd, stdout)
 				return nil, fmt.Errorf(
 					"git returned more than %d literal paths",
 					len(known),
 				)
 			}
 			if outputBytes > expectedOutputBytes || outputBytes > literalPathspecBatchBytes {
-				stopPathOutputCommand(cmd)
+				stopPathOutputCommand(cmd, stdout)
 				return nil, fmt.Errorf(
 					"git returned more than %d aggregate path bytes",
 					expectedOutputBytes,
@@ -449,11 +447,49 @@ func runBoundedPathOutput(
 	}
 }
 
-func stopPathOutputCommand(cmd *exec.Cmd) {
-	if cmd.Process != nil {
-		_ = cmd.Process.Kill()
+func stopPathOutputCommand(cmd *exec.Cmd, stdout io.Closer) {
+	descendants := capturePathOutputDescendants(cmd)
+	defer descendants.close()
+
+	// Close the read side before terminating Git. Git for Windows can use a
+	// launcher/worker process pair; killing only the process os/exec started can
+	// orphan the worker with repository files still open. Closing stdout makes
+	// the writer fail, allowing Git to unwind and reap its own process tree.
+	if stdout != nil {
+		_ = stdout.Close()
 	}
-	_ = cmd.Wait()
+	done := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(done)
+	}()
+
+	timer := time.NewTimer(gitCommandWaitDelay)
+	defer timer.Stop()
+	select {
+	case <-done:
+		// WaitDelay may have released os/exec after a descendant retained a
+		// copied pipe. Stable Windows process handles captured before stdout was
+		// closed prevent that descendant from surviving with repository handles.
+		descendants.terminateAndWait(gitCommandWaitDelay)
+		return
+	case <-timer.C:
+		// A non-Git command or a Git process stuck somewhere other than its
+		// bounded output still gets a hard, time-bounded fallback. WaitDelay
+		// bounds inherited pipes after this direct process is gone.
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		// Stop the root before its captured descendants so it cannot create a
+		// replacement worker between the process snapshot and termination.
+		descendants.terminateAndWait(gitCommandWaitDelay)
+		finalTimer := time.NewTimer(gitCommandWaitDelay)
+		defer finalTimer.Stop()
+		select {
+		case <-done:
+		case <-finalTimer.C:
+		}
+	}
 }
 
 func listLiteralWorktreePathBatch(
@@ -516,8 +552,7 @@ func IndexHasFilesUnder(ctx context.Context, repo, rel string) (bool, error) {
 		// No later output can change an existence answer from true to false.
 		// Stopping here keeps the probe proportional to one match even when
 		// rel contains a very large tracked subtree.
-		_ = cmd.Process.Kill()
-		_ = cmd.Wait()
+		stopPathOutputCommand(cmd, stdout)
 		return true, nil
 	}
 	waitErr := cmd.Wait()

--- a/internal/gitutil/worktree_paths.go
+++ b/internal/gitutil/worktree_paths.go
@@ -236,11 +236,16 @@ func validateNestedIgnoreLimit(limit int) error {
 func visitBoundedNULPaths(cmd *exec.Cmd, visit func(string) bool) error {
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
+	launch, err := preparePathOutputCommand(cmd)
+	if err != nil {
+		return err
+	}
+	defer launch.close()
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return err
 	}
-	job, err := startPathOutputCommand(cmd)
+	job, err := launch.start(cmd)
 	if err != nil {
 		return err
 	}
@@ -370,11 +375,16 @@ func runBoundedPathOutput(
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
+	launch, err := preparePathOutputCommand(cmd)
+	if err != nil {
+		return nil, err
+	}
+	defer launch.close()
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err
 	}
-	job, err := startPathOutputCommand(cmd)
+	job, err := launch.start(cmd)
 	if err != nil {
 		message := strings.TrimSpace(stderr.String())
 		if message == "" {
@@ -552,11 +562,16 @@ func IndexHasFilesUnder(ctx context.Context, repo, rel string) (bool, error) {
 	cmd := newCmd(ctx, repo, "git", args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
+	launch, err := preparePathOutputCommand(cmd)
+	if err != nil {
+		return false, fmt.Errorf("git ls-files literal index probe: %w", err)
+	}
+	defer launch.close()
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return false, fmt.Errorf("git ls-files literal index probe: %w", err)
 	}
-	job, err := startPathOutputCommand(cmd)
+	job, err := launch.start(cmd)
 	if err != nil {
 		return false, fmt.Errorf("git ls-files literal index probe: %w", err)
 	}

--- a/internal/gitutil/worktree_paths.go
+++ b/internal/gitutil/worktree_paths.go
@@ -240,23 +240,25 @@ func visitBoundedNULPaths(cmd *exec.Cmd, visit func(string) bool) error {
 	if err != nil {
 		return err
 	}
-	if err := cmd.Start(); err != nil {
+	job, err := startPathOutputCommand(cmd)
+	if err != nil {
 		return err
 	}
+	defer job.close()
 	reader := bufio.NewReaderSize(stdout, nestedIgnorePathMaxBytes+1)
 	for {
 		record, readErr := reader.ReadSlice(0)
 		if errors.Is(readErr, bufio.ErrBufferFull) {
-			stopPathOutputCommand(cmd, stdout)
+			stopPathOutputCommand(cmd, stdout, job)
 			return fmt.Errorf("git returned a path longer than %d bytes", nestedIgnorePathMaxBytes)
 		}
 		if len(record) > 0 {
 			if record[len(record)-1] != 0 {
-				stopPathOutputCommand(cmd, stdout)
+				stopPathOutputCommand(cmd, stdout, job)
 				return errors.New("git returned a non-NUL-terminated path")
 			}
 			if !visit(string(record[:len(record)-1])) {
-				stopPathOutputCommand(cmd, stdout)
+				stopPathOutputCommand(cmd, stdout, job)
 				return nil
 			}
 		}
@@ -264,7 +266,7 @@ func visitBoundedNULPaths(cmd *exec.Cmd, visit func(string) bool) error {
 			continue
 		}
 		if !errors.Is(readErr, io.EOF) {
-			stopPathOutputCommand(cmd, stdout)
+			stopPathOutputCommand(cmd, stdout, job)
 			return readErr
 		}
 		waitErr := cmd.Wait()
@@ -372,13 +374,15 @@ func runBoundedPathOutput(
 	if err != nil {
 		return nil, err
 	}
-	if err := cmd.Start(); err != nil {
+	job, err := startPathOutputCommand(cmd)
+	if err != nil {
 		message := strings.TrimSpace(stderr.String())
 		if message == "" {
 			message = err.Error()
 		}
 		return nil, errors.New(message)
 	}
+	defer job.close()
 
 	result := make(map[string]struct{}, len(known))
 	outputCount := 0
@@ -387,7 +391,7 @@ func runBoundedPathOutput(
 	for {
 		record, readErr := reader.ReadSlice(0)
 		if errors.Is(readErr, bufio.ErrBufferFull) {
-			stopPathOutputCommand(cmd, stdout)
+			stopPathOutputCommand(cmd, stdout, job)
 			return nil, fmt.Errorf(
 				"git returned a path longer than %d bytes",
 				literalPathOutputMaxPathBytes,
@@ -395,33 +399,33 @@ func runBoundedPathOutput(
 		}
 		if len(record) > 0 {
 			if record[len(record)-1] != 0 {
-				stopPathOutputCommand(cmd, stdout)
+				stopPathOutputCommand(cmd, stdout, job)
 				return nil, errors.New("git returned a non-NUL-terminated path")
 			}
 			if len(record) == 1 {
-				stopPathOutputCommand(cmd, stdout)
+				stopPathOutputCommand(cmd, stdout, job)
 				return nil, errors.New("git returned an empty path")
 			}
 			path := string(record[:len(record)-1])
 			if _, ok := known[path]; !ok {
-				stopPathOutputCommand(cmd, stdout)
+				stopPathOutputCommand(cmd, stdout, job)
 				return nil, fmt.Errorf("git returned unexpected path %q", path)
 			}
 			if _, duplicate := result[path]; duplicate {
-				stopPathOutputCommand(cmd, stdout)
+				stopPathOutputCommand(cmd, stdout, job)
 				return nil, fmt.Errorf("git returned duplicate path %q", path)
 			}
 			outputCount++
 			outputBytes += len(record)
 			if outputCount > len(known) || outputCount > literalPathspecBatchCount {
-				stopPathOutputCommand(cmd, stdout)
+				stopPathOutputCommand(cmd, stdout, job)
 				return nil, fmt.Errorf(
 					"git returned more than %d literal paths",
 					len(known),
 				)
 			}
 			if outputBytes > expectedOutputBytes || outputBytes > literalPathspecBatchBytes {
-				stopPathOutputCommand(cmd, stdout)
+				stopPathOutputCommand(cmd, stdout, job)
 				return nil, fmt.Errorf(
 					"git returned more than %d aggregate path bytes",
 					expectedOutputBytes,
@@ -447,7 +451,10 @@ func runBoundedPathOutput(
 	}
 }
 
-func stopPathOutputCommand(cmd *exec.Cmd, stdout io.Closer) {
+// stopPathOutputCommand does not close job: the caller owns the job handle
+// from the point startPathOutputCommand returns it and must close it exactly
+// once, on every exit path, not only the ones that stop the command early.
+func stopPathOutputCommand(cmd *exec.Cmd, stdout io.Closer, job pathOutputJob) {
 	descendants := capturePathOutputDescendants(cmd)
 	defer descendants.close()
 
@@ -468,9 +475,13 @@ func stopPathOutputCommand(cmd *exec.Cmd, stdout io.Closer) {
 	defer timer.Stop()
 	select {
 	case <-done:
-		// WaitDelay may have released os/exec after a descendant retained a
-		// copied pipe. Stable Windows process handles captured before stdout was
-		// closed prevent that descendant from surviving with repository handles.
+		// The job (if one was created) kills every process it still contains,
+		// including a worker spawned after this point-in-time descendant
+		// snapshot was taken -- closing the race a snapshot alone has against a
+		// launcher that forks late. Stable Windows process handles captured
+		// before stdout was closed remain as a fallback for descendants that
+		// predate the job or existed when no job could be created.
+		job.terminate()
 		descendants.terminateAndWait(gitCommandWaitDelay)
 		return
 	case <-timer.C:
@@ -480,8 +491,10 @@ func stopPathOutputCommand(cmd *exec.Cmd, stdout io.Closer) {
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
 		}
-		// Stop the root before its captured descendants so it cannot create a
-		// replacement worker between the process snapshot and termination.
+		// Stop the job and the root before its captured descendants so neither
+		// can create a replacement worker between the process snapshot and
+		// termination.
+		job.terminate()
 		descendants.terminateAndWait(gitCommandWaitDelay)
 		finalTimer := time.NewTimer(gitCommandWaitDelay)
 		defer finalTimer.Stop()
@@ -543,16 +556,18 @@ func IndexHasFilesUnder(ctx context.Context, repo, rel string) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("git ls-files literal index probe: %w", err)
 	}
-	if err := cmd.Start(); err != nil {
+	job, err := startPathOutputCommand(cmd)
+	if err != nil {
 		return false, fmt.Errorf("git ls-files literal index probe: %w", err)
 	}
+	defer job.close()
 	var first [1]byte
 	n, readErr := stdout.Read(first[:])
 	if n > 0 {
 		// No later output can change an existence answer from true to false.
 		// Stopping here keeps the probe proportional to one match even when
 		// rel contains a very large tracked subtree.
-		stopPathOutputCommand(cmd, stdout)
+		stopPathOutputCommand(cmd, stdout, job)
 		return true, nil
 	}
 	waitErr := cmd.Wait()

--- a/internal/gitutil/worktree_paths_test.go
+++ b/internal/gitutil/worktree_paths_test.go
@@ -81,16 +81,14 @@ func TestRunBoundedPathOutputRejectsUnexpectedStreamingOutput(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestRunBoundedPathOutputRejectsUnexpectedStreamingOutput$")
+	cmd := newCmd(ctx, "", os.Args[0], "-test.run=^TestRunBoundedPathOutputRejectsUnexpectedStreamingOutput$")
 	t.Cleanup(func() {
 		if cmd.Process != nil && cmd.ProcessState == nil {
 			_ = cmd.Process.Kill()
 			_ = cmd.Wait()
 		}
 	})
-	cmd.Env = append(os.Environ(), boundedPathOutputHelperEnv+"=1")
-	cmd.WaitDelay = time.Second
-
+	cmd.Env = append(cmd.Env, boundedPathOutputHelperEnv+"=1")
 	runtime.GC()
 	var before runtime.MemStats
 	runtime.ReadMemStats(&before)

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -377,19 +377,13 @@ func resolveDiffTrees(
 	resolve func(context.Context, string, string) (string, error),
 ) (string, string, error) {
 	resolveTree := func(label string) (string, error) {
-		pinned, directErr := resolve(ctx, repo, label+"^{tree}")
-		if directErr == nil {
-			return pinned, nil
-		}
-		if ctx.Err() != nil {
-			return "", directErr
-		}
-		// A revision-path expression such as HEAD:subdir already names its
-		// result object; appending ^{tree} would instead become part of the
-		// path. Resolve that expression first, then peel the immutable OID.
+		// Resolve the caller's expression exactly before adding syntax of our
+		// own. Appending ^{tree} directly to HEAD:scope can select a different
+		// repository path literally named scope^{tree}; an immutable OID has no
+		// such revision/path ambiguity.
 		objectID, err := resolve(ctx, repo, label)
 		if err != nil {
-			return "", directErr
+			return "", err
 		}
 		return resolve(ctx, repo, objectID+"^{tree}")
 	}

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -17,6 +17,10 @@ import (
 // diff should read twice in order to parse it anyway.
 const maxDiffFileBytes = defaultMaxParseBytes
 
+// Keep metadata prefetch bounded so a short analysis budget does not inspect an
+// entire huge range before the per-file budget check can stop it.
+const analyzeMetadataPrimeFiles = 128
+
 func AnalyzeGitRange(ctx context.Context, repo, base, head string, paths []string) (Result, error) {
 	return AnalyzeGitRangeWithOptions(ctx, repo, base, head, paths, AnalyzeOptions{})
 }
@@ -76,18 +80,18 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 		emitProgressEvent(phase, filesDone, filesTotal, "", true)
 	}
 
-	// Bind both caller-facing revision labels to immutable commits before any
+	// Bind both caller-facing revision labels to immutable trees before any
 	// discovery or content read. A branch can advance between ChangedFiles, the
 	// size probe, and ShowFile; resolving each operation through the original
 	// label would then compare bytes from different ranges and could invalidate
-	// the read ceiling. Keep the labels below for the result's public provenance.
-	pinnedBase, err := gitutil.RevParse(ctx, repo, base+"^{commit}")
+	// the read ceiling. Trees preserve the command's historical tree-ish input
+	// contract; requiring commits would reject valid tree OIDs and expressions.
+	// When both labels are byte-identical, reuse the first resolution so a ref
+	// advance between subprocesses cannot turn an intended empty diff into an
+	// old-tree/new-tree comparison. Keep the labels below for result provenance.
+	pinnedBase, pinnedHead, err := resolveDiffTrees(ctx, repo, base, head, gitutil.RevParse)
 	if err != nil {
-		return Result{}, fmt.Errorf("resolve diff base %q: %w", base, err)
-	}
-	pinnedHead, err := gitutil.RevParse(ctx, repo, head+"^{commit}")
-	if err != nil {
-		return Result{}, fmt.Errorf("resolve diff head %q: %w", head, err)
+		return Result{}, err
 	}
 
 	emitProgress("discover", 0, 0)
@@ -97,6 +101,12 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 	}
 	emitProgress("parse", 0, len(changed))
 	parser := TreeSitterParser{}
+	baseReader := gitutil.NewLimitedFileReader(ctx, repo, pinnedBase, maxDiffFileBytes)
+	headReader := gitutil.NewLimitedFileReader(ctx, repo, pinnedHead, maxDiffFileBytes)
+	defer func() {
+		_ = baseReader.Close()
+		_ = headReader.Close()
+	}()
 	// SchemaVersion is set here, at the one place a content-bearing Result is
 	// constructed; every caller (AnalyzeGitRange, AnalyzeCheckpoint, and the
 	// diff/analyze CLI handlers that call through them) inherits it.
@@ -111,6 +121,32 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 				result.Warnings = append(result.Warnings, budgetSkippedFileWarning(skipped.Path, i, len(changed), options.MaxDuration))
 			}
 			break
+		}
+		if i%analyzeMetadataPrimeFiles == 0 {
+			end := min(i+analyzeMetadataPrimeFiles, len(changed))
+			basePaths := make([]string, 0, end-i)
+			headPaths := make([]string, 0, end-i)
+			for _, candidate := range changed[i:end] {
+				oldCandidatePath := candidate.OldPath
+				if oldCandidatePath == "" {
+					oldCandidatePath = candidate.Path
+				}
+				if extensionUnsupported(oldCandidatePath) && extensionUnsupported(candidate.Path) {
+					continue
+				}
+				if candidate.Status != "A" {
+					basePaths = append(basePaths, oldCandidatePath)
+				}
+				if candidate.Status != "D" {
+					headPaths = append(headPaths, candidate.Path)
+				}
+			}
+			if err := baseReader.Prime(basePaths); err != nil {
+				return Result{}, err
+			}
+			if err := headReader.Prime(headPaths); err != nil {
+				return Result{}, err
+			}
 		}
 		emitProgressEvent("parse", i, len(changed), file.Path, i > 0 && i%100 == 0)
 		path := file.Path
@@ -134,40 +170,66 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 			// largest object in the range rather than by anything the caller
 			// chose -- and unlike the snapshot readers, nothing downstream
 			// would have declined to parse it.
+			var beforeRead, afterRead gitutil.LimitedFileResult
 			if file.Status != "A" {
-				before, beforeOK, err = gitutil.ShowFileLimited(ctx, repo, pinnedBase, oldPath, maxDiffFileBytes)
+				beforeRead, err = baseReader.ReadFile(oldPath)
 				if err != nil {
 					return Result{}, err
 				}
+				before, beforeOK = beforeRead.Content, beforeRead.Status == gitutil.LimitedFileContent
 			}
 			if file.Status != "D" {
-				after, afterOK, err = gitutil.ShowFileLimited(ctx, repo, pinnedHead, path, maxDiffFileBytes)
+				afterRead, err = headReader.ReadFile(path)
 				if err != nil {
 					return Result{}, err
 				}
+				after, afterOK = afterRead.Content, afterRead.Status == gitutil.LimitedFileContent
 			}
-		}
 
-		// A side ChangedFiles reported as present that came back unread was
-		// refused by the ceiling above. ChangedFiles parses `git diff -z`, so
-		// the path is exact rather than quoted and resolves at that revision by
-		// construction; the remaining way ShowFileLimited reports a present
-		// path as unreadable WITHOUT an error is the size refusal. Skip the
-		// delta and say so: an empty side would otherwise be compared against a
-		// parsed one and report every entity in it as phantom removed/added.
-		beforeRefused := file.Status != "A" && !beforeOK
-		afterRefused := file.Status != "D" && !afterOK
-		if beforeRefused || afterRefused {
-			warningPath := path
-			detail := "head version is above the diff read cap"
-			if beforeRefused && !afterRefused {
-				warningPath = oldPath
-				detail = "base version is above the diff read cap"
-			} else if beforeRefused && afterRefused {
-				detail = "base and head versions are above the diff read cap"
+			beforeMissing := file.Status != "A" && beforeRead.Status == gitutil.LimitedFileMissing
+			afterMissing := file.Status != "D" && afterRead.Status == gitutil.LimitedFileMissing
+			if beforeMissing || afterMissing {
+				warningPath := path
+				detail := "head version was missing after changed-file discovery"
+				if beforeMissing && !afterMissing {
+					warningPath = oldPath
+					detail = "base version was missing after changed-file discovery"
+				} else if beforeMissing && afterMissing {
+					detail = "base and head versions were missing after changed-file discovery"
+				}
+				result.Warnings = append(result.Warnings, diffFileReadWarning(warningPath, detail))
 			}
-			result.Warnings = append(result.Warnings, diffFileTooLargeWarning(warningPath, detail))
-			continue
+
+			beforeNonBlob := file.Status != "A" && beforeRead.Status == gitutil.LimitedFileNonBlob
+			afterNonBlob := file.Status != "D" && afterRead.Status == gitutil.LimitedFileNonBlob
+			if beforeNonBlob || afterNonBlob {
+				warningPath := path
+				detail := "head version is a non-blob Git tree entry"
+				if beforeNonBlob && !afterNonBlob {
+					warningPath = oldPath
+					detail = "base version is a non-blob Git tree entry"
+				} else if beforeNonBlob && afterNonBlob {
+					detail = "base and head versions are non-blob Git tree entries"
+				}
+				result.Warnings = append(result.Warnings, diffNonBlobWarning(warningPath, detail))
+			}
+
+			beforeOversize := file.Status != "A" && beforeRead.Status == gitutil.LimitedFileOversize
+			afterOversize := file.Status != "D" && afterRead.Status == gitutil.LimitedFileOversize
+			if beforeOversize || afterOversize {
+				warningPath := path
+				detail := "head version is above the diff read cap"
+				if beforeOversize && !afterOversize {
+					warningPath = oldPath
+					detail = "base version is above the diff read cap"
+				} else if beforeOversize && afterOversize {
+					detail = "base and head versions are above the diff read cap"
+				}
+				result.Warnings = append(result.Warnings, diffFileTooLargeWarning(warningPath, detail))
+			}
+			if beforeMissing || afterMissing || beforeNonBlob || afterNonBlob || beforeOversize || afterOversize {
+				continue
+			}
 		}
 
 		// Support is content-aware: extensionless executables can still route to a
@@ -263,6 +325,14 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 		})
 	}
 	emitProgress("parse", len(changed), len(changed))
+	baseCloseErr := baseReader.Close()
+	headCloseErr := headReader.Close()
+	if baseCloseErr != nil {
+		return Result{}, baseCloseErr
+	}
+	if headCloseErr != nil {
+		return Result{}, headCloseErr
+	}
 
 	emitProgress("reconcile", len(changed), len(changed))
 	result.Warnings = append(result.Warnings, reconcileMoves(deltas)...)
@@ -301,6 +371,43 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 	return result, nil
 }
 
+func resolveDiffTrees(
+	ctx context.Context,
+	repo, base, head string,
+	resolve func(context.Context, string, string) (string, error),
+) (string, string, error) {
+	resolveTree := func(label string) (string, error) {
+		pinned, directErr := resolve(ctx, repo, label+"^{tree}")
+		if directErr == nil {
+			return pinned, nil
+		}
+		if ctx.Err() != nil {
+			return "", directErr
+		}
+		// A revision-path expression such as HEAD:subdir already names its
+		// result object; appending ^{tree} would instead become part of the
+		// path. Resolve that expression first, then peel the immutable OID.
+		objectID, err := resolve(ctx, repo, label)
+		if err != nil {
+			return "", directErr
+		}
+		return resolve(ctx, repo, objectID+"^{tree}")
+	}
+
+	pinnedBase, err := resolveTree(base)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve diff base %q: %w", base, err)
+	}
+	if head == base {
+		return pinnedBase, pinnedBase, nil
+	}
+	pinnedHead, err := resolveTree(head)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve diff head %q: %w", head, err)
+	}
+	return pinnedBase, pinnedHead, nil
+}
+
 // budgetSkippedFileWarning marks one changed file that was never analyzed
 // because the overall wall-clock budget (AnalyzeOptions.MaxDuration) ran out
 // first. It shares the W_ANALYSIS_BUDGET_EXCEEDED code with the dependents
@@ -332,6 +439,33 @@ func diffFileTooLargeWarning(path, detail string) ProviderWarning {
 		FilePath:             path,
 		EffectOnCompleteness: "file skipped; its content was not read, so its changes are not analyzed",
 		Detail:               fmt.Sprintf("%s of %d bytes", detail, maxDiffFileBytes),
+	}
+}
+
+// diffNonBlobWarning marks a changed tree entry that cannot contain source
+// text. Gitlinks are the ordinary case: their object is a commit, and asking
+// `git show` for it would render a patch rather than read file content.
+func diffNonBlobWarning(path, detail string) ProviderWarning {
+	return ProviderWarning{
+		Code:                 "W_UNSUPPORTED_FILE",
+		Severity:             "info",
+		FilePath:             path,
+		EffectOnCompleteness: "file skipped; the Git tree entry has no blob content, so its changes are not analyzed",
+		Detail:               detail,
+	}
+}
+
+// diffFileReadWarning keeps an unexpectedly absent side distinct from the
+// deliberate size refusal above. ChangedFiles and these reads use the same
+// pinned trees, so a present side disappearing is an input/read failure, not
+// evidence that the file exceeded the cap.
+func diffFileReadWarning(path, detail string) ProviderWarning {
+	return ProviderWarning{
+		Code:                 "E_FILE_READ",
+		Severity:             "error",
+		FilePath:             path,
+		EffectOnCompleteness: "file skipped; expected Git blob content was unavailable, so its changes are not analyzed",
+		Detail:               detail,
 	}
 }
 

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -11,6 +11,12 @@ import (
 	"github.com/entireio/entire-graph/internal/gitutil"
 )
 
+// maxDiffFileBytes caps how large a blob the semantic diff will materialize,
+// per side. It is deliberately the same ceiling the snapshot parser uses
+// (defaultMaxParseBytes): a file the graph declines to parse is not one the
+// diff should read twice in order to parse it anyway.
+const maxDiffFileBytes = defaultMaxParseBytes
+
 func AnalyzeGitRange(ctx context.Context, repo, base, head string, paths []string) (Result, error) {
 	return AnalyzeGitRangeWithOptions(ctx, repo, base, head, paths, AnalyzeOptions{})
 }
@@ -108,18 +114,46 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 			beforeOK = file.Status != "A"
 			afterOK = file.Status != "D"
 		} else {
+			// Both sides are read under the same ceiling the snapshot parser
+			// uses. A semantic diff holds TWO blobs of one file at once, so an
+			// unbounded read here sets this command's memory and time by the
+			// largest object in the range rather than by anything the caller
+			// chose -- and unlike the snapshot readers, nothing downstream
+			// would have declined to parse it.
 			if file.Status != "A" {
-				before, beforeOK, err = gitutil.ShowFile(ctx, repo, base, oldPath)
+				before, beforeOK, err = gitutil.ShowFileLimited(ctx, repo, base, oldPath, maxDiffFileBytes)
 				if err != nil {
 					return Result{}, err
 				}
 			}
 			if file.Status != "D" {
-				after, afterOK, err = gitutil.ShowFile(ctx, repo, head, path)
+				after, afterOK, err = gitutil.ShowFileLimited(ctx, repo, head, path, maxDiffFileBytes)
 				if err != nil {
 					return Result{}, err
 				}
 			}
+		}
+
+		// A side ChangedFiles reported as present that came back unread was
+		// refused by the ceiling above. ChangedFiles parses `git diff -z`, so
+		// the path is exact rather than quoted and resolves at that revision by
+		// construction; the remaining way ShowFileLimited reports a present
+		// path as unreadable WITHOUT an error is the size refusal. Skip the
+		// delta and say so: an empty side would otherwise be compared against a
+		// parsed one and report every entity in it as phantom removed/added.
+		beforeRefused := file.Status != "A" && !beforeOK
+		afterRefused := file.Status != "D" && !afterOK
+		if beforeRefused || afterRefused {
+			warningPath := path
+			detail := "head version is above the diff read cap"
+			if beforeRefused && !afterRefused {
+				warningPath = oldPath
+				detail = "base version is above the diff read cap"
+			} else if beforeRefused && afterRefused {
+				detail = "base and head versions are above the diff read cap"
+			}
+			result.Warnings = append(result.Warnings, diffFileTooLargeWarning(warningPath, detail))
+			continue
 		}
 
 		// Support is content-aware: extensionless executables can still route to a
@@ -268,6 +302,22 @@ func budgetSkippedFileWarning(path string, done, total int, budget time.Duration
 		FilePath:             path,
 		EffectOnCompleteness: "file skipped; analysis time budget ran out before this changed file was analyzed",
 		Detail:               detail,
+	}
+}
+
+// diffFileTooLargeWarning builds the warning emitted when one side of a changed
+// file is above maxDiffFileBytes. It reuses the provider's E_FILE_TOO_LARGE
+// code and severity (see provider_parallel.go, and dependents.go for the same
+// reuse) so one code covers "this file was too large to read" everywhere; the
+// effect wording is diff-specific, because here the whole delta is dropped
+// rather than only the file's symbol parsing.
+func diffFileTooLargeWarning(path, detail string) ProviderWarning {
+	return ProviderWarning{
+		Code:                 "E_FILE_TOO_LARGE",
+		Severity:             "warning",
+		FilePath:             path,
+		EffectOnCompleteness: "file skipped; its content was not read, so its changes are not analyzed",
+		Detail:               fmt.Sprintf("%s of %d bytes", detail, maxDiffFileBytes),
 	}
 }
 

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -148,10 +148,10 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 				if extensionUnsupported(oldCandidatePath) && extensionUnsupported(candidate.Path) {
 					continue
 				}
-				if candidate.Status != "A" {
+				if candidate.Status != "A" && gitutil.IsCanonicalGitTreePath(oldCandidatePath) {
 					basePaths = append(basePaths, oldCandidatePath)
 				}
-				if candidate.Status != "D" {
+				if candidate.Status != "D" && gitutil.IsCanonicalGitTreePath(candidate.Path) {
 					headPaths = append(headPaths, candidate.Path)
 				}
 			}
@@ -175,6 +175,20 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 		oldPath := file.OldPath
 		if oldPath == "" {
 			oldPath = path
+		}
+		beforeInvalidPath := file.Status != "A" && !gitutil.IsCanonicalGitTreePath(oldPath)
+		afterInvalidPath := file.Status != "D" && !gitutil.IsCanonicalGitTreePath(path)
+		if beforeInvalidPath || afterInvalidPath {
+			warningPath := path
+			detail := "head path is not a canonical Git tree path"
+			if beforeInvalidPath && !afterInvalidPath {
+				warningPath = oldPath
+				detail = "base path is not a canonical Git tree path"
+			} else if beforeInvalidPath && afterInvalidPath {
+				detail = "base and head paths are not canonical Git tree paths"
+			}
+			result.Warnings = append(result.Warnings, diffFileReadWarning(warningPath, detail))
+			continue
 		}
 
 		var before, after string

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -80,12 +80,14 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 		emitProgressEvent(phase, filesDone, filesTotal, "", true)
 	}
 
-	// Bind both caller-facing revision labels to immutable trees before any
+	// Bind both caller-facing revision labels to immutable raw trees before any
 	// discovery or content read. A branch can advance between ChangedFiles, the
 	// size probe, and ShowFile; resolving each operation through the original
 	// label would then compare bytes from different ranges and could invalidate
 	// the read ceiling. Trees preserve the command's historical tree-ish input
 	// contract; requiring commits would reject valid tree OIDs and expressions.
+	// gitutil disables replace refs for every subprocess, so refs/replace cannot
+	// mutate either pinned tree between discovery, metadata, content, and grep.
 	// When both labels are byte-identical, reuse the first resolution so a ref
 	// advance between subprocesses cannot turn an intended empty diff into an
 	// old-tree/new-tree comparison. Keep the labels below for result provenance.

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -222,6 +222,20 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 				result.Warnings = append(result.Warnings, diffFileReadWarning(warningPath, detail))
 			}
 
+			beforeUnreadable := file.Status != "A" && beforeRead.Status == gitutil.LimitedFileUnreadable
+			afterUnreadable := file.Status != "D" && afterRead.Status == gitutil.LimitedFileUnreadable
+			if beforeUnreadable || afterUnreadable {
+				warningPath := path
+				detail := "head version references an unreadable Git blob object"
+				if beforeUnreadable && !afterUnreadable {
+					warningPath = oldPath
+					detail = "base version references an unreadable Git blob object"
+				} else if beforeUnreadable && afterUnreadable {
+					detail = "base and head versions reference unreadable Git blob objects"
+				}
+				result.Warnings = append(result.Warnings, diffFileReadWarning(warningPath, detail))
+			}
+
 			beforeNonBlob := file.Status != "A" && beforeRead.Status == gitutil.LimitedFileNonBlob
 			afterNonBlob := file.Status != "D" && afterRead.Status == gitutil.LimitedFileNonBlob
 			if beforeNonBlob || afterNonBlob {
@@ -263,7 +277,7 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 				}
 				result.Warnings = append(result.Warnings, diffFileReadWarning(warningPath, detail))
 			}
-			if beforeMissing || afterMissing || beforeNonBlob || afterNonBlob || beforeOversize || afterOversize || beforeUnaddressable || afterUnaddressable {
+			if beforeMissing || afterMissing || beforeUnreadable || afterUnreadable || beforeNonBlob || afterNonBlob || beforeOversize || afterOversize || beforeUnaddressable || afterUnaddressable {
 				continue
 			}
 		}

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -76,8 +76,22 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 		emitProgressEvent(phase, filesDone, filesTotal, "", true)
 	}
 
+	// Bind both caller-facing revision labels to immutable commits before any
+	// discovery or content read. A branch can advance between ChangedFiles, the
+	// size probe, and ShowFile; resolving each operation through the original
+	// label would then compare bytes from different ranges and could invalidate
+	// the read ceiling. Keep the labels below for the result's public provenance.
+	pinnedBase, err := gitutil.RevParse(ctx, repo, base+"^{commit}")
+	if err != nil {
+		return Result{}, fmt.Errorf("resolve diff base %q: %w", base, err)
+	}
+	pinnedHead, err := gitutil.RevParse(ctx, repo, head+"^{commit}")
+	if err != nil {
+		return Result{}, fmt.Errorf("resolve diff head %q: %w", head, err)
+	}
+
 	emitProgress("discover", 0, 0)
-	changed, err := gitutil.ChangedFiles(ctx, repo, base, head, paths)
+	changed, err := gitutil.ChangedFiles(ctx, repo, pinnedBase, pinnedHead, paths)
 	if err != nil {
 		return Result{}, err
 	}
@@ -121,13 +135,13 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 			// chose -- and unlike the snapshot readers, nothing downstream
 			// would have declined to parse it.
 			if file.Status != "A" {
-				before, beforeOK, err = gitutil.ShowFileLimited(ctx, repo, base, oldPath, maxDiffFileBytes)
+				before, beforeOK, err = gitutil.ShowFileLimited(ctx, repo, pinnedBase, oldPath, maxDiffFileBytes)
 				if err != nil {
 					return Result{}, err
 				}
 			}
 			if file.Status != "D" {
-				after, afterOK, err = gitutil.ShowFileLimited(ctx, repo, head, path, maxDiffFileBytes)
+				after, afterOK, err = gitutil.ShowFileLimited(ctx, repo, pinnedHead, path, maxDiffFileBytes)
 				if err != nil {
 					return Result{}, err
 				}
@@ -274,7 +288,7 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 		})
 	}
 
-	if err := addDependentCountsWithProgress(ctx, repo, head, &result, dependentsScanOptions{
+	if err := addDependentCountsWithProgress(ctx, repo, pinnedHead, &result, dependentsScanOptions{
 		progress: func(done, total int, path string) {
 			emitProgressEvent("dependents", done, total, path, path == "")
 		},

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -54,7 +54,7 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 		deadline = started.Add(options.MaxDuration)
 	}
 	overBudget := func() bool {
-		return !deadline.IsZero() && time.Now().After(deadline)
+		return !deadline.IsZero() && !time.Now().Before(deadline)
 	}
 	var lastEmit time.Time
 	// force emits phase boundaries unconditionally; per-file events are
@@ -93,6 +93,15 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 	if err != nil {
 		return Result{}, err
 	}
+	// ChangedFiles intentionally retains the caller's cwd so explicit path
+	// arguments keep Git's native --repo-relative meaning. Its emitted names,
+	// however, are relative to the compared tree. Perform every subsequent
+	// object read and grep from Git's command root so a repository subdirectory
+	// is not applied again when pinnedBase/pinnedHead are already subtree OIDs.
+	objectRepo, err := gitutil.RepoCommandRoot(ctx, repo)
+	if err != nil {
+		return Result{}, err
+	}
 
 	emitProgress("discover", 0, 0)
 	changed, err := gitutil.ChangedFiles(ctx, repo, pinnedBase, pinnedHead, paths)
@@ -101,8 +110,10 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 	}
 	emitProgress("parse", 0, len(changed))
 	parser := TreeSitterParser{}
-	baseReader := gitutil.NewLimitedFileReader(ctx, repo, pinnedBase, maxDiffFileBytes)
-	headReader := gitutil.NewLimitedFileReader(ctx, repo, pinnedHead, maxDiffFileBytes)
+	baseReader := gitutil.NewLimitedFileReader(ctx, objectRepo, pinnedBase, maxDiffFileBytes)
+	headReader := gitutil.NewLimitedFileReader(ctx, objectRepo, pinnedHead, maxDiffFileBytes)
+	baseReader.SetDeadline(deadline)
+	headReader.SetDeadline(deadline)
 	defer func() {
 		_ = baseReader.Close()
 		_ = headReader.Close()
@@ -112,14 +123,17 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 	// diff/analyze CLI handlers that call through them) inherits it.
 	result := Result{Base: base, Head: head, SchemaVersion: SchemaVersion}
 	var deltas []*fileDelta
+	appendBudgetWarnings := func(start int) {
+		for _, skipped := range changed[start:] {
+			result.Warnings = append(result.Warnings, budgetSkippedFileWarning(skipped.Path, start, len(changed), options.MaxDuration))
+		}
+	}
 	for i, file := range changed {
 		if overBudget() {
 			// Stop cleanly: keep everything analyzed so far and enumerate each
 			// skipped changed file with a machine-readable warning, so the
 			// partial result is never silently incomplete.
-			for _, skipped := range changed[i:] {
-				result.Warnings = append(result.Warnings, budgetSkippedFileWarning(skipped.Path, i, len(changed), options.MaxDuration))
-			}
+			appendBudgetWarnings(i)
 			break
 		}
 		if i%analyzeMetadataPrimeFiles == 0 {
@@ -146,6 +160,14 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 			}
 			if err := headReader.Prime(headPaths); err != nil {
 				return Result{}, err
+			}
+			// Component traversal observes the same deadline between metadata
+			// subprocesses. Re-check immediately so the current file and the rest
+			// receive the ordinary budget warnings instead of being misreported as
+			// unaddressable/read failures after Prime stopped at that deadline.
+			if overBudget() {
+				appendBudgetWarnings(i)
+				break
 			}
 		}
 		emitProgressEvent("parse", i, len(changed), file.Path, i > 0 && i%100 == 0)
@@ -232,12 +254,12 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 			afterUnaddressable := file.Status != "D" && afterRead.Status == gitutil.LimitedFileUnaddressable
 			if beforeUnaddressable || afterUnaddressable {
 				warningPath := path
-				detail := "head path has a component above the bounded Git argv limit"
+				detail := "head path could not be resolved within bounded Git metadata traversal"
 				if beforeUnaddressable && !afterUnaddressable {
 					warningPath = oldPath
-					detail = "base path has a component above the bounded Git argv limit"
+					detail = "base path could not be resolved within bounded Git metadata traversal"
 				} else if beforeUnaddressable && afterUnaddressable {
-					detail = "base and head paths have a component above the bounded Git argv limit"
+					detail = "base and head paths could not be resolved within bounded Git metadata traversal"
 				}
 				result.Warnings = append(result.Warnings, diffFileReadWarning(warningPath, detail))
 			}
@@ -372,7 +394,7 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 		})
 	}
 
-	if err := addDependentCountsWithProgress(ctx, repo, pinnedHead, &result, dependentsScanOptions{
+	if err := addDependentCountsWithProgress(ctx, objectRepo, pinnedHead, &result, dependentsScanOptions{
 		progress: func(done, total int, path string) {
 			emitProgressEvent("dependents", done, total, path, path == "")
 		},

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -227,7 +227,21 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 				}
 				result.Warnings = append(result.Warnings, diffFileTooLargeWarning(warningPath, detail))
 			}
-			if beforeMissing || afterMissing || beforeNonBlob || afterNonBlob || beforeOversize || afterOversize {
+
+			beforeUnaddressable := file.Status != "A" && beforeRead.Status == gitutil.LimitedFileUnaddressable
+			afterUnaddressable := file.Status != "D" && afterRead.Status == gitutil.LimitedFileUnaddressable
+			if beforeUnaddressable || afterUnaddressable {
+				warningPath := path
+				detail := "head path has a component above the bounded Git argv limit"
+				if beforeUnaddressable && !afterUnaddressable {
+					warningPath = oldPath
+					detail = "base path has a component above the bounded Git argv limit"
+				} else if beforeUnaddressable && afterUnaddressable {
+					detail = "base and head paths have a component above the bounded Git argv limit"
+				}
+				result.Warnings = append(result.Warnings, diffFileReadWarning(warningPath, detail))
+			}
+			if beforeMissing || afterMissing || beforeNonBlob || afterNonBlob || beforeOversize || afterOversize || beforeUnaddressable || afterUnaddressable {
 				continue
 			}
 		}

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -906,6 +906,52 @@ func TestAnalyzeGitRangeRecoversFromNoncanonicalTreePath(t *testing.T) {
 	t.Fatalf("noncanonical path had no recoverable E_FILE_READ warning: %#v", result.Warnings)
 }
 
+func TestAnalyzeGitRangeIgnoresTreeReplacementMovedAfterDiscovery(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	baseBlob := gitInput(t, repo, "package p\nfunc Target() int { return 1 }\n", "hash-object", "-w", "--stdin")
+	headBlob := gitInput(t, repo, "package p\nfunc Target(value int) int { return value }\n", "hash-object", "-w", "--stdin")
+	baseTree := gitInput(t, repo, fmt.Sprintf("100644 blob %s\tfile.go%c", baseBlob, byte(0)), "mktree", "-z")
+	headTree := gitInput(t, repo, fmt.Sprintf("100644 blob %s\tfile.go%c", headBlob, byte(0)), "mktree", "-z")
+	// Preserve a hostile inherited assignment; production must append its
+	// canonical raw-object value after it. The control command below removes the
+	// variable entirely so Git demonstrably honors the moved replacement.
+	t.Setenv("GIT_NO_REPLACE_OBJECTS", "0")
+
+	replacementMoved := false
+	controlTree := ""
+	result, err := AnalyzeGitRangeWithOptions(t.Context(), repo, baseTree, headTree, nil, AnalyzeOptions{
+		Progress: func(event AnalyzeProgressEvent) {
+			if replacementMoved || event.Phase != "parse" || event.Path != "" {
+				return
+			}
+			replacementMoved = true
+			// ChangedFiles already discovered file.go from the raw trees. Replace the
+			// head tree with the base now; any later Git process that honors this ref
+			// sees identical content and silently loses the signature change.
+			git(t, repo, "update-ref", "refs/replace/"+headTree, baseTree)
+			controlTree = gitOutputHonoringReplaceRefs(t, repo, "cat-file", "-p", headTree)
+		},
+	})
+	if err != nil {
+		t.Fatalf("analyze across moving tree replacement: %v", err)
+	}
+	if !replacementMoved {
+		t.Fatal("fixture did not move the tree replacement after discovery")
+	}
+	if !strings.Contains(controlTree, baseBlob) || strings.Contains(controlTree, headBlob) {
+		t.Fatalf("control Git did not observe moved tree replacement: %q", controlTree)
+	}
+	for _, file := range result.Files {
+		for _, change := range file.Changes {
+			if file.Path == "file.go" && change.Type == "signature_changed" && change.Name == "Target" {
+				return
+			}
+		}
+	}
+	t.Fatalf("raw pinned trees lost Target signature change after replacement moved: %#v", result)
+}
+
 func TestAnalyzeGitRangeKeepsShebangRoutableChangedFiles(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")
@@ -1583,6 +1629,25 @@ func gitInput(t *testing.T, repo, input string, args ...string) string {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func gitOutputHonoringReplaceRefs(t *testing.T, repo string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo
+	env := cmd.Environ()
+	filtered := env[:0]
+	for _, entry := range env {
+		if !strings.HasPrefix(entry, "GIT_NO_REPLACE_OBJECTS=") {
+			filtered = append(filtered, entry)
+		}
+	}
+	cmd.Env = filtered
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git honoring replacements %v: %v\n%s", args, err, out)
 	}
 	return strings.TrimSpace(string(out))
 }

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -158,6 +158,68 @@ func TestAnalyzeGitRangeReportsProgress(t *testing.T) {
 	}
 }
 
+func TestAnalyzeGitRangePinsSymbolicRefsBeforeDiscoveryAndReads(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+
+	write(t, repo, "auth.py", "def validate_token(token):\n    return bool(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "base")
+	baseCommit := rev(t, repo, "HEAD")
+	git(t, repo, "branch", "base-view", baseCommit)
+
+	write(t, repo, "auth.py", "def validate_token(token, issuer=None):\n    return bool(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "first head")
+	firstHead := rev(t, repo, "HEAD")
+	git(t, repo, "branch", "moving-head", firstHead)
+
+	write(t, repo, "auth.py", "def validate_token(token, audience=None):\n    return bool(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "advanced head")
+	advancedHead := rev(t, repo, "HEAD")
+
+	advanced := false
+	result, err := AnalyzeGitRangeWithOptions(t.Context(), repo, "base-view", "moving-head", nil, AnalyzeOptions{
+		Progress: func(event AnalyzeProgressEvent) {
+			// The parse boundary is emitted after ChangedFiles. Moving the ref here
+			// deterministically exercises every content and dependent read that
+			// follows discovery.
+			if event.Phase == "parse" && event.FilesDone == 0 && !advanced {
+				git(t, repo, "update-ref", "refs/heads/moving-head", advancedHead, firstHead)
+				advanced = true
+			}
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !advanced {
+		t.Fatal("test did not advance the symbolic head after discovery")
+	}
+	if result.Base != "base-view" || result.Head != "moving-head" {
+		t.Fatalf("result labels = %q..%q, want caller labels base-view..moving-head", result.Base, result.Head)
+	}
+
+	var signatureChange *EntityChange
+	for fileIndex := range result.Files {
+		for changeIndex := range result.Files[fileIndex].Changes {
+			change := &result.Files[fileIndex].Changes[changeIndex]
+			if change.Name == "validate_token" && change.Type == "signature_changed" {
+				signatureChange = change
+			}
+		}
+	}
+	if signatureChange == nil {
+		t.Fatalf("changes = %#v, want validate_token signature change", result.Files)
+	}
+	if !strings.Contains(signatureChange.NewSignature, "issuer") || strings.Contains(signatureChange.NewSignature, "audience") {
+		t.Fatalf("new signature = %q, want initially pinned head containing issuer, not advanced head containing audience", signatureChange.NewSignature)
+	}
+}
+
 func containsPhase(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -879,6 +879,33 @@ func TestAnalyzeGitRangeReportsUnreadableBlobObject(t *testing.T) {
 	t.Fatalf("unreadable blob had no accurate E_FILE_READ warning: %#v", result.Warnings)
 }
 
+func TestAnalyzeGitRangeRecoversFromNoncanonicalTreePath(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	baseBlob := gitInput(t, repo, "package p\nvar Value = 1\n", "hash-object", "-w", "--stdin")
+	headBlob := gitInput(t, repo, "package p\nvar Value = 2\n", "hash-object", "-w", "--stdin")
+	baseSubtree := gitInput(t, repo, fmt.Sprintf("100644 blob %s\tfile.go%c", baseBlob, byte(0)), "mktree", "-z")
+	headSubtree := gitInput(t, repo, fmt.Sprintf("100644 blob %s\tfile.go%c", headBlob, byte(0)), "mktree", "-z")
+	baseTree := gitInput(t, repo, fmt.Sprintf("040000 tree %s\t..%c", baseSubtree, byte(0)), "mktree", "-z")
+	headTree := gitInput(t, repo, fmt.Sprintf("040000 tree %s\t..%c", headSubtree, byte(0)), "mktree", "-z")
+
+	result, err := AnalyzeGitRange(t.Context(), repo, baseTree, headTree, nil)
+	if err != nil {
+		t.Fatalf("analyze noncanonical raw tree path: %v", err)
+	}
+	if len(result.Files) != 0 {
+		t.Fatalf("noncanonical path produced semantic changes: %#v", result.Files)
+	}
+	for _, warning := range result.Warnings {
+		if warning.Code == "E_FILE_READ" && warning.Severity == "error" &&
+			warning.FilePath == "../file.go" &&
+			warning.Detail == "base and head paths are not canonical Git tree paths" {
+			return
+		}
+	}
+	t.Fatalf("noncanonical path had no recoverable E_FILE_READ warning: %#v", result.Warnings)
+}
+
 func TestAnalyzeGitRangeKeepsShebangRoutableChangedFiles(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -81,6 +81,10 @@ func TestAnalyzeGitRangeAcceptsTreeObjects(t *testing.T) {
 	git(t, repo, "config", "user.email", "graph@example.com")
 
 	write(t, repo, "scope/auth.py", "def validate_token(token):\n    return bool(token)\n")
+	// This sibling makes a direct `baseExpression + ^{tree}` resolve the
+	// wrong repository path instead of failing. Analyze must resolve the exact
+	// caller expression first, then peel its immutable OID.
+	write(t, repo, "scope^{tree}/auth.py", "def decoy():\n    return False\n")
 	git(t, repo, "add", ".")
 	git(t, repo, "commit", "-m", "base")
 	baseCommit := rev(t, repo, "HEAD")
@@ -117,21 +121,54 @@ func TestAnalyzeGitRangeAcceptsTreeObjects(t *testing.T) {
 	}
 }
 
+func TestAnalyzeGitRangeReadsRootPathsFromRepoSubdirectory(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+
+	write(t, repo, "scope/auth.py", "def validate_token(token):\n    return bool(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "base")
+	base := rev(t, repo, "HEAD")
+	write(t, repo, "scope/auth.py", "def validate_token(token, issuer=None):\n    return bool(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "head")
+	head := rev(t, repo, "HEAD")
+
+	result, err := AnalyzeGitRange(t.Context(), filepath.Join(repo, "scope"), base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Files) != 1 || result.Files[0].Path != "scope/auth.py" {
+		t.Fatalf("subdirectory diff files = %#v, want root-relative scope/auth.py", result.Files)
+	}
+	for _, warning := range result.Warnings {
+		if warning.Code == "E_FILE_READ" {
+			t.Fatalf("root-relative changed path was misclassified as missing: %#v", warning)
+		}
+	}
+}
+
 func TestResolveDiffTreesReusesResolutionForSameLabel(t *testing.T) {
 	var revisions []string
 	resolve := func(_ context.Context, _, revision string) (string, error) {
 		revisions = append(revisions, revision)
-		if len(revisions) == 1 {
+		switch revision {
+		case "moving":
+			return "moving-object", nil
+		case "moving-object^{tree}":
 			return "old-tree", nil
+		default:
+			return "new-tree", nil
 		}
-		return "new-tree", nil
 	}
 	base, head, err := resolveDiffTrees(t.Context(), "repo", "moving", "moving", resolve)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(revisions) != 1 || revisions[0] != "moving^{tree}" {
-		t.Fatalf("same ref resolutions = %#v, want one moving^{tree}", revisions)
+	if len(revisions) != 2 || revisions[0] != "moving" || revisions[1] != "moving-object^{tree}" {
+		t.Fatalf("same ref resolutions = %#v, want exact label then one immutable tree peel", revisions)
 	}
 	if base != "old-tree" || head != "old-tree" {
 		t.Fatalf("same ref pinned to %q..%q, want old-tree..old-tree", base, head)

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -74,6 +74,70 @@ func TestAnalyzeGitRangeSetsSchemaVersion(t *testing.T) {
 	}
 }
 
+func TestAnalyzeGitRangeAcceptsTreeObjects(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+
+	write(t, repo, "scope/auth.py", "def validate_token(token):\n    return bool(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "base")
+	baseCommit := rev(t, repo, "HEAD")
+	baseTree := rev(t, repo, "HEAD^{tree}")
+
+	write(t, repo, "scope/auth.py", "def validate_token(token, issuer=None):\n    return bool(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "head")
+	headCommit := rev(t, repo, "HEAD")
+	headTree := rev(t, repo, "HEAD^{tree}")
+
+	result, err := AnalyzeGitRange(t.Context(), repo, baseTree, headTree, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Base != baseTree || result.Head != headTree {
+		t.Fatalf("result labels = %q..%q, want tree labels %q..%q", result.Base, result.Head, baseTree, headTree)
+	}
+	if len(result.Files) != 1 || result.Files[0].Path != "scope/auth.py" {
+		t.Fatalf("tree-object diff files = %#v, want scope/auth.py", result.Files)
+	}
+
+	baseExpression := baseCommit + ":scope"
+	headExpression := headCommit + ":scope"
+	subtreeResult, err := AnalyzeGitRange(t.Context(), repo, baseExpression, headExpression, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if subtreeResult.Base != baseExpression || subtreeResult.Head != headExpression {
+		t.Fatalf("result labels = %q..%q, want expressions %q..%q", subtreeResult.Base, subtreeResult.Head, baseExpression, headExpression)
+	}
+	if len(subtreeResult.Files) != 1 || subtreeResult.Files[0].Path != "auth.py" {
+		t.Fatalf("tree-expression diff files = %#v, want auth.py", subtreeResult.Files)
+	}
+}
+
+func TestResolveDiffTreesReusesResolutionForSameLabel(t *testing.T) {
+	var revisions []string
+	resolve := func(_ context.Context, _, revision string) (string, error) {
+		revisions = append(revisions, revision)
+		if len(revisions) == 1 {
+			return "old-tree", nil
+		}
+		return "new-tree", nil
+	}
+	base, head, err := resolveDiffTrees(t.Context(), "repo", "moving", "moving", resolve)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(revisions) != 1 || revisions[0] != "moving^{tree}" {
+		t.Fatalf("same ref resolutions = %#v, want one moving^{tree}", revisions)
+	}
+	if base != "old-tree" || head != "old-tree" {
+		t.Fatalf("same ref pinned to %q..%q, want old-tree..old-tree", base, head)
+	}
+}
+
 func TestAnalyzeGitRangeSurfacesModuleScopeChange(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")
@@ -551,6 +615,75 @@ func TestAnalyzeGitRangeMarksUnsupportedChangedFiles(t *testing.T) {
 	}
 	if marker.FilePath != "shim.Tests.ps1" || marker.Severity != "info" {
 		t.Fatalf("unexpected marker %#v", marker)
+	}
+}
+
+func TestAnalyzeGitRangeMarksChangedGitlinkAsUnsupported(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	git(t, repo, "config", "commit.gpgsign", "false")
+
+	runGit := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	oidLength := 40
+	if runGit("rev-parse", "--show-object-format") == "sha256" {
+		oidLength = 64
+	}
+	makeGitlinkTree := func(digit string) string {
+		t.Helper()
+		cmd := exec.Command("git", "mktree", "-z", "--missing")
+		cmd.Dir = repo
+		cmd.Stdin = strings.NewReader("160000 commit " + strings.Repeat(digit, oidLength) + "\tmodule.go\x00")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git mktree: %v\n%s", err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	baseTree := makeGitlinkTree("1")
+	headTree := makeGitlinkTree("2")
+	base := runGit("commit-tree", baseTree, "-m", "record first gitlink")
+	head := runGit("commit-tree", headTree, "-p", base, "-m", "advance gitlink")
+
+	result, err := AnalyzeGitRange(t.Context(), repo, base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Files) != 0 {
+		t.Fatalf("gitlink produced semantic file changes: %#v", result.Files)
+	}
+
+	var unsupported *ProviderWarning
+	for i := range result.Warnings {
+		warning := &result.Warnings[i]
+		if warning.Code == "E_FILE_TOO_LARGE" {
+			t.Fatalf("gitlink was misclassified as oversized: %#v", warning)
+		}
+		if warning.Code == "E_FILE_READ" {
+			t.Fatalf("gitlink was misclassified as a missing blob: %#v", warning)
+		}
+		if warning.Code == "W_UNSUPPORTED_FILE" && warning.FilePath == "module.go" {
+			unsupported = warning
+		}
+	}
+	if unsupported == nil {
+		t.Fatalf("missing gitlink W_UNSUPPORTED_FILE warning: %#v", result.Warnings)
+	}
+	if unsupported.Severity != "info" || unsupported.Detail != "base and head versions are non-blob Git tree entries" {
+		t.Fatalf("unexpected gitlink warning: %#v", unsupported)
+	}
+	if !strings.Contains(unsupported.EffectOnCompleteness, "has no blob content") {
+		t.Fatalf("gitlink warning has inaccurate effect: %#v", unsupported)
 	}
 }
 

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -112,7 +112,7 @@ func TestAnalyzeGitRangeAcceptsTreeObjects(t *testing.T) {
 
 	baseExpression := baseCommit + ":scope"
 	headExpression := headCommit + ":scope"
-	subtreeResult, err := AnalyzeGitRange(t.Context(), repo, baseExpression, headExpression, nil)
+	subtreeResult, err := AnalyzeGitRange(t.Context(), filepath.Join(repo, "scope"), baseExpression, headExpression, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,6 +121,30 @@ func TestAnalyzeGitRangeAcceptsTreeObjects(t *testing.T) {
 	}
 	if len(subtreeResult.Files) != 1 || subtreeResult.Files[0].Path != "auth.py" {
 		t.Fatalf("tree-expression diff files = %#v, want auth.py", subtreeResult.Files)
+	}
+	foundSubtreeDependent := false
+	for _, change := range subtreeResult.Files[0].Changes {
+		if change.Name == "validate_token" {
+			foundSubtreeDependent = true
+			if change.DependentsCount != 1 {
+				t.Fatalf("subdirectory subtree dependent count = %d, want 1: %#v", change.DependentsCount, change)
+			}
+		}
+	}
+	if !foundSubtreeDependent {
+		t.Fatalf("subdirectory subtree diff did not report validate_token: %#v", subtreeResult.Files)
+	}
+
+	// Direct full-root tree OIDs retain the historical caller-cwd pathspec
+	// semantics. Unlike commit:scope above, auth.py means scope/auth.py here.
+	baseRootTree := rev(t, repo, baseCommit+"^{tree}")
+	headRootTree := rev(t, repo, headCommit+"^{tree}")
+	rootTreeResult, err := AnalyzeGitRange(t.Context(), filepath.Join(repo, "scope"), baseRootTree, headRootTree, []string{"auth.py"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rootTreeResult.Files) != 1 || rootTreeResult.Files[0].Path != "scope/auth.py" {
+		t.Fatalf("direct root-tree diff files = %#v, want scope/auth.py", rootTreeResult.Files)
 	}
 }
 
@@ -140,7 +164,7 @@ func TestAnalyzeGitRangeReadsRootPathsFromRepoSubdirectory(t *testing.T) {
 	git(t, repo, "commit", "-m", "head")
 	head := rev(t, repo, "HEAD")
 
-	result, err := AnalyzeGitRange(t.Context(), filepath.Join(repo, "scope"), base, head, nil)
+	result, err := AnalyzeGitRange(t.Context(), filepath.Join(repo, "scope"), base, head, []string{"auth.py"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +226,7 @@ func TestAnalyzeGitRangeWarnsForSingleComponentBeyondArgvBound(t *testing.T) {
 	}
 	found := false
 	for _, warning := range result.Warnings {
-		if warning.Code == "E_FILE_READ" && strings.Contains(warning.Detail, "bounded Git argv limit") {
+		if warning.Code == "E_FILE_READ" && strings.Contains(warning.Detail, "bounded Git metadata traversal") {
 			found = true
 		}
 	}
@@ -1525,6 +1549,22 @@ func nestedAnalyzeTree(t *testing.T, repo, content string, depth int) (tree, pat
 	return tree, path
 }
 
+func importDeepAnalyzeHistory(t *testing.T, repo, path, baseContent, headContent string) (base, head string) {
+	t.Helper()
+	var input strings.Builder
+	fmt.Fprintf(&input, "blob\nmark :1\ndata %d\n%s\n", len(baseContent), baseContent)
+	fmt.Fprintf(&input, "commit refs/heads/deep\nmark :2\ncommitter Test <test@example.com> 1 +0000\ndata 4\nbase\nM 100644 :1 %s\n\n", path)
+	fmt.Fprintf(&input, "blob\nmark :3\ndata %d\n%s\n", len(headContent), headContent)
+	fmt.Fprintf(&input, "commit refs/heads/deep\nmark :4\ncommitter Test <test@example.com> 2 +0000\ndata 4\nhead\nfrom :2\nM 100644 :3 %s\n\n", path)
+	cmd := exec.Command("git", "fast-import", "--quiet")
+	cmd.Dir = repo
+	cmd.Stdin = strings.NewReader(input.String())
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git fast-import deep history: %v\n%s", err, out)
+	}
+	return rev(t, repo, "refs/heads/deep^"), rev(t, repo, "refs/heads/deep")
+}
+
 func rev(t *testing.T, repo, value string) string {
 	t.Helper()
 	cmd := exec.Command("git", "rev-parse", value)
@@ -1582,6 +1622,55 @@ func TestAnalyzeGitRangeBudgetExceededEmitsPartialResult(t *testing.T) {
 		if !skipped[want] {
 			t.Fatalf("skipped files %v missing %q", skipped, want)
 		}
+	}
+}
+
+func TestAnalyzeGitRangeDeepPathMetadataHonorsBudget(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	components := make([]string, 800)
+	for index := range components {
+		components[index] = fmt.Sprintf("component-%010d", index)
+	}
+	path := strings.Join(components, "/") + "/file.go"
+	if len(path) != 16807 {
+		t.Fatalf("deep path length = %d, want reviewer fixture length 16807", len(path))
+	}
+	base, head := importDeepAnalyzeHistory(
+		t,
+		repo,
+		path,
+		"package deep\nvar Value = 1\n",
+		"package deep\nvar Value = 2\n",
+	)
+
+	// Use a deterministically exhausted tiny budget for the integration-level
+	// warning contract. The injected-clock LimitedFileReader test separately
+	// proves that an in-progress component walk stops between subprocesses; this
+	// test must not assume how quickly a particular host can launch 256 Git
+	// processes before the fixed process allowance wins the race.
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	result, err := AnalyzeGitRangeWithOptions(ctx, repo, base, head, nil, AnalyzeOptions{
+		MaxDuration: time.Nanosecond,
+	})
+	if err != nil {
+		t.Fatalf("deep-path budget exhaustion must return a partial result: %v", err)
+	}
+	if len(result.Files) != 0 {
+		t.Fatalf("budget-exhausted deep path produced changes: %#v", result.Files)
+	}
+	foundBudget := false
+	for _, warning := range result.Warnings {
+		if warning.Code == "E_FILE_READ" {
+			t.Fatalf("deadline-limited traversal was misreported as a file read failure: %#v", warning)
+		}
+		if warning.Code == "W_ANALYSIS_BUDGET_EXCEEDED" && warning.FilePath == path {
+			foundBudget = true
+		}
+	}
+	if !foundBudget {
+		t.Fatalf("deep-path result lacks per-file budget warning: %#v", result.Warnings)
 	}
 }
 

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -855,6 +855,30 @@ func TestAnalyzeGitRangeMarksChangedGitlinkAsUnsupported(t *testing.T) {
 	}
 }
 
+func TestAnalyzeGitRangeReportsUnreadableBlobObject(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	baseBlob := gitInput(t, repo, "package p\nvar Value = 1\n", "hash-object", "-w", "--stdin")
+	missingOID := strings.Repeat("1", len(baseBlob))
+	baseTree := gitInput(t, repo, fmt.Sprintf("100644 blob %s\tfile.go%c", baseBlob, byte(0)), "mktree", "-z")
+	headTree := gitInput(t, repo, fmt.Sprintf("100644 blob %s\tfile.go%c", missingOID, byte(0)), "mktree", "-z", "--missing")
+
+	result, err := AnalyzeGitRange(t.Context(), repo, baseTree, headTree, nil)
+	if err != nil {
+		t.Fatalf("analyze listed unreadable blob: %v", err)
+	}
+	if len(result.Files) != 0 {
+		t.Fatalf("unreadable blob produced semantic changes: %#v", result.Files)
+	}
+	for _, warning := range result.Warnings {
+		if warning.Code == "E_FILE_READ" && warning.FilePath == "file.go" &&
+			warning.Detail == "head version references an unreadable Git blob object" {
+			return
+		}
+	}
+	t.Fatalf("unreadable blob had no accurate E_FILE_READ warning: %#v", result.Warnings)
+}
+
 func TestAnalyzeGitRangeKeepsShebangRoutableChangedFiles(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -2,9 +2,11 @@ package sem
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -81,6 +83,7 @@ func TestAnalyzeGitRangeAcceptsTreeObjects(t *testing.T) {
 	git(t, repo, "config", "user.email", "graph@example.com")
 
 	write(t, repo, "scope/auth.py", "def validate_token(token):\n    return bool(token)\n")
+	write(t, repo, "scope/use_auth.py", "def check(token):\n    return validate_token(token)\n")
 	// This sibling makes a direct `baseExpression + ^{tree}` resolve the
 	// wrong repository path instead of failing. Analyze must resolve the exact
 	// caller expression first, then peel its immutable OID.
@@ -128,6 +131,7 @@ func TestAnalyzeGitRangeReadsRootPathsFromRepoSubdirectory(t *testing.T) {
 	git(t, repo, "config", "user.email", "graph@example.com")
 
 	write(t, repo, "scope/auth.py", "def validate_token(token):\n    return bool(token)\n")
+	write(t, repo, "scope/use_auth.py", "def check(token):\n    return validate_token(token)\n")
 	git(t, repo, "add", ".")
 	git(t, repo, "commit", "-m", "base")
 	base := rev(t, repo, "HEAD")
@@ -143,9 +147,112 @@ func TestAnalyzeGitRangeReadsRootPathsFromRepoSubdirectory(t *testing.T) {
 	if len(result.Files) != 1 || result.Files[0].Path != "scope/auth.py" {
 		t.Fatalf("subdirectory diff files = %#v, want root-relative scope/auth.py", result.Files)
 	}
+	foundDependent := false
+	for _, change := range result.Files[0].Changes {
+		if change.Name == "validate_token" {
+			foundDependent = true
+			if change.DependentsCount != 1 {
+				t.Fatalf("subdirectory dependent count = %d, want 1: %#v", change.DependentsCount, change)
+			}
+		}
+	}
+	if !foundDependent {
+		t.Fatalf("subdirectory diff did not report validate_token: %#v", result.Files)
+	}
 	for _, warning := range result.Warnings {
 		if warning.Code == "E_FILE_READ" {
 			t.Fatalf("root-relative changed path was misclassified as missing: %#v", warning)
+		}
+	}
+}
+
+func TestAnalyzeGitRangeReadsPathBeyondMetadataArgvBound(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	baseTree, path := nestedAnalyzeTree(t, repo, "package deep\n\nvar Value = 1\n", 80)
+	headTree, headPath := nestedAnalyzeTree(t, repo, "package deep\n\nvar Value = 2\n", 80)
+	if headPath != path || len(path) <= 15<<10 {
+		t.Fatalf("deep fixture path lengths = %d/%d, want same path beyond 15 KiB", len(path), len(headPath))
+	}
+	result, err := AnalyzeGitRange(t.Context(), repo, baseTree, headTree, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Files) != 1 || result.Files[0].Path != path {
+		t.Fatalf("deep-tree diff files = %#v, want exact %d-byte path", result.Files, len(path))
+	}
+}
+
+func TestAnalyzeGitRangeWarnsForSingleComponentBeyondArgvBound(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	component := strings.Repeat("x", (16<<10)+1)
+	makeTree := func(content string) string {
+		t.Helper()
+		blob := gitInput(t, repo, content, "hash-object", "-w", "--stdin")
+		leaf := gitInput(t, repo, fmt.Sprintf("100644 blob %s\tfile.go%c", blob, byte(0)), "mktree", "-z")
+		return gitInput(t, repo, fmt.Sprintf("040000 tree %s\t%s%c", leaf, component, byte(0)), "mktree", "-z")
+	}
+	result, err := AnalyzeGitRange(t.Context(), repo, makeTree("package p\nvar Value = 1\n"), makeTree("package p\nvar Value = 2\n"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Files) != 0 {
+		t.Fatalf("unaddressable path produced semantic changes: %#v", result.Files)
+	}
+	found := false
+	for _, warning := range result.Warnings {
+		if warning.Code == "E_FILE_READ" && strings.Contains(warning.Detail, "bounded Git argv limit") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("missing bounded unaddressable warning: %#v", result.Warnings)
+	}
+}
+
+func TestAnalyzeGitRangeDependentsAvoidLineProtocolPaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows filenames cannot contain newlines or carriage returns")
+	}
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	write(t, repo, "auth.py", "def validate_token(token):\n    return bool(token)\n")
+	write(t, repo, "a\nunsafe.py", "def first(token):\n    return validate_token(token)\n")
+	// This path is also returned by git grep, but its trailing CR makes it an
+	// unsupported parser path. It must never enter the line-framed reader.
+	write(t, repo, "b.py\r", "def second(token):\n    return validate_token(token)\n")
+	const oversizeUnsafePath = "c\nover.py"
+	write(t, repo, oversizeUnsafePath, "validate_token\n"+strings.Repeat("#", defaultMaxParseBytes))
+	write(t, repo, "z_plain.py", "def third(token):\n    return validate_token(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "base")
+	base := rev(t, repo, "HEAD")
+	write(t, repo, "auth.py", "def validate_token(token, issuer=None):\n    return bool(token)\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "head")
+	head := rev(t, repo, "HEAD")
+
+	result, err := AnalyzeGitRange(t.Context(), repo, base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundOversizeWarning := false
+	for _, warning := range result.Warnings {
+		if warning.Code == "E_FILE_TOO_LARGE" && warning.FilePath == oversizeUnsafePath {
+			foundOversizeWarning = true
+		}
+	}
+	if !foundOversizeWarning {
+		t.Fatalf("unsafe oversized dependent was not reported: %#v", result.Warnings)
+	}
+	for _, file := range result.Files {
+		for _, change := range file.Changes {
+			if change.Name == "validate_token" && change.DependentsCount != 2 {
+				t.Fatalf("line-safe dependent count = %d, want newline + ordinary candidates: %#v", change.DependentsCount, change)
+			}
 		}
 	}
 }
@@ -1391,6 +1498,31 @@ func git(t *testing.T, repo string, args ...string) {
 	if err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, out)
 	}
+}
+
+func gitInput(t *testing.T, repo, input string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func nestedAnalyzeTree(t *testing.T, repo, content string, depth int) (tree, path string) {
+	t.Helper()
+	blob := gitInput(t, repo, content, "hash-object", "-w", "--stdin")
+	tree = gitInput(t, repo, fmt.Sprintf("100644 blob %s\tfile.go%c", blob, byte(0)), "mktree", "-z")
+	path = "file.go"
+	component := strings.Repeat("a", 200)
+	for range depth {
+		tree = gitInput(t, repo, fmt.Sprintf("040000 tree %s\t%s%c", tree, component, byte(0)), "mktree", "-z")
+		path = component + "/" + path
+	}
+	return tree, path
 }
 
 func rev(t *testing.T, repo, value string) string {

--- a/internal/sem/blob_read_cap_test.go
+++ b/internal/sem/blob_read_cap_test.go
@@ -1,6 +1,7 @@
 package sem
 
 import (
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -169,4 +170,92 @@ func TestHeadReadersCapNewlineBearingPaths(t *testing.T) {
 			t.Fatal("a newline-bearing path under the cap must still be readable")
 		}
 	})
+}
+
+// TestRefusedNewlinePathKeepsItsFileRecord is the parity guard the cap must not
+// cost. ProviderSnapshotOptions.MaxParseBytes documents (provider.go:356-361)
+// that an oversized file "still emit[s] file records and a partial failure" with
+// the record's blob hash and line count "from a streamed digest". The batch
+// reader keeps that promise: it digests the blob it refuses on the way past.
+//
+// The one-shot fallback taken for a newline-bearing path must keep the same
+// promise. If it only refuses, processProviderFile cannot tell a refused file
+// from an unreadable one (provider_parallel.go:76-126): the FileRecord is
+// dropped, the warning-severity E_FILE_TOO_LARGE becomes an error-severity
+// E_FILE_READ, and completeness falls from ok to degraded. The file then
+// disappears from the snapshot because of how it is NAMED.
+func TestRefusedNewlinePathKeepsItsFileRecord(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Win32 rejects newlines (and every other control character) in file
+		// names, so this input cannot exist there and Git cannot check it out.
+		t.Skip("a newline-bearing file name is unrepresentable on Windows")
+	}
+
+	const newlinePath = "record\nme.py"
+	const oversizeBytes = int64(4096)
+
+	repo := t.TempDir()
+	initRepo(t, repo)
+	writeSparseFile(t, repo, newlinePath, oversizeBytes, "# over the cap\n")
+	write(t, repo, "plain.py", "def helper(value):\n    return value\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	wantHash, wantLines := fileSHA256(t, filepath.Join(repo, newlinePath))
+
+	snapshot, err := BuildProviderSnapshotWithOptions(
+		t.Context(), repo, "test", ProviderSnapshotOptions{MaxParseBytes: 1024},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var record *FileRecord
+	for i := range snapshot.Files {
+		if snapshot.Files[i].Path == newlinePath {
+			record = &snapshot.Files[i]
+		}
+	}
+	if record == nil {
+		t.Fatalf("the refused file lost its record; files = %#v", snapshot.Files)
+	}
+	if int64(record.Bytes) != oversizeBytes || record.Lines != wantLines || record.Blob != wantHash {
+		t.Fatalf(
+			"record = {Bytes:%d Lines:%d Blob:%s}, want {Bytes:%d Lines:%d Blob:%s}",
+			record.Bytes, record.Lines, record.Blob, oversizeBytes, wantLines, wantHash,
+		)
+	}
+	if record.Language != "Python" {
+		t.Fatalf("record language = %q, want Python", record.Language)
+	}
+
+	var failure *PartialFailure
+	for i := range snapshot.Header.PartialFailures {
+		if snapshot.Header.PartialFailures[i].FilePath == newlinePath {
+			failure = &snapshot.Header.PartialFailures[i]
+		}
+	}
+	if failure == nil {
+		t.Fatalf("the refused file disappeared silently; partial failures = %#v", snapshot.Header.PartialFailures)
+	}
+	if failure.Code != "E_FILE_TOO_LARGE" || failure.Severity != "warning" {
+		t.Fatalf("failure = {Code:%s Severity:%s}, want {E_FILE_TOO_LARGE warning}", failure.Code, failure.Severity)
+	}
+	if snapshot.Header.Stats.CompletenessLevel != "ok" {
+		t.Fatalf("completeness = %q, want ok", snapshot.Header.Stats.CompletenessLevel)
+	}
+
+	// The parity must not come from un-capping the read: the fallback still
+	// refuses to materialize the blob.
+	opened, err := openSource(t.Context(), repo, rev(t, repo, "HEAD"), sourceOptions{maxReadBytes: 1024})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if opened.close != nil {
+			_ = opened.close()
+		}
+	}()
+	if content, ok := opened.read(newlinePath); ok {
+		t.Fatalf("read returned %d bytes for a blob above the 1024-byte cap", len(content))
+	}
 }

--- a/internal/sem/blob_read_cap_test.go
+++ b/internal/sem/blob_read_cap_test.go
@@ -72,6 +72,64 @@ func TestAnalyzeGitRangeRefusesBlobsAboveTheReadCap(t *testing.T) {
 	}
 }
 
+func TestCommittedProviderRecoversFromMissingBlobObjectsForSafeAndUnsafePaths(t *testing.T) {
+	repo := t.TempDir()
+	initRepo(t, repo)
+	knownBlob := gitInput(t, repo, "def available():\n    return True\n", "hash-object", "-w", "--stdin")
+	missingOID := strings.Repeat("1", len(knownBlob))
+	const (
+		safePath          = "safe-missing.py"
+		unsafePath        = "unsafe\nmissing.py"
+		invalidUnsafePath = "../unsafe\ninvalid.py"
+	)
+	invalidSubtree := gitInput(
+		t,
+		repo,
+		"100644 blob "+knownBlob+"\tunsafe\ninvalid.py\x00",
+		"mktree", "-z",
+	)
+	treeInput := "040000 tree " + invalidSubtree + "\t..\x00" +
+		"100644 blob " + knownBlob + "\tplain.py\x00" +
+		"100644 blob " + missingOID + "\t" + safePath + "\x00" +
+		"100644 blob " + missingOID + "\t" + unsafePath + "\x00"
+	tree := gitInput(t, repo, treeInput, "mktree", "-z", "--missing")
+	commit := gitInput(t, repo, "missing-object parity\n", "commit-tree", tree)
+	git(t, repo, "update-ref", "HEAD", commit)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test", ProviderSnapshotOptions{})
+	if err != nil {
+		t.Fatalf("snapshot with listed missing objects: %v", err)
+	}
+	foundPlain := false
+	for _, file := range snapshot.Files {
+		if file.Path == "plain.py" {
+			foundPlain = true
+		}
+		if file.Path == safePath || file.Path == unsafePath || file.Path == invalidUnsafePath {
+			t.Fatalf("missing-object path emitted a file record: %#v", file)
+		}
+	}
+	if !foundPlain {
+		t.Fatalf("recoverable missing objects suppressed the readable sibling: %#v", snapshot.Files)
+	}
+
+	failures := map[string]PartialFailure{}
+	for _, failure := range snapshot.Header.PartialFailures {
+		if failure.FilePath == safePath || failure.FilePath == unsafePath || failure.FilePath == invalidUnsafePath {
+			failures[failure.FilePath] = failure
+		}
+	}
+	for _, path := range []string{safePath, unsafePath, invalidUnsafePath} {
+		failure, ok := failures[path]
+		if !ok {
+			t.Fatalf("missing-object path %q had no partial failure: %#v", path, snapshot.Header.PartialFailures)
+		}
+		if failure.Code != "E_FILE_READ" || failure.Severity != "error" || failure.Detail != "file listed but content was unavailable" {
+			t.Fatalf("missing-object path %q failure = %#v, want E_FILE_READ parity", path, failure)
+		}
+	}
+}
+
 // TestHeadReadersCapNewlineBearingPaths pins the bound on the one HEAD read
 // that the `git cat-file --batch` protocol cannot carry. The batch reader is
 // line based, so a Git path containing a newline falls back to a shared bounded

--- a/internal/sem/blob_read_cap_test.go
+++ b/internal/sem/blob_read_cap_test.go
@@ -1,0 +1,172 @@
+package sem
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestAnalyzeGitRangeRefusesBlobsAboveTheReadCap pins the memory and time bound
+// of the semantic diff: `diff`/`commit` read BOTH sides of every changed file,
+// so an uncapped read makes one oversized blob set the command's cost. The file
+// must not vanish either — it is skipped with a machine-readable
+// E_FILE_TOO_LARGE warning, the same code the snapshot path uses.
+func TestAnalyzeGitRangeRefusesBlobsAboveTheReadCap(t *testing.T) {
+	repo := t.TempDir()
+	initRepo(t, repo)
+
+	// One long string literal, so the blob is large but cheap to lex: the test
+	// is about the read, not about parser throughput.
+	// Sized against defaultMaxParseBytes rather than against the diff cap's own
+	// name, so this file compiles against a tree where the cap does not exist
+	// yet and the test can be shown to FAIL there rather than not build.
+	huge := func(fill string) string {
+		return "BLOB = \"" + strings.Repeat(fill, defaultMaxParseBytes+1024) + "\"\n"
+	}
+	write(t, repo, "huge.py", huge("x"))
+	write(t, repo, "small.py", "def helper(value):\n    return value\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	base := rev(t, repo, "HEAD")
+	write(t, repo, "huge.py", huge("y"))
+	write(t, repo, "small.py", "def helper(value):\n    return value + 1\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "change")
+	head := rev(t, repo, "HEAD")
+
+	result, err := AnalyzeGitRange(t.Context(), repo, base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, file := range result.Files {
+		if file.Path == "huge.py" {
+			t.Fatalf("a blob above the %d-byte read cap was analyzed: %#v", defaultMaxParseBytes, file)
+		}
+	}
+	analyzedSmall := false
+	for _, file := range result.Files {
+		if file.Path == "small.py" {
+			analyzedSmall = true
+		}
+	}
+	if !analyzedSmall {
+		t.Fatalf("the cap must refuse only the oversized file; small.py was not analyzed: %#v", result.Files)
+	}
+
+	var refusal *ProviderWarning
+	for i, warning := range result.Warnings {
+		if warning.Code == "E_FILE_TOO_LARGE" && warning.FilePath == "huge.py" {
+			refusal = &result.Warnings[i]
+		}
+	}
+	if refusal == nil {
+		t.Fatalf("a refused file must not disappear silently; warnings = %#v", result.Warnings)
+	}
+	if refusal.Severity != "warning" {
+		t.Fatalf("severity = %q, want warning", refusal.Severity)
+	}
+	if refusal.EffectOnCompleteness == "" || refusal.Detail == "" {
+		t.Fatalf("refusal warning must explain itself: %#v", *refusal)
+	}
+}
+
+// TestHeadReadersCapNewlineBearingPaths pins the bound on the one HEAD read
+// that the `git cat-file --batch` protocol cannot carry. The batch reader is
+// line based, so a Git path containing a newline falls back to a one-shot
+// reader — a fallback selected by the file's NAME, which the repository under
+// analysis chooses. An uncapped fallback therefore lets any repository opt a
+// blob out of the cap by renaming it.
+func TestHeadReadersCapNewlineBearingPaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Win32 rejects newlines (and every other control character) in file
+		// names, so this input cannot exist there and Git cannot check it out.
+		t.Skip("a newline-bearing file name is unrepresentable on Windows")
+	}
+
+	const newlinePath = "over\ncap.py"
+	const smallNewlinePath = "under\ncap.py"
+
+	repo := t.TempDir()
+	initRepo(t, repo)
+	// defaultMaxParseBytes is the ceiling openSearchContentReader applies, so
+	// the oversized fixture is sized against it; openSource takes its ceiling
+	// from the caller and is exercised with a much smaller one below.
+	writeSparseFile(t, repo, newlinePath, int64(defaultMaxParseBytes)+1, "# over the cap\n")
+	write(t, repo, smallNewlinePath, "def helper(value):\n    return value\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	head := rev(t, repo, "HEAD")
+
+	t.Run("openSource", func(t *testing.T) {
+		opened, err := openSource(t.Context(), repo, head, sourceOptions{maxReadBytes: 1024})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if opened.close != nil {
+				_ = opened.close()
+			}
+		}()
+		listed := false
+		for _, path := range opened.paths {
+			if path == newlinePath {
+				listed = true
+			}
+		}
+		if !listed {
+			t.Fatalf("fixture is not exercising the read closure; paths = %#v", opened.paths)
+		}
+		if content, ok := opened.read(newlinePath); ok {
+			t.Fatalf("read returned %d bytes for a blob above the 1024-byte cap", len(content))
+		}
+		if content, ok := opened.readPrefix(newlinePath, 64); ok {
+			t.Fatalf("readPrefix returned %d bytes for a blob above the 1024-byte cap", len(content))
+		}
+		if _, ok := opened.read(smallNewlinePath); !ok {
+			t.Fatal("a newline-bearing path under the cap must still be readable")
+		}
+	})
+
+	// The refused blob must still be accounted for. docs/trust-and-security.md
+	// promises that a file the graph cannot process emits a machine-readable
+	// partial failure "rather than disappearing silently", and that promise is
+	// the reason this assertion does not name a code: it holds whichever code
+	// the snapshot chooses for a read it declined.
+	t.Run("snapshotAccountsForTheRefusedFile", func(t *testing.T) {
+		snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test", ProviderSnapshotOptions{MaxParseBytes: 1024})
+		if err != nil {
+			t.Fatal(err)
+		}
+		reported := false
+		for _, failure := range snapshot.Header.PartialFailures {
+			if failure.FilePath == newlinePath {
+				reported = true
+				if failure.Code == "" || failure.EffectOnCompleteness == "" {
+					t.Fatalf("partial failure must be machine-readable: %#v", failure)
+				}
+			}
+		}
+		if !reported {
+			t.Fatalf("the refused file disappeared silently; partial failures = %#v", snapshot.Header.PartialFailures)
+		}
+	})
+
+	t.Run("openSearchContentReader", func(t *testing.T) {
+		read, closeReader, err := openSearchContentReader(t.Context(), repo, head, true, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if closeReader != nil {
+				_ = closeReader()
+			}
+		}()
+		if content, ok := read(newlinePath); ok {
+			t.Fatalf("read returned %d bytes for a blob above the %d-byte cap", len(content), defaultMaxParseBytes)
+		}
+		if _, ok := read(smallNewlinePath); !ok {
+			t.Fatal("a newline-bearing path under the cap must still be readable")
+		}
+	})
+}

--- a/internal/sem/blob_read_cap_test.go
+++ b/internal/sem/blob_read_cap_test.go
@@ -218,7 +218,7 @@ func TestHeadReadersCapNewlineBearingPaths(t *testing.T) {
 	})
 
 	t.Run("openSearchContentReader", func(t *testing.T) {
-		read, closeReader, err := openSearchContentReader(t.Context(), repo, head, true, nil, nil)
+		read, closeReader, err := openSearchContentReader(t.Context(), repo, head, true, nil, nil, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -266,7 +266,7 @@ func TestHeadReadersFallbackWhenRepoPrefixContainsNewline(t *testing.T) {
 		}
 	}
 
-	read, closeReader, err := openSearchContentReader(t.Context(), repo, head, true, nil, nil)
+	read, closeReader, err := openSearchContentReader(t.Context(), repo, head, true, nil, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -365,4 +365,50 @@ func TestRefusedNewlinePathKeepsItsFileRecord(t *testing.T) {
 	if content, ok := opened.read(newlinePath); ok {
 		t.Fatalf("read returned %d bytes for a blob above the 1024-byte cap", len(content))
 	}
+}
+
+// TestOpenSearchContentReaderHonorsARaisedMaxParseBytes reproduces the trail
+// finding: openSearchContentReader hard-coded defaultMaxParseBytes on its
+// batch reader, its LimitedFileReader fallback, and its worktree source
+// instead of accepting the search's resolved MaxParseBytes. A caller who
+// raised the limit above the package default got a file into the ranked
+// snapshot (BuildProviderSnapshotWithOptions honors the raised limit) only
+// to have this reader refuse it during snippet/body reads — a raise that
+// silently produced missing or truncated search results instead of the
+// larger files it promised.
+func TestOpenSearchContentReaderHonorsARaisedMaxParseBytes(t *testing.T) {
+	const raisedLimit = defaultMaxParseBytes + 8192
+
+	repo := t.TempDir()
+	initRepo(t, repo)
+	huge := "BLOB = \"" + strings.Repeat("x", defaultMaxParseBytes+1024) + "\"\n"
+	write(t, repo, "huge.py", huge)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	head := rev(t, repo, "HEAD")
+
+	t.Run("default limit still refuses the file", func(t *testing.T) {
+		read, closeReader, err := openSearchContentReader(t.Context(), repo, head, true, nil, nil, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = closeReader() }()
+		if content, ok := read("huge.py"); ok {
+			t.Fatalf("read returned %d bytes at the default cap for a file sized just above it", len(content))
+		}
+	})
+
+	t.Run("raised limit lets the file through", func(t *testing.T) {
+		read, closeReader, err := openSearchContentReader(t.Context(), repo, head, true, nil, nil, raisedLimit)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = closeReader() }()
+		content, ok := read("huge.py")
+		if !ok || content != huge {
+			t.Fatalf("read at a raised MaxParseBytes = (%d bytes, ok=%v), want the full %d-byte file: "+
+				"the reader must use the caller's resolved limit, not the package default",
+				len(content), ok, len(huge))
+		}
+	})
 }

--- a/internal/sem/blob_read_cap_test.go
+++ b/internal/sem/blob_read_cap_test.go
@@ -74,7 +74,7 @@ func TestAnalyzeGitRangeRefusesBlobsAboveTheReadCap(t *testing.T) {
 
 // TestHeadReadersCapNewlineBearingPaths pins the bound on the one HEAD read
 // that the `git cat-file --batch` protocol cannot carry. The batch reader is
-// line based, so a Git path containing a newline falls back to a one-shot
+// line based, so a Git path containing a newline falls back to a shared bounded
 // reader — a fallback selected by the file's NAME, which the repository under
 // analysis chooses. An uncapped fallback therefore lets any repository opt a
 // blob out of the cap by renaming it.
@@ -227,7 +227,7 @@ func TestHeadReadersFallbackWhenRepoPrefixContainsNewline(t *testing.T) {
 // the record's blob hash and line count "from a streamed digest". The batch
 // reader keeps that promise: it digests the blob it refuses on the way past.
 //
-// The one-shot fallback taken for a newline-bearing path must keep the same
+// The bounded fallback taken for a newline-bearing path must keep the same
 // promise. If it only refuses, processProviderFile cannot tell a refused file
 // from an unreadable one (provider_parallel.go:76-126): the FileRecord is
 // dropped, the warning-severity E_FILE_TOO_LARGE becomes an error-severity

--- a/internal/sem/blob_read_cap_test.go
+++ b/internal/sem/blob_read_cap_test.go
@@ -87,6 +87,8 @@ func TestHeadReadersCapNewlineBearingPaths(t *testing.T) {
 
 	const newlinePath = "over\ncap.py"
 	const smallNewlinePath = "under\ncap.py"
+	const carriagePath = "carriage.py\r"
+	const carriageContent = "def carriage(value):\n    return value\n"
 
 	repo := t.TempDir()
 	initRepo(t, repo)
@@ -95,6 +97,7 @@ func TestHeadReadersCapNewlineBearingPaths(t *testing.T) {
 	// from the caller and is exercised with a much smaller one below.
 	writeSparseFile(t, repo, newlinePath, int64(defaultMaxParseBytes)+1, "# over the cap\n")
 	write(t, repo, smallNewlinePath, "def helper(value):\n    return value\n")
+	write(t, repo, carriagePath, carriageContent)
 	git(t, repo, "add", ".")
 	git(t, repo, "commit", "-m", "initial")
 	head := rev(t, repo, "HEAD")
@@ -126,6 +129,9 @@ func TestHeadReadersCapNewlineBearingPaths(t *testing.T) {
 		}
 		if _, ok := opened.read(smallNewlinePath); !ok {
 			t.Fatal("a newline-bearing path under the cap must still be readable")
+		}
+		if content, ok := opened.read(carriagePath); !ok || content != carriageContent {
+			t.Fatalf("trailing-CR path = (%q, %v), want exact content", content, ok)
 		}
 	})
 
@@ -169,7 +175,50 @@ func TestHeadReadersCapNewlineBearingPaths(t *testing.T) {
 		if _, ok := read(smallNewlinePath); !ok {
 			t.Fatal("a newline-bearing path under the cap must still be readable")
 		}
+		if content, ok := read(carriagePath); !ok || content != carriageContent {
+			t.Fatalf("search trailing-CR path = (%q, %v), want exact content", content, ok)
+		}
 	})
+}
+
+func TestHeadReadersFallbackWhenRepoPrefixContainsNewline(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows directory names cannot contain newlines")
+	}
+	root := t.TempDir()
+	initRepo(t, root)
+	const firstContent = "def first():\n    return 1\n"
+	const secondContent = "def second():\n    return 2\n"
+	write(t, root, "line\nscope/first.py", firstContent)
+	write(t, root, "line\nscope/second.py", secondContent)
+	git(t, root, "add", ".")
+	git(t, root, "commit", "-m", "newline prefix fixture")
+	head := rev(t, root, "HEAD")
+	repo := filepath.Join(root, "line\nscope")
+
+	opened, err := openSource(t.Context(), repo, head, sourceOptions{maxReadBytes: 1024})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = opened.close() }()
+	for path, want := range map[string]string{"first.py": firstContent, "second.py": secondContent} {
+		content, ok := opened.read(path)
+		if !ok || content != want {
+			t.Fatalf("provider read after newline prefix %q = (%q, %v), want exact content", path, content, ok)
+		}
+	}
+
+	read, closeReader, err := openSearchContentReader(t.Context(), repo, head, true, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = closeReader() }()
+	for path, want := range map[string]string{"first.py": firstContent, "second.py": secondContent} {
+		content, ok := read(path)
+		if !ok || content != want {
+			t.Fatalf("search read after newline prefix %q = (%q, %v), want exact content", path, content, ok)
+		}
+	}
 }
 
 // TestRefusedNewlinePathKeepsItsFileRecord is the parity guard the cap must not

--- a/internal/sem/cache_ignore_inputs_test.go
+++ b/internal/sem/cache_ignore_inputs_test.go
@@ -161,3 +161,89 @@ func TestProviderRecordsKeyIncludesGraphIgnore(t *testing.T) {
 		t.Fatal("editing .graphignore did not invalidate provider records")
 	}
 }
+
+func TestSearchSnapshotKeyIncludesWorktreeInfoExcludeStateAndContent(t *testing.T) {
+	repo := t.TempDir()
+	key := func(options ProviderSnapshotOptions) string {
+		t.Helper()
+		got, err := searchSnapshotKey(repo, "repo", "version", "tree", options)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return got
+	}
+
+	worktreeOptions := ProviderSnapshotOptions{Worktree: true}
+	missing := key(worktreeOptions)
+	headMissing := key(ProviderSnapshotOptions{})
+	infoDir := filepath.Join(repo, ".git", "info")
+	if err := os.MkdirAll(infoDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	exclude := filepath.Join(infoDir, "exclude")
+	if err := os.WriteFile(exclude, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	presentEmpty := key(worktreeOptions)
+	if presentEmpty == missing {
+		t.Fatal("missing info/exclude collided with a present empty file")
+	}
+	if err := os.WriteFile(exclude, []byte("/dist/\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	presentContent := key(worktreeOptions)
+	if presentContent == presentEmpty {
+		t.Fatal("editing info/exclude did not invalidate the worktree key")
+	}
+	if headPresent := key(ProviderSnapshotOptions{}); headPresent != headMissing {
+		t.Fatal("committed-tree key changed for a worktree-only ignore input")
+	}
+}
+
+func TestWorktreeSnapshotCacheInvalidatesForGitInfoExclude(t *testing.T) {
+	repo := cacheTestRepo(t)
+	cacheDir := t.TempDir()
+	options := ProviderSnapshotOptions{Worktree: true, Profile: ProfileFull, NoNetwork: true}
+
+	first, hit, err := LoadOrBuildProviderSnapshot(t.Context(), repo, "test", options, cacheDir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hit {
+		t.Fatal("cold worktree cache reported a hit")
+	}
+	if !hasSymbolNamed(first.Symbols, "Alpha") {
+		t.Fatal("cold snapshot did not include app.go")
+	}
+
+	exclude := gitInfoExcludePath(repo)
+	if exclude == "" {
+		t.Fatal("test repository did not resolve info/exclude")
+	}
+	if err := os.WriteFile(exclude, []byte("/app.go\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	InvalidateWorktreeCleanVerdicts()
+	second, hit, err := LoadOrBuildProviderSnapshot(t.Context(), repo, "test", options, cacheDir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hit {
+		t.Fatal("info/exclude edit reused the stale worktree snapshot")
+	}
+	if hasSymbolNamed(second.Symbols, "Alpha") {
+		t.Fatal("snapshot retained a tracked file excluded by info/exclude")
+	}
+
+	InvalidateWorktreeCleanVerdicts()
+	third, hit, err := LoadOrBuildProviderSnapshot(t.Context(), repo, "test", options, cacheDir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hit {
+		t.Fatal("unchanged info/exclude did not reuse the rebuilt snapshot")
+	}
+	if hasSymbolNamed(third.Symbols, "Alpha") {
+		t.Fatal("warm rebuilt snapshot restored the excluded file")
+	}
+}

--- a/internal/sem/cache_ignore_inputs_test.go
+++ b/internal/sem/cache_ignore_inputs_test.go
@@ -24,7 +24,7 @@ func ignoreInputKeyers(repo string) []ignoreInputKeyer {
 		{
 			name: "provider records",
 			key: func(options ProviderSnapshotOptions) (string, error) {
-				return providerRecordsKey(repo, "repo", "version", "tree", "snapshot", options)
+				return providerRecordsKey(repo, "repo", "version", "commit", "tree", "snapshot", options)
 			},
 		},
 	}
@@ -68,6 +68,67 @@ func TestCacheKeysRejectOversizedIgnoreInputs(t *testing.T) {
 				t.Fatalf("oversized cache-key input error = %v, want size refusal", err)
 			}
 		})
+	}
+}
+
+func TestCaptureProviderCachePolicyBoundsAggregateInputs(t *testing.T) {
+	repo := t.TempDir()
+	comments := filepath.Join(repo, "comments.ignore")
+	if err := os.WriteFile(comments, bytes.Repeat([]byte("#\n"), maxIgnoreFileBytes/2), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tooManyBytes := ProviderSnapshotOptions{IgnoreFiles: []string{
+		comments, comments, comments, comments, comments,
+	}}
+	if _, err := CaptureProviderCachePolicy(repo, tooManyBytes); err == nil || !strings.Contains(err.Error(), "captured bytes") {
+		t.Fatalf("aggregate byte limit error = %v", err)
+	}
+
+	empty := filepath.Join(repo, "empty.ignore")
+	if err := os.WriteFile(empty, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tooManyInputs := ProviderSnapshotOptions{IgnoreFiles: make([]string, maxCapturedIgnoreInputs+1)}
+	for index := range tooManyInputs.IgnoreFiles {
+		tooManyInputs.IgnoreFiles[index] = empty
+	}
+	if _, err := CaptureProviderCachePolicy(repo, tooManyInputs); err == nil || !strings.Contains(err.Error(), "captured inputs") {
+		t.Fatalf("aggregate input limit error = %v", err)
+	}
+}
+
+func TestSearchCacheCaptureBudgetFallsBackToUncachedBuild(t *testing.T) {
+	repo := cacheTestRepo(t)
+	comments := filepath.Join(repo, "comments.ignore")
+	if err := os.WriteFile(comments, bytes.Repeat([]byte("#\n"), maxIgnoreFileBytes/2), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	options := ProviderSnapshotOptions{
+		Profile:     ProfileFull,
+		IgnoreFiles: []string{comments, comments, comments, comments, comments},
+	}
+	cacheDir := t.TempDir()
+	snapshot, hit, err := LoadOrBuildProviderSnapshot(t.Context(), repo, "test", options, cacheDir, false)
+	if err != nil {
+		t.Fatalf("optional cache changed valid uncached behavior: %v", err)
+	}
+	if hit {
+		t.Fatal("aggregate policy overflow unexpectedly produced a cache hit")
+	}
+	if !hasSymbolNamed(snapshot.Symbols, "Alpha") {
+		t.Fatal("uncached fallback omitted the repository snapshot")
+	}
+	response, err := SearchRepository(t.Context(), repo, "test", "Alpha", SearchOptions{
+		Profile:     ProfileFull,
+		TopK:        5,
+		CacheDir:    cacheDir,
+		IgnoreFiles: append([]string(nil), options.IgnoreFiles...),
+	})
+	if err != nil {
+		t.Fatalf("search cache capture changed valid uncached behavior: %v", err)
+	}
+	if len(response.Results) == 0 || response.Results[0].SymbolName != "Alpha" {
+		t.Fatalf("uncached search fallback lost Alpha: %#v", response.Results)
 	}
 }
 
@@ -140,7 +201,7 @@ func TestProviderRecordsKeyIncludesGraphIgnore(t *testing.T) {
 	repo := t.TempDir()
 	key := func() string {
 		t.Helper()
-		got, err := providerRecordsKey(repo, "repo", "version", "tree", "snapshot", ProviderSnapshotOptions{})
+		got, err := providerRecordsKey(repo, "repo", "version", "commit", "tree", "snapshot", ProviderSnapshotOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -162,45 +223,14 @@ func TestProviderRecordsKeyIncludesGraphIgnore(t *testing.T) {
 	}
 }
 
-func TestSearchSnapshotKeyIncludesWorktreeInfoExcludeStateAndContent(t *testing.T) {
+func TestSearchSnapshotKeyRejectsWorktree(t *testing.T) {
 	repo := t.TempDir()
-	key := func(options ProviderSnapshotOptions) string {
-		t.Helper()
-		got, err := searchSnapshotKey(repo, "repo", "version", "tree", options)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return got
-	}
-
-	worktreeOptions := ProviderSnapshotOptions{Worktree: true}
-	missing := key(worktreeOptions)
-	headMissing := key(ProviderSnapshotOptions{})
-	infoDir := filepath.Join(repo, ".git", "info")
-	if err := os.MkdirAll(infoDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	exclude := filepath.Join(infoDir, "exclude")
-	if err := os.WriteFile(exclude, nil, 0o600); err != nil {
-		t.Fatal(err)
-	}
-	presentEmpty := key(worktreeOptions)
-	if presentEmpty == missing {
-		t.Fatal("missing info/exclude collided with a present empty file")
-	}
-	if err := os.WriteFile(exclude, []byte("/dist/\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	presentContent := key(worktreeOptions)
-	if presentContent == presentEmpty {
-		t.Fatal("editing info/exclude did not invalidate the worktree key")
-	}
-	if headPresent := key(ProviderSnapshotOptions{}); headPresent != headMissing {
-		t.Fatal("committed-tree key changed for a worktree-only ignore input")
+	if _, err := searchSnapshotKey(repo, "repo", "version", "tree", ProviderSnapshotOptions{Worktree: true}); err == nil {
+		t.Fatal("working-tree snapshot received a persistent cache key")
 	}
 }
 
-func TestWorktreeSnapshotCacheInvalidatesForGitInfoExclude(t *testing.T) {
+func TestWorktreeSnapshotAppliesGitInfoExcludeWithoutCaching(t *testing.T) {
 	repo := cacheTestRepo(t)
 	cacheDir := t.TempDir()
 	options := ProviderSnapshotOptions{Worktree: true, Profile: ProfileFull, NoNetwork: true}
@@ -223,7 +253,6 @@ func TestWorktreeSnapshotCacheInvalidatesForGitInfoExclude(t *testing.T) {
 	if err := os.WriteFile(exclude, []byte("/app.go\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	InvalidateWorktreeCleanVerdicts()
 	second, hit, err := LoadOrBuildProviderSnapshot(t.Context(), repo, "test", options, cacheDir, false)
 	if err != nil {
 		t.Fatal(err)
@@ -235,15 +264,14 @@ func TestWorktreeSnapshotCacheInvalidatesForGitInfoExclude(t *testing.T) {
 		t.Fatal("snapshot retained a tracked file excluded by info/exclude")
 	}
 
-	InvalidateWorktreeCleanVerdicts()
 	third, hit, err := LoadOrBuildProviderSnapshot(t.Context(), repo, "test", options, cacheDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !hit {
-		t.Fatal("unchanged info/exclude did not reuse the rebuilt snapshot")
+	if hit {
+		t.Fatal("unchanged info/exclude made the worktree snapshot cacheable")
 	}
 	if hasSymbolNamed(third.Symbols, "Alpha") {
-		t.Fatal("warm rebuilt snapshot restored the excluded file")
+		t.Fatal("second rebuilt snapshot restored the excluded file")
 	}
 }

--- a/internal/sem/cache_ignore_inputs_test.go
+++ b/internal/sem/cache_ignore_inputs_test.go
@@ -1,0 +1,163 @@
+package sem
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type ignoreInputKeyer struct {
+	name string
+	key  func(ProviderSnapshotOptions) (string, error)
+}
+
+func ignoreInputKeyers(repo string) []ignoreInputKeyer {
+	return []ignoreInputKeyer{
+		{
+			name: "search snapshot",
+			key: func(options ProviderSnapshotOptions) (string, error) {
+				return searchSnapshotKey(repo, "repo", "version", "tree", options)
+			},
+		},
+		{
+			name: "provider records",
+			key: func(options ProviderSnapshotOptions) (string, error) {
+				return providerRecordsKey(repo, "repo", "version", "tree", "snapshot", options)
+			},
+		},
+	}
+}
+
+func TestCacheKeysRequireExplicitIgnoreInputs(t *testing.T) {
+	repo := t.TempDir()
+	inputs := []struct {
+		name    string
+		options ProviderSnapshotOptions
+	}{
+		{"ignore", ProviderSnapshotOptions{IgnoreFiles: []string{"missing.ignore"}}},
+		{"include", ProviderSnapshotOptions{IncludeFiles: []string{"missing.include"}}},
+	}
+	for _, input := range inputs {
+		for _, keyer := range ignoreInputKeyers(repo) {
+			t.Run(input.name+"/"+keyer.name, func(t *testing.T) {
+				_, err := keyer.key(input.options)
+				if err == nil {
+					t.Fatal("missing explicit input was treated as optional")
+				}
+				if !strings.Contains(err.Error(), "does not exist") {
+					t.Fatalf("error = %v, want required-input wording", err)
+				}
+			})
+		}
+	}
+}
+
+func TestCacheKeysRejectOversizedIgnoreInputs(t *testing.T) {
+	repo := t.TempDir()
+	ignore := filepath.Join(repo, "oversized.ignore")
+	if err := os.WriteFile(ignore, bytes.Repeat([]byte{'#'}, maxIgnoreFileBytes+1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	options := ProviderSnapshotOptions{IgnoreFiles: []string{ignore}}
+	for _, keyer := range ignoreInputKeyers(repo) {
+		t.Run(keyer.name, func(t *testing.T) {
+			_, err := keyer.key(options)
+			if err == nil || !strings.Contains(err.Error(), "exceeds") {
+				t.Fatalf("oversized cache-key input error = %v, want size refusal", err)
+			}
+		})
+	}
+}
+
+func TestCacheKeysDistinguishMissingGraphIgnoreFromMarkerContent(t *testing.T) {
+	repo := t.TempDir()
+	for _, keyer := range ignoreInputKeyers(repo) {
+		t.Run(keyer.name, func(t *testing.T) {
+			missing, err := keyer.key(ProviderSnapshotOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(repo, graphIgnoreFileName), []byte("missing"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			present, err := keyer.key(ProviderSnapshotOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if missing == present {
+				t.Fatal("absent .graphignore collided with a present file containing the old missing marker")
+			}
+			if err := os.Remove(filepath.Join(repo, graphIgnoreFileName)); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestCacheKeysFrameRawIgnoreContent(t *testing.T) {
+	repo := t.TempDir()
+	first := filepath.Join(repo, "first.ignore")
+	second := filepath.Join(repo, "second.ignore")
+	if err := os.WriteFile(second, []byte("right"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Under NUL-delimited, untyped framing these two inputs serialize identically:
+	// the one-file content can impersonate the delimiter, second path, delimiter,
+	// and second content of the two-file form.
+	crafted := append([]byte("left\x00"+filepath.Clean(second)+"\x00"), []byte("right")...)
+	if err := os.WriteFile(first, crafted, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	oneFile := ProviderSnapshotOptions{IgnoreFiles: []string{first}}
+
+	for _, keyer := range ignoreInputKeyers(repo) {
+		t.Run(keyer.name, func(t *testing.T) {
+			if err := os.WriteFile(first, crafted, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			oneKey, err := keyer.key(oneFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(first, []byte("left"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			twoKey, err := keyer.key(ProviderSnapshotOptions{IgnoreFiles: []string{first, second}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if oneKey == twoKey {
+				t.Fatal("raw NUL content crossed field boundaries in the cache key")
+			}
+		})
+	}
+}
+
+func TestProviderRecordsKeyIncludesGraphIgnore(t *testing.T) {
+	repo := t.TempDir()
+	key := func() string {
+		t.Helper()
+		got, err := providerRecordsKey(repo, "repo", "version", "tree", "snapshot", ProviderSnapshotOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return got
+	}
+	absent := key()
+	if err := os.WriteFile(filepath.Join(repo, graphIgnoreFileName), []byte("vendor/\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	present := key()
+	if absent == present {
+		t.Fatal("adding .graphignore did not invalidate provider records")
+	}
+	if err := os.WriteFile(filepath.Join(repo, graphIgnoreFileName), []byte("dist/\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if edited := key(); edited == present {
+		t.Fatal("editing .graphignore did not invalidate provider records")
+	}
+}

--- a/internal/sem/cache_key.go
+++ b/internal/sem/cache_key.go
@@ -1,0 +1,23 @@
+package sem
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+// writeCacheKeyField writes an unambiguous typed field. Both the tag and value
+// are length-prefixed, so attacker-controlled bytes (including NULs and bytes
+// that look like later fields) cannot cross a serialization boundary.
+func writeCacheKeyField(writer io.Writer, tag string, value []byte) {
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(tag)))
+	_, _ = writer.Write(length[:])
+	_, _ = io.WriteString(writer, tag)
+	binary.BigEndian.PutUint64(length[:], uint64(len(value)))
+	_, _ = writer.Write(length[:])
+	_, _ = writer.Write(value)
+}
+
+func writeCacheKeyString(writer io.Writer, tag, value string) {
+	writeCacheKeyField(writer, tag, []byte(value))
+}

--- a/internal/sem/cache_policy.go
+++ b/internal/sem/cache_policy.go
@@ -1,0 +1,260 @@
+package sem
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"path/filepath"
+)
+
+// capturedIgnoreFile is one immutable input to the ignore policy used by a
+// cache transaction. present distinguishes an absent optional .graphignore
+// from a present empty file; explicit files are always present.
+type capturedIgnoreFile struct {
+	path    string
+	content []byte
+	present bool
+}
+
+// capturedIgnorePolicy owns every working-tree policy byte that can shape a
+// committed snapshot. A cache transaction captures it once, then uses this
+// same value for key derivation and matcher construction even if the files on
+// disk change while Git is listing or reading the committed tree.
+type capturedIgnorePolicy struct {
+	absRepo      string
+	graphIgnore  capturedIgnoreFile
+	ignoreFiles  []capturedIgnoreFile
+	includeFiles []capturedIgnoreFile
+}
+
+const (
+	// Capturing cache policy retains raw input bytes until keying and snapshot
+	// construction finish. Bound both dimensions so repeated comment-only files
+	// cannot consume memory without reaching the matcher's parsed-rule ceiling.
+	maxCapturedIgnoreInputs = 128
+	maxCapturedIgnoreBytes  = 4 << 20
+)
+
+type ignorePolicyCaptureBudget struct {
+	inputs int
+	bytes  int
+}
+
+func (budget *ignorePolicyCaptureBudget) add(path string, content []byte) error {
+	if budget.inputs >= maxCapturedIgnoreInputs {
+		return fmt.Errorf("ignore policy exceeds %d captured inputs (at %q)", maxCapturedIgnoreInputs, path)
+	}
+	if len(content) > maxCapturedIgnoreBytes-budget.bytes {
+		return fmt.Errorf("ignore policy exceeds %d captured bytes (at %q)", maxCapturedIgnoreBytes, path)
+	}
+	budget.inputs++
+	budget.bytes += len(content)
+	return nil
+}
+
+// CaptureProviderCachePolicy freezes the bounded external ignore inputs in
+// options for one cache transaction. Carry the returned options through cache
+// lookup, snapshot construction, and cache storage; its policy bytes are not
+// read from disk again during that transaction.
+func CaptureProviderCachePolicy(repo string, options ProviderSnapshotOptions) (ProviderSnapshotOptions, error) {
+	if err := validateCapturedIgnoreInputCount(options.IgnoreFiles, options.IncludeFiles); err != nil {
+		return ProviderSnapshotOptions{}, err
+	}
+	options = cloneProviderSnapshotOptions(options)
+	if options.Profile == "" {
+		options.Profile = ProfileFull
+	}
+	// Freeze the resolved file limit alongside policy bytes. MaxFiles=0
+	// consults ENTIRE_GRAPH_MAX_FILES; resolving it once prevents an environment
+	// change from shaping the build differently from the already-derived key.
+	options.MaxFiles = resolveMaxSourceFiles(options.MaxFiles)
+	absRepo, err := filepath.Abs(repo)
+	if err != nil {
+		return ProviderSnapshotOptions{}, err
+	}
+	policy, err := captureIgnorePolicy(absRepo, options.IgnoreFiles, options.IncludeFiles)
+	if err != nil {
+		return ProviderSnapshotOptions{}, err
+	}
+	options.cachePolicy = policy
+	return options, nil
+}
+
+func validateCapturedIgnoreInputCount(ignoreFiles, includeFiles []string) error {
+	if len(ignoreFiles) > maxCapturedIgnoreInputs || len(includeFiles) > maxCapturedIgnoreInputs-len(ignoreFiles) {
+		return fmt.Errorf("ignore policy exceeds %d captured inputs", maxCapturedIgnoreInputs)
+	}
+	return nil
+}
+
+func cloneProviderSnapshotOptions(options ProviderSnapshotOptions) ProviderSnapshotOptions {
+	options.IgnoreFiles = append([]string(nil), options.IgnoreFiles...)
+	options.IncludeFiles = append([]string(nil), options.IncludeFiles...)
+	options.OnlyFiles = append([]string(nil), options.OnlyFiles...)
+	return options
+}
+
+func ensureProviderCachePolicy(repo string, options ProviderSnapshotOptions) (ProviderSnapshotOptions, error) {
+	if options.cachePolicy == nil {
+		return CaptureProviderCachePolicy(repo, options)
+	}
+	absRepo, err := filepath.Abs(repo)
+	if err != nil {
+		return ProviderSnapshotOptions{}, err
+	}
+	if err := options.cachePolicy.validate(absRepo, options.IgnoreFiles, options.IncludeFiles); err != nil {
+		return ProviderSnapshotOptions{}, err
+	}
+	return options, nil
+}
+
+func captureIgnorePolicy(absRepo string, ignoreFiles, includeFiles []string) (*capturedIgnorePolicy, error) {
+	policy := &capturedIgnorePolicy{absRepo: filepath.Clean(absRepo)}
+	budget := &ignorePolicyCaptureBudget{}
+	var err error
+	policy.ignoreFiles, err = captureExplicitIgnoreFiles(absRepo, ignoreFiles, false, budget)
+	if err != nil {
+		return nil, err
+	}
+	policy.includeFiles, err = captureExplicitIgnoreFiles(absRepo, includeFiles, true, budget)
+	if err != nil {
+		return nil, err
+	}
+	graphIgnorePath := filepath.Join(absRepo, graphIgnoreFileName)
+	content, present, err := readBoundedRegularFile(
+		graphIgnorePath,
+		ignoreFileLabel(false),
+		false,
+		maxIgnoreFileBytes,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if present {
+		if err := budget.add(graphIgnorePath, content); err != nil {
+			return nil, err
+		}
+	}
+	policy.graphIgnore = capturedIgnoreFile{
+		path:    graphIgnorePath,
+		content: content,
+		present: present,
+	}
+	return policy, nil
+}
+
+func captureExplicitIgnoreFiles(absRepo string, paths []string, includeMode bool, budget *ignorePolicyCaptureBudget) ([]capturedIgnoreFile, error) {
+	if len(paths) > maxCapturedIgnoreInputs-budget.inputs {
+		return nil, fmt.Errorf("ignore policy exceeds %d captured inputs", maxCapturedIgnoreInputs)
+	}
+	captured := make([]capturedIgnoreFile, 0, len(paths))
+	for _, rulePath := range paths {
+		resolved := resolveIgnorePath(absRepo, rulePath)
+		content, _, err := readBoundedRegularFile(
+			resolved,
+			ignoreFileLabel(includeMode),
+			true,
+			maxIgnoreFileBytes,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if err := budget.add(resolved, content); err != nil {
+			return nil, err
+		}
+		captured = append(captured, capturedIgnoreFile{
+			path:    resolved,
+			content: content,
+			present: true,
+		})
+	}
+	return captured, nil
+}
+
+func resolveIgnorePath(absRepo, rulePath string) string {
+	if !filepath.IsAbs(rulePath) {
+		rulePath = filepath.Join(absRepo, rulePath)
+	}
+	return filepath.Clean(rulePath)
+}
+
+func (policy *capturedIgnorePolicy) validate(absRepo string, ignoreFiles, includeFiles []string) error {
+	if policy == nil {
+		return fmt.Errorf("captured ignore policy is nil")
+	}
+	if filepath.Clean(absRepo) != policy.absRepo {
+		return fmt.Errorf("captured ignore policy belongs to repository %q, not %q", policy.absRepo, absRepo)
+	}
+	if !capturedIgnorePathsMatch(policy.ignoreFiles, absRepo, ignoreFiles) ||
+		!capturedIgnorePathsMatch(policy.includeFiles, absRepo, includeFiles) {
+		return fmt.Errorf("provider ignore/include paths changed after cache policy capture")
+	}
+	return nil
+}
+
+func capturedIgnorePathsMatch(captured []capturedIgnoreFile, absRepo string, paths []string) bool {
+	if len(captured) != len(paths) {
+		return false
+	}
+	for index, rulePath := range paths {
+		if captured[index].path != resolveIgnorePath(absRepo, rulePath) {
+			return false
+		}
+	}
+	return true
+}
+
+func cachePolicyForOptions(absRepo string, options ProviderSnapshotOptions) (*capturedIgnorePolicy, error) {
+	if options.cachePolicy != nil {
+		if err := options.cachePolicy.validate(absRepo, options.IgnoreFiles, options.IncludeFiles); err != nil {
+			return nil, err
+		}
+		return options.cachePolicy, nil
+	}
+	return captureIgnorePolicy(absRepo, options.IgnoreFiles, options.IncludeFiles)
+}
+
+func (policy *capturedIgnorePolicy) matcher() (ignoreMatcher, error) {
+	var matcher ignoreMatcher
+	if policy.graphIgnore.present {
+		if err := matcher.loadCaptured(policy.graphIgnore, false); err != nil {
+			return ignoreMatcher{}, err
+		}
+	}
+	matcher.loadBuiltinSecretRules()
+	for _, input := range policy.ignoreFiles {
+		if err := matcher.loadCaptured(input, false); err != nil {
+			return ignoreMatcher{}, err
+		}
+	}
+	for _, input := range policy.includeFiles {
+		if err := matcher.loadCaptured(input, true); err != nil {
+			return ignoreMatcher{}, err
+		}
+	}
+	return matcher, nil
+}
+
+func (matcher *ignoreMatcher) loadCaptured(input capturedIgnoreFile, includeMode bool) error {
+	if err := matcher.loadReader(bytes.NewReader(input.content), includeMode); err != nil {
+		return fmt.Errorf("read %s %q: %w", ignoreFileLabel(includeMode), input.path, err)
+	}
+	return nil
+}
+
+// writeCacheKey binds the ordered explicit files and the optional
+// .graphignore to a cache key without consulting the filesystem.
+func (policy *capturedIgnorePolicy) writeCacheKey(writer io.Writer) {
+	for groupIndex, group := range [][]capturedIgnoreFile{policy.ignoreFiles, policy.includeFiles} {
+		writeCacheKeyString(writer, "path-group", fmt.Sprintf("%d", groupIndex))
+		for _, input := range group {
+			writeCacheKeyString(writer, "rule-path", input.path)
+			writeCacheKeyField(writer, "rule-content", input.content)
+		}
+	}
+	if policy.graphIgnore.present {
+		writeCacheKeyField(writer, "graphignore-content", policy.graphIgnore.content)
+	} else {
+		writeCacheKeyField(writer, "graphignore-missing", nil)
+	}
+}

--- a/internal/sem/cache_secret_rules_test.go
+++ b/internal/sem/cache_secret_rules_test.go
@@ -83,10 +83,10 @@ func TestProviderRecordsCacheMissesEntryFromDifferentSecretRules(t *testing.T) {
 
 	// The pre-deny build: a taxonomy that denied nothing.
 	setBuiltinSecretPatterns(t, "")
-	if err := StoreProviderRecords(t.Context(), repo, "dev", "tree-1", "symbols", cacheDir, options, records, nil); err != nil {
+	if err := storeProviderRecordsForTest(t.Context(), repo, "dev", "tree-1", "symbols", cacheDir, options, records, nil); err != nil {
 		t.Fatalf("store records under the pre-deny taxonomy: %v", err)
 	}
-	control, _, hit, err := LoadProviderRecords(t.Context(), repo, "dev", "tree-1", "symbols", cacheDir, options)
+	control, _, hit, err := LoadProviderRecords(t.Context(), repo, "dev", "tree-1", "tree-1", "symbols", cacheDir, options)
 	if err != nil {
 		t.Fatalf("control load under the pre-deny taxonomy: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestProviderRecordsCacheMissesEntryFromDifferentSecretRules(t *testing.T) {
 	// This build, same repo, same provider version, same tree, same mode.
 	builtinSecretIgnorePatterns = livePatterns
 	builtinSecretIgnoreRules = liveRules
-	cached, _, hit, err := LoadProviderRecords(t.Context(), repo, "dev", "tree-1", "symbols", cacheDir, options)
+	cached, _, hit, err := LoadProviderRecords(t.Context(), repo, "dev", "tree-1", "tree-1", "symbols", cacheDir, options)
 	if err != nil {
 		t.Fatalf("load records under the live taxonomy: %v", err)
 	}
@@ -151,11 +151,11 @@ func TestProviderRecordsKeyBindsBuiltinSecretRules(t *testing.T) {
 	repo := t.TempDir()
 	options := ProviderSnapshotOptions{Profile: ProfileFull}
 
-	liveKey, err := providerRecordsKey(repo, "local/victim", "dev", "tree-1", "symbols", options)
+	liveKey, err := providerRecordsKey(repo, "local/victim", "dev", "commit-1", "tree-1", "symbols", options)
 	if err != nil {
 		t.Fatalf("live key: %v", err)
 	}
-	repeatKey, err := providerRecordsKey(repo, "local/victim", "dev", "tree-1", "symbols", options)
+	repeatKey, err := providerRecordsKey(repo, "local/victim", "dev", "commit-1", "tree-1", "symbols", options)
 	if err != nil {
 		t.Fatalf("repeat key: %v", err)
 	}
@@ -164,7 +164,7 @@ func TestProviderRecordsKeyBindsBuiltinSecretRules(t *testing.T) {
 	}
 
 	setBuiltinSecretPatterns(t, "")
-	priorKey, err := providerRecordsKey(repo, "local/victim", "dev", "tree-1", "symbols", options)
+	priorKey, err := providerRecordsKey(repo, "local/victim", "dev", "commit-1", "tree-1", "symbols", options)
 	if err != nil {
 		t.Fatalf("prior key: %v", err)
 	}
@@ -220,11 +220,11 @@ func TestProviderRecordsKeyBindsBuiltinSecretRuleSemantics(t *testing.T) {
 
 	restore := setBuiltinSecretPolicy(t, patterns, map[string]struct{}{"credentials": {}})
 	assertCredentialsDirectoryPolicy(t, false)
-	fileOnlyKey, err := providerRecordsKey(repo, "local/victim", "dev", "tree-1", "symbols", options)
+	fileOnlyKey, err := providerRecordsKey(repo, "local/victim", "dev", "commit-1", "tree-1", "symbols", options)
 	if err != nil {
 		t.Fatalf("file-only key: %v", err)
 	}
-	repeatKey, err := providerRecordsKey(repo, "local/victim", "dev", "tree-1", "symbols", options)
+	repeatKey, err := providerRecordsKey(repo, "local/victim", "dev", "commit-1", "tree-1", "symbols", options)
 	if err != nil {
 		t.Fatalf("repeat file-only key: %v", err)
 	}
@@ -235,7 +235,7 @@ func TestProviderRecordsKeyBindsBuiltinSecretRuleSemantics(t *testing.T) {
 
 	setBuiltinSecretPolicy(t, patterns, nil)
 	assertCredentialsDirectoryPolicy(t, true)
-	ordinaryKey, err := providerRecordsKey(repo, "local/victim", "dev", "tree-1", "symbols", options)
+	ordinaryKey, err := providerRecordsKey(repo, "local/victim", "dev", "commit-1", "tree-1", "symbols", options)
 	if err != nil {
 		t.Fatalf("ordinary Git-semantics key: %v", err)
 	}
@@ -261,10 +261,10 @@ func TestProviderRecordsCacheMissesEntryFromDifferentSecretRuleSemantics(t *test
 
 	restore := setBuiltinSecretPolicy(t, patterns, map[string]struct{}{"credentials": {}})
 	assertCredentialsDirectoryPolicy(t, false)
-	if err := StoreProviderRecords(t.Context(), repo, "dev", "tree-1", "symbols", cacheDir, options, records, nil); err != nil {
+	if err := storeProviderRecordsForTest(t.Context(), repo, "dev", "tree-1", "symbols", cacheDir, options, records, nil); err != nil {
 		t.Fatalf("store records under file-only policy: %v", err)
 	}
-	control, _, hit, err := LoadProviderRecords(t.Context(), repo, "dev", "tree-1", "symbols", cacheDir, options)
+	control, _, hit, err := LoadProviderRecords(t.Context(), repo, "dev", "tree-1", "tree-1", "symbols", cacheDir, options)
 	if err != nil {
 		t.Fatalf("control load under file-only policy: %v", err)
 	}
@@ -275,7 +275,7 @@ func TestProviderRecordsCacheMissesEntryFromDifferentSecretRuleSemantics(t *test
 
 	setBuiltinSecretPolicy(t, patterns, nil)
 	assertCredentialsDirectoryPolicy(t, true)
-	cached, _, hit, err := LoadProviderRecords(t.Context(), repo, "dev", "tree-1", "symbols", cacheDir, options)
+	cached, _, hit, err := LoadProviderRecords(t.Context(), repo, "dev", "tree-1", "tree-1", "symbols", cacheDir, options)
 	if err != nil {
 		t.Fatalf("load under ordinary Git semantics: %v", err)
 	}

--- a/internal/sem/dependents.go
+++ b/internal/sem/dependents.go
@@ -99,24 +99,50 @@ func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, nam
 		options.progress(0, len(files), "")
 	}
 
-	// One persistent `git cat-file --batch` process replaces a `git show`
+	// One persistent `git cat-file --batch` process replaces a one-shot Git
 	// subprocess per candidate file; on large repos the per-file spawn cost
-	// alone was tens of seconds. Falls back to per-file ShowFile only when the
-	// batch process cannot start at all.
+	// alone was tens of seconds. Paths the LF protocol cannot represent and a
+	// batch startup failure use the same bounded typed one-shot reader.
+	oneShotOversize := map[string]int64{}
 	readFile := func(path string) (string, bool, error) {
-		return gitutil.ShowFile(ctx, repo, head, path)
+		result, err := gitutil.ReadFileLimited(ctx, repo, head, path, defaultMaxParseBytes)
+		if err != nil {
+			return "", false, err
+		}
+		if result.Status == gitutil.LimitedFileOversize {
+			oneShotOversize[path] = result.Bytes
+		}
+		return result.Content, result.Status == gitutil.LimitedFileContent, nil
 	}
 	// oversizeBytes reports a file the reader declined because it exceeds the
 	// parse limit, so the scan can warn about it (below) without the read that
 	// would have cost the file's size twice for a file it refuses to parse anyway.
 	// Set for an oversized blob whose streamed bytes contained a changed name.
 	oversizeMatched := map[string]bool{}
-	oversizeBytes := func(string) (int64, bool) { return 0, false }
+	oversizeBytes := func(path string) (int64, bool) {
+		size, ok := oneShotOversize[path]
+		return size, ok
+	}
 	if batch, batchErr := gitutil.NewBatchFileReader(ctx, repo, head); batchErr == nil {
 		defer func() { _ = batch.Close() }()
 		batch.SetMaxBytes(defaultMaxParseBytes)
-		readFile = batch.ReadFile
+		readFile = func(path string) (string, bool, error) {
+			if !batch.IsPathSafe(path) {
+				result, err := gitutil.ReadFileLimited(ctx, repo, head, path, defaultMaxParseBytes)
+				if err != nil {
+					return "", false, err
+				}
+				if result.Status == gitutil.LimitedFileOversize {
+					oneShotOversize[path] = result.Bytes
+				}
+				return result.Content, result.Status == gitutil.LimitedFileContent, nil
+			}
+			return batch.ReadFile(path)
+		}
 		oversizeBytes = func(path string) (int64, bool) {
+			if size, ok := oneShotOversize[path]; ok {
+				return size, true
+			}
 			blob, ok := batch.OversizeBlob(path)
 			return blob.Bytes, ok
 		}
@@ -175,6 +201,9 @@ func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, nam
 			return nil, nil, err
 		}
 		if !ok {
+			// In a fallback full-tree scan, a one-shot unsafe oversize file has
+			// no streamed content evidence. Do not claim relevance merely from
+			// its size; the normal git-grep prefilter makes this rare path exact.
 			if size, oversize := oversizeBytes(path); oversize && (prefiltered || oversizeMatched[path]) {
 				warnings = append(warnings, dependentsFileTooLargeWarning(path, int(size)))
 			}

--- a/internal/sem/dependents.go
+++ b/internal/sem/dependents.go
@@ -85,7 +85,7 @@ func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, nam
 	}
 
 	overBudget := func() bool {
-		return !options.deadline.IsZero() && time.Now().After(options.deadline)
+		return !options.deadline.IsZero() && !time.Now().Before(options.deadline)
 	}
 	if overBudget() {
 		return index, []ProviderWarning{dependentsBudgetWarning(0, -1, options.budget)}, nil
@@ -102,25 +102,35 @@ func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, nam
 	// One persistent `git cat-file --batch` process replaces a one-shot Git
 	// subprocess per candidate file; on large repos the per-file spawn cost
 	// alone was tens of seconds. Paths the LF protocol cannot represent and a
-	// batch startup failure use the same bounded typed one-shot reader.
-	oneShotOversize := map[string]int64{}
-	readFile := func(path string) (string, bool, error) {
-		result, err := gitutil.ReadFileLimited(ctx, repo, head, path, defaultMaxParseBytes)
+	// batch startup failure share one bounded metadata reader, so exceptional
+	// deep paths cannot each reset the component-process allowance.
+	limited := gitutil.NewLimitedFileReader(ctx, repo, head, defaultMaxParseBytes)
+	limited.SetDeadline(options.deadline)
+	defer func() { _ = limited.Close() }()
+
+	limitedOversize := map[string]int64{}
+	limitedUnaddressable := map[string]bool{}
+	readLimitedFile := func(path string) (string, bool, error) {
+		result, err := limited.ReadFile(path)
 		if err != nil {
 			return "", false, err
 		}
 		if result.Status == gitutil.LimitedFileOversize {
-			oneShotOversize[path] = result.Bytes
+			limitedOversize[path] = result.Bytes
+		}
+		if result.Status == gitutil.LimitedFileUnaddressable {
+			limitedUnaddressable[path] = true
 		}
 		return result.Content, result.Status == gitutil.LimitedFileContent, nil
 	}
+	readFile := readLimitedFile
 	// oversizeBytes reports a file the reader declined because it exceeds the
 	// parse limit, so the scan can warn about it (below) without the read that
 	// would have cost the file's size twice for a file it refuses to parse anyway.
 	// Set for an oversized blob whose streamed bytes contained a changed name.
 	oversizeMatched := map[string]bool{}
 	oversizeBytes := func(path string) (int64, bool) {
-		size, ok := oneShotOversize[path]
+		size, ok := limitedOversize[path]
 		return size, ok
 	}
 	if batch, batchErr := gitutil.NewBatchFileReader(ctx, repo, head); batchErr == nil {
@@ -128,19 +138,12 @@ func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, nam
 		batch.SetMaxBytes(defaultMaxParseBytes)
 		readFile = func(path string) (string, bool, error) {
 			if !batch.IsPathSafe(path) {
-				result, err := gitutil.ReadFileLimited(ctx, repo, head, path, defaultMaxParseBytes)
-				if err != nil {
-					return "", false, err
-				}
-				if result.Status == gitutil.LimitedFileOversize {
-					oneShotOversize[path] = result.Bytes
-				}
-				return result.Content, result.Status == gitutil.LimitedFileContent, nil
+				return readLimitedFile(path)
 			}
 			return batch.ReadFile(path)
 		}
 		oversizeBytes = func(path string) (int64, bool) {
-			if size, ok := oneShotOversize[path]; ok {
+			if size, ok := limitedOversize[path]; ok {
 				return size, true
 			}
 			blob, ok := batch.OversizeBlob(path)
@@ -200,12 +203,22 @@ func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, nam
 		if err != nil {
 			return nil, nil, err
 		}
+		// A deep-path metadata read can consume the remaining budget. Stop
+		// immediately after it returns, before its deadline-driven
+		// Unaddressable result is mistaken for a file-read failure.
+		if overBudget() {
+			warnings = append(warnings, dependentsBudgetWarning(i, len(files), options.budget))
+			break
+		}
 		if !ok {
-			// In a fallback full-tree scan, a one-shot unsafe oversize file has
+			// In a fallback full-tree scan, an unsafe oversized file has
 			// no streamed content evidence. Do not claim relevance merely from
 			// its size; the normal git-grep prefilter makes this rare path exact.
 			if size, oversize := oversizeBytes(path); oversize && (prefiltered || oversizeMatched[path]) {
 				warnings = append(warnings, dependentsFileTooLargeWarning(path, int(size)))
+			}
+			if limitedUnaddressable[path] && prefiltered {
+				warnings = append(warnings, dependentsFileUnaddressableWarning(path))
 			}
 			continue
 		}
@@ -306,6 +319,20 @@ func dependentsFileTooLargeWarning(path string, size int) ProviderWarning {
 		FilePath:             path,
 		EffectOnCompleteness: "dependent references in this file were not counted because it exceeds max parser input",
 		Detail:               fmt.Sprintf("file is %d bytes, above max parser input %d bytes", size, defaultMaxParseBytes),
+	}
+}
+
+// dependentsFileUnaddressableWarning reports a known-relevant candidate whose
+// unusual path could not be resolved within the shared bounded metadata
+// traversal. On the full-tree grep fallback, relevance is unknown without the
+// content, so callers deliberately do not emit this warning.
+func dependentsFileUnaddressableWarning(path string) ProviderWarning {
+	return ProviderWarning{
+		Code:                 "E_FILE_READ",
+		Severity:             "error",
+		FilePath:             path,
+		EffectOnCompleteness: "dependent references in this file were not counted because its Git metadata could not be resolved",
+		Detail:               "path could not be resolved within bounded Git metadata traversal",
 	}
 }
 

--- a/internal/sem/dependents.go
+++ b/internal/sem/dependents.go
@@ -99,7 +99,7 @@ func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, nam
 		options.progress(0, len(files), "")
 	}
 
-	// One persistent `git cat-file --batch` process replaces a one-shot Git
+	// One persistent `git cat-file --batch-command` process replaces a one-shot Git
 	// subprocess per candidate file; on large repos the per-file spawn cost
 	// alone was tens of seconds. Paths the LF protocol cannot represent and a
 	// batch startup failure share one bounded metadata reader, so exceptional
@@ -137,7 +137,8 @@ func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, nam
 		size, ok := limitedOversize[path]
 		return size, ok
 	}
-	if batch, batchErr := gitutil.NewBatchFileReader(ctx, repo, head); batchErr == nil {
+	batch, batchErr := gitutil.NewBatchFileReader(ctx, repo, head)
+	if batchErr == nil {
 		defer func() { _ = batch.Close() }()
 		batch.SetMaxBytes(defaultMaxParseBytes)
 		readFile = func(path string) (string, bool, error) {
@@ -180,6 +181,32 @@ func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, nam
 			}
 			carry[path] = window
 		})
+	}
+
+	// Prime exactly the canonical, supported paths that will use the fallback,
+	// in candidate-list order. Without this pass, every LF-unsafe short path
+	// performs its own lazy ls-tree lookup even though LimitedFileReader can
+	// resolve up to 128 exact paths per bounded metadata subprocess. If the
+	// primary content batch failed to start, every readable candidate uses the
+	// same primed fallback instead.
+	limitedPaths := make([]string, 0, len(files))
+	for _, path := range files {
+		if !Supported(path) || !gitutil.IsCanonicalGitTreePath(path) {
+			continue
+		}
+		if batchErr != nil || !batch.IsPathSafe(path) {
+			limitedPaths = append(limitedPaths, path)
+		}
+	}
+	if err := limited.Prime(limitedPaths); err != nil {
+		return nil, nil, err
+	}
+	// A bounded metadata batch can consume the remaining analysis budget. Keep
+	// the existing semantics: stop before parsing and report one budget warning,
+	// rather than misclassifying deadline-driven component results as read errors.
+	if len(files) > 0 && overBudget() {
+		warnings = append(warnings, dependentsBudgetWarning(0, len(files), options.budget))
+		return index, warnings, nil
 	}
 
 	// When the grep prefilter ran, every file below already matched a changed

--- a/internal/sem/dependents.go
+++ b/internal/sem/dependents.go
@@ -109,6 +109,15 @@ func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, nam
 	defer func() { _ = limited.Close() }()
 
 	limitedOversize := map[string]int64{}
+	// limitedOversizeUnscanned records every oversized path whose size came
+	// from LimitedFileReader rather than the batch reader's oversize scanner
+	// below: LimitedFileReader has no content-scanning capability of its own,
+	// so oversizeMatched can never be populated for these paths. That used to
+	// silently read as "did not match" on the full-tree fallback (prefiltered
+	// == false), undercounting dependents for any line-unsafe or
+	// batch-ineligible oversized file that does contain a changed name. With
+	// no candidate evidence either way, warn rather than assume a miss.
+	limitedOversizeUnscanned := map[string]bool{}
 	limitedUnaddressable := map[string]bool{}
 	readLimitedFile := func(path string) (string, bool, error) {
 		if !gitutil.IsCanonicalGitTreePath(path) {
@@ -121,6 +130,7 @@ func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, nam
 		}
 		if result.Status == gitutil.LimitedFileOversize {
 			limitedOversize[path] = result.Bytes
+			limitedOversizeUnscanned[path] = true
 		}
 		if result.Status == gitutil.LimitedFileUnaddressable {
 			limitedUnaddressable[path] = true
@@ -242,13 +252,20 @@ func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, nam
 			break
 		}
 		if !ok {
-			// In a fallback full-tree scan, an unsafe oversized file has
-			// no streamed content evidence. Do not claim relevance merely from
-			// its size; the normal git-grep prefilter makes this rare path exact.
-			if size, oversize := oversizeBytes(path); oversize && (prefiltered || oversizeMatched[path]) {
+			// In a fallback full-tree scan, an unsafe oversized file has no
+			// streamed content evidence unless the batch reader's oversize
+			// scanner actually ran on it (oversizeMatched). A path the batch
+			// reader could not touch at all -- read through LimitedFileReader
+			// instead, tracked by limitedOversizeUnscanned -- has no candidate
+			// evidence in either direction, so it must warn rather than be
+			// silently assumed clean; the same applies to a path this scan
+			// cannot address at all. Both are rare, so this does not reopen
+			// the vendored-blob warning spam the isCandidate check above
+			// exists to avoid.
+			if size, oversize := oversizeBytes(path); oversize && (prefiltered || oversizeMatched[path] || limitedOversizeUnscanned[path]) {
 				warnings = append(warnings, dependentsFileTooLargeWarning(path, int(size)))
 			}
-			if limitedUnaddressable[path] && prefiltered {
+			if limitedUnaddressable[path] {
 				warnings = append(warnings, dependentsFileUnaddressableWarning(path))
 			}
 			continue
@@ -353,10 +370,12 @@ func dependentsFileTooLargeWarning(path string, size int) ProviderWarning {
 	}
 }
 
-// dependentsFileUnaddressableWarning reports a known-relevant candidate whose
-// unusual path could not be resolved within the shared bounded metadata
-// traversal. On the full-tree grep fallback, relevance is unknown without the
-// content, so callers deliberately do not emit this warning.
+// dependentsFileUnaddressableWarning reports a candidate whose unusual path
+// could not be resolved within the shared bounded metadata traversal. Its
+// content is never available by definition, so relevance can never be
+// confirmed OR ruled out on the full-tree grep fallback either; callers emit
+// this warning unconditionally rather than silently undercounting
+// dependents_count for a path that might have been relevant.
 func dependentsFileUnaddressableWarning(path string) ProviderWarning {
 	return ProviderWarning{
 		Code:                 "E_FILE_READ",

--- a/internal/sem/dependents.go
+++ b/internal/sem/dependents.go
@@ -119,6 +119,7 @@ func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, nam
 	// no candidate evidence either way, warn rather than assume a miss.
 	limitedOversizeUnscanned := map[string]bool{}
 	limitedUnaddressable := map[string]bool{}
+	limitedUnavailable := map[string]gitutil.LimitedFileStatus{}
 	readLimitedFile := func(path string) (string, bool, error) {
 		if !gitutil.IsCanonicalGitTreePath(path) {
 			limitedUnaddressable[path] = true
@@ -134,6 +135,10 @@ func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, nam
 		}
 		if result.Status == gitutil.LimitedFileUnaddressable {
 			limitedUnaddressable[path] = true
+		}
+		switch result.Status {
+		case gitutil.LimitedFileMissing, gitutil.LimitedFileNonBlob, gitutil.LimitedFileUnreadable:
+			limitedUnavailable[path] = result.Status
 		}
 		return result.Content, result.Status == gitutil.LimitedFileContent, nil
 	}
@@ -155,7 +160,16 @@ func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, nam
 			if !gitutil.IsCanonicalGitTreePath(path) || !batch.IsPathSafe(path) {
 				return readLimitedFile(path)
 			}
-			return batch.ReadFile(path)
+			content, ok, err := batch.ReadFile(path)
+			if err == nil && !ok {
+				if _, oversize := batch.OversizeBlob(path); !oversize {
+					// Git grep already proved a prefiltered path existed and
+					// matched. A later missing/non-blob batch response means the
+					// promised blob became unavailable between discovery and read.
+					limitedUnavailable[path] = gitutil.LimitedFileUnreadable
+				}
+			}
+			return content, ok, err
 		}
 		oversizeBytes = func(path string) (int64, bool) {
 			if size, ok := limitedOversize[path]; ok {
@@ -267,6 +281,9 @@ func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, nam
 			}
 			if limitedUnaddressable[path] {
 				warnings = append(warnings, dependentsFileUnaddressableWarning(path))
+			}
+			if status, unavailable := limitedUnavailable[path]; unavailable && prefiltered {
+				warnings = append(warnings, dependentsFileUnavailableWarning(path, status))
 			}
 			continue
 		}
@@ -383,6 +400,22 @@ func dependentsFileUnaddressableWarning(path string) ProviderWarning {
 		FilePath:             path,
 		EffectOnCompleteness: "dependent references in this file were not counted because its Git metadata could not be resolved",
 		Detail:               "path could not be resolved within bounded Git metadata traversal",
+	}
+}
+
+func dependentsFileUnavailableWarning(path string, status gitutil.LimitedFileStatus) ProviderWarning {
+	detail := "file matched during dependent discovery but its Git blob was unavailable when content was read"
+	if status == gitutil.LimitedFileNonBlob {
+		detail = "file matched during dependent discovery but its tree entry was no longer a blob when content was read"
+	} else if status == gitutil.LimitedFileMissing {
+		detail = "file matched during dependent discovery but its tree entry was missing when content was read"
+	}
+	return ProviderWarning{
+		Code:                 "E_FILE_READ",
+		Severity:             "error",
+		FilePath:             path,
+		EffectOnCompleteness: "dependent references in this file were not counted because its Git content became unavailable after discovery",
+		Detail:               detail,
 	}
 }
 

--- a/internal/sem/dependents.go
+++ b/internal/sem/dependents.go
@@ -275,14 +275,16 @@ func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, nam
 			// silently assumed clean; the same applies to a path this scan
 			// cannot address at all. Both are rare, so this does not reopen
 			// the vendored-blob warning spam the isCandidate check above
-			// exists to avoid.
+			// exists to avoid. Unavailable content has the same uncertainty: on a
+			// full-tree fallback there is no sound way to prove the unreadable file
+			// did not contain a changed name, so it is always disclosed too.
 			if size, oversize := oversizeBytes(path); oversize && (prefiltered || oversizeMatched[path] || limitedOversizeUnscanned[path]) {
 				warnings = append(warnings, dependentsFileTooLargeWarning(path, int(size)))
 			}
 			if limitedUnaddressable[path] {
 				warnings = append(warnings, dependentsFileUnaddressableWarning(path))
 			}
-			if status, unavailable := limitedUnavailable[path]; unavailable && prefiltered {
+			if status, unavailable := limitedUnavailable[path]; unavailable {
 				warnings = append(warnings, dependentsFileUnavailableWarning(path, status))
 			}
 			continue
@@ -404,17 +406,17 @@ func dependentsFileUnaddressableWarning(path string) ProviderWarning {
 }
 
 func dependentsFileUnavailableWarning(path string, status gitutil.LimitedFileStatus) ProviderWarning {
-	detail := "file matched during dependent discovery but its Git blob was unavailable when content was read"
+	detail := "the tree entry identifies a blob, but its Git content was unavailable during dependent analysis"
 	if status == gitutil.LimitedFileNonBlob {
-		detail = "file matched during dependent discovery but its tree entry was no longer a blob when content was read"
+		detail = "the tree entry was not a blob when dependent content was read"
 	} else if status == gitutil.LimitedFileMissing {
-		detail = "file matched during dependent discovery but its tree entry was missing when content was read"
+		detail = "the tree entry was missing when dependent content was read"
 	}
 	return ProviderWarning{
 		Code:                 "E_FILE_READ",
 		Severity:             "error",
 		FilePath:             path,
-		EffectOnCompleteness: "dependent references in this file were not counted because its Git content became unavailable after discovery",
+		EffectOnCompleteness: "dependent references in this file were not counted because its Git content was unavailable",
 		Detail:               detail,
 	}
 }
@@ -442,8 +444,8 @@ func dependentsParseFailureWarning(path string, status ParseStatus) ProviderWarn
 
 // grepFallbackWarning is surfaced once when the git-grep prefilter itself
 // fails and referenceCandidateFiles falls back to scanning every file in the
-// tree. The fallback keeps dependent counts correct, but it is far slower
-// than the prefiltered path, so callers should know it happened.
+// tree. This avoids trusting partial grep stdout; per-file warnings separately
+// disclose any content the fallback itself cannot read.
 func grepFallbackWarning(err error) ProviderWarning {
 	return ProviderWarning{
 		Code:                 "W_DEPENDENTS_PREFILTER_FAILED",

--- a/internal/sem/dependents.go
+++ b/internal/sem/dependents.go
@@ -111,6 +111,10 @@ func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, nam
 	limitedOversize := map[string]int64{}
 	limitedUnaddressable := map[string]bool{}
 	readLimitedFile := func(path string) (string, bool, error) {
+		if !gitutil.IsCanonicalGitTreePath(path) {
+			limitedUnaddressable[path] = true
+			return "", false, nil
+		}
 		result, err := limited.ReadFile(path)
 		if err != nil {
 			return "", false, err
@@ -137,7 +141,7 @@ func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, nam
 		defer func() { _ = batch.Close() }()
 		batch.SetMaxBytes(defaultMaxParseBytes)
 		readFile = func(path string) (string, bool, error) {
-			if !batch.IsPathSafe(path) {
+			if !gitutil.IsCanonicalGitTreePath(path) || !batch.IsPathSafe(path) {
 				return readLimitedFile(path)
 			}
 			return batch.ReadFile(path)

--- a/internal/sem/dependents_test.go
+++ b/internal/sem/dependents_test.go
@@ -3,7 +3,10 @@ package sem
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -535,6 +538,79 @@ func TestBuildReferenceIndexSharesDeepPathMetadataAllowance(t *testing.T) {
 	}
 	if unaddressable[0].EffectOnCompleteness == "" {
 		t.Fatalf("bounded metadata warning must explain partial dependents: %#v", unaddressable[0])
+	}
+}
+
+// Every newline-bearing candidate is unsafe for cat-file's LF request
+// protocol. Prime must batch their exact metadata before the scan; otherwise
+// each lazy fallback starts its own ls-tree process and the scan cost grows
+// linearly with the candidate count.
+func TestBuildReferenceIndexBatchesLineUnsafeMetadata(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the Git wrapper is a POSIX shell script")
+	}
+	repo := t.TempDir()
+	git(t, repo, "init")
+	const fileCount = 200
+	files := make([]deepDependentFile, fileCount)
+	for i := range files {
+		files[i] = deepDependentFile{
+			path:    fmt.Sprintf("unsafe\ncaller_%03d.py", i),
+			content: fmt.Sprintf("def caller_%03d():\n    return Foo()\n", i),
+		}
+	}
+	head := importDeepDependentFiles(t, repo, files)
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrapperDir := t.TempDir()
+	lsTreeLog := filepath.Join(wrapperDir, "ls-tree.log")
+	wrapper := filepath.Join(wrapperDir, "git")
+	script := `#!/bin/sh
+for arg do
+	if [ "$arg" = "ls-tree" ]; then
+		printf 'ls-tree\n' >> "$LS_TREE_LOG"
+		break
+	fi
+done
+exec "$REAL_GIT" "$@"
+`
+	if err := os.WriteFile(wrapper, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("REAL_GIT", realGit)
+	t.Setenv("LS_TREE_LOG", lsTreeLog)
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	index, warnings, err := buildReferenceIndexWithProgress(
+		ctx,
+		repo,
+		head,
+		map[string]struct{}{"Foo": {}},
+		dependentsScanOptions{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("line-unsafe dependents scan exceeded safety timeout: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("line-unsafe dependents warnings = %#v, want none", warnings)
+	}
+	if got := len(index["Foo"]); got != fileCount {
+		t.Fatalf("line-unsafe dependents = %d, want %d", got, fileCount)
+	}
+	log, err := os.ReadFile(lsTreeLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.Count(string(log), "ls-tree\n"), 2; got != want {
+		t.Fatalf("ls-tree metadata subprocesses = %d, want %d bounded batches", got, want)
 	}
 }
 

--- a/internal/sem/dependents_test.go
+++ b/internal/sem/dependents_test.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -451,35 +450,56 @@ type deepDependentFile struct {
 	content string
 }
 
-// importDeepDependentFiles uses Git's object protocol instead of the
-// filesystem, whose native path limits are far below the adversarial Git tree
-// paths these tests need to exercise.
+// importDeepDependentFiles builds the tree one component at a time. No Git
+// command receives the complete adversarial path: besides avoiding filesystem
+// limits, that keeps the fixture valid on Git for Windows, whose fast-import
+// path parser rejects names this deep even though the object format permits
+// them.
 func importDeepDependentFiles(t *testing.T, repo string, files []deepDependentFile) string {
 	t.Helper()
-	var input strings.Builder
-	for i, file := range files {
-		mark := i + 1
-		fmt.Fprintf(&input, "blob\nmark :%d\ndata %d\n%s\n", mark, len(file.content), file.content)
+	var rootInput strings.Builder
+	for _, file := range files {
+		components := strings.Split(file.path, "/")
+		blob := gitObjectInputOutput(t, repo, file.content, "hash-object", "-w", "--stdin")
+		tree := gitObjectInputOutput(
+			t,
+			repo,
+			fmt.Sprintf("100644 blob %s\t%s%c", blob, components[len(components)-1], byte(0)),
+			"mktree", "-z",
+		)
+		for i := len(components) - 2; i >= 1; i-- {
+			tree = gitObjectInputOutput(
+				t,
+				repo,
+				fmt.Sprintf("040000 tree %s\t%s%c", tree, components[i], byte(0)),
+				"mktree", "-z",
+			)
+		}
+		fmt.Fprintf(&rootInput, "040000 tree %s\t%s%c", tree, components[0], byte(0))
 	}
-	message := "deep dependents"
-	commitMark := len(files) + 1
-	fmt.Fprintf(&input, "commit refs/heads/deep-dependents\nmark :%d\n", commitMark)
-	fmt.Fprint(&input, "committer Test <test@example.com> 1 +0000\n")
-	fmt.Fprintf(&input, "data %d\n%s\n", len(message), message)
-	for i, file := range files {
-		// strconv.Quote emits the C-style quoted path form fast-import uses,
-		// preserving the newline that makes the cat-file batch protocol unsafe.
-		fmt.Fprintf(&input, "M 100644 :%d %s\n", i+1, strconv.Quote(file.path))
-	}
-	input.WriteByte('\n')
+	root := gitObjectInputOutput(t, repo, rootInput.String(), "mktree", "-z")
+	commit := gitObjectInputOutput(
+		t,
+		repo,
+		"",
+		"-c", "user.name=Entire Graph Test",
+		"-c", "user.email=graph@example.com",
+		"commit-tree", root, "-m", "deep dependents",
+	)
+	git(t, repo, "update-ref", "refs/heads/deep-dependents", commit)
+	return commit
+}
 
-	cmd := exec.Command("git", "fast-import", "--quiet")
+func gitObjectInputOutput(t *testing.T, repo, input string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
 	cmd.Dir = repo
-	cmd.Stdin = strings.NewReader(input.String())
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("git fast-import deep dependents: %v\n%s", err, out)
+	cmd.Stdin = strings.NewReader(input)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
 	}
-	return rev(t, repo, "refs/heads/deep-dependents")
+	return strings.TrimSpace(string(out))
 }
 
 func repeatedDeepUnsafePath(branch, depth, componentBytes int) string {

--- a/internal/sem/dependents_test.go
+++ b/internal/sem/dependents_test.go
@@ -305,6 +305,58 @@ func TestBuildReferenceIndexFallbackWarnsOnlyForCandidateFiles(t *testing.T) {
 	}
 }
 
+// TestBuildReferenceIndexFallbackWarnsForLineUnsafeOversizedCandidate
+// reproduces the dependents.go:248 finding: a candidate whose path the batch
+// reader's IsPathSafe rejects (here, an embedded newline) is read through
+// LimitedFileReader instead, which has no content-scanning capability of its
+// own, so oversizeMatched can never be populated for it. On the full-tree
+// fallback (git-grep failed, prefiltered == false) that used to read as "did
+// not match" and silently drop the E_FILE_TOO_LARGE warning even though the
+// file does contain a changed name, undercounting dependents_count with
+// nothing in Result.Warnings to show for it. With no candidate evidence
+// either way, it must warn.
+func TestBuildReferenceIndexFallbackWarnsForLineUnsafeOversizedCandidate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("embedded-newline paths are not representable in a Windows working tree")
+	}
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+
+	// importDeepDependentFiles treats a single path component as both the
+	// containing tree's name and the blob's own name, so a genuinely flat
+	// path needs a directory component to avoid an unrelated self-nesting
+	// quirk in the fixture builder.
+	const unsafePath = "d/unsafe\ncaller.py"
+	head := importDeepDependentFiles(t, repo, []deepDependentFile{{
+		path:    unsafePath,
+		content: paddedPythonSource("unsafe_caller", "Foo", defaultMaxParseBytes+4096),
+	}})
+
+	// The NUL byte forces the grep prefilter to fail, exactly as in
+	// TestBuildReferenceIndexFallbackWarnsOnlyForCandidateFiles, so
+	// buildReferenceIndex takes the full-tree fallback.
+	names := map[string]struct{}{
+		"Foo":         {},
+		"poison\x00x": {},
+	}
+	_, warnings, err := buildReferenceIndex(context.Background(), repo, head, names)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sawTooLarge := false
+	for _, warning := range warnings {
+		if warning.Code == "E_FILE_TOO_LARGE" && warning.FilePath == unsafePath {
+			sawTooLarge = true
+		}
+	}
+	if !sawTooLarge {
+		t.Fatalf("expected E_FILE_TOO_LARGE for the line-unsafe oversized candidate, got %#v", warnings)
+	}
+}
+
 // pfBrokenCallsFooTS is a hard tree-sitter parse failure (mirrors
 // analyze_parsefailure_test.go's pfBrokenTS trick: a malformed leading type
 // alias derails the whole parse) that also contains a whole-token match for

--- a/internal/sem/dependents_test.go
+++ b/internal/sem/dependents_test.go
@@ -168,6 +168,79 @@ exec "$REAL_GIT" "$@"
 	}
 }
 
+func TestBuildReferenceIndexWarnsWhenPromisedBlobIsMissingBeforePrefilter(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+
+	authBase := gitObjectInputOutput(t, repo, "def Foo():\n    return 1\n", "hash-object", "-w", "--stdin")
+	authHead := gitObjectInputOutput(t, repo, "def Foo():\n    return 2\n", "hash-object", "-w", "--stdin")
+	missingCaller := gitObjectInputOutput(t, repo, "def missing_caller():\n    return Foo()\n", "hash-object", "-w", "--stdin")
+	readableCaller := gitObjectInputOutput(t, repo, "def readable_caller():\n    return Foo()\n", "hash-object", "-w", "--stdin")
+	treeInput := func(auth string) string {
+		return fmt.Sprintf(
+			"100644 blob %s\tauth.py%c100644 blob %s\tmissing.py%c100644 blob %s\treadable.py%c",
+			auth, byte(0), missingCaller, byte(0), readableCaller, byte(0),
+		)
+	}
+	baseTree := gitObjectInputOutput(t, repo, treeInput(authBase), "mktree", "-z")
+	base := gitObjectInputOutput(
+		t, repo, "", "-c", "user.name=Entire Graph Test", "-c", "user.email=graph@example.com",
+		"commit-tree", baseTree, "-m", "base",
+	)
+	headTree := gitObjectInputOutput(t, repo, treeInput(authHead), "mktree", "-z")
+	head := gitObjectInputOutput(
+		t, repo, "", "-c", "user.name=Entire Graph Test", "-c", "user.email=graph@example.com",
+		"commit-tree", headTree, "-p", base, "-m", "head",
+	)
+	git(t, repo, "update-ref", "refs/heads/main", head)
+	git(t, repo, "config", "extensions.partialClone", "origin")
+	git(t, repo, "config", "remote.origin.promisor", "true")
+	git(t, repo, "config", "remote.origin.partialclonefilter", "blob:none")
+
+	objectPath := filepath.Join(repo, ".git", "objects", missingCaller[:2], missingCaller[2:])
+	if err := os.Remove(objectPath); err != nil {
+		t.Fatalf("remove promised caller blob: %v", err)
+	}
+	assertMissing := func(stage string) {
+		t.Helper()
+		cmd := exec.Command("git", "cat-file", "-e", missingCaller)
+		cmd.Dir = repo
+		cmd.Env = append(cmd.Environ(), "GIT_NO_LAZY_FETCH=1", "GIT_ALLOW_PROTOCOL=")
+		if err := cmd.Run(); err == nil {
+			t.Fatalf("%s: promised caller blob unexpectedly exists", stage)
+		}
+	}
+	assertMissing("before dependent scan")
+
+	index, warnings, err := buildReferenceIndex(t.Context(), repo, head, map[string]struct{}{"Foo": {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertMissing("after dependent scan")
+	if _, ok := index["Foo"]["readable.py#function:readable_caller"]; !ok {
+		t.Fatalf("readable sibling dependent was not counted: %#v", index["Foo"])
+	}
+	if _, ok := index["Foo"]["missing.py#function:missing_caller"]; ok {
+		t.Fatalf("missing promised dependent was unexpectedly counted: %#v", index["Foo"])
+	}
+
+	var fallbackWarnings, missingWarnings []ProviderWarning
+	for _, warning := range warnings {
+		if warning.Code == "W_DEPENDENTS_PREFILTER_FAILED" {
+			fallbackWarnings = append(fallbackWarnings, warning)
+		}
+		if warning.Code == "E_FILE_READ" && warning.FilePath == "missing.py" {
+			missingWarnings = append(missingWarnings, warning)
+		}
+	}
+	if len(fallbackWarnings) != 1 || len(missingWarnings) != 1 {
+		t.Fatalf("promised missing blob warnings = %#v, want one prefilter and one file-read warning", warnings)
+	}
+	if !strings.Contains(missingWarnings[0].EffectOnCompleteness, "not counted") {
+		t.Fatalf("missing blob warning does not disclose undercount: %#v", missingWarnings[0])
+	}
+}
+
 // TestBuildReferenceIndexEmptyNamesDoesNoWork pins that an empty names map
 // short-circuits before any git call is made -- passing a repo path that
 // does not exist must not surface an error, because buildReferenceIndex
@@ -380,9 +453,6 @@ func TestBuildReferenceIndexFallbackWarnsOnlyForCandidateFiles(t *testing.T) {
 // nothing in Result.Warnings to show for it. With no candidate evidence
 // either way, it must warn.
 func TestBuildReferenceIndexFallbackWarnsForLineUnsafeOversizedCandidate(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("embedded-newline paths are not representable in a Windows working tree")
-	}
 	repo := t.TempDir()
 	git(t, repo, "init")
 	git(t, repo, "config", "user.name", "Entire Graph Test")
@@ -410,14 +480,17 @@ func TestBuildReferenceIndexFallbackWarnsForLineUnsafeOversizedCandidate(t *test
 		t.Fatal(err)
 	}
 
-	sawTooLarge := false
+	var fallbackCount, tooLargeCount int
 	for _, warning := range warnings {
+		if warning.Code == "W_DEPENDENTS_PREFILTER_FAILED" {
+			fallbackCount++
+		}
 		if warning.Code == "E_FILE_TOO_LARGE" && warning.FilePath == unsafePath {
-			sawTooLarge = true
+			tooLargeCount++
 		}
 	}
-	if !sawTooLarge {
-		t.Fatalf("expected E_FILE_TOO_LARGE for the line-unsafe oversized candidate, got %#v", warnings)
+	if fallbackCount != 1 || tooLargeCount != 1 || len(warnings) != 2 {
+		t.Fatalf("warnings = %#v, want exactly one prefilter warning and one E_FILE_TOO_LARGE for the line-unsafe candidate", warnings)
 	}
 }
 

--- a/internal/sem/dependents_test.go
+++ b/internal/sem/dependents_test.go
@@ -867,7 +867,7 @@ func TestHeadReadersShareDeepUnsafeMetadataAllowance(t *testing.T) {
 		}
 	}
 
-	readSearch, closeSearch, err := openSearchContentReader(ctx, repo, head, true, nil, nil)
+	readSearch, closeSearch, err := openSearchContentReader(ctx, repo, head, true, nil, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sem/dependents_test.go
+++ b/internal/sem/dependents_test.go
@@ -104,6 +104,70 @@ func TestBuildReferenceIndexCaseSensitiveWholeToken(t *testing.T) {
 	}
 }
 
+func TestBuildReferenceIndexWarnsWhenPrefilteredBlobDisappears(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the Git wrapper is a POSIX shell script")
+	}
+	repo, head := newDependentsTestRepo(t)
+	objectID := rev(t, repo, head+":caller_one.py")
+	objectPath := filepath.Join(repo, ".git", "objects", objectID[:2], objectID[2:])
+	if _, err := os.Stat(objectPath); err != nil {
+		t.Fatalf("locate loose candidate blob: %v", err)
+	}
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrapperDir := t.TempDir()
+	wrapper := filepath.Join(wrapperDir, "git")
+	script := `#!/bin/sh
+for arg do
+	if [ "$arg" = "grep" ]; then
+		"$REAL_GIT" "$@"
+		status=$?
+		if [ "$status" -eq 0 ]; then
+			unlink "$DELETE_OBJECT"
+		fi
+		exit "$status"
+	fi
+done
+exec "$REAL_GIT" "$@"
+`
+	if err := os.WriteFile(wrapper, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("REAL_GIT", realGit)
+	t.Setenv("DELETE_OBJECT", objectPath)
+	t.Setenv("PATH", wrapperDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	index, warnings, err := buildReferenceIndex(context.Background(), repo, head, map[string]struct{}{"Foo": {}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, counted := index["Foo"]["caller_one.py#function:check"]; counted {
+		t.Fatalf("dependent was counted after its blob disappeared: %#v", index["Foo"])
+	}
+	if _, counted := index["Foo"]["caller_two.py#function:check_again"]; !counted {
+		t.Fatalf("readable dependent disappeared beside the missing blob: %#v", index["Foo"])
+	}
+	var fileWarnings []ProviderWarning
+	for _, warning := range warnings {
+		if warning.FilePath == "caller_one.py" {
+			fileWarnings = append(fileWarnings, warning)
+		}
+	}
+	if len(fileWarnings) != 1 {
+		t.Fatalf("missing blob after dependent prefilter warnings = %#v, want exactly one", fileWarnings)
+	}
+	warning := fileWarnings[0]
+	if warning.Code != "E_FILE_READ" || warning.Severity != "error" ||
+		!strings.Contains(warning.Detail, "unavailable") ||
+		!strings.Contains(warning.EffectOnCompleteness, "not counted") {
+		t.Fatalf("missing blob warning = %#v, want exact E_FILE_READ completeness disclosure", warning)
+	}
+}
+
 // TestBuildReferenceIndexEmptyNamesDoesNoWork pins that an empty names map
 // short-circuits before any git call is made -- passing a repo path that
 // does not exist must not surface an error, because buildReferenceIndex

--- a/internal/sem/dependents_test.go
+++ b/internal/sem/dependents_test.go
@@ -2,6 +2,9 @@ package sem
 
 import (
 	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -437,6 +440,166 @@ func TestAddDependentCountsBudgetExpiredWarnsAndKeepsResult(t *testing.T) {
 	}
 	if got := result.Files[0].Changes[0].DependentsCount; got != 0 {
 		t.Fatalf("dependents count under expired budget = %d, want 0", got)
+	}
+}
+
+type deepDependentFile struct {
+	path    string
+	content string
+}
+
+// importDeepDependentFiles uses Git's object protocol instead of the
+// filesystem, whose native path limits are far below the adversarial Git tree
+// paths these tests need to exercise.
+func importDeepDependentFiles(t *testing.T, repo string, files []deepDependentFile) string {
+	t.Helper()
+	var input strings.Builder
+	for i, file := range files {
+		mark := i + 1
+		fmt.Fprintf(&input, "blob\nmark :%d\ndata %d\n%s\n", mark, len(file.content), file.content)
+	}
+	message := "deep dependents"
+	commitMark := len(files) + 1
+	fmt.Fprintf(&input, "commit refs/heads/deep-dependents\nmark :%d\n", commitMark)
+	fmt.Fprint(&input, "committer Test <test@example.com> 1 +0000\n")
+	fmt.Fprintf(&input, "data %d\n%s\n", len(message), message)
+	for i, file := range files {
+		// strconv.Quote emits the C-style quoted path form fast-import uses,
+		// preserving the newline that makes the cat-file batch protocol unsafe.
+		fmt.Fprintf(&input, "M 100644 :%d %s\n", i+1, strconv.Quote(file.path))
+	}
+	input.WriteByte('\n')
+
+	cmd := exec.Command("git", "fast-import", "--quiet")
+	cmd.Dir = repo
+	cmd.Stdin = strings.NewReader(input.String())
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git fast-import deep dependents: %v\n%s", err, out)
+	}
+	return rev(t, repo, "refs/heads/deep-dependents")
+}
+
+func repeatedDeepUnsafePath(branch, depth, componentBytes int) string {
+	component := strings.Repeat(string(rune('a'+branch)), componentBytes)
+	components := make([]string, depth, depth+1)
+	for i := range components {
+		components[i] = component
+	}
+	components = append(components, fmt.Sprintf("unsafe\ncaller_%d.py", branch))
+	return strings.Join(components, "/")
+}
+
+// TestBuildReferenceIndexSharesDeepPathMetadataAllowance proves that unsafe
+// dependent paths use one LimitedFileReader. Four independent 81-component
+// paths need 324 metadata subprocesses in total; the shared allowance resolves
+// three, then reports the known-relevant remainder as partial. The previous
+// per-file ReadFileLimited fallback reset the allowance four times and read all
+// four paths.
+func TestBuildReferenceIndexSharesDeepPathMetadataAllowance(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+
+	files := make([]deepDependentFile, 4)
+	for i := range files {
+		files[i] = deepDependentFile{
+			path:    repeatedDeepUnsafePath(i, 80, 200),
+			content: fmt.Sprintf("def caller_%d():\n    return Foo()\n", i),
+		}
+	}
+	head := importDeepDependentFiles(t, repo, files)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	index, warnings, err := buildReferenceIndexWithProgress(ctx, repo, head, map[string]struct{}{"Foo": {}}, dependentsScanOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("dependents scan exceeded safety timeout: %v", err)
+	}
+	if got, want := len(index["Foo"]), 3; got != want {
+		t.Fatalf("dependents resolved before shared metadata cap = %d, want %d", got, want)
+	}
+
+	var unaddressable []ProviderWarning
+	for _, warning := range warnings {
+		if warning.Code == "E_FILE_READ" && strings.Contains(warning.Detail, "bounded Git metadata traversal") {
+			unaddressable = append(unaddressable, warning)
+		}
+		if warning.Code == "W_ANALYSIS_BUDGET_EXCEEDED" {
+			t.Fatalf("metadata process cap must not be reported as a time budget expiry: %#v", warning)
+		}
+	}
+	if got, want := len(unaddressable), 1; got != want {
+		t.Fatalf("bounded metadata warnings = %d, want %d: %#v", got, want, warnings)
+	}
+	if unaddressable[0].EffectOnCompleteness == "" {
+		t.Fatalf("bounded metadata warning must explain partial dependents: %#v", unaddressable[0])
+	}
+}
+
+// TestHeadReadersShareDeepUnsafeMetadataAllowance covers the two committed
+// multi-file reader closures outside Analyze. Each has one shared component
+// allowance: four independent 81-component unsafe paths resolve three and
+// classify the fourth as unavailable. A fresh one-shot reader per file would
+// reset the allowance and incorrectly read all four.
+func TestHeadReadersShareDeepUnsafeMetadataAllowance(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	files := make([]deepDependentFile, 4)
+	for i := range files {
+		files[i] = deepDependentFile{
+			path:    repeatedDeepUnsafePath(i, 80, 200),
+			content: fmt.Sprintf("def caller_%d():\n    return %d\n", i, i),
+		}
+	}
+	head := importDeepDependentFiles(t, repo, files)
+	git(t, repo, "symbolic-ref", "HEAD", "refs/heads/deep-dependents")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	source, err := prepareSource(ctx, repo, ProviderSnapshotOptions{MaxParseBytes: 1024})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Read in the opposite order from the deterministic listing. Without the
+	// pre-worker Prime, this reverse schedule would give the allowance to the
+	// last three paths and make provider output depend on worker timing.
+	providerRead := make(map[string]bool, len(files))
+	for i := len(files) - 1; i >= 0; i-- {
+		file := files[i]
+		if content, ok := source.read(file.path); ok && content == file.content {
+			providerRead[file.path] = true
+		}
+	}
+	if err := source.close(); err != nil {
+		t.Fatal(err)
+	}
+	for i, file := range files {
+		want := i < 3
+		if got := providerRead[file.path]; got != want {
+			t.Fatalf("provider read for listed path %d = %v, want %v", i, got, want)
+		}
+	}
+
+	readSearch, closeSearch, err := openSearchContentReader(ctx, repo, head, true, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	searchReads := 0
+	for _, file := range files {
+		if content, ok := readSearch(file.path); ok && content == file.content {
+			searchReads++
+		}
+	}
+	if err := closeSearch(); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := searchReads, 3; got != want {
+		t.Fatalf("search reads before shared metadata cap = %d, want %d", got, want)
+	}
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("shared head readers exceeded safety timeout: %v", err)
 	}
 }
 

--- a/internal/sem/ignore.go
+++ b/internal/sem/ignore.go
@@ -834,6 +834,19 @@ const maxNestedIgnoreFiles = 512
 type nestedIgnoreRules struct {
 	base   ignoreMatcher
 	levels []nestedIgnoreLevel
+	// baseUnreadable is set when the root .gitignore could not be read at the
+	// committed revision (a real I/O error, not simply "no such file") — for
+	// example a promised blob a partial clone cannot lazily fetch because
+	// network egress is disabled. The project's own re-inclusion rules are
+	// then unknowable, so ReincludesDescendant fails OPEN for every path
+	// rather than let the vendored-directory heuristic silently drop
+	// first-party source it would have re-included.
+	baseUnreadable bool
+	// unreadableDirs holds the repo-relative directories whose OWN nested
+	// .gitignore failed to read for the same reason, scoped to that
+	// subtree only: the rest of the tree's rules are still known and still
+	// enforced.
+	unreadableDirs []string
 }
 
 func newNestedIgnoreRules(base ignoreMatcher) *nestedIgnoreRules {
@@ -856,10 +869,21 @@ func (r *nestedIgnoreRules) addFile(file, content string) {
 }
 
 // ReincludesDescendant reports whether the root rules or any nested .gitignore
-// negate a path at or below rel.
+// negate a path at or below rel. It also fails open — reports true, meaning
+// "do not vendor-exclude this" — wherever the rules needed to answer honestly
+// could not be read, rather than silently agree with a heuristic that has no
+// idea what the project's own re-inclusion rules say there.
 func (r *nestedIgnoreRules) ReincludesDescendant(rel string) bool {
+	if r.baseUnreadable {
+		return true
+	}
 	if r.base.ReincludesDescendant(rel) {
 		return true
+	}
+	for _, dir := range r.unreadableDirs {
+		if dirContainsPath(dir, rel) {
+			return true
+		}
 	}
 	for _, level := range r.levels {
 		if level.matcher.reincludesDescendantUnder(level.dir, rel) {
@@ -878,6 +902,18 @@ func pathUnder(dir, rel string) (string, bool) {
 		return "", false
 	}
 	return strings.TrimPrefix(rel, dir+"/"), true
+}
+
+// dirContainsPath reports whether rel names dir itself or something under it.
+// skipVendoredDir queries ReincludesDescendant with rel equal to the candidate
+// vendored directory itself (not one of its files), so an unreadable nested
+// .gitignore's own directory has to match here, not only its descendants —
+// pathUnder alone (a strict "dir/" prefix) never matches that equal case.
+func dirContainsPath(dir, rel string) bool {
+	if dir == "" || rel == dir {
+		return true
+	}
+	return strings.HasPrefix(rel, dir+"/")
 }
 
 func (m ignoreMatcher) MayIncludeDescendant(rel string) bool {

--- a/internal/sem/ignore.go
+++ b/internal/sem/ignore.go
@@ -847,6 +847,10 @@ type nestedIgnoreRules struct {
 	// subtree only: the rest of the tree's rules are still known and still
 	// enforced.
 	unreadableDirs []string
+	// incomplete is set when the bounded reader cannot inspect every nested
+	// .gitignore. Unknown rules can affect any vendored subtree, so the heuristic
+	// must fail open globally instead of silently dropping possible re-inclusions.
+	incomplete bool
 }
 
 func newNestedIgnoreRules(base ignoreMatcher) *nestedIgnoreRules {
@@ -874,7 +878,7 @@ func (r *nestedIgnoreRules) addFile(file, content string) {
 // could not be read, rather than silently agree with a heuristic that has no
 // idea what the project's own re-inclusion rules say there.
 func (r *nestedIgnoreRules) ReincludesDescendant(rel string) bool {
-	if r.baseUnreadable {
+	if r.baseUnreadable || r.incomplete {
 		return true
 	}
 	if r.base.ReincludesDescendant(rel) {

--- a/internal/sem/ignore.go
+++ b/internal/sem/ignore.go
@@ -445,54 +445,14 @@ func (m *ignoreMatcher) loadRequired(file string, includeMode bool) error {
 
 func (m *ignoreMatcher) loadPath(file string, includeMode, required bool) error {
 	label := ignoreFileLabel(includeMode)
-	info, err := os.Stat(file)
-	if errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOTDIR) {
-		if !required {
-			// ENOTDIR: a parent component is not a directory, so the file cannot
-			// exist. For an optional exclude file that is absence, never a hard
-			// failure.
-			return nil
-		}
-		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("%s %q does not exist", label, file)
-		}
-	}
+	content, present, err := readBoundedRegularFile(file, label, required, maxIgnoreFileBytes)
 	if err != nil {
-		return fmt.Errorf("read %s %q: %w", label, file, err)
+		return err
 	}
-	if !info.Mode().IsRegular() {
-		return fmt.Errorf("%s %q is not a regular file", label, file)
+	if !present {
+		return nil
 	}
-	if info.Size() > maxIgnoreFileBytes {
-		return fmt.Errorf(
-			"read %s %q: file exceeds %d bytes",
-			label,
-			file,
-			maxIgnoreFileBytes,
-		)
-	}
-
-	opened, err := os.Open(file)
-	if err != nil {
-		return fmt.Errorf("read %s %q: %w", label, file, err)
-	}
-	defer opened.Close()
-	openedInfo, err := opened.Stat()
-	if err != nil {
-		return fmt.Errorf("read %s %q: %w", label, file, err)
-	}
-	if !openedInfo.Mode().IsRegular() || !os.SameFile(info, openedInfo) {
-		return fmt.Errorf("%s %q changed while opening", label, file)
-	}
-	if openedInfo.Size() > maxIgnoreFileBytes {
-		return fmt.Errorf(
-			"read %s %q: file exceeds %d bytes",
-			label,
-			file,
-			maxIgnoreFileBytes,
-		)
-	}
-	if err := m.loadReader(io.LimitReader(opened, maxIgnoreFileBytes+1), includeMode); err != nil {
+	if err := m.loadReader(bytes.NewReader(content), includeMode); err != nil {
 		return fmt.Errorf("read %s %q: %w", label, file, err)
 	}
 	return nil
@@ -543,33 +503,82 @@ func (m *ignoreMatcher) loadReader(source io.Reader, includeMode bool) error {
 }
 
 func readSmallRegularFile(file string, limit int64) ([]byte, error) {
+	content, _, err := readBoundedRegularFile(file, "Git indirection file", true, limit)
+	return content, err
+}
+
+// readBoundedRegularFile is the one policy for every external ignore/include
+// read, including cache-key derivation. It follows symlinks to regular files,
+// but refuses directories, devices, pipes, sockets, identity swaps, and growth
+// past limit. Optional means only that a genuinely absent path is allowed.
+func readBoundedRegularFile(file, label string, required bool, limit int64) ([]byte, bool, error) {
 	info, err := os.Stat(file)
-	if err != nil {
-		return nil, err
+	if isMissingPathError(err) {
+		if required {
+			return nil, false, fmt.Errorf("%s %q does not exist", label, file)
+		}
+		return nil, false, nil
 	}
-	if !info.Mode().IsRegular() || info.Size() > limit {
-		return nil, fmt.Errorf("file is not a regular file of at most %d bytes", limit)
-	}
-	opened, err := os.Open(file)
 	if err != nil {
-		return nil, err
+		return nil, false, fmt.Errorf("read %s %q: %w", label, file, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, false, fmt.Errorf("%s %q is not a regular file", label, file)
+	}
+	if info.Size() > limit {
+		return nil, false, fmt.Errorf("read %s %q: file exceeds %d bytes", label, file, limit)
+	}
+	opened, err := openBoundedRegularFile(file)
+	if isMissingPathError(err) {
+		if required {
+			return nil, false, fmt.Errorf("%s %q does not exist", label, file)
+		}
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, fmt.Errorf("read %s %q: %w", label, file, err)
 	}
 	defer opened.Close()
+	content, err := readOpenedBoundedRegularFile(opened, info, file, label, limit)
+	if err != nil {
+		return nil, false, err
+	}
+	return content, true, nil
+}
+
+// readOpenedBoundedRegularFile validates the description that will actually be
+// read. Keeping this step separate also makes identity and growth checks
+// deterministic to test without weakening the production path with hooks.
+func readOpenedBoundedRegularFile(opened *os.File, expected os.FileInfo, file, label string, limit int64) ([]byte, error) {
 	openedInfo, err := opened.Stat()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read %s %q: %w", label, file, err)
 	}
-	if !openedInfo.Mode().IsRegular() || !os.SameFile(info, openedInfo) || openedInfo.Size() > limit {
-		return nil, errors.New("file changed while opening")
+	regular, err := openedFileIsRegular(opened, openedInfo)
+	if err != nil {
+		return nil, fmt.Errorf("read %s %q: %w", label, file, err)
+	}
+	if !regular {
+		return nil, fmt.Errorf("%s %q is not a regular file", label, file)
+	}
+	if !os.SameFile(expected, openedInfo) {
+		return nil, fmt.Errorf("%s %q changed while opening", label, file)
+	}
+	if openedInfo.Size() > limit {
+		return nil, fmt.Errorf("read %s %q: file exceeds %d bytes", label, file, limit)
 	}
 	content, err := io.ReadAll(io.LimitReader(opened, limit+1))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read %s %q: %w", label, file, err)
 	}
 	if int64(len(content)) > limit {
-		return nil, fmt.Errorf("file exceeds %d bytes", limit)
+		return nil, fmt.Errorf("read %s %q: file exceeds %d bytes", label, file, limit)
 	}
 	return content, nil
+}
+
+func isMissingPathError(err error) bool {
+	return errors.Is(err, os.ErrNotExist) || errors.Is(err, syscall.ENOTDIR)
 }
 
 func ignoreFileLabel(includeMode bool) string {

--- a/internal/sem/ignore.go
+++ b/internal/sem/ignore.go
@@ -881,7 +881,7 @@ func (r *nestedIgnoreRules) ReincludesDescendant(rel string) bool {
 		return true
 	}
 	for _, dir := range r.unreadableDirs {
-		if dirContainsPath(dir, rel) {
+		if subtreesOverlap(dir, rel) {
 			return true
 		}
 	}
@@ -904,16 +904,15 @@ func pathUnder(dir, rel string) (string, bool) {
 	return strings.TrimPrefix(rel, dir+"/"), true
 }
 
-// dirContainsPath reports whether rel names dir itself or something under it.
-// skipVendoredDir queries ReincludesDescendant with rel equal to the candidate
-// vendored directory itself (not one of its files), so an unreadable nested
-// .gitignore's own directory has to match here, not only its descendants —
-// pathUnder alone (a strict "dir/" prefix) never matches that equal case.
-func dirContainsPath(dir, rel string) bool {
-	if dir == "" || rel == dir {
+// subtreesOverlap reports whether either path is the other path or its
+// ancestor. An unreadable nested .gitignore makes both its own subtree and any
+// ancestor that the vendored-directory heuristic might skip unknowable: if the
+// ancestor were skipped, traversal would never reach the unreadable rules.
+func subtreesOverlap(a, b string) bool {
+	if a == "" || b == "" || a == b {
 		return true
 	}
-	return strings.HasPrefix(rel, dir+"/")
+	return strings.HasPrefix(a, b+"/") || strings.HasPrefix(b, a+"/")
 }
 
 func (m ignoreMatcher) MayIncludeDescendant(rel string) bool {

--- a/internal/sem/ignore_open_unix.go
+++ b/internal/sem/ignore_open_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package sem
+
+import (
+	"os"
+	"syscall"
+)
+
+// openBoundedRegularFile uses a non-blocking open so a path raced from a
+// regular file to a writerless FIFO cannot park before the descriptor-level
+// type and identity checks run. POSIX ignores O_NONBLOCK for regular files.
+func openBoundedRegularFile(file string) (*os.File, error) {
+	return os.OpenFile(file, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+}
+
+func openedFileIsRegular(_ *os.File, info os.FileInfo) (bool, error) {
+	return info.Mode().IsRegular(), nil
+}

--- a/internal/sem/ignore_open_windows.go
+++ b/internal/sem/ignore_open_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package sem
+
+import (
+	"os"
+	"syscall"
+)
+
+func openBoundedRegularFile(file string) (*os.File, error) {
+	return os.Open(file)
+}
+
+// Windows reports reserved DOS devices such as NUL as regular through parts of
+// the os.Stat surface. Check the opened handle too, so only disk files reach the
+// bounded read.
+func openedFileIsRegular(file *os.File, info os.FileInfo) (bool, error) {
+	if !info.Mode().IsRegular() {
+		return false, nil
+	}
+	fileType, err := syscall.GetFileType(syscall.Handle(file.Fd()))
+	if err != nil {
+		return false, err
+	}
+	return fileType == syscall.FILE_TYPE_DISK, nil
+}

--- a/internal/sem/ignore_reader_test.go
+++ b/internal/sem/ignore_reader_test.go
@@ -1,0 +1,163 @@
+package sem
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIgnoreSurfacesShareExactByteLimit(t *testing.T) {
+	repo := t.TempDir()
+	ignore := filepath.Join(repo, "bounded.ignore")
+	exact := bytes.Repeat([]byte("# x\n"), maxIgnoreFileBytes/4)
+	if len(exact) != maxIgnoreFileBytes {
+		t.Fatalf("fixture length = %d, want %d", len(exact), maxIgnoreFileBytes)
+	}
+	if err := os.WriteFile(ignore, exact, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var matcher ignoreMatcher
+	if err := matcher.loadRequired(ignore, false); err != nil {
+		t.Fatalf("loader rejected exact limit: %v", err)
+	}
+	options := ProviderSnapshotOptions{IgnoreFiles: []string{ignore}}
+	for _, keyer := range ignoreInputKeyers(repo) {
+		if _, err := keyer.key(options); err != nil {
+			t.Fatalf("%s key rejected exact limit: %v", keyer.name, err)
+		}
+	}
+
+	if err := os.WriteFile(ignore, append(exact, '#'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	matcher = ignoreMatcher{}
+	if err := matcher.loadRequired(ignore, false); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("loader cap+1 error = %v", err)
+	}
+	for _, keyer := range ignoreInputKeyers(repo) {
+		if _, err := keyer.key(options); err == nil || !strings.Contains(err.Error(), "exceeds") {
+			t.Fatalf("%s key cap+1 error = %v", keyer.name, err)
+		}
+	}
+}
+
+func TestIgnoreSurfacesAllowSymlinkToRegularFile(t *testing.T) {
+	repo := t.TempDir()
+	target := filepath.Join(repo, "shared-ignore")
+	linked := filepath.Join(repo, "linked-ignore")
+	if err := os.WriteFile(target, []byte("vendor/\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, linked); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	var matcher ignoreMatcher
+	if err := matcher.loadRequired(linked, false); err != nil {
+		t.Fatalf("loader rejected regular symlink target: %v", err)
+	}
+	if !matcher.Ignored("vendor/pkg/file.go", false) {
+		t.Fatal("loader did not apply rule read through symlink")
+	}
+	options := ProviderSnapshotOptions{IgnoreFiles: []string{linked}}
+	for _, keyer := range ignoreInputKeyers(repo) {
+		before, err := keyer.key(options)
+		if err != nil {
+			t.Fatalf("%s key rejected regular symlink target: %v", keyer.name, err)
+		}
+		if err := os.WriteFile(target, []byte("dist/\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		after, err := keyer.key(options)
+		if err != nil {
+			t.Fatalf("%s key rejected edited regular symlink target: %v", keyer.name, err)
+		}
+		if before == after {
+			t.Fatalf("%s key ignored an edit through a symlink", keyer.name)
+		}
+		if err := os.WriteFile(target, []byte("vendor/\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestReadOpenedBoundedRegularFileRejectsIdentityAndGrowth(t *testing.T) {
+	dir := t.TempDir()
+	first := filepath.Join(dir, "first")
+	second := filepath.Join(dir, "second")
+	if err := os.WriteFile(first, []byte("same"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(second, []byte("same"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	expected, err := os.Stat(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opened, err := os.Open(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readOpenedBoundedRegularFile(opened, expected, first, "ignore file", 4); err == nil ||
+		!strings.Contains(err.Error(), "changed while opening") {
+		t.Fatalf("identity-swap error = %v", err)
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	expected, err = os.Stat(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opened, err = os.Open(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer opened.Close()
+	if err := os.WriteFile(first, []byte("same+"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readOpenedBoundedRegularFile(opened, expected, first, "ignore file", 4); err == nil ||
+		!strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("post-stat growth error = %v", err)
+	}
+}
+
+func TestCacheKeysPreserveIgnoreInputOrderAndRepeatability(t *testing.T) {
+	repo := t.TempDir()
+	for name, content := range map[string]string{
+		"first.ignore":  "target.go\n",
+		"second.ignore": "!target.go\n",
+	} {
+		if err := os.WriteFile(filepath.Join(repo, name), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	forward := ProviderSnapshotOptions{IgnoreFiles: []string{"first.ignore", "second.ignore"}}
+	reverse := ProviderSnapshotOptions{IgnoreFiles: []string{"second.ignore", "first.ignore"}}
+	for _, keyer := range ignoreInputKeyers(repo) {
+		first, err := keyer.key(forward)
+		if err != nil {
+			t.Fatal(err)
+		}
+		repeat, err := keyer.key(forward)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if repeat != first {
+			t.Fatalf("%s key was not deterministic", keyer.name)
+		}
+		reversed, err := keyer.key(reverse)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if reversed == first {
+			t.Fatalf("%s key erased semantic ignore-file order", keyer.name)
+		}
+	}
+}

--- a/internal/sem/ignore_reader_unix_test.go
+++ b/internal/sem/ignore_reader_unix_test.go
@@ -1,0 +1,124 @@
+//go:build !windows
+
+package sem
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestIgnoreSurfacesRejectCharacterDevice(t *testing.T) {
+	repo := t.TempDir()
+	device := filepath.Join(repo, "device.ignore")
+	if err := os.Symlink(os.DevNull, device); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	var matcher ignoreMatcher
+	checks := []struct {
+		name string
+		run  func() error
+	}{
+		{"loader", func() error { return matcher.loadRequired(device, false) }},
+		{"search key", func() error {
+			_, err := searchSnapshotKey(repo, "repo", "version", "tree", ProviderSnapshotOptions{IgnoreFiles: []string{device}})
+			return err
+		}},
+		{"records key", func() error {
+			_, err := providerRecordsKey(repo, "repo", "version", "tree", "snapshot", ProviderSnapshotOptions{IgnoreFiles: []string{device}})
+			return err
+		}},
+	}
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			if err := check.run(); err == nil || !strings.Contains(err.Error(), "not a regular file") {
+				t.Fatalf("device error = %v", err)
+			}
+		})
+	}
+}
+
+func TestIgnoreSurfacesRejectWriterlessFIFOWithoutBlocking(t *testing.T) {
+	repo := t.TempDir()
+	fifo := filepath.Join(repo, "fifo.ignore")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo unavailable: %v", err)
+	}
+
+	var matcher ignoreMatcher
+	checks := []struct {
+		name string
+		run  func() error
+	}{
+		{"loader", func() error { return matcher.loadRequired(fifo, false) }},
+		{"search key", func() error {
+			_, err := searchSnapshotKey(repo, "repo", "version", "tree", ProviderSnapshotOptions{IgnoreFiles: []string{fifo}})
+			return err
+		}},
+		{"records key", func() error {
+			_, err := providerRecordsKey(repo, "repo", "version", "tree", "snapshot", ProviderSnapshotOptions{IgnoreFiles: []string{fifo}})
+			return err
+		}},
+	}
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			returned := make(chan error, 1)
+			go func() { returned <- check.run() }()
+			select {
+			case err := <-returned:
+				if err == nil || !strings.Contains(err.Error(), "not a regular file") {
+					t.Fatalf("FIFO error = %v", err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("ignore surface blocked on a writerless FIFO")
+			}
+		})
+	}
+}
+
+func TestNonblockingIgnoreOpenReturnsOnWriterlessFIFO(t *testing.T) {
+	dir := t.TempDir()
+	fifo := filepath.Join(dir, "fifo")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo unavailable: %v", err)
+	}
+	type result struct {
+		file *os.File
+		err  error
+	}
+	returned := make(chan result, 1)
+	go func() {
+		file, err := openBoundedRegularFile(fifo)
+		returned <- result{file: file, err: err}
+	}()
+	select {
+	case got := <-returned:
+		if got.err != nil {
+			t.Fatalf("nonblocking FIFO open: %v", got.err)
+		}
+		defer got.file.Close()
+		regular := filepath.Join(dir, "regular")
+		if err := os.WriteFile(regular, []byte("rule\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		expected, err := os.Stat(regular)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := readOpenedBoundedRegularFile(got.file, expected, regular, "ignore file", 32); err == nil ||
+			!strings.Contains(err.Error(), "not a regular file") {
+			t.Fatalf("raced FIFO handle error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		// Unblock a regressed plain read-only open so the test does not leak a
+		// parked goroutine before reporting the failure.
+		if descriptor, err := syscall.Open(fifo, syscall.O_WRONLY|syscall.O_NONBLOCK, 0); err == nil {
+			_ = syscall.Close(descriptor)
+		}
+		t.Fatal("regular-file opener blocked before it could reject the FIFO handle")
+	}
+}

--- a/internal/sem/ignore_reader_unix_test.go
+++ b/internal/sem/ignore_reader_unix_test.go
@@ -29,7 +29,7 @@ func TestIgnoreSurfacesRejectCharacterDevice(t *testing.T) {
 			return err
 		}},
 		{"records key", func() error {
-			_, err := providerRecordsKey(repo, "repo", "version", "tree", "snapshot", ProviderSnapshotOptions{IgnoreFiles: []string{device}})
+			_, err := providerRecordsKey(repo, "repo", "version", "commit", "tree", "snapshot", ProviderSnapshotOptions{IgnoreFiles: []string{device}})
 			return err
 		}},
 	}
@@ -60,7 +60,7 @@ func TestIgnoreSurfacesRejectWriterlessFIFOWithoutBlocking(t *testing.T) {
 			return err
 		}},
 		{"records key", func() error {
-			_, err := providerRecordsKey(repo, "repo", "version", "tree", "snapshot", ProviderSnapshotOptions{IgnoreFiles: []string{fifo}})
+			_, err := providerRecordsKey(repo, "repo", "version", "commit", "tree", "snapshot", ProviderSnapshotOptions{IgnoreFiles: []string{fifo}})
 			return err
 		}},
 	}

--- a/internal/sem/ignore_reader_windows_test.go
+++ b/internal/sem/ignore_reader_windows_test.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package sem
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIgnoreSurfacesRejectWindowsNULDevice(t *testing.T) {
+	repo := t.TempDir()
+	device := filepath.Join(repo, "NUL")
+	var matcher ignoreMatcher
+	checks := []struct {
+		name string
+		run  func() error
+	}{
+		{"loader", func() error { return matcher.loadRequired(device, false) }},
+		{"search key", func() error {
+			_, err := searchSnapshotKey(repo, "repo", "version", "tree", ProviderSnapshotOptions{IgnoreFiles: []string{device}})
+			return err
+		}},
+		{"records key", func() error {
+			_, err := providerRecordsKey(repo, "repo", "version", "tree", "snapshot", ProviderSnapshotOptions{IgnoreFiles: []string{device}})
+			return err
+		}},
+	}
+	for _, check := range checks {
+		t.Run(check.name, func(t *testing.T) {
+			if err := check.run(); err == nil || !strings.Contains(err.Error(), "not a regular file") {
+				t.Fatalf("NUL device error = %v", err)
+			}
+		})
+	}
+}

--- a/internal/sem/ignore_reader_windows_test.go
+++ b/internal/sem/ignore_reader_windows_test.go
@@ -22,7 +22,7 @@ func TestIgnoreSurfacesRejectWindowsNULDevice(t *testing.T) {
 			return err
 		}},
 		{"records key", func() error {
-			_, err := providerRecordsKey(repo, "repo", "version", "tree", "snapshot", ProviderSnapshotOptions{IgnoreFiles: []string{device}})
+			_, err := providerRecordsKey(repo, "repo", "version", "commit", "tree", "snapshot", ProviderSnapshotOptions{IgnoreFiles: []string{device}})
 			return err
 		}},
 	}

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -9782,7 +9782,14 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 		batch.SetMaxBytes(maxReadBytes)
 		read := func(path string) (string, bool) {
 			if strings.Contains(path, "\n") {
-				content, ok, err := gitutil.ShowFile(ctx, repo, committedRevision, path)
+				// The batch protocol is line based, so a newline-bearing Git
+				// path needs the argv-safe one-shot reader. The ceiling is
+				// passed DOWN rather than applied to the returned string: this
+				// fallback is selected by the file's NAME, which the repository
+				// under analysis chooses, so an unbounded read here would let
+				// any repository opt one blob out of the cap that makes this
+				// reader's memory claim true.
+				content, ok, err := gitutil.ShowFileLimited(ctx, repo, committedRevision, path, maxReadBytes)
 				if err != nil || !ok {
 					return "", false
 				}

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -376,6 +376,9 @@ type ProviderSnapshotOptions struct {
 	// (see searchSnapshotKey), so a forced rebuild refreshes the same entry every
 	// other reader serves.
 	ForceRebuild bool
+	// cachePolicy is an immutable, bounded capture of external ignore inputs.
+	// Cache pipelines set it once and carry it through keying and construction.
+	cachePolicy *capturedIgnorePolicy
 }
 
 type BuildPhase string
@@ -760,8 +763,12 @@ type sourceContext struct {
 	read       contentReader
 	readPrefix prefixReader
 	oversize   oversizeReader
-	close      func() error
-	warnings   []ProviderWarning
+	// ignores is the exact matcher that admitted paths. Search carries it to
+	// whole-tree Git-grep filtering so no second policy-file read can diverge
+	// from the corpus listing.
+	ignores  ignoreMatcher
+	close    func() error
+	warnings []ProviderWarning
 }
 
 // oversizeAt reports the oversize record for path when the source has one.
@@ -1427,6 +1434,7 @@ func prepareSource(ctx context.Context, repo string, options ProviderSnapshotOpt
 	opened, err := openSource(ctx, absRepo, committedRevision, sourceOptions{
 		ignoreFiles:  options.IgnoreFiles,
 		includeFiles: options.IncludeFiles,
+		cachePolicy:  options.cachePolicy,
 		maxReadBytes: resolveMaxParseBytes(options.MaxParseBytes),
 		maxFiles:     options.MaxFiles,
 	})
@@ -1480,6 +1488,7 @@ func prepareSource(ctx context.Context, repo string, options ProviderSnapshotOpt
 		read:       opened.read,
 		readPrefix: opened.readPrefix,
 		oversize:   opened.oversize,
+		ignores:    opened.ignores,
 		close:      opened.close,
 		warnings:   warnings,
 	}, nil
@@ -9746,6 +9755,7 @@ func externalParts(id string) (string, string) {
 type sourceOptions struct {
 	ignoreFiles  []string
 	includeFiles []string
+	cachePolicy  *capturedIgnorePolicy
 	// maxReadBytes caps how large a file the content reader will materialize.
 	// Zero or negative removes the cap.
 	maxReadBytes int
@@ -9762,6 +9772,7 @@ type openedSource struct {
 	read       contentReader
 	readPrefix prefixReader
 	oversize   oversizeReader
+	ignores    ignoreMatcher
 	// prime deterministically admits the final filtered committed-tree paths
 	// to any shared bounded metadata reader before parallel workers start.
 	prime    func([]string) error
@@ -9783,7 +9794,15 @@ type openedSource struct {
 func openSource(ctx context.Context, repo, committedRevision string, options sourceOptions) (openedSource, error) {
 	maxReadBytes := int64(options.maxReadBytes)
 	if committedRevision != "" {
-		ignores, err := loadExplicitIgnoreMatcher(repo, options.ignoreFiles, options.includeFiles)
+		var ignores ignoreMatcher
+		var err error
+		if options.cachePolicy != nil {
+			if err = options.cachePolicy.validate(repo, options.ignoreFiles, options.includeFiles); err == nil {
+				ignores, err = options.cachePolicy.matcher()
+			}
+		} else {
+			ignores, err = loadExplicitIgnoreMatcher(repo, options.ignoreFiles, options.includeFiles)
+		}
 		if err != nil {
 			return openedSource{}, err
 		}
@@ -9891,6 +9910,7 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 			read:       read,
 			readPrefix: readPrefix,
 			oversize:   oversize,
+			ignores:    ignores,
 			prime:      prime,
 			close:      closeReaders,
 			warnings:   warnings,
@@ -9945,6 +9965,7 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 		read:       read,
 		readPrefix: readPrefix,
 		oversize:   registry.lookup,
+		ignores:    ignores,
 		warnings:   warnings,
 	}, nil
 }

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -9791,9 +9791,11 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 		if err != nil {
 			return openedSource{}, err
 		}
-		paths = filterVendoredPaths(paths, headVendorIgnoreRules(ctx, repo, committedRevision, paths))
+		vendorRules, vendorWarnings := headVendorIgnoreRules(ctx, repo, committedRevision, paths)
+		paths = filterVendoredPaths(paths, vendorRules)
 		paths = filterIgnoredPaths(paths, ignores)
-		paths, warnings := capSourceFiles(paths, options.maxFiles)
+		paths, capWarnings := capSourceFiles(paths, options.maxFiles)
+		warnings := append(vendorWarnings, capWarnings...)
 		treePathPrefix, err := gitutil.RepoPrefix(ctx, repo)
 		if err != nil {
 			return openedSource{}, err
@@ -10425,8 +10427,19 @@ func filterIgnoredPaths(paths []string, ignores ignoreMatcher) []string {
 // newer HEAD nor miss a project's re-inclusion rules because they sit beside the
 // tree they describe, which is where Git expects them. The tracked listing
 // already in hand is reused to find them, so this costs no extra listing.
-func headVendorIgnoreRules(ctx context.Context, repo, committedRevision string, paths []string) *nestedIgnoreRules {
-	rules := newNestedIgnoreRules(headIgnoreMatcher(ctx, repo, committedRevision))
+func headVendorIgnoreRules(ctx context.Context, repo, committedRevision string, paths []string) (*nestedIgnoreRules, []ProviderWarning) {
+	base, baseUnreadable := headIgnoreMatcherOrError(ctx, repo, committedRevision)
+	rules := newNestedIgnoreRules(base)
+	var warnings []ProviderWarning
+	if baseUnreadable {
+		rules.baseUnreadable = true
+		warnings = append(warnings, ProviderWarning{
+			Code:                 "W_VENDOR_IGNORE_UNREADABLE",
+			Severity:             "warning",
+			FilePath:             ".gitignore",
+			EffectOnCompleteness: "the root .gitignore could not be read at the committed revision, so its re-inclusion rules are unknown; the vendored-directory heuristic is skipped for the whole snapshot rather than risk silently dropping first-party paths it would have re-included",
+		})
+	}
 	for _, entry := range paths {
 		rel := filepath.ToSlash(entry)
 		if path.Base(rel) != ".gitignore" || !strings.Contains(rel, "/") {
@@ -10436,12 +10449,30 @@ func headVendorIgnoreRules(ctx context.Context, repo, committedRevision string, 
 			break
 		}
 		content, ok, err := gitutil.ShowFile(ctx, repo, committedRevision, rel)
-		if err != nil || !ok || len(content) > maxNestedIgnoreFileBytes {
+		if err != nil {
+			// A real read failure — for example a promised blob a partial
+			// clone cannot fetch because network egress is disabled — leaves
+			// this directory's re-inclusion rules unknowable. Recording it
+			// (rather than silently `continue`ing as if the file simply did
+			// not exist) lets ReincludesDescendant fail open for this
+			// subtree instead of the vendored-directory heuristic silently
+			// agreeing that nothing here is re-included.
+			dir := cleanIgnorePath(path.Dir(rel))
+			rules.unreadableDirs = append(rules.unreadableDirs, dir)
+			warnings = append(warnings, ProviderWarning{
+				Code:                 "W_VENDOR_IGNORE_UNREADABLE",
+				Severity:             "warning",
+				FilePath:             rel,
+				EffectOnCompleteness: "this directory's .gitignore could not be read at the committed revision, so its re-inclusion rules are unknown; the vendored-directory heuristic is skipped for this subtree rather than risk silently dropping first-party paths it would have re-included",
+			})
+			continue
+		}
+		if !ok || len(content) > maxNestedIgnoreFileBytes {
 			continue
 		}
 		rules.addFile(rel, content)
 	}
-	return rules
+	return rules, warnings
 }
 
 // worktreeVendorIgnoreRules is headVendorIgnoreRules for the working tree: the
@@ -10475,16 +10506,33 @@ func worktreeVendorIgnoreRules(repo string, base ignoreMatcher, listed []string)
 // headIgnoreMatcher parses the repository's root .gitignore at the same exact
 // committed revision used for listing and content reads, so the vendored-
 // directory heuristic cannot observe a newer HEAD.
+// headIgnoreMatcher reads the root .gitignore at the committed revision. A
+// genuine read failure (for example a promised blob a partial clone cannot
+// fetch because network egress is disabled) is indistinguishable here from the
+// ordinary, common case of no root .gitignore existing at all; callers that
+// need to tell "no rules" from "rules unknown" — because they must not
+// silently agree with the empty result — use headIgnoreMatcherOrError instead.
 func headIgnoreMatcher(ctx context.Context, repo, committedRevision string) ignoreMatcher {
+	matcher, _ := headIgnoreMatcherOrError(ctx, repo, committedRevision)
+	return matcher
+}
+
+// headIgnoreMatcherOrError is headIgnoreMatcher with the failure mode kept
+// visible. The returned bool is true only for a genuine read failure — never
+// for the ordinary case of no root .gitignore existing at all.
+func headIgnoreMatcherOrError(ctx context.Context, repo, committedRevision string) (ignoreMatcher, bool) {
 	content, ok, err := gitutil.ShowFile(ctx, repo, committedRevision, ".gitignore")
-	if err != nil || !ok {
-		return ignoreMatcher{}
+	if err != nil {
+		return ignoreMatcher{}, true
+	}
+	if !ok {
+		return ignoreMatcher{}, false
 	}
 	var matcher ignoreMatcher
 	if err := matcher.loadContent(content, false); err != nil {
-		return ignoreMatcher{}
+		return ignoreMatcher{}, false
 	}
-	return matcher
+	return matcher, false
 }
 
 // vendoredPath filters a HEAD-tree path. Every path in the HEAD listing is

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -9782,12 +9782,12 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 		batch.SetMaxBytes(maxReadBytes)
 		// The oversize registry for the paths the batch reader cannot carry.
 		// batch.OversizeBlob only knows blobs that streamed past IT, so a
-		// refusal in the newline fallback below has to be recorded here or the
+		// refusal in the line-unsafe fallback below has to be recorded here or the
 		// file has no record at all and the snapshot drops it for being NAMED
 		// with a newline.
 		fallback := newFallbackOversizeRegistry(repo, committedRevision, maxReadBytes)
 		read := func(path string) (string, bool) {
-			if strings.Contains(path, "\n") {
+			if !batch.IsPathSafe(path) {
 				// The batch protocol is line based, so a newline-bearing Git
 				// path needs the argv-safe one-shot reader. The ceiling is
 				// passed DOWN rather than applied to the returned string: this
@@ -9795,23 +9795,25 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 				// under analysis chooses, so an unbounded read here would let
 				// any repository opt one blob out of the cap that makes this
 				// reader's memory claim true.
-				content, ok, err := gitutil.ShowFileLimited(ctx, repo, committedRevision, path, maxReadBytes)
+				result, err := gitutil.ReadFileLimited(ctx, repo, committedRevision, path, maxReadBytes)
 				if err != nil {
 					return "", false
 				}
-				if !ok {
-					// A refusal has to leave the same trace the batch reader
+				if result.Status != gitutil.LimitedFileContent {
+					// An oversize refusal has to leave the same trace the batch reader
 					// leaves, or processProviderFile cannot tell a file it
 					// declined from one it could not read: the file record is
 					// dropped, the warning becomes an error-severity
 					// E_FILE_READ, and completeness falls to degraded.
-					// ShowFileLimited refuses without reading, so the digest
+					// ReadFileLimited gives the exact size without reading, but the digest
 					// MaxParseBytes promises is still owed — noted here and
 					// resolved lazily below. An absent path records nothing.
-					fallback.note(path)
+					if result.Status == gitutil.LimitedFileOversize {
+						fallback.note(path)
+					}
 					return "", false
 				}
-				return content, true
+				return result.Content, true
 			}
 			content, ok, err := batch.ReadFile(path)
 			if err != nil || !ok {
@@ -9903,17 +9905,18 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 	}, nil
 }
 
-// fallbackOversizeRegistry remembers the HEAD-tree paths the one-shot newline
+// fallbackOversizeRegistry remembers the HEAD-tree paths the one-shot line-unsafe
 // fallback refused, and resolves each one's record at most once. It is the
 // committed-revision counterpart of oversizeRegistry below, and defers for the
 // same reason: resolving costs a streaming pass over the blob, and preselection
 // only needs to know the file is out of reach, so paying that pass to answer a
 // question nobody asked would trade a memory blow-up for an I/O one.
 //
-// A noted path is not yet known to be oversized — ShowFileLimited refuses
-// without saying why. gitutil.OversizeBlobAtRev decides that against the same
-// ceiling, and a path it does not establish as oversized resolves to no record,
-// so a read that failed for another reason is never reported as too large.
+// A noted path is already known to be oversized from typed metadata, but its
+// content hash and line count still require one streaming pass.
+// gitutil.OversizeBlobAtRev computes those against the same ceiling; a path it
+// cannot re-establish as oversized resolves to no record rather than being
+// misreported.
 type fallbackOversizeRegistry struct {
 	repo     string
 	rev      string

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -10452,15 +10452,19 @@ func headVendorIgnoreRules(ctx context.Context, repo, committedRevision string, 
 			FilePath:             ".gitignore",
 			EffectOnCompleteness: "the root .gitignore could not be read at the committed revision, so its re-inclusion rules are unknown; the vendored-directory heuristic is skipped for the whole snapshot rather than risk silently dropping first-party paths it would have re-included",
 		})
+		return rules, warnings
 	}
-	for _, entry := range paths {
-		rel := filepath.ToSlash(entry)
-		if path.Base(rel) != ".gitignore" || !strings.Contains(rel, "/") {
-			continue
-		}
-		if len(rules.levels) >= maxNestedIgnoreFiles {
-			break
-		}
+	nestedPaths, truncated := boundedNestedIgnorePaths(paths)
+	if truncated {
+		rules.incomplete = true
+		warnings = append(warnings, ProviderWarning{
+			Code:                 "W_VENDOR_IGNORE_LIMIT",
+			Severity:             "warning",
+			EffectOnCompleteness: "not every nested .gitignore could be inspected within the bounded input limit, so the vendored-directory heuristic is skipped for the whole snapshot rather than risk silently dropping first-party paths with unknown re-inclusion rules",
+			Detail:               fmt.Sprintf("nested .gitignore inputs exceeded the limit of %d", maxNestedIgnoreFiles),
+		})
+	}
+	for _, rel := range nestedPaths {
 		content, ok, err := gitutil.ShowFile(ctx, repo, committedRevision, rel)
 		if err != nil {
 			// A real read failure — for example a promised blob a partial
@@ -10486,6 +10490,25 @@ func headVendorIgnoreRules(ctx context.Context, repo, committedRevision string, 
 		rules.addFile(rel, content)
 	}
 	return rules, warnings
+}
+
+// boundedNestedIgnorePaths returns at most maxNestedIgnoreFiles tracked nested
+// .gitignore paths. The separate truncated result lets callers fail open and
+// disclose that some re-inclusion rules remain unknown without issuing an
+// unbounded number of Git subprocesses or retaining unbounded diagnostics.
+func boundedNestedIgnorePaths(paths []string) ([]string, bool) {
+	nested := make([]string, 0, min(len(paths), maxNestedIgnoreFiles))
+	for _, entry := range paths {
+		rel := filepath.ToSlash(entry)
+		if path.Base(rel) != ".gitignore" || !strings.Contains(rel, "/") {
+			continue
+		}
+		if len(nested) >= maxNestedIgnoreFiles {
+			return nested, true
+		}
+		nested = append(nested, rel)
+	}
+	return nested, false
 }
 
 // worktreeVendorIgnoreRules is headVendorIgnoreRules for the working tree: the

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -9866,8 +9866,9 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 		prime := func(paths []string) error {
 			unsafeTreePaths := make([]string, 0, len(paths))
 			for _, path := range paths {
-				if !batch.IsPathSafe(path) {
-					unsafeTreePaths = append(unsafeTreePaths, treePathPrefix+path)
+				treePath := treePathPrefix + path
+				if !batch.IsPathSafe(path) && gitutil.IsCanonicalGitTreePath(treePath) {
+					unsafeTreePaths = append(unsafeTreePaths, treePath)
 				}
 			}
 			return limited.Prime(unsafeTreePaths)

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -9780,6 +9780,12 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 			return openedSource{}, err
 		}
 		batch.SetMaxBytes(maxReadBytes)
+		// The oversize registry for the paths the batch reader cannot carry.
+		// batch.OversizeBlob only knows blobs that streamed past IT, so a
+		// refusal in the newline fallback below has to be recorded here or the
+		// file has no record at all and the snapshot drops it for being NAMED
+		// with a newline.
+		fallback := newFallbackOversizeRegistry(repo, committedRevision, maxReadBytes)
 		read := func(path string) (string, bool) {
 			if strings.Contains(path, "\n") {
 				// The batch protocol is line based, so a newline-bearing Git
@@ -9790,7 +9796,19 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 				// any repository opt one blob out of the cap that makes this
 				// reader's memory claim true.
 				content, ok, err := gitutil.ShowFileLimited(ctx, repo, committedRevision, path, maxReadBytes)
-				if err != nil || !ok {
+				if err != nil {
+					return "", false
+				}
+				if !ok {
+					// A refusal has to leave the same trace the batch reader
+					// leaves, or processProviderFile cannot tell a file it
+					// declined from one it could not read: the file record is
+					// dropped, the warning becomes an error-severity
+					// E_FILE_READ, and completeness falls to degraded.
+					// ShowFileLimited refuses without reading, so the digest
+					// MaxParseBytes promises is still owed — noted here and
+					// resolved lazily below. An absent path records nothing.
+					fallback.note(path)
 					return "", false
 				}
 				return content, true
@@ -9802,6 +9820,9 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 			return content, true
 		}
 		oversize := func(path string) (oversizeFile, bool) {
+			if over, ok := fallback.lookup(ctx, path); ok {
+				return over, true
+			}
 			blob, ok := batch.OversizeBlob(path)
 			if !ok {
 				return oversizeFile{}, false
@@ -9880,6 +9901,76 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 		oversize:   registry.lookup,
 		warnings:   warnings,
 	}, nil
+}
+
+// fallbackOversizeRegistry remembers the HEAD-tree paths the one-shot newline
+// fallback refused, and resolves each one's record at most once. It is the
+// committed-revision counterpart of oversizeRegistry below, and defers for the
+// same reason: resolving costs a streaming pass over the blob, and preselection
+// only needs to know the file is out of reach, so paying that pass to answer a
+// question nobody asked would trade a memory blow-up for an I/O one.
+//
+// A noted path is not yet known to be oversized — ShowFileLimited refuses
+// without saying why. gitutil.OversizeBlobAtRev decides that against the same
+// ceiling, and a path it does not establish as oversized resolves to no record,
+// so a read that failed for another reason is never reported as too large.
+type fallbackOversizeRegistry struct {
+	repo     string
+	rev      string
+	maxBytes int64
+	mu       sync.Mutex
+	pending  map[string]struct{}
+	// resolved caches the answer, nil meaning "asked, and not oversized".
+	resolved map[string]*oversizeFile
+}
+
+func newFallbackOversizeRegistry(repo, rev string, maxBytes int64) *fallbackOversizeRegistry {
+	return &fallbackOversizeRegistry{
+		repo:     repo,
+		rev:      rev,
+		maxBytes: maxBytes,
+		pending:  map[string]struct{}{},
+		resolved: map[string]*oversizeFile{},
+	}
+}
+
+// note records that the fallback refused path. Files are processed in parallel
+// and the batch reader's own registry is private to it, so this keeps its lock.
+func (r *fallbackOversizeRegistry) note(path string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, done := r.resolved[path]; done {
+		return
+	}
+	r.pending[path] = struct{}{}
+}
+
+// lookup resolves a noted path to the record MaxParseBytes promises. The lock is
+// not held across the git call; a concurrent duplicate would only recompute the
+// same answer, because the revision it reads is immutable.
+func (r *fallbackOversizeRegistry) lookup(ctx context.Context, path string) (oversizeFile, bool) {
+	r.mu.Lock()
+	record, done := r.resolved[path]
+	if !done {
+		_, done = r.pending[path]
+		if !done {
+			r.mu.Unlock()
+			return oversizeFile{}, false
+		}
+		r.mu.Unlock()
+		blob, over, err := gitutil.OversizeBlobAtRev(ctx, r.repo, r.rev, path, r.maxBytes)
+		if err == nil && over {
+			record = &oversizeFile{Bytes: blob.Bytes, Hash: blob.Hash, Lines: blob.Lines}
+		}
+		r.mu.Lock()
+		r.resolved[path] = record
+		delete(r.pending, path)
+	}
+	r.mu.Unlock()
+	if record == nil {
+		return oversizeFile{}, false
+	}
+	return *record, true
 }
 
 // oversizeRegistry remembers the working-tree files the reader refused, and

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -1439,6 +1439,14 @@ func prepareSource(ctx context.Context, repo string, options ProviderSnapshotOpt
 		}
 		paths = filtered
 	}
+	if opened.prime != nil {
+		if err := opened.prime(paths); err != nil {
+			if opened.close != nil {
+				err = errors.Join(err, opened.close())
+			}
+			return sourceContext{}, err
+		}
+	}
 
 	warnings := append([]ProviderWarning(nil), opened.warnings...)
 	if options.Worktree {
@@ -9746,8 +9754,11 @@ type openedSource struct {
 	read       contentReader
 	readPrefix prefixReader
 	oversize   oversizeReader
-	close      func() error
-	warnings   []ProviderWarning
+	// prime deterministically admits the final filtered committed-tree paths
+	// to any shared bounded metadata reader before parallel workers start.
+	prime    func([]string) error
+	close    func() error
+	warnings []ProviderWarning
 }
 
 // openSource lists the repository's files and returns a per-file content reader
@@ -9775,11 +9786,16 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 		paths = filterVendoredPaths(paths, headVendorIgnoreRules(ctx, repo, committedRevision, paths))
 		paths = filterIgnoredPaths(paths, ignores)
 		paths, warnings := capSourceFiles(paths, options.maxFiles)
+		treePathPrefix, err := gitutil.RepoPrefix(ctx, repo)
+		if err != nil {
+			return openedSource{}, err
+		}
 		batch, err := gitutil.NewBatchFileReader(ctx, repo, committedRevision)
 		if err != nil {
 			return openedSource{}, err
 		}
 		batch.SetMaxBytes(maxReadBytes)
+		limited := gitutil.NewLimitedFileReader(ctx, repo, committedRevision, maxReadBytes)
 		// The oversize registry for the paths the batch reader cannot carry.
 		// batch.OversizeBlob only knows blobs that streamed past IT, so a
 		// refusal in the line-unsafe fallback below has to be recorded here or the
@@ -9789,13 +9805,14 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 		read := func(path string) (string, bool) {
 			if !batch.IsPathSafe(path) {
 				// The batch protocol is line based, so a newline-bearing Git
-				// path needs the argv-safe one-shot reader. The ceiling is
-				// passed DOWN rather than applied to the returned string: this
+				// path needs the exact-object bounded reader. Sharing it across
+				// files also shares its component cache and process allowance.
+				// The ceiling is passed DOWN rather than applied to the returned string: this
 				// fallback is selected by the file's NAME, which the repository
 				// under analysis chooses, so an unbounded read here would let
 				// any repository opt one blob out of the cap that makes this
 				// reader's memory claim true.
-				result, err := gitutil.ReadFileLimited(ctx, repo, committedRevision, path, maxReadBytes)
+				result, err := limited.ReadFile(treePathPrefix + path)
 				if err != nil {
 					return "", false
 				}
@@ -9805,8 +9822,8 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 					// declined from one it could not read: the file record is
 					// dropped, the warning becomes an error-severity
 					// E_FILE_READ, and completeness falls to degraded.
-					// ReadFileLimited gives the exact size without reading, but the digest
-					// MaxParseBytes promises is still owed — noted here and
+					// LimitedFileReader gives the exact size without reading, but
+					// the digest MaxParseBytes promises is still owed — noted here and
 					// resolved lazily below. An absent path records nothing.
 					if result.Status == gitutil.LimitedFileOversize {
 						fallback.note(path)
@@ -9843,12 +9860,25 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 			}
 			return content, true
 		}
+		closeReaders := func() error {
+			return errors.Join(batch.Close(), limited.Close())
+		}
+		prime := func(paths []string) error {
+			unsafeTreePaths := make([]string, 0, len(paths))
+			for _, path := range paths {
+				if !batch.IsPathSafe(path) {
+					unsafeTreePaths = append(unsafeTreePaths, treePathPrefix+path)
+				}
+			}
+			return limited.Prime(unsafeTreePaths)
+		}
 		return openedSource{
 			paths:      paths,
 			read:       read,
 			readPrefix: readPrefix,
 			oversize:   oversize,
-			close:      batch.Close,
+			prime:      prime,
+			close:      closeReaders,
 			warnings:   warnings,
 		}, nil
 	}
@@ -9905,7 +9935,7 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 	}, nil
 }
 
-// fallbackOversizeRegistry remembers the HEAD-tree paths the one-shot line-unsafe
+// fallbackOversizeRegistry remembers the HEAD-tree paths the bounded line-unsafe
 // fallback refused, and resolves each one's record at most once. It is the
 // committed-revision counterpart of oversizeRegistry below, and defers for the
 // same reason: resolving costs a streaming pass over the blob, and preselection

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -733,6 +733,14 @@ type oversizeFile struct {
 	Bytes int64
 	Hash  string
 	Lines int
+	// Prefix holds up to a few KiB of leading content, captured for free from
+	// the same streaming pass that computes Hash and Lines when the source
+	// can. It backs shebang routing for a committed, extensionless file whose
+	// blob is too large for the ordinary content read to reach at all (Git
+	// blob reads are all-or-nothing, so readPrefix cannot bound its own read
+	// the way the filesystem source's readPrefix does). Empty when the
+	// source has no prefix to offer.
+	Prefix string
 }
 
 // oversizeReader reports why a content read came back empty: a file above the
@@ -9846,7 +9854,7 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 			if !ok {
 				return oversizeFile{}, false
 			}
-			return oversizeFile{Bytes: blob.Bytes, Hash: blob.Hash, Lines: blob.Lines}, true
+			return oversizeFile{Bytes: blob.Bytes, Hash: blob.Hash, Lines: blob.Lines, Prefix: blob.Prefix}, true
 		}
 		// Git blob reads are all-or-nothing, so the HEAD-tree prefix reader
 		// fetches the blob and truncates.
@@ -9994,7 +10002,7 @@ func (r *fallbackOversizeRegistry) lookup(ctx context.Context, path string) (ove
 		r.mu.Unlock()
 		blob, over, err := gitutil.OversizeBlobAtRev(ctx, r.repo, r.rev, path, r.maxBytes)
 		if err == nil && over {
-			record = &oversizeFile{Bytes: blob.Bytes, Hash: blob.Hash, Lines: blob.Lines}
+			record = &oversizeFile{Bytes: blob.Bytes, Hash: blob.Hash, Lines: blob.Lines, Prefix: blob.Prefix}
 		}
 		r.mu.Lock()
 		r.resolved[path] = record

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -9805,6 +9805,9 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 			return openedSource{}, err
 		}
 		batch.SetMaxBytes(maxReadBytes)
+		batch.SetOversizePrefixSelector(func(path string) bool {
+			return !Supported(path)
+		})
 		limited := gitutil.NewLimitedFileReader(ctx, repo, committedRevision, maxReadBytes)
 		// The oversize registry for the paths the batch reader cannot carry.
 		// batch.OversizeBlob only knows blobs that streamed past IT, so a
@@ -9852,7 +9855,7 @@ func openSource(ctx context.Context, repo, committedRevision string, options sou
 			if over, ok := fallback.lookup(ctx, path); ok {
 				return over, true
 			}
-			blob, ok := batch.OversizeBlob(path)
+			blob, ok := batch.TakeOversizeBlob(path)
 			if !ok {
 				return oversizeFile{}, false
 			}
@@ -10004,10 +10007,20 @@ func (r *fallbackOversizeRegistry) lookup(ctx context.Context, path string) (ove
 		r.mu.Unlock()
 		blob, over, err := gitutil.OversizeBlobAtRev(ctx, r.repo, r.rev, path, r.maxBytes)
 		if err == nil && over {
-			record = &oversizeFile{Bytes: blob.Bytes, Hash: blob.Hash, Lines: blob.Lines, Prefix: blob.Prefix}
+			prefix := blob.Prefix
+			if Supported(path) {
+				prefix = ""
+			}
+			record = &oversizeFile{Bytes: blob.Bytes, Hash: blob.Hash, Lines: blob.Lines, Prefix: prefix}
 		}
 		r.mu.Lock()
-		r.resolved[path] = record
+		stored := record
+		if record != nil && record.Prefix != "" {
+			cached := *record
+			cached.Prefix = ""
+			stored = &cached
+		}
+		r.resolved[path] = stored
 		delete(r.pending, path)
 	}
 	r.mu.Unlock()

--- a/internal/sem/provider_parallel.go
+++ b/internal/sem/provider_parallel.go
@@ -57,6 +57,7 @@ func processProviderFile(
 	if ctx.Err() != nil {
 		return result
 	}
+	var routedOversize *oversizeFile
 	// Path-based routing first; files the path cannot classify (extensionless
 	// executables like pyenv's libexec/* scripts) get one bounded prefix read
 	// to route by shebang before being declared unsupported. Git blob reads
@@ -70,6 +71,9 @@ func processProviderFile(
 		if !routable {
 			if over, isOversize := sc.oversizeAt(path); isOversize && over.Prefix != "" {
 				_, routable = languageForShebang(over.Prefix)
+				if routable {
+					routedOversize = &over
+				}
 			}
 		}
 		if !routable {
@@ -86,11 +90,19 @@ func processProviderFile(
 		}
 	}
 
-	content, ok := sc.read(path)
+	var content string
+	var ok bool
+	if routedOversize == nil {
+		content, ok = sc.read(path)
+	}
 	if !ok {
 		// A refused read is not a failed one: the reader declines files above
 		// the byte cap so no single file can set the snapshot's memory ceiling.
-		if over, isOversize := sc.oversizeAt(path); isOversize {
+		over, isOversize := sc.oversizeAt(path)
+		if routedOversize != nil {
+			over, isOversize = *routedOversize, true
+		}
+		if isOversize {
 			langSpec, langOK := languageForPath(path)
 			if !langOK && over.Prefix != "" {
 				// The ordinary bounded prefix read is doomed here for the same

--- a/internal/sem/provider_parallel.go
+++ b/internal/sem/provider_parallel.go
@@ -57,6 +57,8 @@ func processProviderFile(
 	if ctx.Err() != nil {
 		return result
 	}
+	var routedLanguage languageSpec
+	var routedLanguageOK bool
 	var routedOversize *oversizeFile
 	// Path-based routing first; files the path cannot classify (extensionless
 	// executables like pyenv's libexec/* scripts) get one bounded prefix read
@@ -67,16 +69,20 @@ func processProviderFile(
 	// kept one, so it does not fall through to "unsupported" purely because
 	// of its size.
 	if !Supported(path) {
-		routable := shebangRoutable(sc.readPrefix, path)
-		if !routable {
+		if sc.readPrefix != nil {
+			if prefix, prefixOK := sc.readPrefix(path, shebangSniffLimit); prefixOK {
+				routedLanguage, routedLanguageOK = languageForShebang(prefix)
+			}
+		}
+		if !routedLanguageOK {
 			if over, isOversize := sc.oversizeAt(path); isOversize && over.Prefix != "" {
-				_, routable = languageForShebang(over.Prefix)
-				if routable {
+				routedLanguage, routedLanguageOK = languageForShebang(over.Prefix)
+				if routedLanguageOK {
 					routedOversize = &over
 				}
 			}
 		}
-		if !routable {
+		if !routedLanguageOK {
 			if hint := unsupportedLanguageHint(path); hint != "" {
 				result.failures = append(result.failures, PartialFailure{
 					Code:                 "E_UNSUPPORTED_LANGUAGE",
@@ -98,13 +104,18 @@ func processProviderFile(
 	if !ok {
 		// A refused read is not a failed one: the reader declines files above
 		// the byte cap so no single file can set the snapshot's memory ceiling.
-		over, isOversize := sc.oversizeAt(path)
+		var over oversizeFile
+		var isOversize bool
 		if routedOversize != nil {
 			over, isOversize = *routedOversize, true
+		} else {
+			over, isOversize = sc.oversizeAt(path)
 		}
 		if isOversize {
 			langSpec, langOK := languageForPath(path)
-			if !langOK && over.Prefix != "" {
+			if !langOK && routedLanguageOK {
+				langSpec, langOK = routedLanguage, true
+			} else if !langOK && over.Prefix != "" {
 				// The ordinary bounded prefix read is doomed here for the same
 				// reason the read above was refused (Git blob reads are
 				// all-or-nothing); reuse the prefix already captured while

--- a/internal/sem/provider_parallel.go
+++ b/internal/sem/provider_parallel.go
@@ -59,18 +59,31 @@ func processProviderFile(
 	}
 	// Path-based routing first; files the path cannot classify (extensionless
 	// executables like pyenv's libexec/* scripts) get one bounded prefix read
-	// to route by shebang before being declared unsupported.
-	if !Supported(path) && !shebangRoutable(sc.readPrefix, path) {
-		if hint := unsupportedLanguageHint(path); hint != "" {
-			result.failures = append(result.failures, PartialFailure{
-				Code:                 "E_UNSUPPORTED_LANGUAGE",
-				Severity:             "warning",
-				FilePath:             path,
-				EffectOnCompleteness: "file omitted because no parser is available",
-				Detail:               hint,
-			})
+	// to route by shebang before being declared unsupported. Git blob reads
+	// are all-or-nothing, so an oversized committed blob can never satisfy
+	// that bounded prefix read directly; route it instead from the prefix
+	// already captured for free while streaming its digest, when the source
+	// kept one, so it does not fall through to "unsupported" purely because
+	// of its size.
+	if !Supported(path) {
+		routable := shebangRoutable(sc.readPrefix, path)
+		if !routable {
+			if over, isOversize := sc.oversizeAt(path); isOversize && over.Prefix != "" {
+				_, routable = languageForShebang(over.Prefix)
+			}
 		}
-		return result
+		if !routable {
+			if hint := unsupportedLanguageHint(path); hint != "" {
+				result.failures = append(result.failures, PartialFailure{
+					Code:                 "E_UNSUPPORTED_LANGUAGE",
+					Severity:             "warning",
+					FilePath:             path,
+					EffectOnCompleteness: "file omitted because no parser is available",
+					Detail:               hint,
+				})
+			}
+			return result
+		}
 	}
 
 	content, ok := sc.read(path)
@@ -79,10 +92,12 @@ func processProviderFile(
 		// the byte cap so no single file can set the snapshot's memory ceiling.
 		if over, isOversize := sc.oversizeAt(path); isOversize {
 			langSpec, langOK := languageForPath(path)
-			if !langOK {
-				if prefix, prefixOK := sc.readPrefix(path, shebangSniffLimit); prefixOK {
-					langSpec, langOK = languageForShebang(prefix)
-				}
+			if !langOK && over.Prefix != "" {
+				// The ordinary bounded prefix read is doomed here for the same
+				// reason the read above was refused (Git blob reads are
+				// all-or-nothing); reuse the prefix already captured while
+				// streaming this blob's digest instead of retrying it.
+				langSpec, langOK = languageForShebang(over.Prefix)
 			}
 			if !langOK {
 				result.failures = append(result.failures, PartialFailure{

--- a/internal/sem/provider_vendor_ignore_unreadable_test.go
+++ b/internal/sem/provider_vendor_ignore_unreadable_test.go
@@ -1,0 +1,141 @@
+package sem
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// gitRevParseOutput runs `git rev-parse` in repo and returns the trimmed
+// stdout, failing the test on error.
+func gitRevParseOutput(t *testing.T, repo string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"rev-parse"}, args...)...)
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git rev-parse %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// deleteLooseObject removes a committed blob's own loose object file from
+// repo's object store, without touching the tree entry that names it. Git
+// still knows a blob belongs there — `git ls-tree`/`git rev-parse` keep
+// answering from the tree and commit objects, which are untouched — but any
+// read of the blob's OWN content now fails exactly as it would for a
+// promised-but-missing object in a partial clone whose lazy fetch this
+// provider's GIT_ALLOW_PROTOCOL= guard refuses to allow: a real error, never
+// git's "path does not exist" diagnostic.
+func deleteLooseObject(t *testing.T, repo, hash string) {
+	t.Helper()
+	// Loose objects can be packed instead (e.g. after a clone that runs its
+	// own gc), so this repacks loose first to guarantee a loose file exists
+	// to delete; --unpacked with no other args is a no-op if already loose.
+	objPath := filepath.Join(repo, ".git", "objects", hash[:2], hash[2:])
+	if _, err := os.Stat(objPath); err != nil {
+		t.Fatalf("blob %s is not a loose object at %s (%v); repacking may be required for this git version", hash, objPath, err)
+	}
+	if err := os.Remove(objPath); err != nil {
+		t.Fatalf("remove loose object %s: %v", objPath, err)
+	}
+}
+
+// TestSnapshotDoesNotSilentlyDropPathsWhenANestedVendorGitignoreIsUnreadable
+// reproduces the trail finding on headVendorIgnoreRules: this provider's
+// GIT_ALLOW_PROTOCOL= no-egress guard (added to close the pre-2.45
+// GIT_NO_LAZY_FETCH gap) means a partial clone can no longer lazily fetch a
+// promised-but-missing blob, so `git show` for it fails with a REAL error
+// rather than "path does not exist". headVendorIgnoreRules used to treat that
+// error exactly like an absent file, silently discarding the negation
+// `vendor/.gitignore` (`*` + `!pkg/`) declares — and with it, the first-party
+// path `vendor/pkg/keep.go` it re-includes, with no warning at all.
+//
+// A loose object deleted after the commit reproduces the same failure mode
+// ShowFile sees (a real git error, never the missing-path diagnostic)
+// without needing a real partial clone or network denial.
+func TestSnapshotDoesNotSilentlyDropPathsWhenANestedVendorGitignoreIsUnreadable(t *testing.T) {
+	repo := t.TempDir()
+	initRepo(t, repo)
+	writeFile(t, repo, "vendor/.gitignore", "*\n!pkg/\n")
+	writeFile(t, repo, "vendor/pkg/keep.go", "package pkg\n")
+	writeFile(t, repo, "main.go", "package main\n")
+	// vendor/ is a name the vendored-directory heuristic treats as vendored by
+	// default; these files must be force-added despite vendor/.gitignore's own
+	// `*` rule, the same way a project that checks in an allowlisted vendor
+	// subtree has to.
+	git(t, repo, "add", "-f", "-A")
+	git(t, repo, "commit", "-m", "vendor with a re-included subpackage")
+
+	hash := gitRevParseOutput(t, repo, "HEAD:vendor/.gitignore")
+	deleteLooseObject(t, repo, hash)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var sawKeep bool
+	for _, file := range snapshot.Files {
+		if file.Path == "vendor/pkg/keep.go" {
+			sawKeep = true
+		}
+	}
+	if !sawKeep {
+		t.Errorf("vendor/pkg/keep.go missing from snapshot files (%d files); an unreadable nested"+
+			" .gitignore must not silently drop the first-party path its negation re-includes",
+			len(snapshot.Files))
+	}
+
+	var sawWarning bool
+	for _, warning := range snapshot.Header.Warnings {
+		if warning.Code == "W_VENDOR_IGNORE_UNREADABLE" {
+			sawWarning = true
+			if warning.FilePath != "vendor/.gitignore" {
+				t.Errorf("W_VENDOR_IGNORE_UNREADABLE warning FilePath = %q, want %q", warning.FilePath, "vendor/.gitignore")
+			}
+		}
+	}
+	if !sawWarning {
+		t.Error("no W_VENDOR_IGNORE_UNREADABLE warning: an unreadable nested .gitignore must be disclosed, not silent")
+	}
+}
+
+// TestNestedVendorGitignoreStillExcludesUnrelatedVendoredPathsWhenAnotherIsUnreadable
+// is the narrowing half: an unreadable .gitignore must fail open only for the
+// specific subtree its own rules govern, not for every vendored directory in
+// the repository, or the heuristic loses all value the instant any one blob
+// is unreadable. node_modules/ here has no .gitignore of its own at all, so
+// nothing about vendor/.gitignore being unreadable can legitimately affect it.
+func TestNestedVendorGitignoreStillExcludesUnrelatedVendoredPathsWhenAnotherIsUnreadable(t *testing.T) {
+	repo := t.TempDir()
+	initRepo(t, repo)
+	writeFile(t, repo, "vendor/.gitignore", "*\n!pkg/\n")
+	writeFile(t, repo, "vendor/pkg/keep.go", "package pkg\n")
+	writeFile(t, repo, "node_modules/thirdparty.js", "module.exports = {};\n")
+	writeFile(t, repo, "main.go", "package main\n")
+	git(t, repo, "add", "-f", "-A")
+	git(t, repo, "commit", "-m", "a vendored subtree with a re-included subpackage, plus an unrelated vendored dir")
+
+	hash := gitRevParseOutput(t, repo, "HEAD:vendor/.gitignore")
+	deleteLooseObject(t, repo, hash)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	filesByPath := map[string]struct{}{}
+	for _, file := range snapshot.Files {
+		filesByPath[file.Path] = struct{}{}
+	}
+	if _, ok := filesByPath["vendor/pkg/keep.go"]; !ok {
+		t.Error("vendor/pkg/keep.go missing: its own unreadable .gitignore must fail open for its subtree")
+	}
+	if _, ok := filesByPath["node_modules/thirdparty.js"]; ok {
+		t.Error("node_modules/thirdparty.js present: an unrelated vendored directory with no .gitignore" +
+			" of its own must still be excluded when only vendor/.gitignore is unreadable")
+	}
+}

--- a/internal/sem/provider_vendor_ignore_unreadable_test.go
+++ b/internal/sem/provider_vendor_ignore_unreadable_test.go
@@ -139,3 +139,28 @@ func TestNestedVendorGitignoreStillExcludesUnrelatedVendoredPathsWhenAnotherIsUn
 			" of its own must still be excluded when only vendor/.gitignore is unreadable")
 	}
 }
+
+func TestUnreadableNestedVendorGitignoreKeepsItsVendoredAncestor(t *testing.T) {
+	repo := t.TempDir()
+	initRepo(t, repo)
+	writeFile(t, repo, "vendor/pkg/.gitignore", "*\n!keep.go\n")
+	writeFile(t, repo, "vendor/pkg/keep.go", "package pkg\n")
+	writeFile(t, repo, "main.go", "package main\n")
+	git(t, repo, "add", "-f", "-A")
+	git(t, repo, "commit", "-m", "nested vendor rules with a re-included file")
+
+	hash := gitRevParseOutput(t, repo, "HEAD:vendor/pkg/.gitignore")
+	deleteLooseObject(t, repo, hash)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, file := range snapshot.Files {
+		if file.Path == "vendor/pkg/keep.go" {
+			return
+		}
+	}
+	t.Error("vendor/pkg/keep.go missing: an unreadable nested .gitignore must also keep a vendored ancestor that traversal must cross")
+}

--- a/internal/sem/provider_vendor_ignore_unreadable_test.go
+++ b/internal/sem/provider_vendor_ignore_unreadable_test.go
@@ -1,6 +1,7 @@
 package sem
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -163,4 +164,28 @@ func TestUnreadableNestedVendorGitignoreKeepsItsVendoredAncestor(t *testing.T) {
 		}
 	}
 	t.Error("vendor/pkg/keep.go missing: an unreadable nested .gitignore must also keep a vendored ancestor that traversal must cross")
+}
+
+func TestBoundedNestedIgnorePathsCapsEveryAttemptedInput(t *testing.T) {
+	paths := []string{"main.go", ".gitignore"}
+	for i := 0; i < maxNestedIgnoreFiles+1; i++ {
+		paths = append(paths, fmt.Sprintf("dir-%04d/.gitignore", i))
+	}
+
+	got, truncated := boundedNestedIgnorePaths(paths)
+	if !truncated {
+		t.Fatal("boundedNestedIgnorePaths did not disclose an input beyond the limit")
+	}
+	if len(got) != maxNestedIgnoreFiles {
+		t.Fatalf("boundedNestedIgnorePaths returned %d inputs, want bounded %d", len(got), maxNestedIgnoreFiles)
+	}
+	if last := got[len(got)-1]; last != fmt.Sprintf("dir-%04d/.gitignore", maxNestedIgnoreFiles-1) {
+		t.Fatalf("last bounded nested ignore path = %q, want stable input prefix", last)
+	}
+
+	rules := newNestedIgnoreRules(ignoreMatcher{})
+	rules.incomplete = true
+	if !rules.ReincludesDescendant("vendor") {
+		t.Fatal("incomplete nested ignore inputs did not fail open for an arbitrary vendored subtree")
+	}
 }

--- a/internal/sem/records_cache.go
+++ b/internal/sem/records_cache.go
@@ -15,20 +15,21 @@ import (
 )
 
 // Provider records (the streamed snapshot/symbols/edges NDJSON emitted by the
-// `graph` commands) are deterministic for a given git tree, indexing mode, and
-// set of options. Recomputing them on every call is expensive on large repos, so
-// we cache the raw NDJSON bytes keyed on the HEAD tree hash plus everything else
-// that changes the output. This mirrors the search-snapshot cache next door. v5
-// introduces typed, length-prefixed fields and bounded ignore-file reads.
-const providerRecordsCacheVersion = "provider-records-v5"
+// `graph` commands) are deterministic for a given commit, tree, indexing mode,
+// and set of options. Recomputing them on every call is expensive on large
+// repos, so we cache the raw NDJSON bytes under that complete identity. Unlike
+// the structured search cache, an opaque record stream cannot restamp commit
+// provenance on a same-tree hit.
+const providerRecordsCacheVersion = "provider-records-v7"
 
 // cachedProviderRecords is the on-disk envelope for a cached record stream. The
-// key alone is authoritative (sha256 over version+tree+mode+profile+options+
-// path-file contents), but we re-validate the discriminating fields on read as
-// defense-in-depth against a stale or hand-edited cache file.
+// key alone is authoritative (sha256 over version+commit+tree+mode+profile+
+// options+path-file contents), but we re-validate the discriminating fields on
+// read as defense-in-depth against a stale or hand-edited cache file.
 type cachedProviderRecords struct {
 	CacheVersion    string           `json:"cache_version"`
 	ProviderVersion string           `json:"provider_version"`
+	Commit          string           `json:"commit"`
 	Tree            string           `json:"tree"`
 	Mode            string           `json:"mode"`
 	Profile         Profile          `json:"profile"`
@@ -46,7 +47,11 @@ type cachedProviderRecords struct {
 // completeness even though the record commands do not expose it. Callers must
 // NOT use this for --worktree runs (the working tree can differ from HEAD) or
 // for targeted --to/--from/--relation queries.
-func providerRecordsKey(absRepo, repositoryKey, providerVersion, tree, mode string, options ProviderSnapshotOptions) (string, error) {
+func providerRecordsKey(absRepo, repositoryKey, providerVersion, commit, tree, mode string, options ProviderSnapshotOptions) (string, error) {
+	policy, err := cachePolicyForOptions(absRepo, options)
+	if err != nil {
+		return "", err
+	}
 	hash := sha256.New()
 	writeCacheKeyString(hash, "cache-version", providerRecordsCacheVersion)
 	// The built-in credential-store deny decides which files are in this corpus at
@@ -60,6 +65,7 @@ func providerRecordsKey(absRepo, repositoryKey, providerVersion, tree, mode stri
 	// searchSnapshotKey already folds this in; this key did not.
 	writeCacheKeyString(hash, "repository-key", repositoryKey)
 	writeCacheKeyString(hash, "provider-version", providerVersion)
+	writeCacheKeyString(hash, "commit", commit)
 	writeCacheKeyString(hash, "tree", tree)
 	writeCacheKeyString(hash, "mode", mode)
 	writeCacheKeyString(hash, "profile", string(options.Profile))
@@ -74,112 +80,146 @@ func providerRecordsKey(absRepo, repositoryKey, providerVersion, tree, mode stri
 	for _, filePath := range onlyFiles {
 		writeCacheKeyString(hash, "only-file", filepath.ToSlash(filepath.Clean(filePath)))
 	}
-	for groupIndex, group := range [][]string{options.IgnoreFiles, options.IncludeFiles} {
-		writeCacheKeyString(hash, "path-group", fmt.Sprintf("%d", groupIndex))
-		// Preserve caller order: ignore matching is last-rule-wins, including
-		// across repeatable ignore/include files within each group.
-		for _, rulePath := range group {
-			resolved := rulePath
-			if !filepath.IsAbs(resolved) {
-				resolved = filepath.Join(absRepo, resolved)
-			}
-			writeCacheKeyString(hash, "rule-path", filepath.Clean(resolved))
-			content, _, err := readBoundedRegularFile(
-				resolved,
-				ignoreFileLabel(groupIndex == 1),
-				true,
-				maxIgnoreFileBytes,
-			)
-			if err != nil {
-				return "", err
-			}
-			writeCacheKeyField(hash, "rule-content", content)
-		}
-	}
-
-	// .graphignore is applied without an explicit option, so its state must bind
-	// the records entry just as it binds the parsed search snapshot.
-	graphIgnore := filepath.Join(absRepo, graphIgnoreFileName)
-	content, present, err := readBoundedRegularFile(
-		graphIgnore,
-		ignoreFileLabel(false),
-		false,
-		maxIgnoreFileBytes,
-	)
-	if err != nil {
-		return "", err
-	}
-	if present {
-		writeCacheKeyField(hash, "graphignore-content", content)
-	} else {
-		writeCacheKeyField(hash, "graphignore-missing", nil)
-	}
+	policy.writeCacheKey(hash)
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
-// LoadProviderRecords returns the cached NDJSON record stream for repo at the
-// given tree/mode/options, or hit=false when there is no usable cache entry.
-// The returned summary (when present) lets the caller reproduce the partial-parse
-// warning without re-indexing. A missing/corrupt cache is a miss, not an error;
-// only a key-derivation failure (an unreadable ignore/include file) errors.
-func LoadProviderRecords(ctx context.Context, repo, providerVersion, tree, mode, cacheDir string, options ProviderSnapshotOptions) ([]byte, *SnapshotSummary, bool, error) {
-	if cacheDir == "" || tree == "" || options.Worktree {
-		return nil, nil, false, nil
-	}
-	absRepo, err := filepath.Abs(repo)
-	if err != nil {
-		return nil, nil, false, err
-	}
-	key, err := providerRecordsKey(absRepo, repoKey(ctx, absRepo), providerVersion, tree, mode, options)
-	if err != nil {
-		return nil, nil, false, err
-	}
-	entry, err := newCacheEntry(cacheDir, "records", providerRecordsCacheVersion, key)
-	if err != nil {
-		return nil, nil, false, err
-	}
-	cache, err := readProviderRecords(entry)
-	if err != nil || !validCachedProviderRecords(cache, providerVersion, tree, mode, options) {
-		return nil, nil, false, nil
-	}
-	return cache.Records, cache.Summary, true, nil
+// ProviderRecordsCacheTransaction pins the cache key and immutable ignore
+// policy used by one record-stream lookup/build/store cycle.
+type ProviderRecordsCacheTransaction struct {
+	enabled         bool
+	entry           cacheEntry
+	providerVersion string
+	repositoryKey   string
+	commit          string
+	tree            string
+	mode            string
+	options         ProviderSnapshotOptions
 }
 
-// StoreProviderRecords persists a freshly built record stream. Persistence is
-// best effort: retrieval correctness never depends on a writable cache dir, so
-// callers may ignore the returned error.
-func StoreProviderRecords(ctx context.Context, repo, providerVersion, tree, mode, cacheDir string, options ProviderSnapshotOptions, records []byte, summary *SnapshotSummary) error {
-	if cacheDir == "" || tree == "" || options.Worktree {
-		return nil
+// BeginProviderRecordsCache captures every external ignore input once and
+// prepares the one entry used throughout a provider-record cache transaction.
+// Callers must build records with Options before calling Store.
+func BeginProviderRecordsCache(ctx context.Context, repo, providerVersion, commit, tree, mode, cacheDir string, options ProviderSnapshotOptions) (*ProviderRecordsCacheTransaction, error) {
+	transaction := &ProviderRecordsCacheTransaction{
+		providerVersion: providerVersion,
+		commit:          commit,
+		tree:            tree,
+		mode:            mode,
+		options:         options,
+	}
+	if cacheDir == "" || commit == "" || tree == "" || options.Worktree {
+		return transaction, nil
 	}
 	absRepo, err := filepath.Abs(repo)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	key, err := providerRecordsKey(absRepo, repoKey(ctx, absRepo), providerVersion, tree, mode, options)
+	transaction.options, err = CaptureProviderCachePolicy(absRepo, options)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	entry, err := newCacheEntry(cacheDir, "records", providerRecordsCacheVersion, key)
+	transaction.repositoryKey = repoKey(ctx, absRepo)
+	key, err := providerRecordsKey(
+		absRepo,
+		transaction.repositoryKey,
+		providerVersion,
+		commit,
+		tree,
+		mode,
+		transaction.options,
+	)
 	if err != nil {
-		return err
+		return nil, err
+	}
+	transaction.entry, err = newCacheEntry(cacheDir, "records", providerRecordsCacheVersion, key)
+	if err != nil {
+		return nil, err
+	}
+	transaction.enabled = true
+	return transaction, nil
+}
+
+// Options returns the policy-pinned options that must shape records stored by
+// this transaction.
+func (transaction *ProviderRecordsCacheTransaction) Options() ProviderSnapshotOptions {
+	if transaction == nil {
+		return ProviderSnapshotOptions{}
+	}
+	return cloneProviderSnapshotOptions(transaction.options)
+}
+
+// Load returns this transaction's cached record stream, when present.
+func (transaction *ProviderRecordsCacheTransaction) Load() ([]byte, *SnapshotSummary, bool) {
+	if transaction == nil || !transaction.enabled {
+		return nil, nil, false
+	}
+	cache, err := readProviderRecords(transaction.entry)
+	if err != nil || !validCachedProviderRecords(
+		cache,
+		transaction.providerVersion,
+		transaction.commit,
+		transaction.tree,
+		transaction.mode,
+		transaction.options,
+	) {
+		return nil, nil, false
+	}
+	return cache.Records, cache.Summary, true
+}
+
+// Store persists records built with Options only when their observed header
+// still matches the immutable commit, tree, repository identity, provider, and
+// profile that keyed this transaction. A moving HEAD or remote therefore cannot
+// place a later snapshot's record stream under the earlier cache entry.
+func (transaction *ProviderRecordsCacheTransaction) Store(records []byte, summary *SnapshotSummary, observed SnapshotHeader) error {
+	if transaction == nil || !transaction.enabled {
+		return nil
+	}
+	if observed.Tree != transaction.tree ||
+		observed.Commit != transaction.commit ||
+		observed.RepoKey != transaction.repositoryKey ||
+		observed.Provider != ProviderName ||
+		observed.ProviderVersion != transaction.providerVersion ||
+		observed.Profile != string(transaction.options.Profile) {
+		return fmt.Errorf(
+			"provider records snapshot provenance changed while building: got commit=%q tree=%q repo=%q provider=%q version=%q profile=%q, want commit=%q tree=%q repo=%q provider=%q version=%q profile=%q",
+			observed.Commit, observed.Tree, observed.RepoKey, observed.Provider, observed.ProviderVersion, observed.Profile,
+			transaction.commit, transaction.tree, transaction.repositoryKey, ProviderName, transaction.providerVersion, transaction.options.Profile,
+		)
 	}
 	cache := cachedProviderRecords{
 		CacheVersion:    providerRecordsCacheVersion,
-		ProviderVersion: providerVersion,
-		Tree:            tree,
-		Mode:            mode,
-		Profile:         options.Profile,
-		MaxParseBytes:   options.MaxParseBytes,
+		ProviderVersion: transaction.providerVersion,
+		Commit:          transaction.commit,
+		Tree:            transaction.tree,
+		Mode:            transaction.mode,
+		Profile:         transaction.options.Profile,
+		MaxParseBytes:   transaction.options.MaxParseBytes,
 		Records:         records,
 		Summary:         summary,
 	}
-	return writeProviderRecords(entry, cache)
+	return writeProviderRecords(transaction.entry, cache)
 }
 
-func validCachedProviderRecords(cache cachedProviderRecords, providerVersion, tree, mode string, options ProviderSnapshotOptions) bool {
+// LoadProviderRecords returns the cached NDJSON record stream for repo at the
+// given commit/tree/mode/options, or hit=false when there is no usable entry.
+// The returned summary (when present) lets the caller reproduce the partial-parse
+// warning without re-indexing. A missing/corrupt cache is a miss, not an error;
+// only a key-derivation failure (an unreadable ignore/include file) errors.
+func LoadProviderRecords(ctx context.Context, repo, providerVersion, commit, tree, mode, cacheDir string, options ProviderSnapshotOptions) ([]byte, *SnapshotSummary, bool, error) {
+	transaction, err := BeginProviderRecordsCache(ctx, repo, providerVersion, commit, tree, mode, cacheDir, options)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	records, summary, hit := transaction.Load()
+	return records, summary, hit, nil
+}
+
+func validCachedProviderRecords(cache cachedProviderRecords, providerVersion, commit, tree, mode string, options ProviderSnapshotOptions) bool {
 	return cache.CacheVersion == providerRecordsCacheVersion &&
 		cache.ProviderVersion == providerVersion &&
+		cache.Commit == commit &&
 		cache.Tree == tree &&
 		cache.Mode == mode &&
 		cache.Profile == options.Profile &&

--- a/internal/sem/records_cache.go
+++ b/internal/sem/records_cache.go
@@ -18,8 +18,9 @@ import (
 // `graph` commands) are deterministic for a given git tree, indexing mode, and
 // set of options. Recomputing them on every call is expensive on large repos, so
 // we cache the raw NDJSON bytes keyed on the HEAD tree hash plus everything else
-// that changes the output. This mirrors the search-snapshot cache next door.
-const providerRecordsCacheVersion = "provider-records-v4"
+// that changes the output. This mirrors the search-snapshot cache next door. v5
+// introduces typed, length-prefixed fields and bounded ignore-file reads.
+const providerRecordsCacheVersion = "provider-records-v5"
 
 // cachedProviderRecords is the on-disk envelope for a cached record stream. The
 // key alone is authoritative (sha256 over version+tree+mode+profile+options+
@@ -47,57 +48,71 @@ type cachedProviderRecords struct {
 // for targeted --to/--from/--relation queries.
 func providerRecordsKey(absRepo, repositoryKey, providerVersion, tree, mode string, options ProviderSnapshotOptions) (string, error) {
 	hash := sha256.New()
-	writePart := func(value string) {
-		_, _ = io.WriteString(hash, value)
-		_, _ = io.WriteString(hash, "\x00")
-	}
-	writePart(providerRecordsCacheVersion)
+	writeCacheKeyString(hash, "cache-version", providerRecordsCacheVersion)
 	// The built-in credential-store deny decides which files are in this corpus at
 	// all, so a build that disagrees about it must not reach this build's entries.
 	// See builtinSecretRulesDigest for why nothing else in this key separates them.
-	writePart("builtin-secret-rules=" + builtinSecretRulesDigest())
-	writePart(absRepo)
+	writeCacheKeyString(hash, "builtin-secret-rules", builtinSecretRulesDigest())
+	writeCacheKeyString(hash, "repository-path", absRepo)
 	// Repo identity PREFIXES EVERY SYMBOL ID this cache stores, so serving one repository's records
 	// to another hands back IDs attributed to the wrong project. Reproduced by re-pointing a remote:
 	// the warm run still reported gh/entireio/entire-graph after the checkout had become a fork.
 	// searchSnapshotKey already folds this in; this key did not.
-	writePart(repositoryKey)
-	writePart(providerVersion)
-	writePart(tree)
-	writePart(mode)
-	writePart(string(options.Profile))
-	writePart(fmt.Sprintf("%d", options.MaxParseBytes))
+	writeCacheKeyString(hash, "repository-key", repositoryKey)
+	writeCacheKeyString(hash, "provider-version", providerVersion)
+	writeCacheKeyString(hash, "tree", tree)
+	writeCacheKeyString(hash, "mode", mode)
+	writeCacheKeyString(hash, "profile", string(options.Profile))
+	writeCacheKeyString(hash, "max-parse-bytes", fmt.Sprintf("%d", options.MaxParseBytes))
 	// Same graph-shaping argument as searchSnapshotKey, resolved for the same reason: the env var
 	// behind the option has to reach the key too. This cache is the one that is ON BY DEFAULT, so
 	// the hole mattered more here.
-	writePart(fmt.Sprintf("max-files=%d", resolveMaxSourceFiles(options.MaxFiles)))
+	writeCacheKeyString(hash, "max-files", fmt.Sprintf("%d", resolveMaxSourceFiles(options.MaxFiles)))
 	onlyFiles := append([]string(nil), options.OnlyFiles...)
 	sort.Strings(onlyFiles)
-	writePart("only-files")
+	writeCacheKeyString(hash, "only-files", "begin")
 	for _, filePath := range onlyFiles {
-		writePart(filepath.ToSlash(filepath.Clean(filePath)))
+		writeCacheKeyString(hash, "only-file", filepath.ToSlash(filepath.Clean(filePath)))
 	}
 	for groupIndex, group := range [][]string{options.IgnoreFiles, options.IncludeFiles} {
-		writePart(fmt.Sprintf("path-group-%d", groupIndex))
+		writeCacheKeyString(hash, "path-group", fmt.Sprintf("%d", groupIndex))
 		// Preserve caller order: ignore matching is last-rule-wins, including
 		// across repeatable ignore/include files within each group.
-		for _, path := range group {
-			resolved := path
+		for _, rulePath := range group {
+			resolved := rulePath
 			if !filepath.IsAbs(resolved) {
 				resolved = filepath.Join(absRepo, resolved)
 			}
-			writePart(filepath.Clean(resolved))
-			content, err := os.ReadFile(resolved)
+			writeCacheKeyString(hash, "rule-path", filepath.Clean(resolved))
+			content, _, err := readBoundedRegularFile(
+				resolved,
+				ignoreFileLabel(groupIndex == 1),
+				true,
+				maxIgnoreFileBytes,
+			)
 			if err != nil {
-				if errors.Is(err, os.ErrNotExist) {
-					writePart("missing")
-					continue
-				}
 				return "", err
 			}
-			_, _ = hash.Write(content)
-			writePart("")
+			writeCacheKeyField(hash, "rule-content", content)
 		}
+	}
+
+	// .graphignore is applied without an explicit option, so its state must bind
+	// the records entry just as it binds the parsed search snapshot.
+	graphIgnore := filepath.Join(absRepo, graphIgnoreFileName)
+	content, present, err := readBoundedRegularFile(
+		graphIgnore,
+		ignoreFileLabel(false),
+		false,
+		maxIgnoreFileBytes,
+	)
+	if err != nil {
+		return "", err
+	}
+	if present {
+		writeCacheKeyField(hash, "graphignore-content", content)
+	} else {
+		writeCacheKeyField(hash, "graphignore-missing", nil)
 	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }

--- a/internal/sem/records_cache_test.go
+++ b/internal/sem/records_cache_test.go
@@ -3,10 +3,231 @@ package sem
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
+
+func storeProviderRecordsForTest(ctx context.Context, repo, providerVersion, tree, mode, cacheDir string, options ProviderSnapshotOptions, records []byte, summary *SnapshotSummary) error {
+	transaction, err := BeginProviderRecordsCache(ctx, repo, providerVersion, tree, tree, mode, cacheDir, options)
+	if err != nil {
+		return err
+	}
+	return transaction.Store(records, summary, SnapshotHeader{
+		Provider:        ProviderName,
+		ProviderVersion: providerVersion,
+		RepoKey:         transaction.repositoryKey,
+		Commit:          tree,
+		Tree:            tree,
+		Profile:         string(transaction.options.Profile),
+	})
+}
+
+func TestProviderRecordsCacheTransactionRejectsObservedProvenanceMismatch(t *testing.T) {
+	repo := t.TempDir()
+	for _, tc := range []struct {
+		name   string
+		mutate func(*SnapshotHeader)
+	}{
+		{"commit", func(header *SnapshotHeader) { header.Commit = "commit-b" }},
+		{"tree", func(header *SnapshotHeader) { header.Tree = "tree-b" }},
+		{"repository key", func(header *SnapshotHeader) { header.RepoKey = "gh/example/moved" }},
+		{"provider version", func(header *SnapshotHeader) { header.ProviderVersion = "other" }},
+		{"profile", func(header *SnapshotHeader) { header.Profile = string(ProfileFast) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			transaction, err := BeginProviderRecordsCache(
+				t.Context(), repo, "test", "commit-a", "tree-a", "snapshot", t.TempDir(), ProviderSnapshotOptions{},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			header := SnapshotHeader{
+				Provider:        ProviderName,
+				ProviderVersion: "test",
+				RepoKey:         transaction.repositoryKey,
+				Commit:          "commit-a",
+				Tree:            "tree-a",
+				Profile:         string(transaction.options.Profile),
+			}
+			tc.mutate(&header)
+			if err := transaction.Store([]byte("wrong provenance\n"), nil, header); err == nil {
+				t.Fatal("stored records observed with mismatched provenance")
+			}
+			if _, _, hit := transaction.Load(); hit {
+				t.Fatal("provenance-mismatched records reached the cache")
+			}
+		})
+	}
+}
+
+func TestProviderRecordsCacheDiscriminatesSameTreeCommits(t *testing.T) {
+	repo := t.TempDir()
+	cacheDir := t.TempDir()
+	const tree = "same-tree"
+	first, err := BeginProviderRecordsCache(
+		t.Context(), repo, "test", "commit-a", tree, "snapshot", cacheDir, ProviderSnapshotOptions{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := first.Store([]byte("commit-a records\n"), nil, SnapshotHeader{
+		Provider:        ProviderName,
+		ProviderVersion: "test",
+		RepoKey:         first.repositoryKey,
+		Commit:          "commit-a",
+		Tree:            tree,
+		Profile:         string(first.options.Profile),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	second, err := BeginProviderRecordsCache(
+		t.Context(), repo, "test", "commit-b", tree, "snapshot", cacheDir, ProviderSnapshotOptions{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if records, _, hit := second.Load(); hit {
+		t.Fatalf("same-tree commit replayed stale header provenance: %q", records)
+	}
+}
+
+func TestProviderRecordsCacheTransactionFreezesResolvedFileLimit(t *testing.T) {
+	t.Setenv(maxSourceFilesEnv, "1")
+	transaction, err := BeginProviderRecordsCache(
+		t.Context(), t.TempDir(), "test", "commit", "tree", "snapshot", t.TempDir(), ProviderSnapshotOptions{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(maxSourceFilesEnv, "2")
+	if got := transaction.Options().MaxFiles; got != 1 {
+		t.Fatalf("resolved file limit changed after cache keying: got %d, want 1", got)
+	}
+}
+
+func TestProviderRecordsCacheTransactionPinsOptionsSlices(t *testing.T) {
+	repo := t.TempDir()
+	for _, name := range []string{"ignore-a", "ignore-b", "include-a", "include-b"} {
+		if err := os.WriteFile(filepath.Join(repo, name), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	original := ProviderSnapshotOptions{
+		IgnoreFiles:  []string{"ignore-a"},
+		IncludeFiles: []string{"include-a"},
+		OnlyFiles:    []string{"app.go"},
+	}
+	transaction, err := BeginProviderRecordsCache(
+		t.Context(), repo, "test", "commit", "tree", "snapshot", t.TempDir(), original,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original.IgnoreFiles[0] = "ignore-b"
+	original.IncludeFiles[0] = "include-b"
+	original.OnlyFiles[0] = "other.go"
+	returned := transaction.Options()
+	returned.IgnoreFiles[0] = "ignore-b"
+	returned.IncludeFiles[0] = "include-b"
+	returned.OnlyFiles[0] = "other.go"
+
+	pinned := transaction.Options()
+	if pinned.IgnoreFiles[0] != "ignore-a" || pinned.IncludeFiles[0] != "include-a" || pinned.OnlyFiles[0] != "app.go" {
+		t.Fatalf("transaction options were mutated through caller slices: %#v", pinned)
+	}
+}
+
+func TestProviderRecordsCacheTransactionPinsPolicyThroughBuildAndStore(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		policyName string
+		options    func(string) ProviderSnapshotOptions
+	}{
+		{
+			name:       "graphignore",
+			policyName: graphIgnoreFileName,
+			options:    func(string) ProviderSnapshotOptions { return ProviderSnapshotOptions{} },
+		},
+		{
+			name:       "explicit ignore",
+			policyName: "rules.ignore",
+			options: func(path string) ProviderSnapshotOptions {
+				return ProviderSnapshotOptions{IgnoreFiles: []string{path}}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := cacheTestRepo(t)
+			if err := os.WriteFile(filepath.Join(repo, "secret.go"), []byte("package app\n\nfunc SecretPolicyMarker() {}\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			git := func(args ...string) {
+				t.Helper()
+				command := exec.Command("git", args...)
+				command.Dir = repo
+				if out, err := command.CombinedOutput(); err != nil {
+					t.Fatalf("git %v: %v\n%s", args, err, out)
+				}
+			}
+			git("add", "secret.go")
+			git("commit", "-m", "add secret fixture")
+			commit := rev(t, repo, "HEAD^{commit}")
+			tree := rev(t, repo, "HEAD^{tree}")
+			policyPath := filepath.Join(repo, tc.policyName)
+			policyA := []byte("secret.go\n")
+			if err := os.WriteFile(policyPath, policyA, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cacheDir := t.TempDir()
+			transaction, err := BeginProviderRecordsCache(
+				t.Context(), repo, "test", commit, tree, "snapshot", cacheDir, tc.options(policyPath),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Policy B would include secret.go. The transaction must continue to
+			// build and store policy A under policy A's already-derived key.
+			if err := os.WriteFile(policyPath, nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test", transaction.Options())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if hasSymbolNamed(snapshot.Symbols, "SecretPolicyMarker") {
+				t.Fatal("snapshot construction reopened policy B after keying policy A")
+			}
+			records, err := json.Marshal(snapshot.Files)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := transaction.Store(records, nil, snapshot.Header); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := os.WriteFile(policyPath, policyA, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			replay, err := BeginProviderRecordsCache(
+				t.Context(), repo, "test", commit, tree, "snapshot", cacheDir, tc.options(policyPath),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, _, hit := replay.Load()
+			if !hit {
+				t.Fatal("policy A did not reuse the record stream built under policy A")
+			}
+			if bytes.Contains(got, []byte("secret.go")) {
+				t.Fatalf("policy B records were stored under policy A's key: %s", got)
+			}
+		})
+	}
+}
 
 func TestProviderRecordsCacheHitAndMiss(t *testing.T) {
 	t.Parallel()
@@ -22,11 +243,11 @@ func TestProviderRecordsCacheHitAndMiss(t *testing.T) {
 	records := []byte("{\"record_type\":\"header\"}\n{\"record_type\":\"symbol\"}\n")
 	summary := &SnapshotSummary{RecordType: "summary", Stats: ProviderStats{Files: 3}}
 
-	if err := StoreProviderRecords(context.Background(), repo, version, tree, mode, cacheDir, opts, records, summary); err != nil {
+	if err := storeProviderRecordsForTest(context.Background(), repo, version, tree, mode, cacheDir, opts, records, summary); err != nil {
 		t.Fatalf("store: %v", err)
 	}
 
-	got, gotSummary, hit, err := LoadProviderRecords(context.Background(), repo, version, tree, mode, cacheDir, opts)
+	got, gotSummary, hit, err := LoadProviderRecords(context.Background(), repo, version, tree, tree, mode, cacheDir, opts)
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
@@ -55,7 +276,7 @@ func TestProviderRecordsCacheHitAndMiss(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, hit, err := LoadProviderRecords(context.Background(), repo, tc.version, tc.tree, tc.mode, cacheDir, tc.opts)
+			_, _, hit, err := LoadProviderRecords(context.Background(), repo, tc.version, tc.tree, tc.tree, tc.mode, cacheDir, tc.opts)
 			if err != nil {
 				t.Fatalf("load: %v", err)
 			}
@@ -82,13 +303,13 @@ func TestProviderRecordsCacheLoadRejectsSymlinkEscape(t *testing.T) {
 		mode    = "snapshot"
 	)
 	opts := ProviderSnapshotOptions{Profile: ProfileFull}
-	if err := StoreProviderRecords(t.Context(), repo, version, tree, mode, outsideCacheDir, opts, []byte("outside\n"), nil); err != nil {
+	if err := storeProviderRecordsForTest(t.Context(), repo, version, tree, mode, outsideCacheDir, opts, []byte("outside\n"), nil); err != nil {
 		t.Fatalf("seed records cache: %v", err)
 	}
 	if err := os.Symlink(filepath.Join("..", "outside", "records"), filepath.Join(cacheDir, "records")); err != nil {
 		t.Skipf("symlinks unavailable: %v", err)
 	}
-	if _, _, hit, err := LoadProviderRecords(t.Context(), repo, version, tree, mode, cacheDir, opts); err != nil {
+	if _, _, hit, err := LoadProviderRecords(t.Context(), repo, version, tree, tree, mode, cacheDir, opts); err != nil {
 		t.Fatal(err)
 	} else if hit {
 		t.Fatal("provider-records loader followed a symlink outside the opened root")
@@ -104,10 +325,10 @@ func TestProviderRecordsCacheWorktreeBypassed(t *testing.T) {
 	records := []byte("x")
 
 	// Store is a no-op under --worktree, and Load never reports a hit.
-	if err := StoreProviderRecords(context.Background(), repo, "v", "tree", "snapshot", cacheDir, opts, records, nil); err != nil {
+	if err := storeProviderRecordsForTest(context.Background(), repo, "v", "tree", "snapshot", cacheDir, opts, records, nil); err != nil {
 		t.Fatalf("store: %v", err)
 	}
-	if _, _, hit, err := LoadProviderRecords(context.Background(), repo, "v", "tree", "snapshot", cacheDir, opts); err != nil || hit {
+	if _, _, hit, err := LoadProviderRecords(context.Background(), repo, "v", "tree", "tree", "snapshot", cacheDir, opts); err != nil || hit {
 		t.Fatalf("worktree load: hit=%v err=%v", hit, err)
 	}
 }
@@ -123,14 +344,14 @@ func TestCompactAndNativeRecordCachesDoNotCollide(t *testing.T) {
 		nativeMode  = "snapshot"
 		compactMode = "snapshot:compact-ndjson-v1"
 	)
-	if err := StoreProviderRecords(context.Background(), repo, version, tree, nativeMode, cacheDir, opts, []byte("native\n"), nil); err != nil {
+	if err := storeProviderRecordsForTest(context.Background(), repo, version, tree, nativeMode, cacheDir, opts, []byte("native\n"), nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := StoreProviderRecords(context.Background(), repo, version, tree, compactMode, cacheDir, opts, []byte("compact\n"), nil); err != nil {
+	if err := storeProviderRecordsForTest(context.Background(), repo, version, tree, compactMode, cacheDir, opts, []byte("compact\n"), nil); err != nil {
 		t.Fatal(err)
 	}
 	for _, tc := range []struct{ mode, want string }{{nativeMode, "native\n"}, {compactMode, "compact\n"}} {
-		got, _, hit, err := LoadProviderRecords(context.Background(), repo, version, tree, tc.mode, cacheDir, opts)
+		got, _, hit, err := LoadProviderRecords(context.Background(), repo, version, tree, tree, tc.mode, cacheDir, opts)
 		if err != nil || !hit || string(got) != tc.want {
 			t.Fatalf("load %s = %q hit=%t err=%v", tc.mode, got, hit, err)
 		}
@@ -147,14 +368,14 @@ func TestProviderRecordsCacheKeyIncludesIgnoreFileContent(t *testing.T) {
 	}
 	opts := ProviderSnapshotOptions{Profile: ProfileFull, IgnoreFiles: []string{ignore}}
 
-	before, err := providerRecordsKey(repo, "id", "v", "tree", "snapshot", opts)
+	before, err := providerRecordsKey(repo, "id", "v", "commit", "tree", "snapshot", opts)
 	if err != nil {
 		t.Fatalf("key before: %v", err)
 	}
 	if err := os.WriteFile(ignore, []byte("second"), 0o600); err != nil {
 		t.Fatalf("rewrite ignore: %v", err)
 	}
-	after, err := providerRecordsKey(repo, "id", "v", "tree", "snapshot", opts)
+	after, err := providerRecordsKey(repo, "id", "v", "commit", "tree", "snapshot", opts)
 	if err != nil {
 		t.Fatalf("key after: %v", err)
 	}
@@ -191,11 +412,11 @@ func TestProviderRecordsCacheKeyPreservesRuleFileOrder(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			inOrderKey, err := providerRecordsKey(repo, "id", "v", "tree", "snapshot", tc.inOrder)
+			inOrderKey, err := providerRecordsKey(repo, "id", "v", "commit", "tree", "snapshot", tc.inOrder)
 			if err != nil {
 				t.Fatalf("key in order: %v", err)
 			}
-			reversedKey, err := providerRecordsKey(repo, "id", "v", "tree", "snapshot", tc.reversed)
+			reversedKey, err := providerRecordsKey(repo, "id", "v", "commit", "tree", "snapshot", tc.reversed)
 			if err != nil {
 				t.Fatalf("key reversed: %v", err)
 			}
@@ -232,16 +453,16 @@ func TestProviderRecordsCachePreservesIgnoreFileOrder(t *testing.T) {
 		mode    = "snapshot"
 	)
 	allowedRecords := []byte("{\"record_type\":\"file\",\"path\":\".env\"}\n")
-	if err := StoreProviderRecords(t.Context(), repo, version, tree, mode, cacheDir, allowEnv, allowedRecords, nil); err != nil {
+	if err := storeProviderRecordsForTest(t.Context(), repo, version, tree, mode, cacheDir, allowEnv, allowedRecords, nil); err != nil {
 		t.Fatalf("store allowing-order records: %v", err)
 	}
 
-	got, _, hit, err := LoadProviderRecords(t.Context(), repo, version, tree, mode, cacheDir, allowEnv)
+	got, _, hit, err := LoadProviderRecords(t.Context(), repo, version, tree, tree, mode, cacheDir, allowEnv)
 	if err != nil || !hit || !bytes.Contains(got, []byte(".env")) {
 		t.Fatalf("allowing order did not return its .env stream: records=%q hit=%t err=%v", got, hit, err)
 	}
 
-	got, _, hit, err = LoadProviderRecords(t.Context(), repo, version, tree, mode, cacheDir, denyEnv)
+	got, _, hit, err = LoadProviderRecords(t.Context(), repo, version, tree, tree, mode, cacheDir, denyEnv)
 	if err != nil {
 		t.Fatalf("load denying-order records: %v", err)
 	}
@@ -250,10 +471,10 @@ func TestProviderRecordsCachePreservesIgnoreFileOrder(t *testing.T) {
 	}
 
 	// A rebuilt denying-order stream remains reusable for the identical order.
-	if err := StoreProviderRecords(t.Context(), repo, version, tree, mode, cacheDir, denyEnv, nil, nil); err != nil {
+	if err := storeProviderRecordsForTest(t.Context(), repo, version, tree, mode, cacheDir, denyEnv, nil, nil); err != nil {
 		t.Fatalf("store denying-order records: %v", err)
 	}
-	got, _, hit, err = LoadProviderRecords(t.Context(), repo, version, tree, mode, cacheDir, denyEnv)
+	got, _, hit, err = LoadProviderRecords(t.Context(), repo, version, tree, tree, mode, cacheDir, denyEnv)
 	if err != nil || !hit || bytes.Contains(got, []byte(".env")) {
 		t.Fatalf("identical denying order did not reuse its empty stream: records=%q hit=%t err=%v", got, hit, err)
 	}
@@ -269,11 +490,11 @@ func TestProviderRecordsKeyDiscriminatesFileCap(t *testing.T) {
 	repo := t.TempDir()
 	capped := ProviderSnapshotOptions{MaxFiles: 5}
 	uncapped := ProviderSnapshotOptions{}
-	a, err := providerRecordsKey(repo, "id", "v", "tree", "snapshot", capped)
+	a, err := providerRecordsKey(repo, "id", "v", "commit", "tree", "snapshot", capped)
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err := providerRecordsKey(repo, "id", "v", "tree", "snapshot", uncapped)
+	b, err := providerRecordsKey(repo, "id", "v", "commit", "tree", "snapshot", uncapped)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -289,11 +510,11 @@ func TestProviderRecordsKeyDiscriminatesRepoIdentity(t *testing.T) {
 	t.Parallel()
 	repo := t.TempDir()
 	opts := ProviderSnapshotOptions{}
-	a, err := providerRecordsKey(repo, "gh/ownerone/probe", "v", "tree", "snapshot", opts)
+	a, err := providerRecordsKey(repo, "gh/ownerone/probe", "v", "commit", "tree", "snapshot", opts)
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err := providerRecordsKey(repo, "gh/ownertwo/probe", "v", "tree", "snapshot", opts)
+	b, err := providerRecordsKey(repo, "gh/ownertwo/probe", "v", "commit", "tree", "snapshot", opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -347,19 +568,19 @@ func TestSearchSnapshotKeyDiscriminatesEnvFileCap(t *testing.T) {
 
 func TestProviderRecordsKeyDiscriminatesEnvFileCap(t *testing.T) {
 	repo := t.TempDir()
-	uncapped, err := providerRecordsKey(repo, "id", "v", "tree", "snapshot", ProviderSnapshotOptions{})
+	uncapped, err := providerRecordsKey(repo, "id", "v", "commit", "tree", "snapshot", ProviderSnapshotOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv(maxSourceFilesEnv, "5")
-	capped, err := providerRecordsKey(repo, "id", "v", "tree", "snapshot", ProviderSnapshotOptions{})
+	capped, err := providerRecordsKey(repo, "id", "v", "commit", "tree", "snapshot", ProviderSnapshotOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if capped == uncapped {
 		t.Fatalf("%s=5 and uncapped provider records share a key", maxSourceFilesEnv)
 	}
-	explicit, err := providerRecordsKey(repo, "id", "v", "tree", "snapshot", ProviderSnapshotOptions{MaxFiles: 5})
+	explicit, err := providerRecordsKey(repo, "id", "v", "commit", "tree", "snapshot", ProviderSnapshotOptions{MaxFiles: 5})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -370,7 +591,7 @@ func TestProviderRecordsKeyDiscriminatesEnvFileCap(t *testing.T) {
 	// the larger entry, or a caller who asked to see less is handed more of the
 	// tree than it asked for. Neither direction announces itself in the answer.
 	t.Setenv(maxSourceFilesEnv, "2")
-	lowered, err := providerRecordsKey(repo, "id", "v", "tree", "snapshot", ProviderSnapshotOptions{})
+	lowered, err := providerRecordsKey(repo, "id", "v", "commit", "tree", "snapshot", ProviderSnapshotOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -388,7 +609,7 @@ func TestCacheKeysCanonicalizeEffectiveFileCapSemantics(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		recordsKey, err := providerRecordsKey(repo, "id", "v", "tree", "snapshot", ProviderSnapshotOptions{})
+		recordsKey, err := providerRecordsKey(repo, "id", "v", "commit", "tree", "snapshot", ProviderSnapshotOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/sem/search.go
+++ b/internal/sem/search.go
@@ -1473,15 +1473,15 @@ func openSearchContentReader(
 		// so the reader declines it rather than materializing it twice over.
 		batch.SetMaxBytes(defaultMaxParseBytes)
 		read := func(path string) (string, bool) {
-			if strings.Contains(path, "\n") {
+			if !batch.IsPathSafe(path) {
 				// Same ceiling as the batch reader above. The argv-safe
 				// fallback exists because the batch protocol cannot carry a
 				// newline-bearing path, not to exempt that path from the cap:
 				// the file's name is chosen by the repository being searched,
 				// so an unbounded read here would be a name-shaped hole in the
 				// bound.
-				content, ok, err := gitutil.ShowFileLimited(ctx, repo, commit, path, defaultMaxParseBytes)
-				return content, ok && err == nil
+				result, err := gitutil.ReadFileLimited(ctx, repo, commit, path, defaultMaxParseBytes)
+				return result.Content, err == nil && result.Status == gitutil.LimitedFileContent
 			}
 			content, ok, err := batch.ReadFile(path)
 			return content, ok && err == nil

--- a/internal/sem/search.go
+++ b/internal/sem/search.go
@@ -1474,7 +1474,13 @@ func openSearchContentReader(
 		batch.SetMaxBytes(defaultMaxParseBytes)
 		read := func(path string) (string, bool) {
 			if strings.Contains(path, "\n") {
-				content, ok, err := gitutil.ShowFile(ctx, repo, commit, path)
+				// Same ceiling as the batch reader above. The argv-safe
+				// fallback exists because the batch protocol cannot carry a
+				// newline-bearing path, not to exempt that path from the cap:
+				// the file's name is chosen by the repository being searched,
+				// so an unbounded read here would be a name-shaped hole in the
+				// bound.
+				content, ok, err := gitutil.ShowFileLimited(ctx, repo, commit, path, defaultMaxParseBytes)
 				return content, ok && err == nil
 			}
 			content, ok, err := batch.ReadFile(path)

--- a/internal/sem/search.go
+++ b/internal/sem/search.go
@@ -871,7 +871,7 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 	queryStarted := time.Now()
 	useHead := !options.Worktree && snapshot.Header.Commit != ""
 	read, closeSource, err := openSearchContentReader(
-		ctx, repo, snapshot.Header.Commit, useHead, options.IgnoreFiles, options.IncludeFiles,
+		ctx, repo, snapshot.Header.Commit, useHead, options.IgnoreFiles, options.IncludeFiles, options.MaxParseBytes,
 	)
 	if err != nil {
 		return SearchResponse{}, err
@@ -1504,7 +1504,23 @@ func openSearchContentReader(
 	repo, commit string,
 	useHead bool,
 	ignoreFiles, includeFiles []string,
+	maxParseBytes int,
 ) (contentReader, func() error, error) {
+	// The content reader's cap is a ceiling on what a search RESULT can show,
+	// not a mirror of the parser's eligibility cutoff: a file too large to
+	// parse into the graph can still surface as a lexical (git-tree-grep)
+	// match, and that match still needs its snippet read. So the floor here
+	// stays the package default regardless of a caller-LOWERED MaxParseBytes
+	// -- only a caller-RAISED MaxParseBytes should raise it further, else a
+	// file the raised limit let into the snapshot would be refused right back
+	// out during ranking/snippet reads. A negative resolved value means
+	// "uncapped" (resolveMaxParseBytes's documented escape hatch) and must
+	// stay uncapped rather than be floored back up to the default.
+	resolvedMaxParseBytes := resolveMaxParseBytes(maxParseBytes)
+	maxBytes := resolvedMaxParseBytes
+	if resolvedMaxParseBytes >= 0 {
+		maxBytes = max(defaultMaxParseBytes, resolvedMaxParseBytes)
+	}
 	if useHead {
 		treePathPrefix, err := gitutil.RepoPrefix(ctx, repo)
 		if err != nil {
@@ -1515,9 +1531,13 @@ func openSearchContentReader(
 			return nil, nil, err
 		}
 		// Snippet and body reads never need a file the indexer refuses to parse,
-		// so the reader declines it rather than materializing it twice over.
-		batch.SetMaxBytes(defaultMaxParseBytes)
-		limited := gitutil.NewLimitedFileReader(ctx, repo, commit, defaultMaxParseBytes)
+		// so the reader declines it rather than materializing it twice over. Use
+		// the wider of the package default and the caller's resolved search
+		// limit: if a caller raised MaxParseBytes, a file the raised limit lets
+		// into the snapshot must not then be refused here during ranking/snippet
+		// reads.
+		batch.SetMaxBytes(int64(maxBytes))
+		limited := gitutil.NewLimitedFileReader(ctx, repo, commit, int64(maxBytes))
 		read := func(path string) (string, bool) {
 			if !batch.IsPathSafe(path) {
 				// Same ceiling as the batch reader above. The shared exact-object
@@ -1541,7 +1561,7 @@ func openSearchContentReader(
 	opened, err := openSource(ctx, repo, "", sourceOptions{
 		ignoreFiles:  ignoreFiles,
 		includeFiles: includeFiles,
-		maxReadBytes: defaultMaxParseBytes,
+		maxReadBytes: maxBytes,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/internal/sem/search.go
+++ b/internal/sem/search.go
@@ -73,6 +73,10 @@ type SearchOptions struct {
 	// mutation between transaction capture and the first cache lookup. It is
 	// deliberately unexported and nil in production.
 	afterCachePolicyCapture func()
+	// afterPreindexLoad is a deterministic test seam for repository-identity
+	// mutation between a complete cache lookup and source preselection. It is
+	// deliberately unexported and nil in production.
+	afterPreindexLoad func()
 	// BodyHeadRanks caps how deep the COMPLETE-BODY upgrade reaches, independently of the
 	// locator head. 0 means the built-in depth (searchEnclosureHeadRanks). It may only narrow
 	// the head, never widen it, so the growth allowance stays sized for the bodies it funds.
@@ -735,6 +739,9 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 			return SearchResponse{}, err
 		}
 	}
+	if options.afterPreindexLoad != nil {
+		options.afterPreindexLoad()
+	}
 	preindexLoadLatency := time.Since(indexStarted)
 	preselectStarted := time.Now()
 	selection, err := preselectSearchFiles(
@@ -742,6 +749,14 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 	)
 	if err != nil {
 		return SearchResponse{}, err
+	}
+	// The repository identity can change without changing HEAD (for example
+	// when a remote URL changes). Symbols embed that identity, so a complete
+	// preindex loaded before preselection is usable only when both identities
+	// still match. Treat drift as a miss and rebuild from the captured source.
+	if preindexCacheHit && !searchSnapshotMatchesSelection(preindexedSnapshot, selection) {
+		preindexedSnapshot = ProviderSnapshot{}
+		preindexCacheHit = false
 	}
 	preselectLatency := time.Since(preselectStarted)
 	selectedFiles := selection.files
@@ -754,11 +769,11 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 		// graph. Do not build a cold graph merely to return no results, but do
 		// preserve cached partial failures/completeness and cache-hit provenance.
 		cachedSnapshot, cacheHit := preindexedSnapshot, preindexCacheHit
-		// Tree, not commit, is what determines whether the graph is still valid:
-		// two different commits sharing a tree parse identically, so only a tree
-		// change mid-search is a real race worth rejecting.
-		if cacheHit && selection.commit != "" && cachedSnapshot.Header.Tree != selection.tree {
-			return SearchResponse{}, errors.New("repository HEAD changed during search; retry against a stable commit")
+		// Commit can differ when two commits share a tree, but the tree and
+		// repository identity must still match: the latter participates in stable
+		// symbol IDs even when source bytes are unchanged.
+		if cacheHit && selection.commit != "" && !searchSnapshotMatchesSelection(cachedSnapshot, selection) {
+			return SearchResponse{}, errors.New("repository identity or HEAD changed during search; retry against a stable repository")
 		}
 		totalLatency := time.Since(searchStarted).Milliseconds()
 		repoRoot, commit, tree := selection.repoRoot, selection.commit, selection.tree
@@ -848,9 +863,10 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 		}
 		indexLatency += time.Since(indexStarted)
 	}
-	// See the analogous no-hit guard above: tree identity is what matters here.
-	if selection.commit != "" && snapshot.Header.Tree != selection.tree {
-		return SearchResponse{}, errors.New("repository HEAD changed during search; retry against a stable commit")
+	// See the analogous no-hit guard above. Tree identity pins source bytes;
+	// repository identity additionally pins the stable IDs built from them.
+	if selection.commit != "" && !searchSnapshotMatchesSelection(snapshot, selection) {
+		return SearchResponse{}, errors.New("repository identity or HEAD changed during search; retry against a stable repository")
 	}
 	queryStarted := time.Now()
 	useHead := !options.Worktree && snapshot.Header.Commit != ""
@@ -1743,6 +1759,7 @@ type searchFileSelection struct {
 	sparseDocumentLength      int
 	sparseFilesContentRead    int
 	repoRoot                  string
+	repoKey                   string
 	commit                    string
 	tree                      string
 	warnings                  []ProviderWarning
@@ -1807,6 +1824,7 @@ func preselectSearchFiles(
 	selection := searchFileSelection{
 		ignores:                   ignores,
 		repoRoot:                  source.absRepo,
+		repoKey:                   source.key,
 		commit:                    source.commit,
 		tree:                      source.tree,
 		warnings:                  append([]ProviderWarning{}, source.warnings...),
@@ -1838,7 +1856,8 @@ func preselectSearchFiles(
 	// current HEAD; the grep below runs against source.commit directly, so a
 	// same-tree preindex built at a different commit is still an exact match.
 	exactFullPreindex := preindexCacheHit &&
-		preindexedSnapshot.Header.Tree == source.tree
+		preindexedSnapshot.Header.Tree == source.tree &&
+		preindexedSnapshot.Header.RepoKey == source.key
 	grepPatterns, grepSafe := searchGitGrepPatterns(q.terms)
 	if exactFullPreindex && !options.Worktree && !options.Deep && grepSafe {
 		matches, grepErr := gitutil.GrepTreePaths(ctx, source.absRepo, source.commit, grepPatterns)
@@ -2103,6 +2122,10 @@ func preselectSearchFiles(
 		selection.gitGrepTreeish = ""
 	}
 	return selection, nil
+}
+
+func searchSnapshotMatchesSelection(snapshot ProviderSnapshot, selection searchFileSelection) bool {
+	return snapshot.Header.Tree == selection.tree && snapshot.Header.RepoKey == selection.repoKey
 }
 
 func searchTermsSafeForGitGrep(terms []string) bool {

--- a/internal/sem/search.go
+++ b/internal/sem/search.go
@@ -69,6 +69,10 @@ type SearchOptions struct {
 	// standard cold default may widen adaptively; explicit and TopK-adaptive
 	// MaxIndexedFiles values remain exact compatibility limits.
 	progressivePreselection bool
+	// afterCachePolicyCapture is a deterministic test seam for policy-file
+	// mutation between transaction capture and the first cache lookup. It is
+	// deliberately unexported and nil in production.
+	afterCachePolicyCapture func()
 	// BodyHeadRanks caps how deep the COMPLETE-BODY upgrade reaches, independently of the
 	// locator head. 0 means the built-in depth (searchEnclosureHeadRanks). It may only narrow
 	// the head, never widen it, so the growth allowance stays sized for the bodies it funds.
@@ -698,10 +702,31 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 		MaxParseBytes: options.MaxParseBytes,
 		Profile:       options.Profile,
 	}
+	searchCacheDisabled := options.DisableCache
+	if !options.Worktree && !searchCacheDisabled && options.CacheDir != "" {
+		capturedOptions, captureErr := CaptureProviderCachePolicy(repo, baseSnapshotOptions)
+		if captureErr != nil {
+			// Capturing retains every policy input at once and therefore has a
+			// stricter aggregate bound than sequential matcher construction. An
+			// optional cache must not reject a search that the uncached path can
+			// safely execute.
+			searchCacheDisabled = true
+		} else {
+			baseSnapshotOptions = capturedOptions
+			// Keep lexical preselection on the same immutable path ordering as
+			// provider keying and construction. The captured policy itself travels
+			// in baseSnapshotOptions to avoid rereading the files below.
+			options.IgnoreFiles = capturedOptions.IgnoreFiles
+			options.IncludeFiles = capturedOptions.IncludeFiles
+			if options.afterCachePolicyCapture != nil {
+				options.afterCachePolicyCapture()
+			}
+		}
+	}
 	var preindexedSnapshot ProviderSnapshot
 	preindexCacheHit := false
 	indexStarted := time.Now()
-	if !options.Worktree && !options.DisableCache {
+	if !options.Worktree && !searchCacheDisabled {
 		var err error
 		preindexedSnapshot, preindexCacheHit, err = loadCachedCompleteSearchSnapshot(
 			ctx, repo, providerVersion, baseSnapshotOptions, options.CacheDir,
@@ -713,7 +738,7 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 	preindexLoadLatency := time.Since(indexStarted)
 	preselectStarted := time.Now()
 	selection, err := preselectSearchFiles(
-		ctx, repo, q, sparseQuery, options, preindexedSnapshot, preindexCacheHit,
+		ctx, repo, q, sparseQuery, options, baseSnapshotOptions, preindexedSnapshot, preindexCacheHit,
 	)
 	if err != nil {
 		return SearchResponse{}, err
@@ -809,7 +834,7 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 		// ordinary build when derivation fails (for example after a HEAD move).
 		indexStarted = time.Now()
 		snapshot, cacheHit, err = loadOrDeriveSelectiveSearchSnapshot(
-			ctx, repo, providerVersion, snapshotOptions, options.CacheDir, options.DisableCache, preindexedSnapshot,
+			ctx, repo, providerVersion, snapshotOptions, options.CacheDir, searchCacheDisabled, preindexedSnapshot,
 		)
 		if err != nil {
 			return SearchResponse{}, err
@@ -817,7 +842,7 @@ func SearchRepository(ctx context.Context, repo, providerVersion, query string, 
 		indexLatency += time.Since(indexStarted)
 	} else if !cacheHit {
 		indexStarted = time.Now()
-		snapshot, cacheHit, err = loadOrBuildSearchGraphSnapshot(ctx, repo, providerVersion, snapshotOptions, options.CacheDir, options.DisableCache)
+		snapshot, cacheHit, err = loadOrBuildSearchGraphSnapshot(ctx, repo, providerVersion, snapshotOptions, options.CacheDir, searchCacheDisabled)
 		if err != nil {
 			return SearchResponse{}, err
 		}
@@ -1764,33 +1789,21 @@ func preselectSearchFiles(
 	repo string,
 	q, sparseQuery searchQuery,
 	options SearchOptions,
+	snapshotOptions ProviderSnapshotOptions,
 	preindexedSnapshot ProviderSnapshot,
 	preindexCacheHit bool,
 ) (searchFileSelection, error) {
-	source, err := prepareSource(ctx, repo, ProviderSnapshotOptions{
-		NoNetwork:    true,
-		Worktree:     options.Worktree,
-		IgnoreFiles:  options.IgnoreFiles,
-		IncludeFiles: options.IncludeFiles,
-	})
+	source, err := prepareSource(ctx, repo, snapshotOptions)
 	if err != nil {
 		return searchFileSelection{}, err
 	}
 	if source.close != nil {
 		defer source.close()
 	}
-	// The same exclude stack prepareSource listed the corpus with, so the one route that reaches
-	// outside that listing can apply the identical verdict. Which loader applies is decided the
-	// way openSource decides it: a committed-tree listing sees .graphignore plus the explicit
-	// files, a working-tree listing the full Git exclude stack as well.
-	loadIgnores := loadWorktreeIgnoreMatcher
-	if !options.Worktree {
-		loadIgnores = loadExplicitIgnoreMatcher
-	}
-	ignores, err := loadIgnores(source.absRepo, options.IgnoreFiles, options.IncludeFiles)
-	if err != nil {
-		return searchFileSelection{}, err
-	}
+	// Keep the exact matcher that admitted source.paths. Re-reading policy files
+	// here could give the whole-tree Git-grep route a different verdict and let
+	// it name a path the corpus listing denied, even when caching is bypassed.
+	ignores := source.ignores
 	selection := searchFileSelection{
 		ignores:                   ignores,
 		repoRoot:                  source.absRepo,

--- a/internal/sem/search.go
+++ b/internal/sem/search.go
@@ -1465,6 +1465,10 @@ func openSearchContentReader(
 	ignoreFiles, includeFiles []string,
 ) (contentReader, func() error, error) {
 	if useHead {
+		treePathPrefix, err := gitutil.RepoPrefix(ctx, repo)
+		if err != nil {
+			return nil, nil, err
+		}
 		batch, err := gitutil.NewBatchFileReader(ctx, repo, commit)
 		if err != nil {
 			return nil, nil, err
@@ -1472,21 +1476,26 @@ func openSearchContentReader(
 		// Snippet and body reads never need a file the indexer refuses to parse,
 		// so the reader declines it rather than materializing it twice over.
 		batch.SetMaxBytes(defaultMaxParseBytes)
+		limited := gitutil.NewLimitedFileReader(ctx, repo, commit, defaultMaxParseBytes)
 		read := func(path string) (string, bool) {
 			if !batch.IsPathSafe(path) {
-				// Same ceiling as the batch reader above. The argv-safe
+				// Same ceiling as the batch reader above. The shared exact-object
 				// fallback exists because the batch protocol cannot carry a
 				// newline-bearing path, not to exempt that path from the cap:
 				// the file's name is chosen by the repository being searched,
 				// so an unbounded read here would be a name-shaped hole in the
-				// bound.
-				result, err := gitutil.ReadFileLimited(ctx, repo, commit, path, defaultMaxParseBytes)
+				// bound. One reader also shares the component traversal allowance
+				// and prefix cache across all requested files.
+				result, err := limited.ReadFile(treePathPrefix + path)
 				return result.Content, err == nil && result.Status == gitutil.LimitedFileContent
 			}
 			content, ok, err := batch.ReadFile(path)
 			return content, ok && err == nil
 		}
-		return read, batch.Close, nil
+		closeReaders := func() error {
+			return errors.Join(batch.Close(), limited.Close())
+		}
+		return read, closeReaders, nil
 	}
 	opened, err := openSource(ctx, repo, "", sourceOptions{
 		ignoreFiles:  ignoreFiles,

--- a/internal/sem/search_cache.go
+++ b/internal/sem/search_cache.go
@@ -23,8 +23,8 @@ import (
 // into every entry key, so bumping it moves new entries to a fresh directory
 // and any prior-version directory can simply be deleted wholesale — cleanup is
 // "remove old version dirs" instead of per-entry reachability analysis.
-// (v5 isolated the tree-only key layout; v6, on main, supersedes it.)
-const searchSnapshotCacheVersion = "search-snapshot-v8"
+// v9 introduces typed, length-prefixed fields and bounded ignore-file reads.
+const searchSnapshotCacheVersion = "search-snapshot-v9"
 
 type cachedSymbolByteRange struct {
 	Start int `json:"start"`
@@ -777,17 +777,13 @@ func LoadOrBuildProviderSnapshot(
 // exact facts about the tree.
 func searchSnapshotKey(absRepo, repositoryKey, providerVersion, tree string, options ProviderSnapshotOptions) (string, error) {
 	hash := sha256.New()
-	writePart := func(value string) {
-		_, _ = io.WriteString(hash, value)
-		_, _ = io.WriteString(hash, "\x00")
-	}
-	writePart(searchSnapshotCacheVersion)
-	writePart(absRepo)
-	writePart(repositoryKey)
-	writePart(providerVersion)
-	writePart(tree)
-	writePart(string(options.Profile))
-	writePart(fmt.Sprintf("%d", options.MaxParseBytes))
+	writeCacheKeyString(hash, "cache-version", searchSnapshotCacheVersion)
+	writeCacheKeyString(hash, "repository-path", absRepo)
+	writeCacheKeyString(hash, "repository-key", repositoryKey)
+	writeCacheKeyString(hash, "provider-version", providerVersion)
+	writeCacheKeyString(hash, "tree", tree)
+	writeCacheKeyString(hash, "profile", string(options.Profile))
+	writeCacheKeyString(hash, "max-parse-bytes", fmt.Sprintf("%d", options.MaxParseBytes))
 	// The resolved file cap SHAPES THE GRAPH: a run capped at N files produces a snapshot missing
 	// everything past N, and without the cap in the key that truncated snapshot is served to a later
 	// uncapped caller. Measured on this repo: a cap-5 build wrote 28 symbols, and the next uncapped
@@ -803,39 +799,39 @@ func searchSnapshotKey(absRepo, repositoryKey, providerVersion, tree string, opt
 	// It cuts both ways, which is why the term has to be the resolved value rather than a lower
 	// bound: an entry built with a HIGHER cap also survives a later LOWERED one, handing back more
 	// of the tree than the caller asked to see. Neither direction announces itself.
-	writePart(fmt.Sprintf("max-files=%d", resolveMaxSourceFiles(options.MaxFiles)))
+	writeCacheKeyString(hash, "max-files", fmt.Sprintf("%d", resolveMaxSourceFiles(options.MaxFiles)))
 	// Working-tree entries live in their own key space. The marker is only
-	// written for them so committed-tree keys — and every cache already on disk
-	// built under them — stay byte-identical.
+	// written for them; the versioned field framing already distinguishes this
+	// generation from every cache previously written to disk.
 	if options.Worktree {
-		writePart("worktree")
+		writeCacheKeyString(hash, "worktree", "true")
 	}
 	onlyFiles := append([]string(nil), options.OnlyFiles...)
 	sort.Strings(onlyFiles)
-	writePart("only-files")
+	writeCacheKeyString(hash, "only-files", "begin")
 	for _, filePath := range onlyFiles {
-		writePart(filepath.ToSlash(filepath.Clean(filePath)))
+		writeCacheKeyString(hash, "only-file", filepath.ToSlash(filepath.Clean(filePath)))
 	}
 	for groupIndex, group := range [][]string{options.IgnoreFiles, options.IncludeFiles} {
-		writePart(fmt.Sprintf("path-group-%d", groupIndex))
+		writeCacheKeyString(hash, "path-group", fmt.Sprintf("%d", groupIndex))
 		// Preserve caller order: ignore matching is last-rule-wins, including
 		// across repeatable ignore/include files within each group.
-		for _, path := range group {
-			resolved := path
+		for _, rulePath := range group {
+			resolved := rulePath
 			if !filepath.IsAbs(resolved) {
 				resolved = filepath.Join(absRepo, resolved)
 			}
-			writePart(filepath.Clean(resolved))
-			content, err := os.ReadFile(resolved)
+			writeCacheKeyString(hash, "rule-path", filepath.Clean(resolved))
+			content, _, err := readBoundedRegularFile(
+				resolved,
+				ignoreFileLabel(groupIndex == 1),
+				true,
+				maxIgnoreFileBytes,
+			)
 			if err != nil {
-				if errors.Is(err, os.ErrNotExist) {
-					writePart("missing")
-					continue
-				}
 				return "", err
 			}
-			_, _ = hash.Write(content)
-			writePart("")
+			writeCacheKeyField(hash, "rule-content", content)
 		}
 	}
 	// The repo-root .graphignore is applied implicitly, so it must key the entry
@@ -847,17 +843,21 @@ func searchSnapshotKey(absRepo, repositoryKey, providerVersion, tree string, opt
 	// .graphignore does: it decides which files the snapshot may contain, and
 	// therefore which files the ranked payload, the snippets and the context blocks
 	// can quote. See builtinSecretRulesDigest.
-	writePart("builtin-secret-rules=" + builtinSecretRulesDigest())
-	writePart("graphignore")
+	writeCacheKeyString(hash, "builtin-secret-rules", builtinSecretRulesDigest())
 	graphIgnore := filepath.Join(absRepo, graphIgnoreFileName)
-	switch content, err := os.ReadFile(graphIgnore); {
-	case err == nil:
-		_, _ = hash.Write(content)
-		writePart("")
-	case errors.Is(err, os.ErrNotExist):
-		writePart("missing")
-	default:
+	content, present, err := readBoundedRegularFile(
+		graphIgnore,
+		ignoreFileLabel(false),
+		false,
+		maxIgnoreFileBytes,
+	)
+	if err != nil {
 		return "", err
+	}
+	if present {
+		writeCacheKeyField(hash, "graphignore-content", content)
+	} else {
+		writeCacheKeyField(hash, "graphignore-missing", nil)
 	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }

--- a/internal/sem/search_cache.go
+++ b/internal/sem/search_cache.go
@@ -251,10 +251,10 @@ func loadOrBuildSearchSnapshot(
 	if err != nil {
 		return ProviderSnapshot{}, false, err
 	}
-	if snapshot.Header.Tree != tree {
+	if err := validateBuiltSearchSnapshot(snapshot, repositoryKey, providerVersion, tree, options); err != nil {
 		return ProviderSnapshot{}, false, fmt.Errorf(
-			"HEAD changed while building search snapshot: got commit %q tree %q, started at commit %q tree %q",
-			snapshot.Header.Commit, snapshot.Header.Tree, commit, tree,
+			"search snapshot provenance changed while building from commit %q tree %q: %w",
+			commit, tree, err,
 		)
 	}
 	// The tree we started at is still what got built even if a same-tree
@@ -346,10 +346,10 @@ func preindexProviderSnapshotWithPersistenceReader(
 	if err != nil {
 		return ProviderSnapshot{}, false, err
 	}
-	if snapshot.Header.Tree != tree {
+	if err := validateBuiltSearchSnapshot(snapshot, repositoryKey, providerVersion, tree, options); err != nil {
 		return ProviderSnapshot{}, false, fmt.Errorf(
-			"preindex snapshot provenance mismatch: got tree %q (commit %q), want tree %q (commit %q); only tree identity is checked",
-			snapshot.Header.Tree, snapshot.Header.Commit, tree, commit,
+			"preindex snapshot provenance mismatch for commit %q tree %q: %w",
+			commit, tree, err,
 		)
 	}
 	if cacheHit {
@@ -383,6 +383,34 @@ func preindexProviderSnapshotWithPersistenceReader(
 		}
 	}
 	return snapshot, cacheHit, nil
+}
+
+// validateBuiltSearchSnapshot closes the transaction between cache keying and
+// snapshot construction. Git tree identity alone is enough for source bytes,
+// but repository identity participates in stable symbol IDs, while provider
+// version and profile select the shape of the graph. A concurrent config or
+// option change must therefore fail before the snapshot is returned or stored.
+// Commit is deliberately excluded: different commits with the same tree have
+// identical graph content and are re-stamped to the commit captured by the
+// caller after this validation succeeds.
+func validateBuiltSearchSnapshot(
+	snapshot ProviderSnapshot,
+	repositoryKey, providerVersion, tree string,
+	options ProviderSnapshotOptions,
+) error {
+	header := snapshot.Header
+	if header.Tree != tree ||
+		header.RepoKey != repositoryKey ||
+		header.Provider != ProviderName ||
+		header.ProviderVersion != providerVersion ||
+		header.Profile != string(options.Profile) {
+		return fmt.Errorf(
+			"got repo %q tree %q provider %q version %q profile %q; want repo %q tree %q provider %q version %q profile %q",
+			header.RepoKey, header.Tree, header.Provider, header.ProviderVersion, header.Profile,
+			repositoryKey, tree, ProviderName, providerVersion, options.Profile,
+		)
+	}
+	return nil
 }
 
 func newCachedSearchSnapshot(providerVersion, commit, tree string, options ProviderSnapshotOptions, snapshot ProviderSnapshot) cachedSearchSnapshot {

--- a/internal/sem/search_cache.go
+++ b/internal/sem/search_cache.go
@@ -859,6 +859,32 @@ func searchSnapshotKey(absRepo, repositoryKey, providerVersion, tree string, opt
 	} else {
 		writeCacheKeyField(hash, "graphignore-missing", nil)
 	}
+	// A worktree snapshot also applies the repository's private info/exclude
+	// file. It lives under Git metadata rather than the worktree, so neither the
+	// HEAD tree nor git status changes when its policy changes. Bind its optional
+	// state and content explicitly or a warm relation-query cache can continue to
+	// serve paths the user has just excluded.
+	if options.Worktree {
+		exclude := gitInfoExcludePath(absRepo)
+		if exclude == "" {
+			writeCacheKeyField(hash, "git-info-exclude-missing", nil)
+		} else {
+			content, present, err := readBoundedRegularFile(
+				exclude,
+				ignoreFileLabel(false),
+				false,
+				maxIgnoreFileBytes,
+			)
+			if err != nil {
+				return "", err
+			}
+			if present {
+				writeCacheKeyField(hash, "git-info-exclude-content", content)
+			} else {
+				writeCacheKeyField(hash, "git-info-exclude-missing", nil)
+			}
+		}
+	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 

--- a/internal/sem/search_cache.go
+++ b/internal/sem/search_cache.go
@@ -13,18 +13,15 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
-	"time"
-
-	"github.com/entireio/entire-graph/internal/gitutil"
 )
 
 // searchSnapshotCacheVersion names the on-disk cache directory and is hashed
 // into every entry key, so bumping it moves new entries to a fresh directory
 // and any prior-version directory can simply be deleted wholesale — cleanup is
 // "remove old version dirs" instead of per-entry reachability analysis.
-// v9 introduces typed, length-prefixed fields and bounded ignore-file reads.
-const searchSnapshotCacheVersion = "search-snapshot-v9"
+// v11 retires every entry produced before the final immutable-policy and
+// unconditional-worktree-bypass transaction checks were complete.
+const searchSnapshotCacheVersion = "search-snapshot-v11"
 
 type cachedSymbolByteRange struct {
 	Start int `json:"start"`
@@ -38,12 +35,9 @@ type cachedSearchSnapshot struct {
 	Tree            string  `json:"tree"`
 	Profile         Profile `json:"profile"`
 	MaxParseBytes   int     `json:"max_parse_bytes"`
-	// Worktree records which view produced this entry. Working-tree snapshots
-	// carry provenance a committed-tree snapshot does not (W_WORKTREE_SNAPSHOT),
-	// so the two views never share an entry even when their content is equal.
-	// This became load-bearing when a clean working tree turned cacheable at all
-	// (worktreeSnapshotCacheable): before that, `options.Worktree` bypassed the
-	// cache outright and no working-tree entry could exist to collide.
+	// Worktree is retained for decoding and validating older in-memory fixtures.
+	// Persistent worktree caching is disabled because Git listing inputs and
+	// working-tree contents cannot be pinned to one atomic cache transaction.
 	Worktree bool             `json:"worktree,omitempty"`
 	Snapshot ProviderSnapshot `json:"snapshot"`
 	// FileRecord.Lines, SymbolRecord.Local, and exact symbol byte ranges are
@@ -73,99 +67,12 @@ type cachedSignatureTypes struct {
 	Returns string `json:"returns,omitempty"`
 }
 
-// worktreeCleanTTL bounds how stale a working-tree cleanliness verdict may be.
-// One command issues several snapshot lookups (graph scope, complete preindex,
-// selective build) and must not pay for a `git status` each time; a window this
-// short cannot span an edit that happens between two of them, while a
-// long-lived library consumer still re-checks on every new command.
-const worktreeCleanTTL = 2 * time.Second
-
-type worktreeCleanVerdict struct {
-	clean     bool
-	checkedAt time.Time
-}
-
-var worktreeCleanVerdicts sync.Map // absRepo -> worktreeCleanVerdict
-
-// absOrRepo resolves repo to an absolute path, falling back to the input when
-// that is impossible. It exists so a cleanliness verdict is memoized under the
-// same key the cache lookups use.
-func absOrRepo(repo string) string {
-	if abs, err := filepath.Abs(repo); err == nil {
-		return abs
-	}
-	return repo
-}
-
-// worktreeSnapshotCacheable reports whether these options may be served from,
-// and stored in, the tree-keyed snapshot cache.
-//
-// Committed-tree snapshots always could. A working-tree snapshot may too, but
-// only while the working tree's INDEXABLE content is identical to HEAD: then the
-// tree hash names that content exactly, which is the whole premise of the cache
-// key. This is what makes the relation verbs (neighbors/impact, which index the
-// whole repository) warm on their second call instead of re-indexing from
-// scratch — and it never hides a dirty edit, because a dirty indexable file
-// fails the check and bypasses the cache exactly as before.
-//
-// "Indexable" is the load-bearing word. Requiring a wholly pristine tree made a
-// stray untracked file that no parser ever opens — .DS_Store, a compiled binary,
-// a log, an editor swap file — disable the cache for the entire repository, so
-// every query re-indexed from scratch. A path that cannot contribute a symbol or
-// a relation cannot make a snapshot stale either, so it is not a reason to throw
-// one away.
-//
-// The test is extensionUnsupported, which is what the indexer uses to decide whether to PARSE a
-// file — but parsing is not the only way a file reaches the graph. buildManifestImportResolver
-// also reads the CONTENT of the repo-root manifests, and two of those (go.mod, setup.cfg) carry
-// no supported extension while deciding how every import in the repository resolves. Forgiving
-// them served a snapshot whose call edges were still resolved against the previous module path.
-// They are excluded by name through isManifestImportFile, and TestManifestImportFilesCoverReads
-// fails if that list falls behind the manifests actually read.
-//
-// Otherwise the rule is deliberately conservative in the safe direction: an extensionless path
-// counts as supported, because a shebang can make it a script, and any supported path still
-// bypasses the cache whatever its status.
-//
-// Ignored files never reach this loop: git status omits them, and the provider's walk skips them
-// too, so neither side can serve what the other would have indexed. Note the two do not agree in
-// general — git never ignores a TRACKED file, while the walk applies the ignore stack to every
-// path — but that disagreement only ever reports a path as dirty that the walk would have
-// skipped, which costs a re-index and cannot serve a stale one.
-func worktreeSnapshotCacheable(ctx context.Context, absRepo string, options ProviderSnapshotOptions) bool {
-	if !options.Worktree {
-		return true
-	}
-	if cached, ok := worktreeCleanVerdicts.Load(absRepo); ok {
-		verdict := cached.(worktreeCleanVerdict)
-		if time.Since(verdict.checkedAt) < worktreeCleanTTL {
-			return verdict.clean
-		}
-	}
-	clean := true
-	dirty, err := gitutil.WorktreeDirtyPaths(ctx, absRepo)
-	if err != nil {
-		clean = false
-	}
-	for _, path := range dirty {
-		if !extensionUnsupported(path) || isManifestImportFile(path) {
-			clean = false
-			break
-		}
-	}
-	worktreeCleanVerdicts.Store(absRepo, worktreeCleanVerdict{clean: clean, checkedAt: time.Now()})
-	return clean
-}
-
-// InvalidateWorktreeCleanVerdicts drops the memoized cleanliness verdicts. A
-// one-shot command never needs it (the memo cannot outlive the process), but a
-// long-lived embedder that has just written to a working tree can call it to
-// force the next query to re-check rather than wait out the TTL.
-func InvalidateWorktreeCleanVerdicts() {
-	worktreeCleanVerdicts.Range(func(key, _ any) bool {
-		worktreeCleanVerdicts.Delete(key)
-		return true
-	})
+// worktreeSnapshotCacheable deliberately rejects every working-tree snapshot.
+// A cleanliness comparison cannot pin Git's listing, info/exclude, nested
+// ignore files, and filesystem content to one atomic view; A→B→A changes can
+// therefore evade any pre/post recheck and poison a persistent entry.
+func worktreeSnapshotCacheable(_ context.Context, _ string, options ProviderSnapshotOptions) bool {
+	return !options.Worktree
 }
 
 // loadOrBuildSearchGraphSnapshot preserves the exact candidate-file scope even
@@ -203,6 +110,14 @@ func loadCachedCompleteSearchSnapshot(
 	if !worktreeSnapshotCacheable(ctx, absRepo, options) {
 		return ProviderSnapshot{}, false, nil
 	}
+	capturedOptions, captureErr := ensureProviderCachePolicy(absRepo, options)
+	if captureErr != nil {
+		// Cache policy is stricter than sequential matcher construction because
+		// it retains every input at once. An optional cache must not make an
+		// otherwise valid query fail; let the caller continue to a cold build.
+		return ProviderSnapshot{}, false, nil
+	}
+	options = capturedOptions
 	commit, tree, headErr := resolveCommittedHEAD(ctx, absRepo)
 	if headErr != nil {
 		return ProviderSnapshot{}, false, nil
@@ -262,6 +177,16 @@ func loadOrBuildSearchSnapshot(
 		snapshot, buildErr := BuildProviderSnapshotWithOptions(ctx, repo, providerVersion, options)
 		return snapshot, false, buildErr
 	}
+	capturedOptions, captureErr := ensureProviderCachePolicy(absRepo, options)
+	if captureErr != nil {
+		// Capture can reject an aggregate input set that the sequential matcher
+		// can safely consume. Preserve cache/no-cache behavior parity by taking
+		// the existing uncached build path; ordinary input errors still surface
+		// from that build.
+		snapshot, buildErr := BuildProviderSnapshotWithOptions(ctx, repo, providerVersion, options)
+		return snapshot, false, buildErr
+	}
+	options = capturedOptions
 	commit, tree, headErr := resolveCommittedHEAD(ctx, absRepo)
 	if headErr != nil {
 		snapshot, buildErr := BuildProviderSnapshotWithOptions(ctx, repo, providerVersion, options)
@@ -397,6 +322,10 @@ func preindexProviderSnapshotWithPersistenceReader(
 		options.Profile = ProfileFull
 	}
 	absRepo, err := filepath.Abs(repo)
+	if err != nil {
+		return ProviderSnapshot{}, false, err
+	}
+	options, err = CaptureProviderCachePolicy(absRepo, options)
 	if err != nil {
 		return ProviderSnapshot{}, false, err
 	}
@@ -776,6 +705,13 @@ func LoadOrBuildProviderSnapshot(
 // accepted because those edges are heuristic and confidence-scored, not
 // exact facts about the tree.
 func searchSnapshotKey(absRepo, repositoryKey, providerVersion, tree string, options ProviderSnapshotOptions) (string, error) {
+	if options.Worktree {
+		return "", errors.New("working-tree snapshots cannot have persistent cache keys")
+	}
+	policy, err := cachePolicyForOptions(absRepo, options)
+	if err != nil {
+		return "", err
+	}
 	hash := sha256.New()
 	writeCacheKeyString(hash, "cache-version", searchSnapshotCacheVersion)
 	writeCacheKeyString(hash, "repository-path", absRepo)
@@ -800,39 +736,11 @@ func searchSnapshotKey(absRepo, repositoryKey, providerVersion, tree string, opt
 	// bound: an entry built with a HIGHER cap also survives a later LOWERED one, handing back more
 	// of the tree than the caller asked to see. Neither direction announces itself.
 	writeCacheKeyString(hash, "max-files", fmt.Sprintf("%d", resolveMaxSourceFiles(options.MaxFiles)))
-	// Working-tree entries live in their own key space. The marker is only
-	// written for them; the versioned field framing already distinguishes this
-	// generation from every cache previously written to disk.
-	if options.Worktree {
-		writeCacheKeyString(hash, "worktree", "true")
-	}
 	onlyFiles := append([]string(nil), options.OnlyFiles...)
 	sort.Strings(onlyFiles)
 	writeCacheKeyString(hash, "only-files", "begin")
 	for _, filePath := range onlyFiles {
 		writeCacheKeyString(hash, "only-file", filepath.ToSlash(filepath.Clean(filePath)))
-	}
-	for groupIndex, group := range [][]string{options.IgnoreFiles, options.IncludeFiles} {
-		writeCacheKeyString(hash, "path-group", fmt.Sprintf("%d", groupIndex))
-		// Preserve caller order: ignore matching is last-rule-wins, including
-		// across repeatable ignore/include files within each group.
-		for _, rulePath := range group {
-			resolved := rulePath
-			if !filepath.IsAbs(resolved) {
-				resolved = filepath.Join(absRepo, resolved)
-			}
-			writeCacheKeyString(hash, "rule-path", filepath.Clean(resolved))
-			content, _, err := readBoundedRegularFile(
-				resolved,
-				ignoreFileLabel(groupIndex == 1),
-				true,
-				maxIgnoreFileBytes,
-			)
-			if err != nil {
-				return "", err
-			}
-			writeCacheKeyField(hash, "rule-content", content)
-		}
 	}
 	// The repo-root .graphignore is applied implicitly, so it must key the entry
 	// exactly as an explicit --ignore-file does. Without it, editing
@@ -844,47 +752,7 @@ func searchSnapshotKey(absRepo, repositoryKey, providerVersion, tree string, opt
 	// therefore which files the ranked payload, the snippets and the context blocks
 	// can quote. See builtinSecretRulesDigest.
 	writeCacheKeyString(hash, "builtin-secret-rules", builtinSecretRulesDigest())
-	graphIgnore := filepath.Join(absRepo, graphIgnoreFileName)
-	content, present, err := readBoundedRegularFile(
-		graphIgnore,
-		ignoreFileLabel(false),
-		false,
-		maxIgnoreFileBytes,
-	)
-	if err != nil {
-		return "", err
-	}
-	if present {
-		writeCacheKeyField(hash, "graphignore-content", content)
-	} else {
-		writeCacheKeyField(hash, "graphignore-missing", nil)
-	}
-	// A worktree snapshot also applies the repository's private info/exclude
-	// file. It lives under Git metadata rather than the worktree, so neither the
-	// HEAD tree nor git status changes when its policy changes. Bind its optional
-	// state and content explicitly or a warm relation-query cache can continue to
-	// serve paths the user has just excluded.
-	if options.Worktree {
-		exclude := gitInfoExcludePath(absRepo)
-		if exclude == "" {
-			writeCacheKeyField(hash, "git-info-exclude-missing", nil)
-		} else {
-			content, present, err := readBoundedRegularFile(
-				exclude,
-				ignoreFileLabel(false),
-				false,
-				maxIgnoreFileBytes,
-			)
-			if err != nil {
-				return "", err
-			}
-			if present {
-				writeCacheKeyField(hash, "git-info-exclude-content", content)
-			} else {
-				writeCacheKeyField(hash, "git-info-exclude-missing", nil)
-			}
-		}
-	}
+	policy.writeCacheKey(hash)
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
@@ -902,12 +770,9 @@ func validCachedSearchSnapshot(cache cachedSearchSnapshot, repositoryKey, provid
 		cache.Profile == options.Profile &&
 		cache.MaxParseBytes == options.MaxParseBytes &&
 		cache.Snapshot.Header.RepoKey == repositoryKey &&
-		// Both identity gates are required and neither implies the other: RepoKey
-		// separates two checkouts that share a tree hash, Worktree separates the two
-		// VIEWS of one checkout. A clean working tree is now cacheable
-		// (worktreeSnapshotCacheable), so a working-tree entry and a committed-tree
-		// entry can have the same repo, tree and profile while carrying different
-		// provenance (W_WORKTREE_SNAPSHOT) — without this they would collide.
+		// Both identity gates remain required for decoding older entries: RepoKey
+		// separates two checkouts that share a tree hash, while Worktree prevents a
+		// retired working-tree entry from ever serving a committed-tree request.
 		cache.Worktree == options.Worktree &&
 		cache.Snapshot.Header.Tree == tree &&
 		cache.Snapshot.Header.Provider == ProviderName &&

--- a/internal/sem/search_cache.go
+++ b/internal/sem/search_cache.go
@@ -220,6 +220,12 @@ func loadOrBuildSearchSnapshot(
 				// letting an optional cache break retrieval.
 				return ProviderSnapshot{}, false
 			}
+			if validateBuiltSearchSnapshot(selective, repositoryKey, providerVersion, tree, options) != nil {
+				// The derivation reopens the repository to enumerate the selective
+				// source. If identity or HEAD moved since this transaction was keyed,
+				// discard the result and take the ordinary build path below.
+				return ProviderSnapshot{}, false
+			}
 			// Persisting the exact selective view makes repeated identical queries
 			// a direct cache hit. As with ordinary search caching, this is best effort.
 			_ = writeSearchSnapshot(entry, newCachedSearchSnapshot(providerVersion, commit, tree, options, selective))
@@ -804,6 +810,7 @@ func validCachedSearchSnapshot(cache cachedSearchSnapshot, repositoryKey, provid
 		cache.Worktree == options.Worktree &&
 		cache.Snapshot.Header.Tree == tree &&
 		cache.Snapshot.Header.Provider == ProviderName &&
+		cache.Snapshot.Header.ProviderVersion == providerVersion &&
 		cache.Snapshot.Header.Profile == string(options.Profile)
 }
 

--- a/internal/sem/search_cache_test.go
+++ b/internal/sem/search_cache_test.go
@@ -1292,6 +1292,106 @@ func TestSearchSnapshotCacheKeyPreservesIgnoreFileOrder(t *testing.T) {
 	}
 }
 
+func TestSearchCacheTransactionPinsPolicyAcrossCompleteAndSelectiveSnapshots(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	write(t, repo, ".search-policy", "denied.go\n")
+	write(t, repo, "denied.go", `package sample
+
+func PolicyTransactionNeedle() bool { return true }
+`)
+	write(t, repo, "control.go", `package sample
+
+// Control documents the cache transaction fallback.
+func Control() bool { return true }
+`)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+
+	cacheDir := t.TempDir()
+	providerOptions := ProviderSnapshotOptions{
+		Profile:     ProfileSyntaxOnly,
+		IgnoreFiles: []string{".search-policy"},
+	}
+	preindexed, hit, err := PreindexProviderSnapshot(t.Context(), repo, "test-version", providerOptions, cacheDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hit {
+		t.Fatal("first policy-A preindex unexpectedly hit cache")
+	}
+	if snapshotHasSymbol(preindexed, "PolicyTransactionNeedle") {
+		t.Fatal("policy-A preindex retained the denied symbol")
+	}
+
+	policyMutated := false
+	searchOptions := SearchOptions{
+		Profile:         ProfileSyntaxOnly,
+		TopK:            5,
+		MaxIndexedFiles: 1,
+		CacheDir:        cacheDir,
+		IgnoreFiles:     []string{".search-policy"},
+		afterCachePolicyCapture: func() {
+			policyMutated = true
+			write(t, repo, ".search-policy", "# policy B includes every source file\n")
+		},
+	}
+	policyAResponse, err := SearchRepository(
+		t.Context(), repo, "test-version", "PolicyTransactionNeedle cache transaction", searchOptions,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !policyMutated {
+		t.Fatal("test did not mutate the policy after transaction capture")
+	}
+	if !policyAResponse.Stats.IndexCacheHit {
+		t.Fatal("policy-A search did not load the preindexed complete snapshot")
+	}
+	if policyAResponse.Stats.FilesIndexed == 0 {
+		t.Fatalf("policy-A search skipped selective derivation: %#v", policyAResponse.Stats)
+	}
+	if len(policyAResponse.Results) == 0 || policyAResponse.Results[0].FilePath != "control.go" {
+		t.Fatalf("policy-A search did not derive the matching control file: %#v", policyAResponse.Results)
+	}
+	for _, result := range policyAResponse.Results {
+		if result.FilePath == "denied.go" {
+			t.Fatalf("policy-A transaction admitted a file enabled only by policy B: %#v", policyAResponse.Results)
+		}
+	}
+
+	// The first transaction must not derive the missing policy-A symbol from
+	// its complete snapshot and persist that omission under policy B's selective
+	// key. Two B searches prove both the cold build and its direct cache replay.
+	searchOptions.afterCachePolicyCapture = nil
+	for attempt := 0; attempt < 2; attempt++ {
+		response, searchErr := SearchRepository(
+			t.Context(), repo, "test-version", "PolicyTransactionNeedle cache transaction", searchOptions,
+		)
+		if searchErr != nil {
+			t.Fatal(searchErr)
+		}
+		found := false
+		for _, result := range response.Results {
+			if result.SymbolName == "PolicyTransactionNeedle" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("policy-B search %d replayed a policy-A omission: %#v", attempt+1, response.Results)
+		}
+		if attempt == 0 && response.Stats.IndexCacheHit {
+			t.Fatal("first policy-B search unexpectedly hit a poisoned selective entry")
+		}
+		if attempt == 1 && !response.Stats.IndexCacheHit {
+			t.Fatal("second policy-B search did not reuse its correct selective entry")
+		}
+	}
+}
+
 // TestOnlyFilesDerivationReStampsCommitAfterSameTreeCommit pins the re-stamp
 // on the OnlyFiles-derivation branch of loadOrBuildSearchSnapshot: a selective
 // snapshot derived from a complete same-tree cache entry built at an older

--- a/internal/sem/search_cache_test.go
+++ b/internal/sem/search_cache_test.go
@@ -194,11 +194,12 @@ func TestCacheWritesTolerateSymlinkedCacheDirectories(t *testing.T) {
 func TestValidCachedSearchSnapshotKeysRepoAndIgnoresCommit(t *testing.T) {
 	options := ProviderSnapshotOptions{Profile: ProfileFull}
 	snapshot := ProviderSnapshot{Header: SnapshotHeader{
-		RepoKey:  "github.com/example/repo",
-		Commit:   "old-commit",
-		Tree:     "tree",
-		Provider: ProviderName,
-		Profile:  string(ProfileFull),
+		RepoKey:         "github.com/example/repo",
+		Commit:          "old-commit",
+		Tree:            "tree",
+		Provider:        ProviderName,
+		ProviderVersion: "test-version",
+		Profile:         string(ProfileFull),
 	}}
 	cache := newCachedSearchSnapshot("test-version", "old-commit", "tree", options, snapshot)
 	if !validCachedSearchSnapshot(cache, snapshot.Header.RepoKey, "test-version", "tree", options) {
@@ -207,6 +208,11 @@ func TestValidCachedSearchSnapshotKeysRepoAndIgnoresCommit(t *testing.T) {
 	if validCachedSearchSnapshot(cache, "github.com/example/other", "test-version", "tree", options) {
 		t.Fatal("cache entry from another repository identity must not be reused")
 	}
+	cache.Snapshot.Header.ProviderVersion = "other-version"
+	if validCachedSearchSnapshot(cache, snapshot.Header.RepoKey, "test-version", "tree", options) {
+		t.Fatal("cache entry with mismatched snapshot provider version must not be reused")
+	}
+	cache.Snapshot.Header.ProviderVersion = "test-version"
 	cache.Commit = "different-commit"
 	cache.Snapshot.Header.Commit = "different-commit"
 	if !validCachedSearchSnapshot(cache, snapshot.Header.RepoKey, "test-version", "tree", options) {

--- a/internal/sem/search_cache_test.go
+++ b/internal/sem/search_cache_test.go
@@ -214,6 +214,72 @@ func TestValidCachedSearchSnapshotKeysRepoAndIgnoresCommit(t *testing.T) {
 	}
 }
 
+func TestValidateBuiltSearchSnapshotPinsGraphProvenanceButNotCommit(t *testing.T) {
+	options := ProviderSnapshotOptions{Profile: ProfileFull}
+	want := SnapshotHeader{
+		Provider:        ProviderName,
+		ProviderVersion: "test-version",
+		RepoKey:         "github.com/example/repo",
+		Commit:          "commit-built-mid-transaction",
+		Tree:            "tree",
+		Profile:         string(ProfileFull),
+	}
+	validate := func(header SnapshotHeader) error {
+		return validateBuiltSearchSnapshot(
+			ProviderSnapshot{Header: header}, want.RepoKey, want.ProviderVersion, want.Tree, options,
+		)
+	}
+	if err := validate(want); err != nil {
+		t.Fatalf("matching snapshot rejected: %v", err)
+	}
+	sameTreeDifferentCommit := want
+	sameTreeDifferentCommit.Commit = "another-commit"
+	if err := validate(sameTreeDifferentCommit); err != nil {
+		t.Fatalf("commit-only drift rejected: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*SnapshotHeader)
+	}{
+		{"repository key", func(header *SnapshotHeader) { header.RepoKey = "github.com/example/other" }},
+		{"tree", func(header *SnapshotHeader) { header.Tree = "other-tree" }},
+		{"provider", func(header *SnapshotHeader) { header.Provider = "other-provider" }},
+		{"provider version", func(header *SnapshotHeader) { header.ProviderVersion = "other-version" }},
+		{"profile", func(header *SnapshotHeader) { header.Profile = string(ProfileFast) }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			header := want
+			test.mutate(&header)
+			if err := validate(header); err == nil {
+				t.Fatalf("mismatched %s was accepted: %#v", test.name, header)
+			}
+		})
+	}
+}
+
+func TestSearchSnapshotMatchesSelectionPinsRepositoryIdentityAndTree(t *testing.T) {
+	selection := searchFileSelection{repoKey: "github.com/example/repo", tree: "tree"}
+	snapshot := ProviderSnapshot{Header: SnapshotHeader{RepoKey: selection.repoKey, Tree: selection.tree}}
+	if !searchSnapshotMatchesSelection(snapshot, selection) {
+		t.Fatal("matching snapshot and selection rejected")
+	}
+	snapshot.Header.Commit = "commit-drift-does-not-matter"
+	if !searchSnapshotMatchesSelection(snapshot, selection) {
+		t.Fatal("commit-only drift rejected")
+	}
+	snapshot.Header.RepoKey = "github.com/example/other"
+	if searchSnapshotMatchesSelection(snapshot, selection) {
+		t.Fatal("repository-identity drift accepted")
+	}
+	snapshot.Header.RepoKey = selection.repoKey
+	snapshot.Header.Tree = "other-tree"
+	if searchSnapshotMatchesSelection(snapshot, selection) {
+		t.Fatal("tree drift accepted")
+	}
+}
+
 func TestMergePartialFailuresDeduplicatesByCodeAndFile(t *testing.T) {
 	base := []PartialFailure{{Code: "E_PARSE_TIMEOUT", FilePath: "src/a.ts"}}
 	merged := mergePartialFailures(base, []PartialFailure{
@@ -1233,6 +1299,60 @@ func IdentitySensitiveTarget() bool { return true }
 		t.Fatal(err)
 	}
 	assertNewRepoKeyResult("full", full)
+}
+
+func TestSearchRejectsPreindexWhenRepoKeyChangesAfterCacheLoad(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	git(t, repo, "remote", "add", "origin", "https://github.com/acme/legacy.git")
+	write(t, repo, "target.go", `package target
+
+func IdentityRaceTarget() bool { return true }
+`)
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+
+	cacheDir := t.TempDir()
+	if _, hit, err := PreindexProviderSnapshot(t.Context(), repo, "test-version", ProviderSnapshotOptions{
+		Profile: ProfileSyntaxOnly,
+	}, cacheDir); err != nil {
+		t.Fatal(err)
+	} else if hit {
+		t.Fatal("first preindex unexpectedly hit cache")
+	}
+
+	mutated := false
+	response, err := SearchRepository(t.Context(), repo, "test-version", "IdentityRaceTarget", SearchOptions{
+		Profile:       ProfileSyntaxOnly,
+		TopK:          5,
+		IndexAllFiles: true,
+		CacheDir:      cacheDir,
+		afterPreindexLoad: func() {
+			mutated = true
+			git(t, repo, "remote", "set-url", "origin", "https://github.com/acme/renamed.git")
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !mutated {
+		t.Fatal("test did not mutate repository identity after loading the complete preindex")
+	}
+	if response.Stats.IndexCacheHit {
+		t.Fatalf("search reported the old-identity preindex as a hit: %#v", response.Stats)
+	}
+	for _, result := range response.Results {
+		if result.SymbolName != "IdentityRaceTarget" {
+			continue
+		}
+		if !strings.HasPrefix(result.SymbolID, "gh/acme/renamed:") {
+			t.Fatalf("search returned stale repository identity in symbol ID %q", result.SymbolID)
+		}
+		return
+	}
+	t.Fatalf("search lost IdentityRaceTarget: %#v", response.Results)
 }
 
 func TestSearchSnapshotCacheKeyPreservesIgnoreFileOrder(t *testing.T) {

--- a/internal/sem/search_cache_worktree_test.go
+++ b/internal/sem/search_cache_worktree_test.go
@@ -31,11 +31,9 @@ func cacheTestRepo(t *testing.T) string {
 	return repo
 }
 
-// A working-tree snapshot of a CLEAN tree is exactly a snapshot of HEAD's
-// content, so it may be cached — that is what stops the relation verbs, which
-// index the whole repository, from re-indexing on every call. A dirty tree must
-// still bypass the cache entirely.
-func TestWorktreeSnapshotCachesOnlyWhileTreeMatchesHEAD(t *testing.T) {
+// Worktree queries always rebuild until raw worktree equality can be checked
+// without invoking repository-selected Git conversion filters.
+func TestWorktreeSnapshotAlwaysBypassesCache(t *testing.T) {
 	repo := cacheTestRepo(t)
 	cacheDir := t.TempDir()
 	options := ProviderSnapshotOptions{Worktree: true, Profile: ProfileFull, NoNetwork: true}
@@ -55,23 +53,22 @@ func TestWorktreeSnapshotCachesOnlyWhileTreeMatchesHEAD(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !hit {
-		t.Fatal("clean worktree query did not reuse the cached index")
+	if hit {
+		t.Fatal("clean worktree query reused the cache")
 	}
 	if len(second.Symbols) != len(first.Symbols) {
-		t.Fatalf("cached snapshot differs: %d symbols vs %d", len(second.Symbols), len(first.Symbols))
+		t.Fatalf("rebuilt snapshot differs: %d symbols vs %d", len(second.Symbols), len(first.Symbols))
 	}
 	// A working-tree snapshot keeps its provenance warning; it must not be
 	// silently replaced by a committed-tree entry.
 	if !hasWarningCode(second.Header.Warnings, "W_WORKTREE_SNAPSHOT") {
-		t.Fatalf("cached worktree snapshot lost its provenance warning: %#v", second.Header.Warnings)
+		t.Fatalf("rebuilt worktree snapshot lost its provenance warning: %#v", second.Header.Warnings)
 	}
 
 	if err := os.WriteFile(filepath.Join(repo, "app.go"),
 		[]byte("package app\n\nfunc Alpha() { Beta() }\nfunc Beta() {}\nfunc Delta() { Beta() }\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	InvalidateWorktreeCleanVerdicts()
 	dirty, hit, err := LoadOrBuildProviderSnapshot(context.Background(), repo, "test", options, cacheDir, false)
 	if err != nil {
 		t.Fatal(err)
@@ -84,8 +81,8 @@ func TestWorktreeSnapshotCachesOnlyWhileTreeMatchesHEAD(t *testing.T) {
 	}
 }
 
-// An untracked file is indexed by a working-tree walk but absent from HEAD, so
-// its presence alone must disable caching.
+// Working-tree snapshots always bypass persistence; this case verifies that
+// the resulting rebuild observes an untracked source file.
 func TestWorktreeSnapshotBypassesCacheForUntrackedFiles(t *testing.T) {
 	repo := cacheTestRepo(t)
 	cacheDir := t.TempDir()
@@ -96,7 +93,6 @@ func TestWorktreeSnapshotBypassesCacheForUntrackedFiles(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(repo, "extra.go"), []byte("package app\n\nfunc Extra() { Beta() }\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	InvalidateWorktreeCleanVerdicts()
 	snapshot, hit, err := LoadOrBuildProviderSnapshot(context.Background(), repo, "test", options, cacheDir, false)
 	if err != nil {
 		t.Fatal(err)
@@ -109,8 +105,8 @@ func TestWorktreeSnapshotBypassesCacheForUntrackedFiles(t *testing.T) {
 	}
 }
 
-// Committed-tree and working-tree entries occupy separate key spaces: neither
-// may be served for the other, because their provenance differs.
+// A committed-tree entry must never serve a worktree query, whose mutable
+// provenance requires a fresh build.
 func TestWorktreeAndHeadSnapshotEntriesDoNotShare(t *testing.T) {
 	repo := cacheTestRepo(t)
 	cacheDir := t.TempDir()
@@ -121,21 +117,19 @@ func TestWorktreeAndHeadSnapshotEntriesDoNotShare(t *testing.T) {
 		t.Fatalf("cold head build = (hit %v, err %v)", hit, err)
 	}
 	// The head entry exists now; a worktree query must still build its own.
-	InvalidateWorktreeCleanVerdicts()
 	if _, hit, err := LoadOrBuildProviderSnapshot(context.Background(), repo, "test", worktree, cacheDir, false); err != nil || hit {
 		t.Fatalf("worktree query reused a committed-tree entry: (hit %v, err %v)", hit, err)
 	}
-	// And each view now hits its own entry.
+	// The committed view hits its entry, while the worktree still rebuilds.
 	if _, hit, err := LoadOrBuildProviderSnapshot(context.Background(), repo, "test", head, cacheDir, false); err != nil || !hit {
 		t.Fatalf("head re-query = (hit %v, err %v)", hit, err)
 	}
-	InvalidateWorktreeCleanVerdicts()
 	worktreeSnapshot, hit, err := LoadOrBuildProviderSnapshot(context.Background(), repo, "test", worktree, cacheDir, false)
-	if err != nil || !hit {
+	if err != nil || hit {
 		t.Fatalf("worktree re-query = (hit %v, err %v)", hit, err)
 	}
 	if !hasWarningCode(worktreeSnapshot.Header.Warnings, "W_WORKTREE_SNAPSHOT") {
-		t.Fatal("worktree entry served without its provenance warning")
+		t.Fatal("rebuilt worktree snapshot omitted its provenance warning")
 	}
 }
 
@@ -153,7 +147,6 @@ func TestWorktreeSnapshotWithoutCommittedHEADIsNotCached(t *testing.T) {
 	options := ProviderSnapshotOptions{Worktree: true, Profile: ProfileFull, NoNetwork: true}
 	cacheDir := t.TempDir()
 	for attempt := 0; attempt < 2; attempt++ {
-		InvalidateWorktreeCleanVerdicts()
 		if _, hit, err := LoadOrBuildProviderSnapshot(context.Background(), repo, "test", options, cacheDir, false); err != nil || hit {
 			t.Fatalf("attempt %d = (hit %v, err %v), want (false, nil)", attempt, hit, err)
 		}
@@ -178,11 +171,9 @@ func hasSymbolNamed(symbols []SymbolRecord, name string) bool {
 	return false
 }
 
-// The complement of the test above: a file no parser ever opens cannot change a
-// snapshot, so its presence must NOT throw the index away. Before this, a single
-// .DS_Store or a compiled binary in the tree made every query re-index the whole
-// repository from scratch.
-func TestWorktreeSnapshotStillCachesWithUnindexableUntrackedFiles(t *testing.T) {
+// Worktree bypass is unconditional, including when every new path is a file no
+// parser opens. Cache behavior must not depend on a path-eligibility heuristic.
+func TestWorktreeSnapshotBypassesCacheWithUnindexableUntrackedFiles(t *testing.T) {
 	repo := cacheTestRepo(t)
 	cacheDir := t.TempDir()
 	options := ProviderSnapshotOptions{Worktree: true, Profile: ProfileFull, NoNetwork: true}
@@ -192,9 +183,8 @@ func TestWorktreeSnapshotStillCachesWithUnindexableUntrackedFiles(t *testing.T) 
 		t.Fatal(err)
 	}
 
-	// Every name here must carry an extension that maps to no language.
-	// An EXTENSIONLESS path stays conservative on purpose (a shebang can make it
-	// a script), so it keeps bypassing the cache — see the sibling assertion below.
+	// Every name here carries an extension that maps to no language, proving
+	// that unconditional bypass does not depend on whether a parser claims it.
 	for name, content := range map[string]string{
 		".DS_Store":           "\x00\x00binary junk",
 		"entire-graph.bin":    "\x7fELF not source",
@@ -205,24 +195,21 @@ func TestWorktreeSnapshotStillCachesWithUnindexableUntrackedFiles(t *testing.T) 
 			t.Fatal(err)
 		}
 	}
-	InvalidateWorktreeCleanVerdicts()
 	second, hit, err := LoadOrBuildProviderSnapshot(context.Background(), repo, "test", options, cacheDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !hit {
-		t.Fatal("unindexable untracked files disabled the cache")
+	if hit {
+		t.Fatal("worktree snapshot reused the cache with unindexable untracked files")
 	}
 	if len(second.Symbols) != len(first.Symbols) {
-		t.Fatalf("cached snapshot differs: %d symbols vs %d", len(second.Symbols), len(first.Symbols))
+		t.Fatalf("rebuilt snapshot differs: %d symbols vs %d", len(second.Symbols), len(first.Symbols))
 	}
 
-	// An extensionless untracked file stays conservative: a shebang can make it a
-	// script, so the graph must assume it is indexable and skip the cache.
+	// An extensionless untracked file also leaves unconditional bypass intact.
 	if err := os.WriteFile(filepath.Join(repo, "somebinary"), []byte("\x7fELF"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	InvalidateWorktreeCleanVerdicts()
 	if _, hit, err := LoadOrBuildProviderSnapshot(context.Background(), repo, "test", options, cacheDir, false); err != nil {
 		t.Fatal(err)
 	} else if hit {
@@ -231,14 +218,10 @@ func TestWorktreeSnapshotStillCachesWithUnindexableUntrackedFiles(t *testing.T) 
 	if err := os.Remove(filepath.Join(repo, "somebinary")); err != nil {
 		t.Fatal(err)
 	}
-	InvalidateWorktreeCleanVerdicts()
-
-	// Adding ONE indexable untracked file alongside them must still bypass: the
-	// forgiveness is per-path, not a blanket "ignore untracked".
+	// Adding one indexable source verifies that the subsequent rebuild exposes it.
 	if err := os.WriteFile(filepath.Join(repo, "extra.go"), []byte("package app\n\nfunc Extra() { Beta() }\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	InvalidateWorktreeCleanVerdicts()
 	third, hit, err := LoadOrBuildProviderSnapshot(context.Background(), repo, "test", options, cacheDir, false)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/sem/search_test.go
+++ b/internal/sem/search_test.go
@@ -86,7 +86,7 @@ func Match%02d() string { return "needle" }
 				Profile:                 ProfileSyntaxOnly,
 				MaxIndexedFiles:         2,
 				progressivePreselection: true,
-			}, ProviderSnapshot{}, false)
+			}, ProviderSnapshotOptions{NoNetwork: true, Worktree: true}, ProviderSnapshot{}, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -119,7 +119,8 @@ func TestColdPreselectionKeepsLegacyOrderAndStatsWhenEligibleSetFitsBase(t *test
 	q := buildSearchQuery("quasar nebula")
 	selection, err := preselectSearchFiles(
 		t.Context(), repo, q, buildSparseSearchQuery("quasar nebula"),
-		SearchOptions{Worktree: true, MaxIndexedFiles: 3}, ProviderSnapshot{}, false,
+		SearchOptions{Worktree: true, MaxIndexedFiles: 3},
+		ProviderSnapshotOptions{NoNetwork: true, Worktree: true}, ProviderSnapshot{}, false,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -154,7 +155,8 @@ func TestColdPreselectionExcludesConstraintOnlyDistractorWhenLegacySetFitsBase(t
 	}
 	selection, err := preselectSearchFiles(
 		t.Context(), repo, q, buildSparseSearchQuery("needle"),
-		SearchOptions{Worktree: true, MaxIndexedFiles: 2}, ProviderSnapshot{}, false,
+		SearchOptions{Worktree: true, MaxIndexedFiles: 2},
+		ProviderSnapshotOptions{NoNetwork: true, Worktree: true}, ProviderSnapshot{}, false,
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/sem/shebang_test.go
+++ b/internal/sem/shebang_test.go
@@ -194,6 +194,38 @@ func TestSnapshotRoutesOversizedCommittedShebangScriptsByCapturedPrefix(t *testi
 	}
 }
 
+func TestProcessProviderFileDoesNotRestreamKnownOversizedShebang(t *testing.T) {
+	const path = "bin/large-script"
+	reads := 0
+	read := func(string) (string, bool) {
+		reads++
+		return "", false
+	}
+	source := sourceContext{
+		key:  "test-repo",
+		read: read,
+		readPrefix: func(path string, limit int) (string, bool) {
+			return read(path)
+		},
+		oversize: func(string) (oversizeFile, bool) {
+			return oversizeFile{
+				Bytes:  8192,
+				Hash:   "sha256:test",
+				Lines:  2,
+				Prefix: "#!/usr/bin/env bash\necho ok\n",
+			}, true
+		},
+	}
+
+	result := processProviderFile(t.Context(), source, profileSpec{}, 1024, 0, path)
+	if result.file == nil || result.file.Language != "Bash" {
+		t.Fatalf("oversized shebang result = %#v, want Bash file record", result)
+	}
+	if reads != 1 {
+		t.Fatalf("oversized shebang content reads = %d, want 1 streamed refusal", reads)
+	}
+}
+
 func fileHasSymbolNamed(snapshot ProviderSnapshot, path, name string) bool {
 	for _, symbol := range snapshot.Symbols {
 		if symbol.FilePath == path && symbol.Name == name {

--- a/internal/sem/shebang_test.go
+++ b/internal/sem/shebang_test.go
@@ -226,6 +226,59 @@ func TestProcessProviderFileDoesNotRestreamKnownOversizedShebang(t *testing.T) {
 	}
 }
 
+func TestSnapshotPreservesWorkingTreeShebangLanguageWhenOversized(t *testing.T) {
+	const path = "large-worktree-script"
+	source := sourceContext{
+		key: "test-repo",
+		read: func(string) (string, bool) {
+			return "", false
+		},
+		readPrefix: func(string, int) (string, bool) {
+			return "#!/usr/bin/env bash\necho ok\n", true
+		},
+		// Worktree oversize records intentionally retain no content prefix:
+		// routing already obtained one through the bounded filesystem read above.
+		oversize: func(string) (oversizeFile, bool) {
+			return oversizeFile{Bytes: 8192, Hash: "sha256:test", Lines: 2}, true
+		},
+	}
+
+	result := processProviderFile(t.Context(), source, profileSpec{}, 2048, 0, path)
+	if result.file == nil || result.file.Language != "Bash" {
+		t.Fatalf("oversized working-tree shebang result = %#v, want Bash file record", result)
+	}
+	if len(result.failures) != 1 || result.failures[0].Code != "E_FILE_TOO_LARGE" {
+		t.Fatalf("oversized working-tree shebang failures = %#v, want E_FILE_TOO_LARGE", result.failures)
+	}
+}
+
+func TestFallbackOversizeRegistryConsumesCachedPrefix(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	const path = "odd\nscript"
+	content := "#!/usr/bin/env bash\n" + strings.Repeat("echo oversized\n", 256)
+	blob := gitObjectInputOutput(t, repo, content, "hash-object", "-w", "--stdin")
+	tree := gitObjectInputOutput(t, repo, "100644 blob "+blob+"\t"+path+string(byte(0)), "mktree", "-z")
+	commit := gitObjectInputOutput(
+		t, repo, "", "-c", "user.name=Entire Graph Test", "-c", "user.email=graph@example.com",
+		"commit-tree", tree, "-m", "oversized shebang",
+	)
+
+	registry := newFallbackOversizeRegistry(repo, commit, 128)
+	registry.note(path)
+	first, ok := registry.lookup(t.Context(), path)
+	if !ok || !strings.HasPrefix(first.Prefix, "#!/usr/bin/env bash") {
+		t.Fatalf("first fallback oversize lookup = %#v (ok=%v), want captured shebang prefix", first, ok)
+	}
+	if cached := registry.resolved[path]; cached == nil || cached.Prefix != "" || cached.Hash == "" {
+		t.Fatalf("cached fallback oversize record = %#v, want metadata with consumed Prefix", cached)
+	}
+	second, ok := registry.lookup(t.Context(), path)
+	if !ok || second.Prefix != "" || second.Hash != first.Hash || second.Bytes != first.Bytes {
+		t.Fatalf("second fallback oversize lookup = %#v (ok=%v), want cached metadata without Prefix", second, ok)
+	}
+}
+
 func fileHasSymbolNamed(snapshot ProviderSnapshot, path, name string) bool {
 	for _, symbol := range snapshot.Symbols {
 		if symbol.FilePath == path && symbol.Name == name {

--- a/internal/sem/shebang_test.go
+++ b/internal/sem/shebang_test.go
@@ -1,6 +1,8 @@
 package sem
 
 import (
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -119,6 +121,76 @@ if __name__ == "__main__":
 	}
 	if _, ok := filesByPath["node_modules/pkg/cli"]; ok {
 		t.Fatalf("vendored node_modules script must stay skipped")
+	}
+}
+
+// TestSnapshotRoutesOversizedCommittedShebangScriptsByCapturedPrefix
+// reproduces two trail findings: a committed, extensionless shebang script
+// that is ALSO oversized cannot satisfy the ordinary bounded prefix read at
+// all (Git blob reads are all-or-nothing, so the git-tree source's
+// readPrefix has to fully read the blob first), so routing used to fail
+// before the oversize registry was ever consulted and the file vanished
+// with no file record and no partial failure. It must instead be routed
+// from the prefix already captured for free while streaming the blob's
+// digest, and reported as E_FILE_TOO_LARGE like any other oversized file.
+func TestSnapshotRoutesOversizedCommittedShebangScriptsByCapturedPrefix(t *testing.T) {
+	repo := t.TempDir()
+	initRepo(t, repo)
+
+	// Longer than shebangSniffLimit so the language check never reaches the
+	// zero-filled padding writeSparseFile adds beyond this header, and small
+	// enough to stay well under the oversize cap chosen below.
+	header := "#!/usr/bin/env bash\n" + strings.Repeat("# padding line to clear the shebang sniff window\n", 30)
+	if len(header) <= shebangSniffLimit {
+		t.Fatalf("fixture header is %d bytes, want more than shebangSniffLimit (%d)", len(header), shebangSniffLimit)
+	}
+	const maxParseBytes = 2048
+	const totalSize = maxParseBytes * 4
+	if len(header) >= maxParseBytes {
+		t.Fatalf("fixture header is %d bytes, want under maxParseBytes (%d)", len(header), maxParseBytes)
+	}
+
+	const batchSafePath = "bin/pytool-big"
+	writeSparseFile(t, repo, batchSafePath, totalSize, header)
+
+	const newlinePath = "bin/py\ntool-big"
+	if runtime.GOOS != "windows" {
+		writeSparseFile(t, repo, newlinePath, totalSize, header)
+	}
+
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "oversized extensionless shebang scripts")
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{MaxParseBytes: maxParseBytes})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	filesByPath := map[string]FileRecord{}
+	for _, file := range snapshot.Files {
+		filesByPath[file.Path] = file
+	}
+	failuresByPath := map[string]PartialFailure{}
+	for _, failure := range snapshot.Header.PartialFailures {
+		failuresByPath[failure.FilePath] = failure
+	}
+
+	paths := []string{batchSafePath}
+	if runtime.GOOS != "windows" {
+		paths = append(paths, newlinePath)
+	}
+	for _, path := range paths {
+		file, ok := filesByPath[path]
+		if !ok {
+			t.Fatalf("oversized shebang script %q missing from snapshot files (silently dropped): %#v", path, snapshot.Files)
+		}
+		if file.Language != "Bash" {
+			t.Fatalf("oversized shebang script %q language = %q, want Bash", path, file.Language)
+		}
+		failure, ok := failuresByPath[path]
+		if !ok || failure.Code != "E_FILE_TOO_LARGE" {
+			t.Fatalf("oversized shebang script %q partial failure = %#v (ok=%v), want E_FILE_TOO_LARGE", path, failure, ok)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/87
<!-- entire-trail-link-end -->

## The bug

The two cache-key hashers read `.graphignore` and every `--ignore-file` / `--include-file` with a bare `os.ReadFile`, before anything checked what those paths actually were:

| site | read |
|---|---|
| `internal/sem/search_cache.go:847` | `os.ReadFile(graphIgnore)` — the implicit repo-root `.graphignore` |
| `internal/sem/search_cache.go:829` | `os.ReadFile(resolved)` — explicit ignore/include paths |
| `internal/sem/records_cache.go:85` | `os.ReadFile(resolved)` — explicit ignore/include paths |

A type guard for exactly this input already exists one layer down: `ignoreMatcher.loadOptional` / `loadRequired` (`internal/sem/ignore.go:148-176`) refuse anything that is not a regular file, with `"%s %q is not a regular file"`. But the cache key is derived **first**, on every cache-enabled invocation, so that guard never got the chance to run. These three reads were a straight bypass of an existing control — not a missing check, a checked-too-late one.

The consequence is unbounded memory consumption driven by a repository's own contents: **CWE-400 / CWE-770, reached via CWE-59 (link following)**.

## The exploit

Repo shape — one symlink, committed:

```sh
git init victim && cd victim
echo 'package a' > a.go
ln -s /dev/zero .graphignore
git add -A && git commit -m init
```

Any default command on a fresh clone. No flag, no argument, no network:

```sh
entire graph index --repo .     # also: impact / def / neighbors / search
```

`os.ReadFile` keeps doubling its buffer against an infinite character device. Sampled RSS of the unmodified binary, killed at 1.2 s:

```
t=100ms RSS=16MB     t=500ms RSS=2118MB     t=900ms  RSS=3876MB
t=200ms RSS=299MB    t=600ms RSS=2693MB     t=1000ms RSS=4597MB
t=300ms RSS=984MB    t=700ms RSS=3035MB     t=1100ms RSS=4982MB
t=400ms RSS=1388MB   t=800ms RSS=3508MB     t=1200ms RSS=5044MB   <- killed
```

5.0 GB in 1.2 s, still climbing at roughly 4 GB/s. `--no-cache` was **unaffected** — it derives no key at all — and that asymmetry is what isolated the fault to these three reads rather than to the walk or the parser.

Same binary, after the fix:

```
$ entire graph index --repo . --head
ignore file "/tmp/zerorepo/.graphignore" is not a regular file
    0.02s user 0.02s system   (0.037s total)
```

The cache-enabled path now produces the same refusal `--no-cache` always did.

## The fix

All three sites route through one helper, `readIgnoreFileForKey`, which applies the loader's guarantee **at** the read instead of after it:

1. **`os.Lstat` first.** It inspects the final component *without* following it, so the decision to dereference is taken by this function and not by whatever the link points at.
2. **A symlink is then resolved with `os.Stat`** — the same call, with the same meaning, the ignore loader uses. This is deliberate: rejecting every link outright would have been stricter than the loader and would have broken a `.graphignore` that is a link to a real ignore file. Anything that does not resolve to a regular file (character or block device, FIFO, directory, socket) is refused with the loader's own wording. Nothing non-regular is ever opened, so a FIFO cannot block the open either.
3. **The open handle is then fstat'd before a byte is read** (`readOpenedIgnoreFileForKey`), and a handle whose own mode is not regular is refused. That is what closes the TOCTOU window between the path check and the open rather than merely narrowing it: a name can be swapped between two lookups, a file description cannot.

There is deliberately **no byte cap**. See "Review follow-up" below — the first revision of this branch had one, and it was a regression.

## Why it cannot regress existing behaviour

The hashed bytes are **identical for every input that previously produced a key**, so no cache-version bump is needed and entries already on disk stay valid. Derived the same five keys under both revisions:

```
                    origin/main                        this branch
absent            334abed8...f3fdee9f      ==      334abed8...f3fdee9f
regular           a8da5718...0843c5ca      ==      a8da5718...0843c5ca
symlink->regular  a8da5718...0843c5ca      ==      a8da5718...0843c5ca
explicit          94f72484...6c3959e7      ==      94f72484...6c3959e7
records-explicit  4ba74ff1...9fcf39289     ==      4ba74ff1...9fcf39289
```

Shape by shape:

| `.graphignore` is | before | after |
|---|---|---|
| absent | `"missing"` marker | unchanged |
| a regular file ≤ 1 MiB | contents hashed | unchanged, byte for byte |
| a symlink to a regular file ≤ 1 MiB | contents hashed | unchanged, byte for byte |
| a symlink to a device / FIFO / dir | **unbounded read, then OOM** | immediate refusal |
| a regular file > 1 MiB | contents hashed | unchanged, byte for byte |

The only shapes whose behaviour changes are the ones that could not have completed successfully anyway: `loadOptional` was going to hard-error on them moments later, which is precisely what `--no-cache` already did.

Re-verified after the follow-up commit with two real binaries rather than by argument — a repo whose `.graphignore` is a symlink to a regular file plus an explicit `--ignore-file`, indexed by one build and then by the other into the same `--cache-dir`:

```
warm with 3876c95 (byte cap)  ->  index with ce3f50e   index_cache_hit: True
warm with ce3f50e (no cap)    ->  index with 3876c95   index_cache_hit: True
```

A hit in both directions is the hashed bytes being identical; entries already on disk stay valid and no cache-version bump is needed.

`errors.Is(err, os.ErrNotExist)` remains the *only* not-exist case special-cased, exactly as before — `ENOTDIR` and friends still surface as errors rather than silently becoming `"missing"`.

Full package suite: **2139 tests pass**.

## Tests added

`TestSearchSnapshotKeyGuardsIgnoreFileReads` (`internal/sem/search_cache_test.go`) and `TestProviderRecordsKeyGuardsIgnoreFileReads` (`internal/sem/records_cache_test.go`), covering all three read sites:

- `.graphignore` resolving to a character device is refused
- an explicit `--ignore-file` resolving to a character device is refused (both hashers)
- **no-regression pin:** a `.graphignore` symlinked to a regular file still keys by its target's contents, and editing that target still changes the key

Added by the follow-up commit:

- `TestCacheKeyAcceptsEveryIgnoreFileTheLoaderAccepts` — parity pin. For a **regular** file the hashers must accept exactly what `ignoreMatcher` accepts. Each subtest asserts the loader accepts the fixture *first*, so it cannot pass by both sides refusing.
- `TestReadOpenedIgnoreFileForKeyRefusesANonRegularHandle` — drives the fd-level guard directly, since the only way to reach it through `readIgnoreFileForKey` is to win a race against its own stat. Fixture is `/dev/null`, not `/dev/zero`: same character-device class, same branch, but EOF-bounded, so deleting the guard fails the assertion instead of exhausting the runner. Confirmed non-vacuous by deleting the check — `read a character device through the fd-level guard instead of refusing it (0 bytes)`.
- `TestReadOpenedIgnoreFileForKeyReadsARegularHandleWhole` — the other half: a regular file past 1 MiB comes back byte-for-byte, so the fd guard has not become a size policy or a short read.

`os.DevNull` stands in for `/dev/zero`: same character-device class, same guard, but bounded — so the pre-fix failure surfaces as a wrong answer rather than exhausting the machine running the suite.

### Failing-first evidence

New tests against **unmodified `origin/main`** (`git show origin/main:<file>` restored over both source files, tests kept):

```
--- FAIL: TestProviderRecordsKeyGuardsIgnoreFileReads (0.00s)
    records_cache_test.go:318: key hasher read a character-device --ignore-file
      instead of refusing it (key 1d9bdcc792f41b6e...)
--- FAIL: TestSearchSnapshotKeyGuardsIgnoreFileReads (0.00s)
    --- FAIL: .../explicit_ignore_file_resolving_to_a_character_device_is_refused
        search_cache_test.go:1513: ... (key 02b978ec19f7c54f...)
    --- FAIL: .../graphignore_resolving_to_a_character_device_is_refused
        search_cache_test.go:1497: ... (key fc6a43c6b9150ff7...)
    --- FAIL: .../oversized_regular_graphignore_is_refused
        search_cache_test.go:1529: key hasher materialized an oversized
          .graphignore instead of refusing it (key d15e33f1aed89645...)
FAIL    github.com/entireio/entire-graph/internal/sem   0.719s
```

With the fix restored, the same selector is green (6 passed). The no-regression subtest passes under *both* revisions, which is the point of it.

## Gate

Re-run on `ce3f50e`:

```
gofmt -s -l .   (empty)
go vet ./...    clean
go build ./...  clean
go test ./internal/sem   ok, 62.5s   2143 passed / 0 failed
```

## Review follow-up (ce3f50e): the byte cap was a regression, and it is gone

Trail review, `internal/sem/search_cache.go:926`, medium: the 1 MiB cap rejected root `.graphignore` and explicit `--ignore-file` / `--include-file` inputs that `ignoreMatcher.loadFile` accepts, because `maxNestedIgnoreFileBytes` only ever governed per-directory `.gitignore` files — and there it is a **skip**, never fatal (`ignore.go:378`, `provider.go:10260,10284`).

**Reproduced against `3876c95` before changing anything**, with a legal generated `.graphignore` of 1,048,586 bytes (short `vendor/depNNNNNNNN/**` rules) and one `a.go`:

```
$ entire graph index  --repo . --head --cache-dir C
ignore file ".../.graphignore" exceeds 1048576 bytes            exit 1
$ entire graph search --repo . --query alpha --cache-dir C
ignore file ".../.graphignore" exceeds 1048576 bytes            exit 1
$ entire graph search --repo . --query alpha --no-cache
{"results":[{"rank":1,"file_path":"a.go",...}]}                 exit 0
```

Cache-enabled search and index dead, `--no-cache` fine: the cache changing the answer, not just the speed. The reviewer's two options were to cap in the loader too, or to stop applying the nested-file limit here. Capping the loader would break that repo under *every* mode, so the cap goes.

Failing-first, at runtime on `3876c95` with the new test only:

```
--- FAIL: TestCacheKeyAcceptsEveryIgnoreFileTheLoaderAccepts
    --- FAIL: .../oversized_regular_graphignore_keys_by_content
        search_cache_test.go:1624: key hasher refused an ignore file the loader
          accepts: ignore file ".../.graphignore" exceeds 1048576 bytes
    --- FAIL: .../oversized_explicit_ignore_file_keys_both_caches
        search_cache_test.go:1649: search key hasher refused an --ignore-file the
          loader accepts: ... exceeds 1048576 bytes
```

Green after the fix, and the same fixture now works end to end — `index` exit 0, first `search` `index_cache_hit: false`, second `index_cache_hit: true`.

**The exploit this branch exists for is still closed**, re-run against the fixed binary (`ln -s /dev/zero .graphignore`):

```
$ entire graph index  --repo . --head    ignore file ".../.graphignore" is not a regular file
   0.03s real   17.5 MB max RSS
$ entire graph search --repo . --query alpha
   0.02s real   17.0 MB max RSS
```

The cap was never what bounded it. `/dev/zero` is infinite and no regular file is; the type guard is what stops the read, and the fstat on the open handle plus the non-blocking open below are what stop the raced version of it. What remains, unchanged from `origin/main` and now identical under `--no-cache` and with caching, is that a genuinely enormous *regular* ignore file is materialized — by `os.ReadFile` in `ignoreMatcher.loadFile` first of all. Making that a cap is a loader policy change, not this branch's bug fix, so it is left to the loader.

## Notes for reviewers

- Contract untouched: no json tag removed or renamed, no cache version changed, no network call added.
- **Out of scope, reported not fixed:** `providerRecordsKey` never hashes the implicit repo-root `.graphignore` at all, while `searchSnapshotKey` does. That is a pre-existing cache-invalidation gap, not a security issue, and closing it *would* change the hashed bytes and require a `providerRecordsCacheVersion` bump — so it is deliberately left alone here.
- `internal/sem/ignore.go` was not modified; the fix reuses its `ignoreFileLabel` and mirrors its guard rather than restructuring the loader. After `ce3f50e` it no longer borrows `maxNestedIgnoreFileBytes`, which is what made the guard stricter than the loader.

## Follow-up: the raced FIFO the fd-level guard could not reach (`e4059fc`)

Review objection: the fstat guard runs *after* `os.Open`, so it cannot help when the open itself never returns. A path swapped to a FIFO between the stat and the open passes the stat, and a read-only open of a writerless FIFO parks in `open(2)` indefinitely — a hang instead of a refusal, on the default cache-enabled path of every verb. Reproduced, not assumed.

Failing-first at runtime on `ce3f50e` with the new test only — one goroutine `rename(2)`-swapping the requested path between a symlink to a regular file and a symlink to a FIFO, another calling `readIgnoreFileForKey` in a loop:

```
--- FAIL: TestReadIgnoreFileForKeyOpenCannotBlockOnARacedFIFO (30.00s)
    search_cache_fifo_test.go:96: readIgnoreFileForKey blocked: the open ran on a
      path raced to a FIFO after the stat said regular file, so it parked in
      open(2) before the fd-level guard could refuse the handle
```

The fix opens with `O_NONBLOCK` in `openIgnoreFileForKey` — the single sink both cache-key hashers already share, so `searchSnapshotKey`, the implicit `.graphignore` read and `providerRecordsKey` all inherit it. On a FIFO the open now returns immediately with no writer attached and the existing fd-level guard refuses the handle by its own mode.

```
--- PASS: TestReadIgnoreFileForKeyOpenCannotBlockOnARacedFIFO (0.27s)
```

Nothing changes for the legitimate input. POSIX ignores `O_NONBLOCK` for regular files, and this is deliberately **not** `O_NOFOLLOW`: a symlink to a real ignore file still resolves and is still keyed by its contents, which is this branch's stated guarantee. `TestReadOpenedIgnoreFileForKey*` and `TestCacheKeyAcceptsEveryIgnoreFileTheLoaderAccepts` stay green, as does the whole `internal/sem` package (2144 tests).

`syscall.O_NONBLOCK` is undefined on Windows, so the flag lives in a `//go:build !windows` file; the Windows build keeps the plain open and the fd-level guard, because the input has no Windows form — there is no `mkfifo` and named pipes are not created by renaming a filesystem entry into place. The test is `//go:build !windows` for the same reason.
