### PR TITLE
fix(cli): stop init-agents writing through a link into the git directory

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -88,7 +88,14 @@ by its name, so a repository whose administrative directory is not called `.git`
 — `git init --separate-git-dir=admin`, or a checkout driven by `GIT_DIR` — is
 covered by the same refusal.
 
-Hard links are also
+The landing must also be an agent-instruction file. An alias exists so that
+`AGENTS.md` and `CLAUDE.md` can share one instruction file, so a target that is
+markdown by extension, or a rules file such as `.cursorrules`, is written; a
+target that is some other existing file — a `Makefile`, `.envrc`, or
+`.github/workflows/ci.yml` — is refused rather than having a managed block
+appended to it. A target that does not exist yet is still created, which is what
+the dangling-alias case below relies on, and a target this command wrote on an
+earlier run stays writable whatever it is named. Hard links are also
 supported, but every hard-linked pathname names the same inode: an update
 through `AGENTS.md` or `CLAUDE.md` is therefore visible through any other hard
 link to that file, including one outside the project. A directory, named pipe,

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -83,7 +83,12 @@ directory — `.git` at any depth, including a nested checkout's and a linked
 worktree's `.git` pointer — is refused as well. `.git` is inside the project root
 but is not project content, and no instruction file belongs there; writing a
 managed block into `config` or a hook would corrupt the repository rather than
-configure an agent. Hard links are also
+configure an agent. The git directory is recognised by its structure rather than
+by its name, so a repository whose administrative directory is not called `.git`
+— `git init --separate-git-dir=admin`, or a checkout driven by `GIT_DIR` — is
+covered by the same refusal.
+
+Hard links are also
 supported, but every hard-linked pathname names the same inode: an update
 through `AGENTS.md` or `CLAUDE.md` is therefore visible through any other hard
 link to that file, including one outside the project. A directory, named pipe,

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -77,7 +77,13 @@ content from that validated snapshot.
 Each path must be missing or resolve to a regular file. Symlinks to regular
 files are supported, with the target written either relatively or as an
 absolute path, as long as it stays inside the project root; a symlink that
-resolves outside is refused and nothing is installed. Hard links are also
+resolves outside is refused and nothing is installed. Staying inside the project
+root is necessary but not sufficient: a symlink that lands inside a git
+directory — `.git` at any depth, including a nested checkout's and a linked
+worktree's `.git` pointer — is refused as well. `.git` is inside the project root
+but is not project content, and no instruction file belongs there; writing a
+managed block into `config` or a hook would corrupt the repository rather than
+configure an agent. Hard links are also
 supported, but every hard-linked pathname names the same inode: an update
 through `AGENTS.md` or `CLAUDE.md` is therefore visible through any other hard
 link to that file, including one outside the project. A directory, named pipe,

--- a/docs/trust-and-security.md
+++ b/docs/trust-and-security.md
@@ -179,9 +179,14 @@ these rules existed misses instead of re-emitting the paths it named.
   rebuild, nothing else. Queries never modify repository source files.
 - `init-agents` writes through exactly three repository paths, disclosed in
   [agent activation](agents.md): `.entire/graph-agent.md` and managed blocks
-  in `AGENTS.md` and `CLAUDE.md`. A hard-linked pathname elsewhere names the
-  same inode and therefore observes the same update; the activation guide
-  calls out that filesystem property explicitly.
+  in `AGENTS.md` and `CLAUDE.md`. A repository-committed symlink at one of
+  those paths may redirect the write to another file, which is what makes the
+  alias support in the activation guide work; the redirection is confined to
+  the project root, and additionally refused when it lands in a git directory,
+  so a hostile checkout cannot aim a managed block at `.git/config` or a hook.
+  A hard-linked pathname elsewhere names the same inode and therefore observes
+  the same update; the activation guide calls out that filesystem property
+  explicitly.
 - `index --report <path>` writes a Markdown graph report to the path you give
   it.
 - `verify --record-baseline <path>` creates parent directories as needed and

--- a/docs/trust-and-security.md
+++ b/docs/trust-and-security.md
@@ -182,8 +182,10 @@ these rules existed misses instead of re-emitting the paths it named.
   in `AGENTS.md` and `CLAUDE.md`. A repository-committed symlink at one of
   those paths may redirect the write to another file, which is what makes the
   alias support in the activation guide work; the redirection is confined to
-  the project root, and additionally refused when it lands in a git directory,
-  so a hostile checkout cannot aim a managed block at `.git/config` or a hook.
+  the project root, and additionally refused when it lands in a git directory —
+  recognised by structure, so an administrative directory not named `.git` is
+  covered too — so a hostile checkout cannot aim a managed block at
+  `.git/config` or a hook.
   A hard-linked pathname elsewhere names the same inode and therefore observes
   the same update; the activation guide calls out that filesystem property
   explicitly.

--- a/docs/trust-and-security.md
+++ b/docs/trust-and-security.md
@@ -184,8 +184,9 @@ these rules existed misses instead of re-emitting the paths it named.
   alias support in the activation guide work; the redirection is confined to
   the project root, and additionally refused when it lands in a git directory —
   recognised by structure, so an administrative directory not named `.git` is
-  covered too — so a hostile checkout cannot aim a managed block at
-  `.git/config` or a hook.
+  covered too — or on an existing file that is not an agent-instruction file, so
+  a hostile checkout cannot aim a managed block at `.git/config`, a hook, a
+  `Makefile`, `.envrc`, or a CI workflow.
   A hard-linked pathname elsewhere names the same inode and therefore observes
   the same update; the activation guide calls out that filesystem property
   explicitly.

