### PR TITLE
feat(search): version the search response envelope

### DIFF
--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -468,11 +468,15 @@ func writeNdjsonSearch(out interface{ Write([]byte) (int, error) }, response sem
 		encoder.SetEscapeHTML(false)
 		if err := encoder.Encode(map[string]any{
 			"record_type": "search_header",
-			"query":       response.Query,
-			"repo_root":   response.RepoRoot,
-			"commit":      response.Commit,
-			"tree":        response.Tree,
-			"profile":     response.Profile,
+			// The header record carries the envelope version for the same reason
+			// the JSON payload does: a consumer reading the stream must be able to
+			// branch on the shape before it parses a single result record.
+			"format_version": response.FormatVersion,
+			"query":          response.Query,
+			"repo_root":      response.RepoRoot,
+			"commit":         response.Commit,
+			"tree":           response.Tree,
+			"profile":        response.Profile,
 		}); err != nil {
 			return err
 		}

--- a/internal/cli/search_format_version_test.go
+++ b/internal/cli/search_format_version_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/entireio/entire-graph/internal/sem"
+)
+
+// Every other machine-readable surface tells a consumer which shape it is
+// looking at. Measured on origin/main against one fixture repository:
+//
+//	schema_version : diff, commit, capabilities, symbols, edges, snapshot,
+//	                 compact-ndjson
+//	format_version : impact, neighbors, def, index, stats
+//	NEITHER        : search --format json, search --format ndjson
+//
+// search is the documented entry point ("start here") and JSON is its DEFAULT
+// format, so the one surface a consumer is most likely to parse was the one it
+// could not version-check. These tests keep the discriminator on both formats.
+func TestSearchJSONCarriesFormatVersion(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	response := sem.SearchResponse{FormatVersion: sem.SearchFormatVersion, Query: "q", Results: []sem.SearchResult{}}
+	if err := writeSearchResponse(&out, response, "json", 0); err != nil {
+		t.Fatal(err)
+	}
+	var payload struct {
+		FormatVersion *int `json:"format_version"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("decode search json: %v\n%s", err, out.String())
+	}
+	if payload.FormatVersion == nil {
+		t.Fatalf("search json carries no format_version:\n%s", out.String())
+	}
+	if *payload.FormatVersion != sem.SearchFormatVersion {
+		t.Fatalf("format_version = %d, want %d", *payload.FormatVersion, sem.SearchFormatVersion)
+	}
+}
+
+func TestSearchNDJSONHeaderCarriesFormatVersion(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	response := sem.SearchResponse{FormatVersion: sem.SearchFormatVersion, Query: "q", Results: []sem.SearchResult{}}
+	if err := writeNdjsonSearch(&out, response); err != nil {
+		t.Fatal(err)
+	}
+	first, _, found := strings.Cut(out.String(), "\n")
+	if !found {
+		t.Fatalf("ndjson stream has no header line:\n%s", out.String())
+	}
+	var header struct {
+		RecordType    string `json:"record_type"`
+		FormatVersion *int   `json:"format_version"`
+	}
+	if err := json.Unmarshal([]byte(first), &header); err != nil {
+		t.Fatalf("decode ndjson header: %v\n%s", err, first)
+	}
+	if header.RecordType != "search_header" {
+		t.Fatalf("first record = %q, want search_header", header.RecordType)
+	}
+	if header.FormatVersion == nil {
+		t.Fatalf("ndjson search_header carries no format_version:\n%s", first)
+	}
+	if *header.FormatVersion != sem.SearchFormatVersion {
+		t.Fatalf("format_version = %d, want %d", *header.FormatVersion, sem.SearchFormatVersion)
+	}
+}

--- a/internal/sem/search.go
+++ b/internal/sem/search.go
@@ -424,13 +424,27 @@ type SearchStats struct {
 	PreselectLatencyMS int64 `json:"preselect_latency_ms"`
 }
 
+// SearchFormatVersion versions the search RESPONSE ENVELOPE, the same axis
+// impact, def, neighbors, index and stats already emit as format_version. It is
+// deliberately not sem.SchemaVersion: this is a query response, not one of the
+// persisted 1.x record artifacts ADR 0001 freezes, and conflating the two would
+// make every search-payload change look like a change to the ingestion schema.
+const SearchFormatVersion = 1
+
 type SearchResponse struct {
-	Query    string         `json:"query"`
-	RepoRoot string         `json:"repo_root"`
-	Commit   string         `json:"commit,omitempty"`
-	Tree     string         `json:"tree,omitempty"`
-	Profile  string         `json:"profile"`
-	Results  []SearchResult `json:"results"`
+	// FormatVersion leads the payload so a consumer can branch on it before
+	// reading anything else. Search was the only machine-readable surface with no
+	// version discriminator at all: its five sibling query commands emit
+	// format_version and the record/snapshot surfaces emit schema_version, but a
+	// consumer parsing search JSON had nothing to tell one payload shape from the
+	// next.
+	FormatVersion int            `json:"format_version"`
+	Query         string         `json:"query"`
+	RepoRoot      string         `json:"repo_root"`
+	Commit        string         `json:"commit,omitempty"`
+	Tree          string         `json:"tree,omitempty"`
+	Profile       string         `json:"profile"`
+	Results       []SearchResult `json:"results"`
 	// The three blocks below live outside `results`, and they are declared in the order they
 	// are rendered — see the section order documented in search_blocks.go.
 	//
@@ -660,7 +674,22 @@ var sparseSearchStopWords = map[string]bool{
 
 // SearchRepository performs local hybrid lexical/semantic retrieval. It uses
 // no qrels, hosted models, embeddings, or network access.
+// SearchRepository stamps the response envelope version at the ONE place a
+// content-bearing SearchResponse leaves this package, rather than at each
+// construction site. searchRepository has two success returns and error returns
+// throughout; stamping per site means a third success path added later silently
+// emits format_version 0, which a consumer cannot tell from "field absent".
+// This mirrors how AnalyzeGitRangeWithOptions stamps SchemaVersion.
 func SearchRepository(ctx context.Context, repo, providerVersion, query string, options SearchOptions) (SearchResponse, error) {
+	response, err := searchRepository(ctx, repo, providerVersion, query, options)
+	if err != nil {
+		return SearchResponse{}, err
+	}
+	response.FormatVersion = SearchFormatVersion
+	return response, nil
+}
+
+func searchRepository(ctx context.Context, repo, providerVersion, query string, options SearchOptions) (SearchResponse, error) {
 	q := buildSearchQuery(query)
 	if len(q.terms) == 0 {
 		return SearchResponse{}, errors.New("search query has no meaningful terms")

--- a/internal/sem/search_format_version_test.go
+++ b/internal/sem/search_format_version_test.go
@@ -1,0 +1,25 @@
+package sem
+
+import "testing"
+
+// The envelope stamp is worth nothing unless the code path that builds a real
+// response sets it: an unstamped response serializes as format_version 0, which
+// is indistinguishable from a consumer's "field absent" default. Both
+// content-bearing construction sites in SearchRepository must carry it.
+func TestSearchRepositoryStampsFormatVersion(t *testing.T) {
+	repo := cacheTestRepo(t)
+	for _, name := range []string{"Alpha", "no-such-symbol-anywhere-in-this-repository"} {
+		t.Run(name, func(t *testing.T) {
+			response, err := SearchRepository(t.Context(), repo, "test", name, SearchOptions{
+				Profile: ProfileFull, TopK: 5,
+			})
+			if err != nil {
+				t.Fatalf("search: %v", err)
+			}
+			if response.FormatVersion != SearchFormatVersion {
+				t.Fatalf("format_version = %d, want %d (results=%d)",
+					response.FormatVersion, SearchFormatVersion, len(response.Results))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/116
<!-- entire-trail-link-end -->

## Problem

`search` was the only machine-readable surface with **no version discriminator at all**. Measured
on origin/main against one fixture repository, one command per row:

| discriminator | surfaces |
|---|---|
| `schema_version` | `diff`, `commit`, `capabilities`, `symbols`, `edges`, `snapshot`, `snapshot --format compact-ndjson` |
| `format_version` | `impact`, `neighbors`, `def`, `index`, `stats` |
| **neither** | **`search --format json`**, **`search --format ndjson`** |

```
$ eg search --repo . --query "widget render" --format json | python3 -c "import sys,json;print(list(json.load(sys.stdin).keys()))"
['query', 'repo_root', 'commit', 'tree', 'profile', 'results', 'verify_command', 'stats', 'warnings', 'partial_failures', 'completeness']
```

`search` is the documented entry point ("start here") and JSON is its **default** format, so the
one surface a consumer is most likely to parse was the one it could not version-check.

## Fix

`SearchResponse` gains `format_version`, on the same axis its five sibling query commands already
emit, and the ndjson `search_header` record carries it too so a streaming consumer can branch
before parsing a result record.

Deliberately **not** `sem.SchemaVersion`. This is a query response, not one of the persisted `1.x`
record artifacts ADR 0001 freezes. Conflating the two would make every search-payload change read
as a change to the ingestion schema — and search's payload blocks evolve far faster than the
snapshot records do. `SearchFormatVersion` starts at `1`, matching `impact`/`def`/`neighbors`/
`index`/`stats`.

`SearchRepository` stamps it at the **one** place a content-bearing response leaves the package,
mirroring how `AnalyzeGitRangeWithOptions` stamps `SchemaVersion`. That was not cosmetic: the
first version of this change stamped both success returns, and a mutation test showed only one of
them was actually reachable from the test fixtures — a third success path added later would have
emitted `format_version: 0`, which a consumer cannot distinguish from "field absent".

After:

```
$ eg search --repo . --query "widget render" --format json | head -c 60
{"format_version":1,"query":"widget render","repo_root":"/...

$ eg search --repo . --query "widget render" --format ndjson | head -1 | head -c 90
{"commit":"f34f61f...","format_version":1,"profile":"fast",...,"record_type":"search_header",...
```

## Tests

- `internal/cli/search_format_version_test.go` — both output formats carry the field, decoded into
  a `*int` so "absent" is distinguishable from `0`
- `internal/sem/search_format_version_test.go` — the real provider path stamps it, over both a
  hit and a no-result query

Confirmed binding by mutation: deleting the stamp fails the sem test on both subtests; deleting
the ndjson header field fails the cli test. Restoring each passes.

## Verification

CI is green on this branch: `lint`, `build` and `test` on ubuntu/macos/windows, `statusline` on
ubuntu/macos, and `bm25-adapter` — 10/10. Entire Gates reports Checks, Findings and Up-to-date
passing; only Approvals is outstanding, pending a human reviewer.

Locally: `go build ./...`, `gofmt -s -l .` and `go vet ./...` clean, the full package tests green,
and the mutation runs described above.

Race detector: CI runs `go test ./...` **without** `-race`, so that leg was verified locally,
scoped to the packages and test families this change touches —
`go test -race -count=1 -run 'Search|Format' ./internal/sem/ ./internal/cli/` — clean, zero data races.

A full `go test -race ./...` could not be completed on this machine: it is shared with unrelated
parallel jobs, and `internal/sem` under `-race` exceeded a 45-minute timeout
(`panic: test timed out after 45m0s`) with zero data races and zero `--- FAIL` subtests recorded.
`origin/main` times out the same way here, so this is the environment, not the change.
`internal/cli` did complete under `-race` on this branch: `ok ... 729.9s`.
