### PR TITLE
test(gitutil,sem): preserve repository execution regressions

### DIFF
--- a/internal/gitutil/git_hardening_test.go
+++ b/internal/gitutil/git_hardening_test.go
@@ -1,0 +1,243 @@
+package gitutil
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// execMarkerScript writes an executable POSIX script into a directory of its
+// own and returns the script path plus the path of the "fired" file the script
+// creates when it runs. The script finds that file through $0 rather than an
+// embedded path, so the marker path never has to survive being quoted into a
+// shell word. The script path itself still does — git runs core.fsmonitor
+// through `sh -c`, where the configured value is shell input rather than an
+// argv element — so callers that put it in config wrap it in posixShellWord.
+func execMarkerScript(t *testing.T, name string, exitCode int) (script, marker string) {
+	t.Helper()
+	dir := t.TempDir()
+	script = filepath.Join(dir, name)
+	body := fmt.Sprintf("#!/bin/sh\n: > \"$(dirname \"$0\")/fired\"\nexit %d\n", exitCode)
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return script, filepath.Join(dir, "fired")
+}
+
+// posixShellWord single-quotes a value so a POSIX shell parses it as one word:
+// without it, a temporary directory containing a space would split the
+// core.fsmonitor command and silently downgrade the control below to a skip.
+func posixShellWord(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
+}
+
+// markerFired reports whether the script ran, and clears the marker so the next
+// assertion starts from a known state.
+func markerFired(t *testing.T, marker string) bool {
+	t.Helper()
+	if _, err := os.Stat(marker); err != nil {
+		return false
+	}
+	if err := os.Remove(marker); err != nil {
+		t.Fatal(err)
+	}
+	return true
+}
+
+// TestGitSubprocessesDisableRepositoryFsmonitorHook pins the fix for a
+// confused-deputy bug: core.fsmonitor is a configuration value git EXECUTES
+// (through `sh -c`) whenever it refreshes the index, and the value is read from
+// the *target repository's* .git/config — attacker-controlled input for a tool
+// whose entire purpose is indexing repositories the user has not audited.
+// `git ls-files` and working-tree `git grep` both refresh the index, so before
+// the fix simply listing a repository ran whatever command its config named.
+func TestGitSubprocessesDisableRepositoryFsmonitorHook(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("git invokes the core.fsmonitor hook through `sh -c`, so this fixture needs a POSIX shell and a #!-script; the hardening itself is per-invocation config injection and identical on every platform")
+	}
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	git(t, repo, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(repo, "keep.go"), []byte("package keep\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "tracked file")
+
+	hook, marker := execMarkerScript(t, "fsmonitor-hook", 0)
+	git(t, repo, "config", "core.fsmonitor", posixShellWord(hook))
+
+	// Control. Prove this git really does run the hook for the argv this package
+	// uses; otherwise a git build that ignored core.fsmonitor would make every
+	// assertion below pass without the fix being present.
+	control := exec.Command("git", "ls-files", "-z", "--cached", "--others", "--exclude-standard")
+	control.Dir = repo
+	if out, err := control.CombinedOutput(); err != nil {
+		t.Fatalf("control `git ls-files`: %v\n%s", err, out)
+	}
+	if !markerFired(t, marker) {
+		t.Skip("this git does not run core.fsmonitor for `git ls-files`, so the hardening is unobservable here")
+	}
+
+	worktree, err := ListWorktreeFiles(t.Context(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if markerFired(t, marker) {
+		t.Error("ListWorktreeFiles executed the repository's core.fsmonitor command")
+	}
+	if !slices.Contains(worktree, "keep.go") {
+		t.Errorf("ListWorktreeFiles lost its listing after hardening: %#v", worktree)
+	}
+
+	if _, err := ListIndexFiles(t.Context(), repo); err != nil {
+		t.Fatal(err)
+	}
+	if markerFired(t, marker) {
+		t.Error("ListIndexFiles executed the repository's core.fsmonitor command")
+	}
+
+	if _, err := ListIgnoredWorktreeFiles(t.Context(), repo); err != nil {
+		t.Fatal(err)
+	}
+	if markerFired(t, marker) {
+		t.Error("ListIgnoredWorktreeFiles executed the repository's core.fsmonitor command")
+	}
+
+	// The two working-tree grep paths build their own exec.Cmd instead of going
+	// through newCmd, so they need the same hardening rather than inheriting it.
+	matches, err := GrepIndexMatches(t.Context(), repo, []string{"package"}, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if markerFired(t, marker) {
+		t.Error("GrepIndexMatches executed the repository's core.fsmonitor command")
+	}
+	if len(matches) == 0 {
+		t.Error("GrepIndexMatches lost its matches after hardening")
+	}
+
+	paths, err := GrepFixedStringPaths(t.Context(), repo, "", "package")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if markerFired(t, marker) {
+		t.Error("GrepFixedStringPaths executed the repository's core.fsmonitor command")
+	}
+	if !slices.Contains(paths, "keep.go") {
+		t.Errorf("GrepFixedStringPaths lost its listing after hardening: %#v", paths)
+	}
+}
+
+// TestGitLogSubprocessesDisableRepositorySignatureVerification pins the second
+// half of the same class: gpg.program is a configuration value git EXECUTES,
+// and log.showSignature — also repository config — is what makes git reach it.
+// A commit carrying a `gpgsig` header is enough to trigger verification, and a
+// repository the tool does not trust controls both the header and the program.
+func TestGitLogSubprocessesDisableRepositorySignatureVerification(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the fake gpg program is a #!-script, which needs a POSIX exec; the hardening itself is per-invocation config injection and identical on every platform")
+	}
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	git(t, repo, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(repo, "keep.go"), []byte("package keep\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "tracked file")
+	if err := os.WriteFile(filepath.Join(repo, "keep.go"), []byte("package keep\n\nvar Second = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", ".")
+	// The checkpoint trailer goes on HEAD, which is the commit signCommitHeader
+	// then forges a signature onto: git only reaches gpg.program for a commit it
+	// actually displays, so the commit FindCommitWithCheckpoint selects has to be
+	// the signed one or the assertion below would pass vacuously.
+	const checkpoint = "cp-hardening-fixture"
+	git(t, repo, "commit", "-m", "second change\n\nEntire-Checkpoint: "+checkpoint)
+
+	signCommitHeader(t, repo)
+
+	gpg, marker := execMarkerScript(t, "gpg", 1)
+	git(t, repo, "config", "log.showSignature", "true")
+	git(t, repo, "config", "gpg.program", gpg)
+
+	// Control, as above: prove this git reaches gpg.program for the argv the
+	// package uses before asserting that the hardened call does not.
+	control := exec.Command("git", "log", "--all", "--format=%H", "-n", "1")
+	control.Dir = repo
+	if out, err := control.CombinedOutput(); err != nil {
+		t.Fatalf("control `git log`: %v\n%s", err, out)
+	}
+	if !markerFired(t, marker) {
+		t.Skip("this git does not run gpg.program for `git log`, so the hardening is unobservable here")
+	}
+
+	commit, err := FindCommitWithCheckpoint(t.Context(), repo, checkpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if markerFired(t, marker) {
+		t.Error("FindCommitWithCheckpoint executed the repository's gpg.program")
+	}
+	if commit == "" {
+		t.Error("FindCommitWithCheckpoint lost its result after hardening")
+	}
+
+	if _, err := FileCochanges(t.Context(), repo, "HEAD", 8); err != nil {
+		t.Fatal(err)
+	}
+	if markerFired(t, marker) {
+		t.Error("FileCochanges executed the repository's gpg.program")
+	}
+}
+
+// signCommitHeader rewrites HEAD as a byte-identical commit carrying a bogus
+// `gpgsig` header, which is all git needs to attempt signature verification.
+// No real key is involved: the point is reaching gpg.program at all.
+func signCommitHeader(t *testing.T, repo string) {
+	t.Helper()
+	raw := gitStdout(t, repo, "cat-file", "commit", "HEAD")
+	headerEnd := bytes.Index(raw, []byte("\n\n"))
+	if headerEnd < 0 {
+		t.Fatalf("commit object has no header/message separator: %q", raw)
+	}
+	const gpgsig = "gpgsig -----BEGIN PGP SIGNATURE-----\n \n ZmFrZQ==\n -----END PGP SIGNATURE-----\n"
+	signed := make([]byte, 0, len(raw)+len(gpgsig))
+	signed = append(signed, raw[:headerEnd+1]...)
+	signed = append(signed, gpgsig...)
+	signed = append(signed, raw[headerEnd+1:]...)
+
+	write := exec.Command("git", "hash-object", "-w", "-t", "commit", "--stdin")
+	write.Dir = repo
+	write.Stdin = bytes.NewReader(signed)
+	out, err := write.Output()
+	if err != nil {
+		t.Fatalf("git hash-object: %v", err)
+	}
+	newCommit := string(bytes.TrimSpace(out))
+	branch := string(bytes.TrimSpace(gitStdout(t, repo, "symbolic-ref", "HEAD")))
+	git(t, repo, "update-ref", branch, newCommit)
+}
+
+func gitStdout(t *testing.T, repo string, args ...string) []byte {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %v: %v", args, err)
+	}
+	return out
+}

--- a/internal/sem/search_cache_worktree_test.go
+++ b/internal/sem/search_cache_worktree_test.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 )
 
 func cacheTestRepo(t *testing.T) string {
@@ -29,6 +31,78 @@ func cacheTestRepo(t *testing.T) string {
 	runCacheGit("add", ".")
 	runCacheGit("commit", "-m", "initial")
 	return repo
+}
+
+func TestWorktreeSnapshotCacheProbeDoesNotRunGitFilters(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the executable filter fixture uses a POSIX shell; worktree cache bypass itself is platform-independent")
+	}
+	for _, configKey := range []string{"filter.evil.clean", "filter.evil.process"} {
+		t.Run(configKey, func(t *testing.T) {
+			repo := cacheTestRepo(t)
+			attributes := filepath.Join(repo, ".gitattributes")
+			if err := os.WriteFile(attributes, []byte("*.go filter=evil\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			git := func(args ...string) {
+				t.Helper()
+				command := exec.Command("git", args...)
+				command.Dir = repo
+				if out, err := command.CombinedOutput(); err != nil {
+					t.Fatalf("git %v: %v\n%s", args, err, out)
+				}
+			}
+			git("add", ".gitattributes")
+			git("commit", "-m", "select filter driver")
+
+			marker := filepath.Join(t.TempDir(), "filter-fired")
+			helper := filepath.Join(t.TempDir(), "filter-helper")
+			script := "#!/bin/sh\n: > \"$1\"\nexit 1\n"
+			if err := os.WriteFile(helper, []byte(script), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			filterCommand := shellQuote(helper) + " " + shellQuote(marker)
+			git("config", configKey, filterCommand)
+			git("config", "filter.evil.required", "false")
+
+			app := filepath.Join(repo, "app.go")
+			forceGitContentCheck := func() {
+				t.Helper()
+				future := time.Now().Add(2 * time.Second)
+				if err := os.Chtimes(app, future, future); err != nil {
+					t.Fatal(err)
+				}
+			}
+			forceGitContentCheck()
+			control := exec.Command("git", "--no-optional-locks", "status", "--porcelain", "--untracked-files=all", "-z")
+			control.Dir = repo
+			_ = control.Run()
+			if _, err := os.Stat(marker); err != nil {
+				t.Fatalf("control git status did not execute %s: %v", configKey, err)
+			}
+			if err := os.Remove(marker); err != nil {
+				t.Fatal(err)
+			}
+
+			forceGitContentCheck()
+			options := ProviderSnapshotOptions{Worktree: true, Profile: ProfileFull, NoNetwork: true}
+			snapshot, hit, err := LoadOrBuildProviderSnapshot(context.Background(), repo, "test", options, t.TempDir(), false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if hit {
+				t.Fatal("worktree snapshot unexpectedly reported a cache hit")
+			}
+			if _, err := os.Stat(marker); err == nil {
+				t.Fatalf("worktree snapshot load executed %s", configKey)
+			} else if !os.IsNotExist(err) {
+				t.Fatal(err)
+			}
+			if !hasSymbolNamed(snapshot.Symbols, "Alpha") {
+				t.Error("worktree snapshot lost its symbols while proving filters do not run")
+			}
+		})
+	}
 }
 
 // Worktree queries always rebuild until raw worktree equality can be checked


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/108
<!-- entire-trail-link-end -->

Test-only successor to #134, whose production implementation was superseded by merged #132.

Adds regression coverage proving that repository-controlled:

- `core.fsmonitor` commands are not executed (`TestGitSubprocessesDisableRepositoryFsmonitorHook`)
- signature-verification programs (`gpg.program` via `log.showSignature`) are not executed (`TestGitLogSubprocessesDisableRepositorySignatureVerification`)
- `clean` and `process` conversion filters are not executed during worktree cache probing (`TestWorktreeSnapshotCacheProbeDoesNotRunGitFilters`, subtests `filter.evil.clean` and `filter.evil.process`)

No production behavior is changed. The diff touches only `internal/gitutil/git_hardening_test.go` (new) and `internal/sem/search_cache_worktree_test.go` (one test + helper + imports inserted; all post-#132 tests preserved). None of #134's production code, documentation, or stale branch history is carried forward.

## Provenance

- Base (live main at branch time): `e31e2553cef565b9c5021177eafad6c2d9adc345`
- Closed #134 head (source material, pinned): `24bf7643d969bd8f03b3b1bbf3fe966fdc009090`
- Branch created fresh from live main; test material integrated by hand, not merged.
- Final head: `8c440d62708ca20aca512ff4b72bbaac1504e93e` (single commit; Entire checkpoint `07cd5a9392aa` synced with the push).

## Verification (darwin/amd64, go1.26.5, git 2.54.0)

```
go test ./internal/gitutil -run '^(TestGitSubprocessesDisableRepositoryFsmonitorHook|TestGitLogSubprocessesDisableRepositorySignatureVerification)$' -count=1 -v   # PASS (both)
go test ./internal/sem -run '^TestWorktreeSnapshotCacheProbeDoesNotRunGitFilters$' -count=1 -v   # PASS (both filter subtests)
go test -race ./internal/gitutil -run '...same two...' -count=1    # ok
go test -race ./internal/sem -run '^TestWorktreeSnapshotCacheProbeDoesNotRunGitFilters$' -count=1   # ok
go test ./internal/gitutil ./internal/sem -count=1                 # ok (26.5s / 203.9s)
mise run check                                                     # fmt + vet + race tests + build: passed (527s)
GOOS=windows go vet ./internal/gitutil                             # clean (sem needs a native Windows CGO toolchain; CI's windows runner covers it)
entire graph diff --base e31e255... --head HEAD --json             # added test functions only; no production symbols
```

## Independent review

A read-only Claude Opus 5 review ran against the branch (no edit access): no blockers or majors; it independently confirmed non-vacuity by mutation (renaming the `GIT_CONFIG_KEY_n` pins in `git.go` makes the gitutil tests fail; reintroducing a `git status` probe in `worktreeSnapshotCacheable` makes the sem subtests fail). Its substantive minors were reproduced and fixed here:

- the `core.fsmonitor` hook path is now single-quoted (`posixShellWord`) — before, a `TMPDIR` containing a space silently downgraded the test to a skip (reproduced, then re-verified passing under `TMPDIR="/tmp/tmp dir with space"`);
- the sem test now pairs its negative assertion with a positive one (`hasSymbolNamed(snapshot.Symbols, "Alpha")`) so an empty snapshot cannot pass vacuously;
- the duplicate quoting helper was dropped in favor of the package's existing `shellQuote`;
- the Windows skip messages no longer mislabel the hardening as "argv-level" (it is per-invocation config injection).

Remaining nits (assertion ordering after `t.Fatal(err)`, discarded `ListIndexFiles`/`FileCochanges` results, control-failure `t.Skip` vs hard-fail, fsmonitor hook emitting no update token) are noted but deliberately not addressed to keep the diff close to the #134 source material. A Cursor CLI review was attempted but is unavailable: the CLI is installed but unauthenticated, and login is interactive.

## Skips and platform guards (disclosed)

- All three tests `t.Skip` on Windows: the fixtures are `#!/bin/sh` marker scripts (git runs `core.fsmonitor` through `sh -c`, and the fake `gpg`/filter programs need a POSIX exec). The hardening under test is argv-level and identical on every platform; only the *fixtures* are POSIX-bound. CI (`ubuntu-latest`, `macos-latest`, `windows-latest`) compiles all three tests everywhere and executes them on the POSIX runners.
- Two conditional skips guard observability: if the local git build never runs `core.fsmonitor` for `ls-files` or `gpg.program` for `log`, the control assertion skips rather than passing vacuously. On this machine (git 2.54.0) both controls fired, so the assertions ran for real.
- Residual limitation: the underlying behavior was not natively re-validated on Windows for this PR. The tests skip there by design, so a Windows run adds compile coverage only; porting the fixtures would add Windows-only script complexity to a test-only PR. The production hardening itself shipped and was reviewed in #132.

No new billable resources were used.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only coverage of existing Git subprocess hardening; no production behavior changes. Windows skips mean those runners only compile the fixtures.
> 
> **Overview**
> Adds regression tests for existing Git subprocess hardening so untrusted repo config cannot run code during indexing.
> 
> `TestGitSubprocessesDisableRepositoryFsmonitorHook` plants a `core.fsmonitor` marker script and asserts listing/grep helpers (`ListWorktreeFiles`, `ListIndexFiles`, `ListIgnoredWorktreeFiles`, `GrepIndexMatches`, `GrepFixedStringPaths`) do not fire it. `TestGitLogSubprocessesDisableRepositorySignatureVerification` forges a `gpgsig` header and asserts `FindCommitWithCheckpoint` and `FileCochanges` do not run `gpg.program`.
> 
> `TestWorktreeSnapshotCacheProbeDoesNotRunGitFilters` covers `filter.*.clean` and `filter.*.process`: a control `git status` must run the filter, then a worktree snapshot load must not, while still producing symbols.
> 
> Controls skip if the local Git never invokes those hooks, so the tests cannot pass vacuously. POSIX-only fixtures skip on Windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c440d62708ca20aca512ff4b72bbaac1504e93e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->