--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -252,7 +252,7 @@ func runInitAgents(opts Options, args []string) error {
 	if guideWasMissing {
 		guideCreated, err = writeNewContainedFile(repoRoot, guideName, []byte(agentGuide), 0o644)
 	} else {
-		err = writeContainedFile(repoRoot, guideName, []byte(agentGuide), 0o644)
+		err = writeContainedFile(repoRoot, guideName, []byte(agentGuide), 0o644, guideName, agentsName, claudeName)
 	}
 	if err != nil {
 		return rollback(err, guideCreated)
@@ -265,7 +265,7 @@ func runInitAgents(opts Options, args []string) error {
 	}
 	fmt.Fprintf(opts.Stdout, "wrote %s\n", guidePath)
 
-	if err := writeContainedFile(repoRoot, agentsName, agentsContent, 0o644); err != nil {
+	if err := writeContainedFile(repoRoot, agentsName, agentsContent, 0o644, guideName, agentsName, claudeName); err != nil {
 		return fmt.Errorf("init-agents: AGENTS.md: %w", err)
 	}
 	fmt.Fprintf(opts.Stdout, "updated %s\n", agentsPath)
@@ -289,7 +289,7 @@ func runInitAgents(opts Options, args []string) error {
 	if err == nil && os.SameFile(agentsInfo, claudeInfo) {
 		return nil
 	}
-	if err := writeContainedFile(repoRoot, claudeName, claudeContent, 0o644); err != nil {
+	if err := writeContainedFile(repoRoot, claudeName, claudeContent, 0o644, guideName, agentsName, claudeName); err != nil {
 		return fmt.Errorf("init-agents: CLAUDE.md: %w", err)
 	}
 	fmt.Fprintf(opts.Stdout, "updated %s\n", claudePath)
@@ -1365,13 +1365,34 @@ func readContainedFile(root *os.Root, name string, limit int64) ([]byte, error) 
 
 // writeContainedFile is os.WriteFile confined to root. The perm argument applies only when the
 // file is created, matching os.WriteFile, so an existing file keeps its mode.
-func writeContainedFile(root *os.Root, name string, content []byte, perm os.FileMode) error {
+func writeContainedFile(root *os.Root, name string, content []byte, perm os.FileMode, managed ...string) error {
 	resolved, err := resolveContainedName(root, name)
 	if err != nil {
 		return err
 	}
-	file, err := root.OpenFile(resolved, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	// O_TRUNC is deliberately NOT in this open, and the file is judged from the
+	// HANDLE rather than from the resolved name.
+	//
+	// Both follow from the same gap. resolveContainedName decides on a path, and
+	// the path is not the thing written: OpenFile re-resolves it, so a link
+	// swapped in between the two is followed (os.Root refuses a link that
+	// ESCAPES the root, atomically, but follows one that stays inside — and
+	// `.git` is inside). Judging the open handle removes the window, because the
+	// handle IS what the write lands on.
+	//
+	// And truncation is already the damage. Opening `.git/config` with O_TRUNC
+	// destroys it before any guard below can object, so the truncate happens
+	// only after the handle has been accepted.
+	file, err := root.OpenFile(resolved, os.O_WRONLY|os.O_CREATE, perm)
 	if err != nil {
+		return err
+	}
+	if err := refuseSharedInode(root, file, name, resolved, managed); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Truncate(0); err != nil {
+		_ = file.Close()
 		return err
 	}
 	_, writeErr := file.Write(content)
@@ -1381,6 +1402,75 @@ func writeContainedFile(root *os.Root, name string, content []byte, perm os.File
 	}
 	return closeErr
 }
+
+// refuseSharedInode rejects an open managed target that is a HARD link.
+//
+// Every other guard here reasons about a path, and a hard link has no path to
+// reason about. `ln .git/config CLAUDE.md` gives git's config a second name in
+// the working tree: it resolves to "CLAUDE.md", carries no `.git` component, and
+// Lstat reports an ordinary regular file, so PathLandsInGitDir cannot see it.
+// Writing the managed block through that name appends to git's own config —
+// exactly the corruption the git-directory refusal exists to prevent, reached by
+// a route it does not cover. Measured before this guard: `init-agents` exited 0
+// and `.git/config` was rewritten.
+//
+// The rule is link count rather than "is it inside .git", because the handle
+// cannot be asked where else its inode is named. That means it also refuses a
+// hard link to a harmless file. An instruction file with a second name is
+// vanishingly rare, sharing one is what the DOCUMENTED alias (a symlink) is for,
+// and the failure mode on the other side is silent corruption of the repository
+// — so this fails closed, on the same reasoning as the case-folded `.GIT`
+// refusal above.
+func refuseSharedInode(root *os.Root, file *os.File, name, resolved string, managed []string) error {
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	links, known := fileLinkCount(info)
+	if !known || links <= 1 {
+		return nil
+	}
+	// A shared inode is only dangerous if one of its OTHER names is somewhere
+	// this command must not write. Hard-linking two managed instruction files
+	// together is documented and supported, so the question is not "is this
+	// file linked" but "is every one of its names a managed target".
+	//
+	// Counting is what answers that without being able to enumerate an inode's
+	// names: if as many managed targets share this inode as the inode has
+	// names, then all of its names are accounted for and all of them are ours.
+	// One unaccounted name means some other path — `.git/config`, a hook —
+	// reaches the same bytes, and the write must be refused.
+	device, inode, identified := fileIdentity(info)
+	if !identified {
+		return nil
+	}
+	accounted := uint64(0)
+	for _, candidate := range managed {
+		candidateResolved, resolveErr := resolveContainedName(root, candidate)
+		if resolveErr != nil {
+			continue
+		}
+		candidateInfo, statErr := root.Stat(candidateResolved)
+		if statErr != nil {
+			continue
+		}
+		candidateDevice, candidateInode, candidateIdentified := fileIdentity(candidateInfo)
+		if candidateIdentified && candidateDevice == device && candidateInode == inode {
+			accounted++
+		}
+	}
+	if accounted >= links {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: %s resolves to %s, which has %d names but only %d of them are managed instruction files; an unaccounted name may reach a file this command must never write, such as one in the git directory",
+		errSharedInodeManagedTarget, name, filepath.ToSlash(resolved), links, accounted,
+	)
+}
+
+// errSharedInodeManagedTarget marks a managed target that shares its inode with
+// another directory entry.
+var errSharedInodeManagedTarget = errors.New("refusing to write through a hard link")
 
 // writeNewContainedFile is the create-only counterpart to writeContainedFile. The returned
 // FileInfo identifies the entry this call acquired even if writing or closing it subsequently

--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -710,11 +710,88 @@ func resolveContainedNameWithOptions(root *os.Root, name string, allowMissingDir
 			errGitDirManagedTarget, name, filepath.ToSlash(resolved),
 		)
 	}
+	if administrative, inside := landsInGitAdministrativeDirectory(root, resolved); inside {
+		return "", fmt.Errorf(
+			"%w: %s resolves to %s, inside %s, which is this repository's git directory whatever it is named",
+			errGitDirManagedTarget, name, filepath.ToSlash(resolved), filepath.ToSlash(administrative),
+		)
+	}
 	return resolved, nil
 }
 
 // errGitDirManagedTarget marks a managed target whose resolution lands in the git directory.
 var errGitDirManagedTarget = errors.New("refusing to write into the git directory")
+
+// landsInGitAdministrativeDirectory reports the git administrative directory a resolved landing is
+// inside, whatever that directory is NAMED, and whether it found one.
+//
+// sem.PathLandsInGitDir above answers a question about a NAME: it refuses a landing that spells a
+// `.git` component. That is the only shape it can see, and git does not require that shape. A
+// repository created with `git init --separate-git-dir=admin` keeps a `.git` POINTER FILE holding
+// `gitdir: <path>` and its real administrative directory somewhere else; a repository initialised
+// under GIT_DIR has no `.git` entry at all. In both, `git rev-parse --absolute-git-dir` names a
+// directory whose components spell nothing the name rule recognises, so every route the name rule
+// closes reopens. Measured on this branch before this check, in a `--separate-git-dir` repository
+// whose administrative directory is `admin/`: a committed `CLAUDE.md -> admin/config` exited 0 with
+// the managed block appended to git's real config, after which every git command failed with
+// "fatal: bad config line 9"; `.entire -> admin/refs/heads` wrote the guide into the real ref store
+// and git reported "ignoring broken ref refs/heads/graph-agent.md"; and `AGENTS.md ->
+// admin/hooks/pre-commit` appended to an executable hook.
+//
+// The question is put to the FILESYSTEM rather than to `git rev-parse`, and re-asked at every
+// resolution rather than answered once at startup. Both follow from the rule the rest of this file
+// already holds itself to: the preflight is not the enforcement, so a directory that becomes a git
+// directory between two operations must be refused by the operation that finds it, which a value
+// cached at startup cannot do. Asking git would also make the answer depend on a binary being
+// installed, on $GIT_DIR in this process's environment, and on the current working directory —
+// none of which describe the repository named by --repo.
+//
+// What is asked is git's own is_git_directory(): a HEAD, plus objects/ and refs/. The
+// commondir/gitdir alternative admits a linked worktree's administrative directory, which keeps
+// those two pointer files in place of its own object and ref stores.
+//
+// The `.git` pointer file's TEXT is deliberately not consulted. sem's gitDirExcluder — the READ
+// side of this same boundary, which already resolves separate-git-dir pointers — records why: the
+// pointer is attacker-controlled input, so git resolves it and then asks is_git_directory() of the
+// target anyway, and a `gitdir:` naming an ordinary directory is "fatal: not a git repository" to
+// git rather than a git directory. Once that structure test is applied, the pointer says nothing
+// this walk has not already asked: a landing inside the target has the target among its own
+// ancestors, and a target outside the repository is refused by os.Root before it gets here. Reading
+// the text without the structure test would only add a way for a repository to make an ordinary
+// directory of its own unwritable.
+func landsInGitAdministrativeDirectory(root *os.Root, resolved string) (string, bool) {
+	components := splitPathComponents(resolved)
+	for i := 1; i <= len(components); i++ {
+		prefix := filepath.Join(components[:i]...)
+		if prefix == "" || prefix == "." {
+			continue
+		}
+		if isGitAdministrativeDirectory(root, prefix) {
+			return prefix, true
+		}
+	}
+	return "", false
+}
+
+// isGitAdministrativeDirectory applies git's own is_git_directory() test to a repo-relative
+// directory: a HEAD, plus either the object and ref stores or the commondir/gitdir pointers a
+// linked worktree keeps instead of them.
+func isGitAdministrativeDirectory(root *os.Root, dir string) bool {
+	if info, err := root.Stat(filepath.Join(dir, "HEAD")); err != nil || info.IsDir() {
+		return false
+	}
+	objects, objectsErr := root.Stat(filepath.Join(dir, "objects"))
+	refs, refsErr := root.Stat(filepath.Join(dir, "refs"))
+	if objectsErr == nil && refsErr == nil && objects.IsDir() && refs.IsDir() {
+		return true
+	}
+	for _, pointer := range []string{"commondir", "gitdir"} {
+		if info, err := root.Stat(filepath.Join(dir, pointer)); err == nil && !info.IsDir() {
+			return true
+		}
+	}
+	return false
+}
 
 func resolveContainedLanding(root *os.Root, name string, allowMissingDirectory bool) (string, error) {
 	pending := splitPathComponents(name)

--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -1611,12 +1611,8 @@ func writeContainedFile(root *os.Root, name string, content []byte, perm os.File
 // — so this fails closed, on the same reasoning as the case-folded `.GIT`
 // refusal above.
 func refuseSharedInode(root *os.Root, file *os.File, name, resolved string, managed []string) error {
-	info, err := file.Stat()
-	if err != nil {
-		return err
-	}
-	links, known := fileLinkCount(info)
-	if !known || links <= 1 {
+	links, device, inode, identified := openFileIdentity(file)
+	if !identified || links <= 1 {
 		return nil
 	}
 	// A shared inode is only dangerous if one of its OTHER names is somewhere
@@ -1629,21 +1625,36 @@ func refuseSharedInode(root *os.Root, file *os.File, name, resolved string, mana
 	// names, then all of its names are accounted for and all of them are ours.
 	// One unaccounted name means some other path — `.git/config`, a hook —
 	// reaches the same bytes, and the write must be refused.
-	device, inode, identified := fileIdentity(info)
-	if !identified {
-		return nil
-	}
 	accounted := uint64(0)
 	for _, candidate := range managed {
+		// The entry must be a HARD LINK to count, and a symlink is not one.
+		//
+		// Only real directory entries contribute to an inode's link count, so
+		// counting a symlink alias inflates `accounted` without inflating
+		// `links` and hands back exactly the permission this guard exists to
+		// withhold. Measured before this check: CLAUDE.md hard-linked to
+		// .git/config (2 names) plus AGENTS.md symlinked to CLAUDE.md counted 2
+		// managed names against 2 links, so init-agents exited 0 and rewrote
+		// git's config. Sharing one instruction file through a SYMLINK is the
+		// documented alias and stays supported; it simply is not evidence about
+		// who else holds a hard link.
+		linkInfo, lstatErr := root.Lstat(candidate)
+		if lstatErr != nil || linkInfo.Mode()&fs.ModeSymlink != 0 {
+			continue
+		}
 		candidateResolved, resolveErr := resolveContainedName(root, candidate)
 		if resolveErr != nil {
 			continue
 		}
-		candidateInfo, statErr := root.Stat(candidateResolved)
-		if statErr != nil {
+		// Opened rather than stat'd because identity is a handle question on
+		// Windows. The symlink check above already ran, so this opens a real
+		// directory entry.
+		candidateFile, openErr := root.Open(candidateResolved)
+		if openErr != nil {
 			continue
 		}
-		candidateDevice, candidateInode, candidateIdentified := fileIdentity(candidateInfo)
+		_, candidateDevice, candidateInode, candidateIdentified := openFileIdentity(candidateFile)
+		_ = candidateFile.Close()
 		if candidateIdentified && candidateDevice == device && candidateInode == inode {
 			accounted++
 		}

--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -13,6 +13,8 @@ import (
 	"slices"
 	"strings"
 	"syscall"
+
+	"github.com/entireio/entire-graph/internal/sem"
 )
 
 // agentGuide is the canonical, agent-agnostic operating guide for coding agents using the
@@ -345,6 +347,12 @@ func ensureContainedInRepo(root *os.Root, name, path string, createsParents bool
 			)
 		}
 		return nil
+	case errors.Is(err, errGitDirManagedTarget):
+		return fmt.Errorf(
+			"%s: %w; init-agents installs instruction files, and none of them belongs in the "+
+				"git directory, so repoint or remove the link, then rerun init-agents",
+			path, err,
+		)
 	case isRootEscape(err):
 		return fmt.Errorf(
 			"%s: refusing to write through a link that leaves the repository (%w); "+
@@ -553,7 +561,10 @@ func isRootEscape(err error) bool {
 	// kernel's answer as text rather than as a wrapped errno — so it reaches here looking
 	// syscall-free. It is a broken path, not an escape; saying otherwise would send the
 	// reader hunting a link that leaves when none does.
-	return !errors.Is(err, errUnresolvableAlias) &&
+	// errGitDirManagedTarget is likewise not an escape: it is raised for a link that stays
+	// comfortably inside the root and lands in `.git`. Classifying it as an escape would tell
+	// the reader the link leaves the repository when the whole point is that it does not.
+	return !errors.Is(err, errUnresolvableAlias) && !errors.Is(err, errGitDirManagedTarget) &&
 		!errors.Is(err, os.ErrClosed) && !errors.Is(err, os.ErrInvalid)
 }
 
@@ -664,7 +675,48 @@ func resolveContainedDirectoryName(root *os.Root, name string) (string, error) {
 	return resolveContainedNameWithOptions(root, name, true)
 }
 
+// resolveContainedNameWithOptions is resolveContainedLanding plus the one landing that
+// containment alone cannot refuse: a managed target that resolves INSIDE the repository's git
+// directory.
+//
+// os.Root keeps the write in the project root, and until now that was the whole argument — see
+// the os.OpenRoot comment in runInitAgents, which reasons that a link staying inside the
+// repository is safe to follow because the repository is where init-agents writes anyway. That
+// is true of repository CONTENT and false of `.git`, which is inside the root and is not content.
+// A hostile checkout that commits `CLAUDE.md -> .git/config` gets the managed block appended to
+// git's own config, and git then refuses to operate on the repository at all ("fatal: bad config
+// line N"); `.git/hooks/*` is the same primitive aimed somewhere worse. Nothing about the
+// documented alias needs it: docs/agents.md offers symlinks so AGENTS.md and CLAUDE.md can share
+// ONE INSTRUCTION FILE, and no instruction file lives in `.git`.
+//
+// It is also the boundary the rest of the tool already holds from the other side. The indexer
+// refuses to READ inside a git directory whatever its name or depth (hasGitDirComponent, which
+// this asks through sem.PathLandsInGitDir rather than restating); a writer that will not read
+// there must not write there either.
+//
+// This sits on the resolver rather than on the preflight because the preflight is not the
+// enforcement: ensureContainedInRepo is explicitly not atomic with the write, so a link swapped
+// in afterwards would pass a preflight-only check. Every stat, read and write of a managed target
+// resolves through here, so each one re-asks, and a link swapped between them is refused by the
+// operation that finds it.
 func resolveContainedNameWithOptions(root *os.Root, name string, allowMissingDirectory bool) (string, error) {
+	resolved, err := resolveContainedLanding(root, name, allowMissingDirectory)
+	if err != nil {
+		return "", err
+	}
+	if sem.PathLandsInGitDir(resolved) {
+		return "", fmt.Errorf(
+			"%w: %s resolves to %s, inside the repository's git directory, where init-agents must never write",
+			errGitDirManagedTarget, name, filepath.ToSlash(resolved),
+		)
+	}
+	return resolved, nil
+}
+
+// errGitDirManagedTarget marks a managed target whose resolution lands in the git directory.
+var errGitDirManagedTarget = errors.New("refusing to write into the git directory")
+
+func resolveContainedLanding(root *os.Root, name string, allowMissingDirectory bool) (string, error) {
 	pending := splitPathComponents(name)
 	var resolved []string
 	requiresDirectory := false

--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -353,6 +353,15 @@ func ensureContainedInRepo(root *os.Root, name, path string, createsParents bool
 				"git directory, so repoint or remove the link, then rerun init-agents",
 			path, err,
 		)
+	case errors.Is(err, errNonInstructionManagedTarget):
+		// Named before isRootEscape for the same reason the case above is: this refusal is
+		// raised by the resolver rather than by os.Root, so it carries no syscall errno and
+		// would otherwise be reported as a repository escape — sending the reader to hunt a
+		// link that leaves the root when the link never left it.
+		return fmt.Errorf(
+			"%s: %w, then rerun init-agents",
+			path, err,
+		)
 	case isRootEscape(err):
 		return fmt.Errorf(
 			"%s: refusing to write through a link that leaves the repository (%w); "+
@@ -716,6 +725,14 @@ func resolveContainedNameWithOptions(root *os.Root, name string, allowMissingDir
 			errGitDirManagedTarget, name, filepath.ToSlash(resolved), filepath.ToSlash(administrative),
 		)
 	}
+	// Directory resolutions are excluded because the landing they name is a directory, and the
+	// question below is about the FILE a managed instruction target is written into. The guide
+	// directory's own containment is settled by the refusals above.
+	if !allowMissingDirectory {
+		if err := refuseNonInstructionLanding(root, name, resolved); err != nil {
+			return "", err
+		}
+	}
 	return resolved, nil
 }
 
@@ -791,6 +808,101 @@ func isGitAdministrativeDirectory(root *os.Root, dir string) bool {
 		}
 	}
 	return false
+}
+
+// errNonInstructionManagedTarget marks a managed target whose resolved landing is not an
+// agent-instruction file.
+var errNonInstructionManagedTarget = errors.New("refusing to write outside an agent-instruction file")
+
+// maxManagedLandingBytes bounds how much of a landing is read to recognise it. It bounds the READ,
+// not the file: an instruction file larger than this is recognised by its name like any other, and
+// only a landing whose name is unrecognised is read at all.
+const maxManagedLandingBytes = 4 << 20
+
+// agentInstructionFileNames are agent-instruction files that carry no markdown extension. Every
+// entry only ever ADMITS a landing, so the list being incomplete costs a refusal a user can work
+// around by renaming, never a corrupted file — which is the whole reason this is a list of what
+// may be written rather than a list of what may not.
+var agentInstructionFileNames = map[string]struct{}{
+	".cursorrules":   {},
+	".clinerules":    {},
+	".windsurfrules": {},
+	".goosehints":    {},
+}
+
+// agentGuideHeading is the guide's own first line, which is what identifies a file this command
+// previously wrote the guide into. Deriving it from the guide keeps the two from drifting apart.
+var agentGuideHeading = strings.SplitN(agentGuide, "\n", 2)[0]
+
+// isInstructionFileName reports whether a landing's base name is an agent-instruction file.
+//
+// Markdown is the test because markdown is what init-agents writes. The comparison folds case for
+// the same reason PathLandsInGitDir folds: macOS and Windows resolve these names
+// case-insensitively, so `README.MD` and `readme.md` are one file there.
+func isInstructionFileName(base string) bool {
+	switch strings.ToLower(filepath.Ext(base)) {
+	case ".md", ".markdown", ".mdown", ".mkd":
+		return true
+	}
+	_, known := agentInstructionFileNames[strings.ToLower(base)]
+	return known
+}
+
+// refuseNonInstructionLanding refuses a managed target that resolves onto an EXISTING file which is
+// not an agent-instruction file.
+//
+// The git-directory refusals above name one destination each. That is a denylist, and a denylist of
+// destinations cannot be finished: `CLAUDE.md -> Makefile`, `-> .github/workflows/ci.yml` and
+// `-> .envrc` were all measured on this branch appending the managed block to the victim's real
+// build, CI and environment files, exit 0 — and every build system, task runner and shell
+// initialisation file yet to be invented is another entry someone has to remember to add. The list
+// that CAN be finished is the list of things init-agents is for: docs/agents.md offers the alias so
+// that AGENTS.md and CLAUDE.md may share ONE INSTRUCTION FILE, so an alias that lands anywhere else
+// is not a use of the feature, and refusing it costs the documented case nothing.
+//
+// Three landings are deliberately not refused, and each is a case where there is nothing to
+// protect:
+//
+//   - A landing that DOES NOT EXIST. init-agents creates all of its targets, and the documented
+//     dangling alias (CLAUDE.md -> AGENTS.md before AGENTS.md exists) depends on it. Nothing is
+//     destroyed: the file this command creates holds this command's own markdown, mode 0644, and
+//     shows up untracked in `git status` — the harm this refusal exists for is the SILENT rewrite
+//     of a file that was already doing a job.
+//   - A landing that already carries this command's own output. A file init-agents wrote once must
+//     stay writable on the next run whatever it is named, or a first run would succeed and every
+//     later one fail.
+//   - A landing that is not a regular file, or cannot be stat'ed. Those are not this refusal's
+//     question; the operation that follows reports them for what they are.
+func refuseNonInstructionLanding(root *os.Root, name, resolved string) error {
+	if isInstructionFileName(filepath.Base(resolved)) {
+		return nil
+	}
+	info, err := root.Stat(resolved)
+	if err != nil || !info.Mode().IsRegular() {
+		return nil
+	}
+	if landingCarriesManagedContent(root, resolved) {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: %s resolves to %s, which is not an agent-instruction file; init-agents installs its managed block only into instruction files, so alias it to one",
+		errNonInstructionManagedTarget, name, filepath.ToSlash(resolved),
+	)
+}
+
+// landingCarriesManagedContent reports whether a landing already holds output this command wrote:
+// the managed pointer block, or the guide's own heading.
+func landingCarriesManagedContent(root *os.Root, resolved string) bool {
+	file, err := root.Open(resolved)
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+	content, err := io.ReadAll(io.LimitReader(file, maxManagedLandingBytes))
+	if err != nil {
+		return false
+	}
+	return bytes.Contains(content, []byte(agentPointerBegin)) || bytes.Contains(content, []byte(agentGuideHeading))
 }
 
 func resolveContainedLanding(root *os.Root, name string, allowMissingDirectory bool) (string, error) {

--- a/internal/cli/agents_hardlink_unix.go
+++ b/internal/cli/agents_hardlink_unix.go
@@ -3,35 +3,32 @@
 package cli
 
 import (
-	"io/fs"
+	"os"
 	"syscall"
 )
 
-// fileLinkCount reports how many directory entries point at an open file's inode,
-// and whether the platform could answer at all.
+// openFileIdentity reports how many directory entries name an OPEN file's
+// inode, and the (device, inode) pair that identifies it independently of any
+// name.
 //
-// It is the only way to see a HARD link. Every other guard in this file reasons
-// about a path — its components, what it resolves to, whether a component is a
-// symlink — and a hard link has no path to reason about: `ln .git/config
-// CLAUDE.md` makes CLAUDE.md a second name for the same inode, so it resolves to
-// "CLAUDE.md", carries no `.git` component, and Lstat reports an ordinary
-// regular file. The name is innocent; the inode is not.
-func fileLinkCount(info fs.FileInfo) (uint64, bool) {
-	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		return 0, false
+// The link count is the only way to see a HARD link. Every other guard in this
+// file reasons about a path — its components, what it resolves to, whether a
+// component is a symlink — and a hard link has no path to reason about: `ln
+// .git/config CLAUDE.md` makes CLAUDE.md a second name for the same inode, so
+// it resolves to "CLAUDE.md", carries no `.git` component, and Lstat reports an
+// ordinary regular file. The name is innocent; the inode is not.
+//
+// It takes the open FILE rather than a FileInfo because Windows can only answer
+// either question from a handle, and a guard that no-ops on one platform is not
+// a guard.
+func openFileIdentity(file *os.File) (links, device, inode uint64, ok bool) {
+	info, err := file.Stat()
+	if err != nil {
+		return 0, 0, 0, false
 	}
-	return uint64(stat.Nlink), true
-}
-
-// fileIdentity returns the (device, inode) pair that identifies a file
-// independently of any name it is reachable by. It is what lets two managed
-// targets be recognised as ONE file when the repository hard-links them, which
-// docs/agents.md documents as a supported way to share a single instruction file.
-func fileIdentity(info fs.FileInfo) (device, inode uint64, ok bool) {
 	stat, isStat := info.Sys().(*syscall.Stat_t)
 	if !isStat {
-		return 0, 0, false
+		return 0, 0, 0, false
 	}
-	return uint64(stat.Dev), uint64(stat.Ino), true
+	return uint64(stat.Nlink), uint64(stat.Dev), uint64(stat.Ino), true
 }

--- a/internal/cli/agents_hardlink_unix.go
+++ b/internal/cli/agents_hardlink_unix.go
@@ -1,0 +1,37 @@
+//go:build !windows
+
+package cli
+
+import (
+	"io/fs"
+	"syscall"
+)
+
+// fileLinkCount reports how many directory entries point at an open file's inode,
+// and whether the platform could answer at all.
+//
+// It is the only way to see a HARD link. Every other guard in this file reasons
+// about a path — its components, what it resolves to, whether a component is a
+// symlink — and a hard link has no path to reason about: `ln .git/config
+// CLAUDE.md` makes CLAUDE.md a second name for the same inode, so it resolves to
+// "CLAUDE.md", carries no `.git` component, and Lstat reports an ordinary
+// regular file. The name is innocent; the inode is not.
+func fileLinkCount(info fs.FileInfo) (uint64, bool) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, false
+	}
+	return uint64(stat.Nlink), true
+}
+
+// fileIdentity returns the (device, inode) pair that identifies a file
+// independently of any name it is reachable by. It is what lets two managed
+// targets be recognised as ONE file when the repository hard-links them, which
+// docs/agents.md documents as a supported way to share a single instruction file.
+func fileIdentity(info fs.FileInfo) (device, inode uint64, ok bool) {
+	stat, isStat := info.Sys().(*syscall.Stat_t)
+	if !isStat {
+		return 0, 0, false
+	}
+	return uint64(stat.Dev), uint64(stat.Ino), true
+}

--- a/internal/cli/agents_hardlink_windows.go
+++ b/internal/cli/agents_hardlink_windows.go
@@ -2,13 +2,31 @@
 
 package cli
 
-import "io/fs"
+import (
+	"os"
+	"syscall"
+)
 
-// fileLinkCount cannot answer on Windows: the FileInfo Go exposes there carries
-// no link count, and obtaining one needs a handle query this package does not
-// make. Reporting "unknown" rather than 1 keeps the caller from treating an
-// unanswerable question as a clean answer — the guard is skipped, not faked.
-func fileLinkCount(fs.FileInfo) (uint64, bool) { return 0, false }
-
-// fileIdentity is likewise unanswerable from the FileInfo Go exposes on Windows.
-func fileIdentity(fs.FileInfo) (device, inode uint64, ok bool) { return 0, 0, false }
+// openFileIdentity is the Windows half of the hard-link guard. NTFS supports
+// hard links (`mklink /H`, CreateHardLink), so the protection has to work here:
+// a guard that no-ops on a platform whose filesystem has the feature is a guard
+// in name only.
+//
+// The FileInfo Go exposes on Windows carries neither a link count nor a file
+// identity, which is why an earlier version reported "unknown" and skipped the
+// check. GetFileInformationByHandle answers both from the open handle:
+// NumberOfLinks is the link count, and (VolumeSerialNumber, FileIndexHigh,
+// FileIndexLow) is the volume-scoped identity — Windows' equivalent of
+// (device, inode).
+//
+// FileIndex is stable while the file is open, which is exactly the window this
+// is used in: the handle is already held, and the answer is only needed for the
+// write about to happen on it.
+func openFileIdentity(file *os.File) (links, device, inode uint64, ok bool) {
+	var info syscall.ByHandleFileInformation
+	if err := syscall.GetFileInformationByHandle(syscall.Handle(file.Fd()), &info); err != nil {
+		return 0, 0, 0, false
+	}
+	index := uint64(info.FileIndexHigh)<<32 | uint64(info.FileIndexLow)
+	return uint64(info.NumberOfLinks), uint64(info.VolumeSerialNumber), index, true
+}

--- a/internal/cli/agents_hardlink_windows.go
+++ b/internal/cli/agents_hardlink_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package cli
+
+import "io/fs"
+
+// fileLinkCount cannot answer on Windows: the FileInfo Go exposes there carries
+// no link count, and obtaining one needs a handle query this package does not
+// make. Reporting "unknown" rather than 1 keeps the caller from treating an
+// unanswerable question as a clean answer — the guard is skipped, not faked.
+func fileLinkCount(fs.FileInfo) (uint64, bool) { return 0, false }
+
+// fileIdentity is likewise unanswerable from the FileInfo Go exposes on Windows.
+func fileIdentity(fs.FileInfo) (device, inode uint64, ok bool) { return 0, 0, false }

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -3054,3 +3054,53 @@ func TestAgentGuideHeadingIdentifiesTheGuide(t *testing.T) {
 		t.Fatalf("the guide heading matches unrelated file content: %q", agentGuideHeading)
 	}
 }
+
+// TestInitAgentsRefusesHardLinkWhoseCountASymlinkAliasInflates covers the way
+// the hard-link guard could be talked out of firing.
+//
+// The guard asks whether every one of an inode's names is a managed instruction
+// file, and answers by counting managed names that resolve to the same inode.
+// Only real directory entries contribute to an inode's LINK COUNT, so a symlink
+// alias — the documented way to share one instruction file — resolves to the
+// inode without being one of its names, and counting it inflates the managed
+// tally without inflating the link count.
+//
+// Measured before the fix: CLAUDE.md hard-linked to .git/config (2 names) plus
+// AGENTS.md symlinked to CLAUDE.md counted 2 managed names against 2 links, so
+// `init-agents` exited 0 and rewrote git's config — the exact corruption the
+// guard exists to prevent, reached by inflating its own evidence.
+func TestInitAgentsRefusesHardLinkWhoseCountASymlinkAliasInflates(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+
+	victimPath := filepath.Join(repo, ".git", "config")
+	if err := os.MkdirAll(filepath.Dir(victimPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const victimContent = "[core]\n\tbare = false\n"
+	if err := os.WriteFile(victimPath, []byte(victimContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(victimPath, filepath.Join(repo, "CLAUDE.md")); err != nil {
+		t.Skipf("hard links unavailable on this filesystem: %v", err)
+	}
+	if err := os.Symlink("CLAUDE.md", filepath.Join(repo, "AGENTS.md")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	var out bytes.Buffer
+	runErr := Run(context.Background(), Options{Stdout: &out, Stderr: &out}, []string{"init-agents", "--repo", repo})
+	if runErr == nil {
+		t.Fatalf("init-agents succeeded while writing through a hard link into the git directory:\n%s", out.String())
+	}
+	if !errors.Is(runErr, errSharedInodeManagedTarget) {
+		t.Fatalf("want a hard-link refusal, got %v\n%s", runErr, out.String())
+	}
+	after, err := os.ReadFile(victimPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != victimContent {
+		t.Fatalf(".git/config was written through a hard link:\n%s", after)
+	}
+}

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -2896,3 +2896,161 @@ func TestInitAgentsRefusesGitDirectoryNotNamedDotGit(t *testing.T) {
 		})
 	}
 }
+
+// TestInitAgentsRefusesLandingThatIsNotAnInstructionFile pins the write to the kind of file
+// init-agents exists to write.
+//
+// The git-directory refusals name one destination each, which is a denylist, and a denylist of
+// destinations cannot be finished. Measured on this branch before the fix, each of these exited 0
+// with the managed block appended to the victim's real build, CI, environment or package file. The
+// rule that replaces the list is the one thing that IS bounded: docs/agents.md offers the alias so
+// AGENTS.md and CLAUDE.md may share one INSTRUCTION FILE, so a landing that is not an instruction
+// file is not a use of the feature.
+func TestInitAgentsRefusesLandingThatIsNotAnInstructionFile(t *testing.T) {
+	t.Parallel()
+	skipIfSymlinksUnrepresentable(t)
+
+	for _, testCase := range []struct {
+		name    string
+		managed string
+		victim  string
+		content string
+	}{
+		{name: "workflow", managed: "CLAUDE.md", victim: filepath.Join(".github", "workflows", "ci.yml"), content: "name: ci\non: [push]\n"},
+		{name: "makefile", managed: "CLAUDE.md", victim: "Makefile", content: "all:\n\techo hi\n"},
+		{name: "direnv", managed: "CLAUDE.md", victim: ".envrc", content: "export FOO=bar\n"},
+		{name: "package manifest", managed: "AGENTS.md", victim: "package.json", content: "{\"scripts\":{\"build\":\"tsc\"}}\n"},
+		{name: "shell profile", managed: "AGENTS.md", victim: ".bashrc", content: "export PATH=$PATH:/bin\n"},
+		{name: "guide alias", managed: filepath.Join(".entire", "graph-agent.md"), victim: "Makefile", content: "all:\n\techo hi\n"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			repo := t.TempDir()
+			victimPath := filepath.Join(repo, testCase.victim)
+			mkdirAllForTest(t, filepath.Dir(victimPath))
+			writeFileForTest(t, victimPath, testCase.content)
+
+			managedPath := filepath.Join(repo, testCase.managed)
+			mkdirAllForTest(t, filepath.Dir(managedPath))
+			relativeVictim, err := filepath.Rel(filepath.Dir(managedPath), victimPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			symlinkForTest(t, relativeVictim, managedPath)
+
+			var out bytes.Buffer
+			runErr := Run(context.Background(), Options{Stdout: &out, Stderr: &out}, []string{"init-agents", "--repo", repo})
+			if runErr == nil {
+				t.Fatalf("init-agents wrote its managed block into %s; output:\n%s", testCase.victim, out.String())
+			}
+			if !strings.Contains(runErr.Error(), "agent-instruction file") {
+				t.Fatalf("the refusal did not name the instruction-file rule: %v", runErr)
+			}
+			// The refusal comes from the resolver, so it carries no syscall errno and is
+			// indistinguishable from os.Root's own escape sentinel unless the classifier
+			// names it. Every link here stays inside the repository.
+			if strings.Contains(runErr.Error(), "leaves the repository") {
+				t.Fatalf("a link that never left the root was reported as a repository escape: %v", runErr)
+			}
+			if got := readFileForTest(t, victimPath); got != testCase.content {
+				t.Fatalf("%s was written through:\nwant: %q\n got: %q", testCase.victim, testCase.content, got)
+			}
+			for _, unwritten := range []string{"AGENTS.md", "CLAUDE.md", filepath.Join(".entire", "graph-agent.md")} {
+				if unwritten == testCase.managed {
+					continue
+				}
+				if _, statErr := os.Lstat(filepath.Join(repo, unwritten)); !os.IsNotExist(statErr) {
+					t.Fatalf("partial install: %s exists after the refusal (%v)", unwritten, statErr)
+				}
+			}
+		})
+	}
+}
+
+// TestInitAgentsAllowsInstructionFileLandings bounds the refusal above from the other side. Each of
+// these is a landing the documented alias is FOR, and each must keep working: a markdown file the
+// repository already had, an agent rules file that carries no markdown extension, and — twice — a
+// landing this command itself created, because a rule that admitted a target on the first run and
+// refused it on the second would be worse than no rule.
+func TestInitAgentsAllowsInstructionFileLandings(t *testing.T) {
+	t.Parallel()
+	skipIfSymlinksUnrepresentable(t)
+
+	t.Run("existing markdown target", func(t *testing.T) {
+		t.Parallel()
+		repo := t.TempDir()
+		shared := filepath.Join(repo, "docs", "shared.md")
+		mkdirAllForTest(t, filepath.Dir(shared))
+		writeFileForTest(t, shared, "# Shared rules\n")
+		symlinkForTest(t, filepath.Join("docs", "shared.md"), filepath.Join(repo, "AGENTS.md"))
+		symlinkForTest(t, "AGENTS.md", filepath.Join(repo, "CLAUDE.md"))
+
+		runInitAgentsForTest(t, repo)
+
+		got := readFileForTest(t, shared)
+		if !strings.Contains(got, "# Shared rules") || !strings.Contains(got, testAgentPointerBlock) {
+			t.Fatalf("the shared instruction file lost content or the pointer:\n%s", got)
+		}
+	})
+
+	t.Run("rules file without a markdown extension", func(t *testing.T) {
+		t.Parallel()
+		repo := t.TempDir()
+		rules := filepath.Join(repo, ".cursorrules")
+		writeFileForTest(t, rules, "# Cursor rules\n")
+		symlinkForTest(t, ".cursorrules", filepath.Join(repo, "CLAUDE.md"))
+
+		runInitAgentsForTest(t, repo)
+
+		got := readFileForTest(t, rules)
+		if !strings.Contains(got, "# Cursor rules") || !strings.Contains(got, testAgentPointerBlock) {
+			t.Fatalf("the rules file lost content or the pointer:\n%s", got)
+		}
+	})
+
+	t.Run("landing this command created is writable again", func(t *testing.T) {
+		t.Parallel()
+		repo := t.TempDir()
+		// No markdown extension and not on any list: admitted the first time because it
+		// does not exist, and the second time because it now carries this command's block.
+		symlinkForTest(t, "NOTES", filepath.Join(repo, "AGENTS.md"))
+
+		runInitAgentsForTest(t, repo)
+		runInitAgentsForTest(t, repo)
+
+		got := readFileForTest(t, filepath.Join(repo, "NOTES"))
+		if strings.Count(got, agentPointerBegin) != 1 {
+			t.Fatalf("the second run did not update the block in place:\n%s", got)
+		}
+	})
+
+	t.Run("guide landing this command created is writable again", func(t *testing.T) {
+		t.Parallel()
+		repo := t.TempDir()
+		mkdirAllForTest(t, filepath.Join(repo, ".entire"))
+		symlinkForTest(t, filepath.Join("..", "GUIDE"), filepath.Join(repo, ".entire", "graph-agent.md"))
+
+		runInitAgentsForTest(t, repo)
+		runInitAgentsForTest(t, repo)
+
+		if got := readFileForTest(t, filepath.Join(repo, "GUIDE")); got != agentGuide {
+			t.Fatalf("the guide landing did not hold the guide after two runs:\n%s", got)
+		}
+	})
+}
+
+// TestAgentGuideHeadingIdentifiesTheGuide guards the derivation the re-run case above depends on. A
+// heading that went empty, or that stopped appearing in the guide, would make
+// landingCarriesManagedContent either admit every file or admit none.
+func TestAgentGuideHeadingIdentifiesTheGuide(t *testing.T) {
+	t.Parallel()
+	if len(agentGuideHeading) < len("# entire-graph") {
+		t.Fatalf("the guide heading is too short to identify anything: %q", agentGuideHeading)
+	}
+	if !strings.Contains(agentGuide, agentGuideHeading) {
+		t.Fatalf("the guide no longer contains its own heading %q", agentGuideHeading)
+	}
+	if strings.Contains("all:\n\techo hi\n", agentGuideHeading) {
+		t.Fatalf("the guide heading matches unrelated file content: %q", agentGuideHeading)
+	}
+}

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -2694,3 +2694,80 @@ func requireGitDirRefusal(t *testing.T, err error, out string) {
 		t.Fatalf("refusal named neither the git directory nor an unresolvable path: %v", err)
 	}
 }
+
+// TestInitAgentsRefusesManagedTargetHardLinkedIntoGitDirectory covers the route
+// the git-directory refusal cannot see.
+//
+// Every guard around it reasons about a PATH — its components, what it resolves
+// to, whether a component is a symlink. A hard link has no path to reason about:
+// `ln .git/config CLAUDE.md` gives git's config a second name in the working
+// tree, so it resolves to "CLAUDE.md", carries no `.git` component, and Lstat
+// reports an ordinary regular file. PathLandsInGitDir is structurally unable to
+// refuse it.
+//
+// Measured on this branch before the guard: `init-agents` exited 0 (nil error)
+// and `.git/config` was rewritten with the managed block appended — the exact
+// corruption this PR exists to prevent, reached by a route it did not cover.
+func TestInitAgentsRefusesManagedTargetHardLinkedIntoGitDirectory(t *testing.T) {
+	t.Parallel()
+
+	for _, managed := range []string{"CLAUDE.md", "AGENTS.md"} {
+		t.Run(managed, func(t *testing.T) {
+			t.Parallel()
+			repo := t.TempDir()
+
+			victimPath := filepath.Join(repo, ".git", "config")
+			if err := os.MkdirAll(filepath.Dir(victimPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			const victimContent = "[core]\n\tbare = false\n"
+			if err := os.WriteFile(victimPath, []byte(victimContent), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Link(victimPath, filepath.Join(repo, managed)); err != nil {
+				t.Skipf("hard links unavailable on this filesystem: %v", err)
+			}
+
+			var out bytes.Buffer
+			runErr := Run(context.Background(), Options{Stdout: &out, Stderr: &out}, []string{"init-agents", "--repo", repo})
+			if runErr == nil {
+				t.Fatalf("init-agents succeeded while writing through a hard link into the git directory:\n%s", out.String())
+			}
+			if !errors.Is(runErr, errSharedInodeManagedTarget) {
+				t.Fatalf("want a hard-link refusal, got %v\n%s", runErr, out.String())
+			}
+
+			after, err := os.ReadFile(victimPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(after) != victimContent {
+				t.Fatalf(".git/config was written through a hard link:\n%s", after)
+			}
+		})
+	}
+}
+
+// TestInitAgentsWritesAnOrdinaryInstructionFile keeps the hard-link guard from
+// becoming a blanket refusal. A guard that rejected every managed target would
+// pass the test above and break the command, so the ordinary path is asserted
+// beside it.
+func TestInitAgentsWritesAnOrdinaryInstructionFile(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "AGENTS.md"), []byte("# house rules\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	if err := Run(context.Background(), Options{Stdout: &out, Stderr: &out}, []string{"init-agents", "--repo", repo}); err != nil {
+		t.Fatalf("init-agents on an ordinary file: %v\n%s", err, out.String())
+	}
+	body, err := os.ReadFile(filepath.Join(repo, "AGENTS.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "house rules") {
+		t.Fatalf("the user's own text must survive:\n%s", body)
+	}
+}

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -2420,3 +2420,254 @@ func TestInitAgentsRefusesWhenTheManagedBlockWouldCrossTheReadLimit(t *testing.T
 		}
 	}
 }
+
+// TestInitAgentsRefusesManagedTargetInsideGitDirectory pins the landing that containment alone
+// cannot refuse. os.Root keeps the write inside the project root, and `.git` is inside the project
+// root, so a committed `CLAUDE.md -> .git/config` used to be followed: the managed block landed in
+// git's own config and git then refused to operate on the repository at all.
+//
+// Each case is a link that STAYS inside the repository, so none of them is an escape and none is
+// caught by the escape refusal above.
+func TestInitAgentsRefusesManagedTargetInsideGitDirectory(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name    string
+		managed string
+		victim  string
+		// linkSpelling overrides the symlink target text. It is set only where the point of
+		// the case is that the spelling and the landing differ.
+		linkSpelling string
+	}{
+		{name: "claude to git config", managed: "CLAUDE.md", victim: filepath.Join(".git", "config")},
+		{name: "agents to git hook", managed: "AGENTS.md", victim: filepath.Join(".git", "hooks", "pre-commit")},
+		{name: "guide to git config", managed: filepath.Join(".entire", "graph-agent.md"), victim: filepath.Join(".git", "config")},
+		{name: "nested checkout git config", managed: "AGENTS.md", victim: filepath.Join("vendor", "dep", ".git", "config")},
+		// A symlink target is text the repository chose, and macOS and Windows resolve it
+		// case-insensitively: an exact ".git" comparison is a bypass on both.
+		{name: "uppercase git spelling", managed: "CLAUDE.md", victim: filepath.Join(".git", "config"), linkSpelling: ".GIT/config"},
+		{name: "mixed case git spelling", managed: "CLAUDE.md", victim: filepath.Join(".git", "config"), linkSpelling: ".Git/config"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			repo := t.TempDir()
+
+			victimPath := filepath.Join(repo, testCase.victim)
+			if err := os.MkdirAll(filepath.Dir(victimPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			const victimContent = "[core]\n\tbare = false\n"
+			if err := os.WriteFile(victimPath, []byte(victimContent), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			managedPath := filepath.Join(repo, testCase.managed)
+			if err := os.MkdirAll(filepath.Dir(managedPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			relativeVictim, err := filepath.Rel(filepath.Dir(managedPath), victimPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if testCase.linkSpelling != "" {
+				if !caseInsensitiveFilesystem(t, repo) {
+					t.Skip("filesystem is case-sensitive, so this spelling names nothing")
+				}
+				relativeVictim = filepath.FromSlash(testCase.linkSpelling)
+			}
+			if err := os.Symlink(relativeVictim, managedPath); err != nil {
+				t.Skipf("symlinks unavailable: %v", err)
+			}
+
+			var out bytes.Buffer
+			runErr := Run(context.Background(), Options{Stdout: &out, Stderr: &out}, []string{"init-agents", "--repo", repo})
+			if runErr == nil {
+				t.Fatalf("init-agents wrote through a link into the git directory; output:\n%s", out.String())
+			}
+			if !strings.Contains(runErr.Error(), "git directory") {
+				t.Fatalf("error does not name the git directory: %v", runErr)
+			}
+
+			after, err := os.ReadFile(victimPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(after) != victimContent {
+				t.Fatalf("%s was written through:\n%s", testCase.victim, after)
+			}
+
+			// The refusal is a preflight for ALL managed targets, so nothing is installed.
+			for _, unwritten := range []string{"AGENTS.md", "CLAUDE.md", filepath.Join(".entire", "graph-agent.md")} {
+				if unwritten == testCase.managed {
+					continue
+				}
+				if _, err := os.Lstat(filepath.Join(repo, unwritten)); !os.IsNotExist(err) {
+					t.Fatalf("partial install: %s exists after the refusal (%v)", unwritten, err)
+				}
+			}
+		})
+	}
+}
+
+// TestInitAgentsRefusesIndirectRoutesIntoGitDirectory pins the refusal to the RESOLVED landing
+// rather than to the link's spelling. Both shapes below reach `.git/config` without naming it as a
+// plain relative path, so a check that read the symlink text would miss them: one is spelled as an
+// absolute path that re-enters the repository, the other reaches it in two hops through a
+// symlinked directory.
+func TestInitAgentsRefusesIndirectRoutesIntoGitDirectory(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name  string
+		build func(t *testing.T, repo string)
+	}{
+		{
+			name: "absolute target re-entering the repository",
+			build: func(t *testing.T, repo string) {
+				t.Helper()
+				if err := os.Symlink(filepath.Join(repo, ".git", "config"), filepath.Join(repo, "CLAUDE.md")); err != nil {
+					t.Skipf("symlinks unavailable: %v", err)
+				}
+			},
+		},
+		{
+			name: "two hops through a symlinked directory",
+			build: func(t *testing.T, repo string) {
+				t.Helper()
+				if err := os.MkdirAll(filepath.Join(repo, "sub"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(filepath.Join("..", ".git"), filepath.Join(repo, "sub", "glink")); err != nil {
+					t.Skipf("symlinks unavailable: %v", err)
+				}
+				if err := os.Symlink(filepath.Join("sub", "glink", "config"), filepath.Join(repo, "AGENTS.md")); err != nil {
+					t.Skipf("symlinks unavailable: %v", err)
+				}
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			repo := t.TempDir()
+			gitDir := filepath.Join(repo, ".git")
+			if err := os.MkdirAll(gitDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			const config = "[core]\n\tbare = false\n"
+			configPath := filepath.Join(gitDir, "config")
+			if err := os.WriteFile(configPath, []byte(config), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			testCase.build(t, repo)
+
+			var out bytes.Buffer
+			err := Run(context.Background(), Options{Stdout: &out, Stderr: &out}, []string{"init-agents", "--repo", repo})
+			if err == nil {
+				t.Fatalf("init-agents wrote through an indirect route into the git directory; output:\n%s", out.String())
+			}
+			if !strings.Contains(err.Error(), "git directory") {
+				t.Fatalf("error does not name the git directory: %v", err)
+			}
+			after, readErr := os.ReadFile(configPath)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if string(after) != config {
+				t.Fatalf("git config was written through:\n%s", after)
+			}
+		})
+	}
+}
+
+// TestInitAgentsRefusesGuideDirectoryAliasedToGitDirectory covers the directory target, which
+// resolves through resolveContainedDirectoryName rather than the file resolver: `.entire -> .git`
+// would otherwise have MkdirAll accept the git directory as the guide's home and drop
+// graph-agent.md inside it.
+func TestInitAgentsRefusesGuideDirectoryAliasedToGitDirectory(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	gitDir := filepath.Join(repo, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(".git", filepath.Join(repo, ".entire")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	var out bytes.Buffer
+	err := Run(context.Background(), Options{Stdout: &out, Stderr: &out}, []string{"init-agents", "--repo", repo})
+	if err == nil {
+		t.Fatalf("init-agents installed the guide into the git directory; output:\n%s", out.String())
+	}
+	if !strings.Contains(err.Error(), "git directory") {
+		t.Fatalf("error does not name the git directory: %v", err)
+	}
+	if _, statErr := os.Lstat(filepath.Join(gitDir, "graph-agent.md")); !os.IsNotExist(statErr) {
+		t.Fatalf("guide written inside the git directory (%v)", statErr)
+	}
+}
+
+// TestInitAgentsStillFollowsInRepositoryAliases guards the other side of the refusal above. The
+// git-directory landing is the only one being added; docs/agents.md documents in-repository
+// symlinks as supported, and both shapes it names must keep working.
+func TestInitAgentsStillFollowsInRepositoryAliases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("shared instruction file", func(t *testing.T) {
+		t.Parallel()
+		repo := t.TempDir()
+		if err := os.Symlink("AGENTS.md", filepath.Join(repo, "CLAUDE.md")); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+		var out bytes.Buffer
+		if err := Run(context.Background(), Options{Stdout: &out, Stderr: &out}, []string{"init-agents", "--repo", repo}); err != nil {
+			t.Fatalf("documented alias refused: %v\n%s", err, out.String())
+		}
+		agents, err := os.ReadFile(filepath.Join(repo, "AGENTS.md"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Count(string(agents), agentPointerBegin) != 1 {
+			t.Fatalf("shared instruction file did not receive exactly one block:\n%s", agents)
+		}
+	})
+
+	t.Run("link to an ordinary in-repository file", func(t *testing.T) {
+		t.Parallel()
+		repo := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(repo, "docs"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		target := filepath.Join(repo, "docs", "guide.md")
+		if err := os.WriteFile(target, []byte("# house rules\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(filepath.Join("docs", "guide.md"), filepath.Join(repo, "AGENTS.md")); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+		var out bytes.Buffer
+		if err := Run(context.Background(), Options{Stdout: &out, Stderr: &out}, []string{"init-agents", "--repo", repo}); err != nil {
+			t.Fatalf("documented alias refused: %v\n%s", err, out.String())
+		}
+		got, err := os.ReadFile(target)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(got), "# house rules") || !strings.Contains(string(got), agentPointerBegin) {
+			t.Fatalf("alias target not updated in place:\n%s", got)
+		}
+	})
+}
+
+// caseInsensitiveFilesystem asks the filesystem under dir rather than assuming from GOOS: a
+// case-sensitive volume on macOS and a case-insensitive one on Linux are both ordinary.
+func caseInsensitiveFilesystem(t *testing.T, dir string) bool {
+	t.Helper()
+	probe := filepath.Join(dir, ".case-probe")
+	if err := os.WriteFile(probe, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Remove(probe) }()
+	_, err := os.Stat(filepath.Join(dir, ".CASE-PROBE"))
+	return err == nil
+}

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -2023,6 +2023,14 @@ type aliasPlant struct {
 	name   string
 	target string
 	plant  func(t *testing.T, repo string) string
+	// refusedEvenIfTheKernelCanReachIt marks a landing init-agents refuses on purpose whatever
+	// the kernel says, because it is inside the git directory. The oracle below otherwise
+	// requires agreement with the kernel, and that requirement is exactly what this exception
+	// exists to bound: on a platform whose path rules make one of these spellings reachable —
+	// Windows, which collapses ".." lexically before opening anything — "agree with the
+	// kernel" means "install the managed block into .git/config", which is the bug, not the
+	// contract.
+	refusedEvenIfTheKernelCanReachIt bool
 }
 
 // untraversableAliasPlants are the in-repository alias spellings whose landing exists only after
@@ -2096,8 +2104,9 @@ var untraversableAliasPlants = []aliasPlant{
 		},
 	},
 	{
-		name:   "landing inside the git directory",
-		target: "AGENTS.md",
+		name:                             "landing inside the git directory",
+		target:                           "AGENTS.md",
+		refusedEvenIfTheKernelCanReachIt: true,
 		plant: func(t *testing.T, repo string) string {
 			t.Helper()
 			victim := filepath.Join(repo, ".git", "config")
@@ -2166,7 +2175,9 @@ func TestInitAgentsRefusesAliasCollapsingUntraversableComponent(t *testing.T) {
 // than restate the kernel's path rules — restating them is how the collapse came to be written —
 // it asks the filesystem what each spelling does and requires init-agents to agree: install
 // exactly when the kernel can open that path, refuse when it cannot, and, when both succeed, land
-// on the file the kernel's own resolution reaches. Every alias here stays inside the repository,
+// on the file the kernel's own resolution reaches. The single exception is a landing inside the
+// git directory, which is refused whatever the kernel answers; see
+// refusedEvenIfTheKernelCanReachIt. Every alias here stays inside the repository,
 // which is what makes the two comparable; an alias that leaves is refused by design and is covered
 // by TestInitAgentsRefusesAbsoluteAliasLeavingRepository.
 func TestInitAgentsAliasResolutionMatchesTheKernel(t *testing.T) {
@@ -2224,6 +2235,18 @@ func TestInitAgentsAliasResolutionMatchesTheKernel(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 			err := Run(context.Background(), Options{Stdout: &stdout, Stderr: &stderr}, []string{"init-agents", "--repo", repo})
 
+			if tt.refusedEvenIfTheKernelCanReachIt {
+				// The one deliberate divergence. Reachability is the kernel's to answer and
+				// it is not the question here: a landing in the git directory is refused
+				// whether the kernel could take the path or not.
+				if err == nil {
+					t.Fatalf("init-agents installed into the git directory; the kernel reaching it (%v) does not make it a legal landing", kernelErr)
+				}
+				if !strings.Contains(err.Error(), "git directory") && !strings.Contains(err.Error(), "cannot resolve") {
+					t.Fatalf("refusal named neither the git directory nor an unresolvable path: %v", err)
+				}
+				return
+			}
 			if (kernelErr == nil) != (err == nil) {
 				t.Fatalf("init-agents disagreed with the filesystem about %s:\nkernel: %v\n  init: %v", tt.target, kernelErr, err)
 			}
@@ -2481,12 +2504,7 @@ func TestInitAgentsRefusesManagedTargetInsideGitDirectory(t *testing.T) {
 
 			var out bytes.Buffer
 			runErr := Run(context.Background(), Options{Stdout: &out, Stderr: &out}, []string{"init-agents", "--repo", repo})
-			if runErr == nil {
-				t.Fatalf("init-agents wrote through a link into the git directory; output:\n%s", out.String())
-			}
-			if !strings.Contains(runErr.Error(), "git directory") {
-				t.Fatalf("error does not name the git directory: %v", runErr)
-			}
+			requireGitDirRefusal(t, runErr, out.String())
 
 			after, err := os.ReadFile(victimPath)
 			if err != nil {
@@ -2562,12 +2580,7 @@ func TestInitAgentsRefusesIndirectRoutesIntoGitDirectory(t *testing.T) {
 
 			var out bytes.Buffer
 			err := Run(context.Background(), Options{Stdout: &out, Stderr: &out}, []string{"init-agents", "--repo", repo})
-			if err == nil {
-				t.Fatalf("init-agents wrote through an indirect route into the git directory; output:\n%s", out.String())
-			}
-			if !strings.Contains(err.Error(), "git directory") {
-				t.Fatalf("error does not name the git directory: %v", err)
-			}
+			requireGitDirRefusal(t, err, out.String())
 			after, readErr := os.ReadFile(configPath)
 			if readErr != nil {
 				t.Fatal(readErr)
@@ -2596,12 +2609,7 @@ func TestInitAgentsRefusesGuideDirectoryAliasedToGitDirectory(t *testing.T) {
 
 	var out bytes.Buffer
 	err := Run(context.Background(), Options{Stdout: &out, Stderr: &out}, []string{"init-agents", "--repo", repo})
-	if err == nil {
-		t.Fatalf("init-agents installed the guide into the git directory; output:\n%s", out.String())
-	}
-	if !strings.Contains(err.Error(), "git directory") {
-		t.Fatalf("error does not name the git directory: %v", err)
-	}
+	requireGitDirRefusal(t, err, out.String())
 	if _, statErr := os.Lstat(filepath.Join(gitDir, "graph-agent.md")); !os.IsNotExist(statErr) {
 		t.Fatalf("guide written inside the git directory (%v)", statErr)
 	}
@@ -2670,4 +2678,19 @@ func caseInsensitiveFilesystem(t *testing.T, dir string) bool {
 	defer func() { _ = os.Remove(probe) }()
 	_, err := os.Stat(filepath.Join(dir, ".CASE-PROBE"))
 	return err == nil
+}
+
+// requireGitDirRefusal asserts the refusal without over-fitting its wording to one platform. The
+// landing is what matters; the ROUTE to it can fail first for a reason that is not this rule.
+// Windows decides a symlink's type when it is created and cannot traverse a file link as a
+// directory, so a multi-hop or directory-valued spelling can be refused as unresolvable there and
+// as a git-directory landing everywhere else. Both are refusals of the same write.
+func requireGitDirRefusal(t *testing.T, err error, out string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("init-agents wrote into the git directory; output:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "git directory") && !strings.Contains(err.Error(), "cannot resolve") {
+		t.Fatalf("refusal named neither the git directory nor an unresolvable path: %v", err)
+	}
 }

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -2771,3 +2771,128 @@ func TestInitAgentsWritesAnOrdinaryInstructionFile(t *testing.T) {
 		t.Fatalf("the user's own text must survive:\n%s", body)
 	}
 }
+
+// plantGitAdministrativeDirectory builds a git administrative directory at dir that is NOT named
+// `.git`, so the name rule cannot see it. It is written by hand rather than by shelling out to
+// `git init --separate-git-dir`, so the test states exactly which structure the refusal keys on and
+// needs no git binary; the layout is the one `git init` produces and the one git's own
+// is_git_directory() recognises.
+func plantGitAdministrativeDirectory(t *testing.T, dir string) {
+	t.Helper()
+	mkdirAllForTest(t, filepath.Join(dir, "objects"))
+	mkdirAllForTest(t, filepath.Join(dir, "refs", "heads"))
+	mkdirAllForTest(t, filepath.Join(dir, "hooks"))
+	writeFileForTest(t, filepath.Join(dir, "HEAD"), "ref: refs/heads/main\n")
+	writeFileForTest(t, filepath.Join(dir, "config"), gitAdministrativeConfig)
+}
+
+const gitAdministrativeConfig = "[core]\n\trepositoryformatversion = 0\n\tbare = false\n"
+
+// TestInitAgentsRefusesGitDirectoryNotNamedDotGit pins the git-directory refusal to the directory
+// git actually uses rather than to the name `.git`.
+//
+// sem.PathLandsInGitDir judges a repo-relative STRING, so it refuses a landing that SPELLS a `.git`
+// component and nothing else. Git does not require that spelling: `git init --separate-git-dir=admin`
+// leaves a `.git` POINTER FILE and puts the real administrative directory at `admin/`, and a
+// repository initialised under GIT_DIR has no `.git` entry at all. Measured on this branch before
+// the fix, in a `--separate-git-dir` repository: `CLAUDE.md -> admin/config` exited 0 with the
+// managed block appended to git's real config, after which every git command failed with "fatal:
+// bad config line 9".
+//
+// The `.entire` case is the one no filename rule can catch. Its landing is `graph-agent.md`, an
+// ordinary markdown name that the instruction-file allowlist admits — it is refused only because of
+// WHERE it lands, which is inside the real ref store.
+func TestInitAgentsRefusesGitDirectoryNotNamedDotGit(t *testing.T) {
+	t.Parallel()
+	skipIfSymlinksUnrepresentable(t)
+
+	for _, testCase := range []struct {
+		name string
+		// build plants the repository and returns the file that must not be written.
+		build func(t *testing.T, repo string) string
+	}{
+		{
+			name: "gitlink pointer to an in-tree administrative directory",
+			build: func(t *testing.T, repo string) string {
+				t.Helper()
+				plantGitAdministrativeDirectory(t, filepath.Join(repo, "admin"))
+				writeFileForTest(t, filepath.Join(repo, ".git"), "gitdir: admin\n")
+				symlinkForTest(t, filepath.Join("admin", "config"), filepath.Join(repo, "CLAUDE.md"))
+				return filepath.Join(repo, "admin", "config")
+			},
+		},
+		{
+			name: "administrative directory with no gitlink at all",
+			build: func(t *testing.T, repo string) string {
+				t.Helper()
+				plantGitAdministrativeDirectory(t, filepath.Join(repo, "admin"))
+				hook := filepath.Join(repo, "admin", "hooks", "pre-commit")
+				writeFileForTest(t, hook, "#!/bin/sh\nexit 0\n")
+				symlinkForTest(t, filepath.Join("admin", "hooks", "pre-commit"), filepath.Join(repo, "AGENTS.md"))
+				return hook
+			},
+		},
+		{
+			name: "guide directory alias into the real ref store",
+			build: func(t *testing.T, repo string) string {
+				t.Helper()
+				plantGitAdministrativeDirectory(t, filepath.Join(repo, "admin"))
+				writeFileForTest(t, filepath.Join(repo, ".git"), "gitdir: admin\n")
+				symlinkForTest(t, filepath.Join("admin", "refs", "heads"), filepath.Join(repo, ".entire"))
+				return filepath.Join(repo, "admin", "refs", "heads", "graph-agent.md")
+			},
+		},
+		{
+			name: "administrative directory with no object or ref store",
+			build: func(t *testing.T, repo string) string {
+				t.Helper()
+				// A linked worktree's administrative directory keeps commondir and gitdir
+				// in place of its own object and ref stores, so a test that asked only for
+				// those two would not recognise it.
+				worktreeAdmin := filepath.Join(repo, "wt")
+				mkdirAllForTest(t, worktreeAdmin)
+				writeFileForTest(t, filepath.Join(worktreeAdmin, "HEAD"), "ref: refs/heads/main\n")
+				writeFileForTest(t, filepath.Join(worktreeAdmin, "commondir"), "../..\n")
+				victim := filepath.Join(worktreeAdmin, "gitdir")
+				writeFileForTest(t, victim, "/elsewhere/.git\n")
+				writeFileForTest(t, filepath.Join(repo, ".git"), "gitdir: wt\n")
+				symlinkForTest(t, filepath.Join("wt", "gitdir"), filepath.Join(repo, "CLAUDE.md"))
+				return victim
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			repo := t.TempDir()
+			victim := testCase.build(t, repo)
+			before, existed := "", false
+			if content, err := os.ReadFile(victim); err == nil {
+				before, existed = string(content), true
+			}
+
+			var out bytes.Buffer
+			runErr := Run(context.Background(), Options{Stdout: &out, Stderr: &out}, []string{"init-agents", "--repo", repo})
+			requireGitDirRefusal(t, runErr, out.String())
+
+			if existed {
+				if got := readFileForTest(t, victim); got != before {
+					t.Fatalf("%s was written through:\nwant: %q\n got: %q", victim, before, got)
+				}
+			} else if _, statErr := os.Lstat(victim); !os.IsNotExist(statErr) {
+				t.Fatalf("%s was created inside the git directory (stat error %v)", victim, statErr)
+			}
+			for _, unwritten := range []string{"AGENTS.md", "CLAUDE.md", filepath.Join(".entire", "graph-agent.md")} {
+				path := filepath.Join(repo, unwritten)
+				info, statErr := os.Lstat(path)
+				if os.IsNotExist(statErr) {
+					continue
+				}
+				if statErr == nil && info.Mode()&os.ModeSymlink != 0 {
+					// The planted alias itself, untouched.
+					continue
+				}
+				t.Fatalf("partial install: %s exists after the refusal (%v)", unwritten, statErr)
+			}
+		})
+	}
+}

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -10999,6 +10999,34 @@ func hasGitDirComponent(rel string) bool {
 	return false
 }
 
+// PathLandsInGitDir reports whether a repo-relative path RESOLVES into a git directory. It
+// answers hasGitDirComponent's question for a caller outside this package that is about to hand
+// the path to the KERNEL, rather than reading the name back out of a directory walk.
+//
+// Everything above about depth applies here unchanged — a nested checkout's `vendor/dep/.git` and
+// a linked worktree's `.git` pointer file are both git directories — and this deliberately reuses
+// that whole-component rule rather than inventing a second one.
+//
+// It differs in exactly one way, and the difference belongs to the filesystem rather than to
+// taste. hasGitDirComponent judges names the walker ENUMERATED, which are the names as they exist
+// on disk. This judges a name the caller RESOLVED — on the far end of a symlink chain whose text a
+// repository chose — and on the two platforms most development happens on, macOS and Windows, the
+// kernel matches that text case-insensitively: a committed `CLAUDE.md -> .GIT/config` opens
+// `.git/config`. An exact comparison is a bypass on precisely those platforms, so this folds.
+//
+// Folding where the filesystem does not can only refuse a path through a directory genuinely
+// named `.GIT`, which is not a git directory — and is not an instruction file's home either. The
+// trade therefore runs the safe way: it fails closed, and only on a spelling nothing legitimate
+// uses.
+func PathLandsInGitDir(rel string) bool {
+	for _, component := range strings.Split(filepath.ToSlash(rel), "/") {
+		if strings.EqualFold(component, ".git") {
+			return true
+		}
+	}
+	return false
+}
+
 // maxGitPointerBytes bounds how much of a `commondir` file is READ. It bounds
 // the read, not the file: `commondir` carries no size limit of git's own, so
 // this is a read-safety bound this tool chooses, not one git enforces. See


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/117
<!-- entire-trail-link-end -->

## Impact

`init-agents` follows a repository-committed symlink into the repository's own git directory and writes the managed block through it. A hostile checkout that commits

    CLAUDE.md -> .git/config

gets the pointer block appended to git's own config, and git then refuses to operate on the repository at all:

    fatal: bad config line 9 in file .git/config

`.git/hooks/*` is the same primitive aimed somewhere worse. The tool also reports the write as `updated .../CLAUDE.md`, so the file it actually damaged is never named.

This is the same class as #136/#137 at a call site those did not reach. #137 confined `init-agents` to the repository root; `--report` / `--record-baseline` (#136) additionally refuse a symlinked component, and `outputpath.go` says why in as many words: os.Root "stops the write leaving the root, but it happily FOLLOWS a link that stays inside it (on every platform, Windows included), and `.git/config` is inside it." `init-agents` kept only the containment half, and `runInitAgents` records the reasoning that made that look sufficient — a link "that stays inside the repository is still followed — which is what the documented AGENTS.md/CLAUDE.md alias needs". That is true of repository *content* and false of `.git`, which is inside the root and is not content.

`docs/trust-and-security.md` claimed `init-agents` "writes through exactly three repository paths". It wrote through a fourth.

## Repro (before this change)

    mkdir -p /tmp/hostile && cd /tmp/hostile && git init -q .
    printf 'package main\nfunc main(){}\n' > main.go
    ln -s .git/config CLAUDE.md
    git add -A && git commit -qm x

    entire-graph init-agents --repo .
    # wrote    /tmp/hostile/.entire/graph-agent.md
    # updated  /tmp/hostile/AGENTS.md
    # updated  /tmp/hostile/CLAUDE.md      <- actually .git/config

    git status
    # fatal: bad config line 9 in file .git/config

`ln -s .GIT/config CLAUDE.md` does the same on macOS and Windows, and is the reason the fix folds case.

## Fix

Refuse a managed target whose resolution lands inside a git directory — `.git` at any depth, including a nested checkout's `vendor/dep/.git` and a linked worktree's `.git` pointer file.

The check sits on `resolveContainedNameWithOptions`, the single resolver every stat, read and write of a managed target goes through, rather than on the preflight. `ensureContainedInRepo` is explicitly documented as not atomic with the write, so a preflight-only check would be passed by a link swapped in afterwards; on the resolver each operation re-asks, and the one that finds the swapped link refuses it. It also covers the directory target, where `.entire -> .git` would otherwise make the git directory the guide's home.

The comparison folds case, which is the second half of the bug. A symlink target is text the *repository* chose, and macOS and Windows resolve it case-insensitively, so `CLAUDE.md -> .GIT/config` opens `.git/config` and walks past an exact `".git"` comparison. Folding where the filesystem does not can only refuse a path through a directory genuinely named `.GIT`, which is not a git directory and not an instruction file's home either, so the trade fails closed.

"Inside a git directory" is not restated. `sem.hasGitDirComponent` already answers it for the indexer — whole component, any depth, `.git` files included — and the new `sem.PathLandsInGitDir` sits beside it, reusing that rule and documenting the one deliberate difference. `hasGitDirComponent` itself stays exact: its only other caller, `skipVendoredDir`, judges names that came out of a directory *walk*, where the kernel's matching rules never enter, so folding there would change indexing semantics for no gain. A writer that will not read inside a git directory (#132) must not write there either.

The refusal is classified apart from `isRootEscape`: the link stays comfortably inside the root, so calling it an escape would send the reader hunting a link that leaves when none does.

Everything `docs/agents.md` documents still works and is now pinned by tests — the shared-instruction-file alias (`CLAUDE.md -> AGENTS.md`) and an in-repository symlink to an ordinary file (`AGENTS.md -> docs/guide.md`). Both docs are corrected.

## Mutation verification

Two mutations, because the fix has two independent halves.

**A — disable the predicate** (`if false && strings.EqualFold(...)`): all 6 refusal subtests fail with `init-agents wrote through a link into the git directory`, as does the directory-alias test. The 2 alias subtests keep passing in both states, so they are not vacuous and the refusal is not achieving them by breaking the feature.

**B — keep the predicate, drop only the fold** (`component == ".git"`): fails exactly the 2 subtests that exist for it, `uppercase git spelling` and `mixed case git spelling`, and nothing else. The fold is load-bearing and separately pinned.

The refusal tests also assert no partial install: the other managed files must not exist after the error. The case-spelling cases probe the filesystem for case-insensitivity and skip on a case-sensitive volume rather than assuming from GOOS.

## Gate

`go build ./...`, `go vet ./...` and `gofmt` are clean, and `go test ./...` passed in full before the final case-fold commit; the init-agents suite (`-run TestInitAgents`, 139 tests) is green in 5s.

The full `-race` gate was not completed locally. `mise run check` fails on this machine with `panic: test timed out after 10m0s` in both `internal/cli` and `internal/sem` and zero `--- FAIL` subtests, which is Go's default per-package timeout under a load average around 20. The control settles it: the same `go test -timeout 9m ./internal/cli/` on an unmodified `origin/main` worktree times out at **540.7s**, against **542.7s** on this branch. The timeout is environmental and pre-existing, not this change. CI on a clean runner is the gate that matters here.
