### PR TITLE
fix(sem): resolve bare calls to Julia module-scoped functions

### DIFF
--- a/internal/sem/golden_test.go
+++ b/internal/sem/golden_test.go
@@ -895,3 +895,41 @@ func TestJuliaShortFormAndNestedModuleScope(t *testing.T) {
 		t.Errorf("a nested module's own body call was rejected: %v", edges)
 	}
 }
+
+// TestJuliaOneLineLongFormDefinitionIsNotTheModuleBody pins the last shape the module-body
+// narrowing has to handle.
+//
+// A long-form definition written on ONE line -- `function f(); helper(); end` -- has no
+// body line to blank, and masking its head alone left the body in the module's block, so
+// the module was credited with the call its child makes. The definition is masked
+// textually instead, from its head through the MATCHING `end`; depth is counted over
+// Julia's block openers, because a definition may contain them and the first `end` is
+// then not its own.
+func TestJuliaOneLineLongFormDefinitionIsNotTheModuleBody(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "m.jl"),
+		[]byte("module M; helper()=1; function f(); helper(); end; end\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, symbol := range snapshot.Symbols {
+		symbolsByID[symbol.ID] = symbol
+	}
+	edges := map[string]bool{}
+	for _, relation := range snapshot.Relations {
+		if relation.Type == "CALLS" {
+			edges[symbolsByID[relation.FromID].QualifiedName+" -> "+symbolsByID[relation.ToID].QualifiedName] = true
+		}
+	}
+	if edges["M -> M.helper"] {
+		t.Errorf("the module was credited with a call inside its child's one-line body: %v", edges)
+	}
+	if !edges["M.f -> M.helper"] {
+		t.Errorf("the child's own call was masked away with it: %v", edges)
+	}
+}

--- a/internal/sem/golden_test.go
+++ b/internal/sem/golden_test.go
@@ -977,3 +977,38 @@ func TestJuliaShortFormWithReturnTypeOrConstraint(t *testing.T) {
 		}
 	}
 }
+
+// TestJuliaBlockMaskIgnoresEndInsideAString pins what counts as a block terminator.
+//
+// `function f(); println("end"); helper(); end` contains the word `end` inside a STRING.
+// Counting it as syntax ended the mask early and left the rest of the definition -- every
+// call in it -- attributed to the enclosing module, which is the fabrication the mask
+// exists to prevent, produced by the mask itself.
+func TestJuliaBlockMaskIgnoresEndInsideAString(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "m.jl"),
+		[]byte("module M; helper()=1; function f(); println(\"end\"); helper(); end; end\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, symbol := range snapshot.Symbols {
+		symbolsByID[symbol.ID] = symbol
+	}
+	edges := map[string]bool{}
+	for _, relation := range snapshot.Relations {
+		if relation.Type == "CALLS" {
+			edges[symbolsByID[relation.FromID].QualifiedName+" -> "+symbolsByID[relation.ToID].QualifiedName] = true
+		}
+	}
+	if edges["M -> M.helper"] {
+		t.Errorf("the mask stopped at a string and left the body to the module: %v", edges)
+	}
+	if !edges["M.f -> M.helper"] {
+		t.Errorf("the definition's own call was lost: %v", edges)
+	}
+}

--- a/internal/sem/golden_test.go
+++ b/internal/sem/golden_test.go
@@ -802,3 +802,50 @@ func TestJuliaModuleOwnsOnlyItsOwnBodyAndOnlyItsOwnScope(t *testing.T) {
 		}
 	}
 }
+
+// TestJuliaOneLineModuleKeepsItsOwnCall pins the module-body scan against a module whose
+// child shares its line.
+//
+// `module M; setup() = 1; setup(); end` puts the module, its child and a real module-level
+// call on ONE line. Blanking the child's lines therefore deleted the call the narrowing
+// exists to keep, and a SymbolRecord carries only line numbers, so there is no byte range
+// to mask instead. The child's BODY is blanked and its definition HEAD is masked by name,
+// which says the same thing without deleting whatever else shares the line.
+func TestJuliaOneLineModuleKeepsItsOwnCall(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	for name, content := range map[string]string{
+		"one.jl":  "module M; setup() = 1; setup(); end\n",
+		"many.jl": "module N\nfunction helper()\n    return 1\nend\nfunction go()\n    helper()\nend\nhelper()\nend\n",
+	} {
+		if err := os.WriteFile(filepath.Join(repo, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, symbol := range snapshot.Symbols {
+		symbolsByID[symbol.ID] = symbol
+	}
+	edges := map[string]bool{}
+	for _, relation := range snapshot.Relations {
+		if relation.Type == "CALLS" {
+			edges[symbolsByID[relation.FromID].QualifiedName+" -> "+symbolsByID[relation.ToID].QualifiedName] = true
+		}
+	}
+	for _, want := range []string{
+		"M -> M.setup",  // the one-line module still owns its own call
+		"N -> N.helper", // a module-level call in a multi-line module
+		"N.go -> N.helper",
+	} {
+		if !edges[want] {
+			t.Errorf("missing edge %q; got %v", want, edges)
+		}
+	}
+	if edges["N -> N.go"] {
+		t.Errorf("a definition head was read as a call: %v", edges)
+	}
+}

--- a/internal/sem/golden_test.go
+++ b/internal/sem/golden_test.go
@@ -684,3 +684,61 @@ func TestHeuristicRelationTypesMatchDocumentation(t *testing.T) {
 		}
 	}
 }
+
+// TestJuliaBareCallStaysInsideItsOwnLanguageAndScope pins the two edges the Julia method
+// arm must not create.
+//
+// Admitting method targets is what lets a bare `name(args...)` -- Julia's only call form
+// -- reach a module-scoped definition. Two things ride along with it unless refused. The
+// global fallback it draws on is language-agnostic, so an unresolved call bound to a
+// globally unique JAVA method of the same name, which Julia cannot invoke. And a
+// `module M ... end` block spans every nested definition, so scanning the module's own
+// text saw the call names written inside its FUNCTIONS and credited the module with
+// making them -- the same call appearing twice, once from the function that made it and
+// once from a symbol that did not.
+//
+// The intra-module case is asserted alongside because both fixes withdraw candidates, and
+// a withdrawal that also drops the real edge has traded one wrong answer for another.
+func TestJuliaBareCallStaysInsideItsOwnLanguageAndScope(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+
+	writeFileForTest := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(repo, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFileForTest("m.jl", "module M\nfunction go()\n    runTask()\nend\nend\n")
+	writeFileForTest("T.java", "public class T { void runTask() { } }\n")
+	writeFileForTest("n.jl", "module N\nfunction outer()\n    inner()\nend\nfunction inner()\n    return 1\nend\nend\n")
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, symbol := range snapshot.Symbols {
+		symbolsByID[symbol.ID] = symbol
+	}
+
+	intraModule := 0
+	for _, relation := range snapshot.Relations {
+		if relation.Type != "CALLS" {
+			continue
+		}
+		from, to := symbolsByID[relation.FromID], symbolsByID[relation.ToID]
+		if from.Language == "Julia" && to.Language != "Julia" {
+			t.Errorf("Julia %s resolved a bare call to %s/%s, which it cannot invoke", from.Name, to.Language, to.Name)
+		}
+		if from.Language == "Julia" && from.Kind == "module" {
+			t.Errorf("module %s credited with calling %s; the call belongs to the function that wrote it", from.Name, to.Name)
+		}
+		if from.Name == "outer" && to.Name == "inner" {
+			intraModule++
+		}
+	}
+	if intraModule != 1 {
+		t.Fatalf("the legitimate intra-module call outer -> inner was withdrawn too (found %d)", intraModule)
+	}
+}

--- a/internal/sem/golden_test.go
+++ b/internal/sem/golden_test.go
@@ -742,3 +742,63 @@ func TestJuliaBareCallStaysInsideItsOwnLanguageAndScope(t *testing.T) {
 		t.Fatalf("the legitimate intra-module call outer -> inner was withdrawn too (found %d)", intraModule)
 	}
 }
+
+// TestJuliaModuleOwnsOnlyItsOwnBodyAndOnlyItsOwnScope pins the two boundaries a Julia
+// bare call sits inside.
+//
+// SCOPE: a module is a hard namespace boundary in every file. From outside M its
+// definitions are reachable as `M.name(...)` and no other way, so a bare call in one
+// module must not bind a same-named method of another just because their files differ.
+//
+// BODY: a `module M ... end` block spans every definition under it, so scanning it whole
+// credited the module with the calls its FUNCTIONS make. Refusing the module outright
+// fixed that and took a real edge with it -- `setup()` written at module scope has no
+// other symbol to belong to. The module owns what its own body runs, and nothing else.
+func TestJuliaModuleOwnsOnlyItsOwnBodyAndOnlyItsOwnScope(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	for name, content := range map[string]string{
+		"a.jl": "module A\nfunction alpha()\n    return 1\nend\nend\n",
+		"b.jl": "module B\nfunction caller()\n    alpha()\nend\nend\n",
+		"m.jl": "module M\nfunction setup()\n    return 1\nend\nfunction helper()\n    return 2\nend\nfunction go()\n    helper()\nend\nsetup()\nend\n",
+	} {
+		if err := os.WriteFile(filepath.Join(repo, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, symbol := range snapshot.Symbols {
+		symbolsByID[symbol.ID] = symbol
+	}
+
+	edges := map[string]bool{}
+	for _, relation := range snapshot.Relations {
+		if relation.Type != "CALLS" {
+			continue
+		}
+		from, to := symbolsByID[relation.FromID], symbolsByID[relation.ToID]
+		edges[from.QualifiedName+" -> "+to.QualifiedName] = true
+	}
+
+	for _, want := range []string{
+		"M.go -> M.helper", // a nested call belongs to the function that wrote it
+		"M -> M.setup",     // a module-body call belongs to the module
+	} {
+		if !edges[want] {
+			t.Errorf("missing edge %q; got %v", want, edges)
+		}
+	}
+	for _, unwanted := range []string{
+		"B.caller -> A.alpha", // crosses a module boundary, so it needs A.alpha(...)
+		"M -> M.helper",       // written inside go(), not in the module body
+	} {
+		if edges[unwanted] {
+			t.Errorf("edge %q must not be emitted; got %v", unwanted, edges)
+		}
+	}
+}

--- a/internal/sem/golden_test.go
+++ b/internal/sem/golden_test.go
@@ -933,3 +933,47 @@ func TestJuliaOneLineLongFormDefinitionIsNotTheModuleBody(t *testing.T) {
 		t.Errorf("the child's own call was masked away with it: %v", edges)
 	}
 }
+
+// TestJuliaShortFormWithReturnTypeOrConstraint pins the shapes a short-form definition
+// may take before its `=`.
+//
+// Julia writes a return type or a constraint between the argument list and the equals
+// sign -- `f(x)::Int = helper()` and `g(x) where T = helper()` are both definitions.
+// Requiring `=` to follow the parenthesis immediately left those bodies in the module's
+// block, so the module was credited both with defining them and with every call they make.
+func TestJuliaShortFormWithReturnTypeOrConstraint(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	for name, content := range map[string]string{
+		"s.jl": "module S\nhelper() = 1\nf(x)::Int = helper()\nend\n",
+		"w.jl": "module W\nhelper() = 1\ng(x) where T = helper()\nend\n",
+	} {
+		if err := os.WriteFile(filepath.Join(repo, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, symbol := range snapshot.Symbols {
+		symbolsByID[symbol.ID] = symbol
+	}
+	edges := map[string]bool{}
+	for _, relation := range snapshot.Relations {
+		if relation.Type == "CALLS" {
+			edges[symbolsByID[relation.FromID].QualifiedName+" -> "+symbolsByID[relation.ToID].QualifiedName] = true
+		}
+	}
+	for _, want := range []string{"S.f -> S.helper", "W.g -> W.helper"} {
+		if !edges[want] {
+			t.Errorf("the definition's own call was lost: missing %q in %v", want, edges)
+		}
+	}
+	for _, unwanted := range []string{"S -> S.helper", "S -> S.f", "W -> W.helper", "W -> W.g"} {
+		if edges[unwanted] {
+			t.Errorf("the module was credited with %q: %v", unwanted, edges)
+		}
+	}
+}

--- a/internal/sem/golden_test.go
+++ b/internal/sem/golden_test.go
@@ -849,3 +849,49 @@ func TestJuliaOneLineModuleKeepsItsOwnCall(t *testing.T) {
 		t.Errorf("a definition head was read as a call: %v", edges)
 	}
 }
+
+// TestJuliaShortFormAndNestedModuleScope pins two shapes the module-body narrowing has to
+// get right.
+//
+// SHORT FORM: `f() = helper()` is one line, so no body line is blanked for it. Masking
+// only the definition HEAD left `helper()` in the module's block and credited the module
+// with a call its child makes. The mask now covers the right-hand side too.
+//
+// NESTED MODULE: a child of `Outer.Inner` records its container qualified, so comparing
+// the module's SHORT name rejected every module-body call inside a nested module before
+// the same-container check could accept it.
+func TestJuliaShortFormAndNestedModuleScope(t *testing.T) {
+	t.Parallel()
+	repo := t.TempDir()
+	for name, content := range map[string]string{
+		"sf.jl":   "module S\nhelper() = 1\nf() = helper()\nend\n",
+		"nest.jl": "module Outer\nmodule Inner\nfunction setup()\n    return 1\nend\nsetup()\nend\nend\n",
+	} {
+		if err := os.WriteFile(filepath.Join(repo, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbolsByID := map[string]SymbolRecord{}
+	for _, symbol := range snapshot.Symbols {
+		symbolsByID[symbol.ID] = symbol
+	}
+	edges := map[string]bool{}
+	for _, relation := range snapshot.Relations {
+		if relation.Type == "CALLS" {
+			edges[symbolsByID[relation.FromID].QualifiedName+" -> "+symbolsByID[relation.ToID].QualifiedName] = true
+		}
+	}
+	if !edges["S.f -> S.helper"] {
+		t.Errorf("the short-form child's own call was lost: %v", edges)
+	}
+	if edges["S -> S.helper"] {
+		t.Errorf("the module was credited with a call its child makes: %v", edges)
+	}
+	if !edges["Inner -> Inner.setup"] {
+		t.Errorf("a nested module's own body call was rejected: %v", edges)
+	}
+}

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -1944,11 +1944,19 @@ func juliaModuleScopedTargetReachable(from, to SymbolRecord) bool {
 func juliaModuleOwnBlock(from SymbolRecord, block string, fileSymbols []SymbolRecord) string {
 	lines := strings.Split(block, "\n")
 	var childNames []string
+	var oneLineChildren []string
 	for _, child := range fileSymbols {
 		if child.ID == from.ID || child.ContainerID != from.ID {
 			continue
 		}
 		childNames = append(childNames, child.Name)
+		if child.StartLine == child.EndLine {
+			// Entirely on one line, so the body-blanking below has no line to
+			// take and the head mask alone leaves the body in place. Masked
+			// textually instead, from `function name` through its matching
+			// `end`.
+			oneLineChildren = append(oneLineChildren, child.Name)
+		}
 		// The child's BODY is blanked, but not the line its definition starts
 		// on. A one-line module -- `module M; setup() = 1; setup(); end` -- puts
 		// the child, the module and a real module-level call on that same line,
@@ -1961,7 +1969,65 @@ func juliaModuleOwnBlock(from SymbolRecord, block string, fileSymbols []SymbolRe
 			}
 		}
 	}
-	return juliaMaskDefinitionHeads(strings.Join(lines, "\n"), childNames)
+	masked := strings.Join(lines, "\n")
+	for _, name := range oneLineChildren {
+		masked = juliaMaskLongFormDefinition(masked, name)
+	}
+	return juliaMaskDefinitionHeads(masked, childNames)
+}
+
+// juliaMaskLongFormDefinition blanks `function name ... end` through its MATCHING
+// `end`, leaving everything around it.
+//
+// It exists for a definition that occupies a single line, where there is no body
+// line to blank and masking the head alone leaves the body in the module's block:
+// `module M; helper()=1; function f(); helper(); end; end` credited the module with
+// calling helper, and cross-attributed the children to each other.
+//
+// Depth is counted over Julia's block openers, because a definition may contain
+// them and the FIRST `end` is then not its own.
+func juliaMaskLongFormDefinition(block, name string) string {
+	head := regexp.MustCompile(`\bfunction\s+` + regexp.QuoteMeta(name) + `\b`)
+	openers := regexp.MustCompile(`\b(function|if|for|while|begin|let|do|try|quote|struct|module|macro)\b`)
+	end := regexp.MustCompile(`\bend\b`)
+	for {
+		where := head.FindStringIndex(block)
+		if where == nil {
+			return block
+		}
+		depth, cursor := 0, where[0]
+		for cursor < len(block) {
+			nextOpen := openers.FindStringIndex(block[cursor:])
+			nextEnd := end.FindStringIndex(block[cursor:])
+			if nextEnd == nil {
+				// Unterminated: mask to the end rather than leave the body.
+				return maskRangeKeepingNewlines(block, where[0], len(block))
+			}
+			if nextOpen != nil && nextOpen[0] < nextEnd[0] {
+				depth++
+				cursor += nextOpen[1]
+				continue
+			}
+			depth--
+			cursor += nextEnd[1]
+			if depth == 0 {
+				return maskRangeKeepingNewlines(block, where[0], cursor)
+			}
+		}
+		return maskRangeKeepingNewlines(block, where[0], len(block))
+	}
+}
+
+// maskRangeKeepingNewlines blanks [start,stop) but keeps line breaks, so every
+// offset and line number around the masked span is unchanged.
+func maskRangeKeepingNewlines(block string, start, stop int) string {
+	out := []byte(block)
+	for i := start; i < stop && i < len(out); i++ {
+		if out[i] != '\n' {
+			out[i] = ' '
+		}
+	}
+	return string(out)
 }
 
 // juliaMaskDefinitionHeads blanks the definition HEADS of the given names, leaving

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -1872,43 +1872,7 @@ func juliaCallerScope(from SymbolRecord) string {
 	return from.ContainerID
 }
 
-// juliaModuleScopedTargetReachable keeps the Julia arm of nameCallMayTargetMethod
-// honest. Admitting methods let bare `name(args...)` — Julia's only call form —
-// reach module-scoped definitions, but `module M ... end` is a hard namespace
-// boundary: from outside M, its definitions are reachable only as `M.name(...)`.
-// Without this, one file holding two modules resolved a bare call to whichever
-// same-named definition happened to be declared nearest, and a top-level call
-// reached into a module it cannot see.
-//
-// The gate is deliberately narrow — same file, method kind — so it can only
-// withdraw candidates the method arm itself introduced, never a target that
-// resolved before it.
-// juliaScopeName is the name of the module a symbol's own code is written in:
-// its container for an ordinary definition, and itself for a module.
-func juliaScopeName(symbol SymbolRecord) string {
-	if symbol.Kind == "module" {
-		// The QUALIFIED name, because a child of a nested module records its
-		// container qualified too: `Outer.Inner`, not `Inner`. Comparing the
-		// short name rejected every module-body call to a child of a nested
-		// module before the same-container check could accept it.
-		if symbol.QualifiedName != "" {
-			return symbol.QualifiedName
-		}
-		return symbol.Name
-	}
-	return containerName(symbol.QualifiedName)
-}
-
-// juliaModuleScope identifies the module a Julia symbol's own code is written
-// in: the module symbol's ID, for comparing scopes inside one file, and its
-// NAME, for the namespace comparison that has to survive a module spanning
-// several files through `include`.
-type juliaModuleScope struct {
-	id   string
-	name string
-}
-
-// juliaModuleScopesByID maps every Julia symbol to the module its code is
+// juliaModuleScopesByID maps every Julia symbol to the ID of the module its code is
 // written in, found by walking the CONTAINER CHAIN to the nearest module rather
 // than reading the immediate container.
 //
@@ -1926,21 +1890,20 @@ type juliaModuleScope struct {
 //
 // Built once over the whole symbol pass because the walk is otherwise repeated
 // per candidate call target.
-func juliaModuleScopesByID(symbolsByID map[string]SymbolRecord) map[string]juliaModuleScope {
-	scopes := make(map[string]juliaModuleScope, len(symbolsByID))
-	var resolve func(symbol SymbolRecord, depth int) juliaModuleScope
-	resolve = func(symbol SymbolRecord, depth int) juliaModuleScope {
+func juliaModuleScopesByID(symbolsByID map[string]SymbolRecord) map[string]string {
+	scopes := make(map[string]string, len(symbolsByID))
+	var resolve func(symbol SymbolRecord, depth int) string
+	resolve = func(symbol SymbolRecord, depth int) string {
 		if scope, ok := scopes[symbol.ID]; ok {
 			return scope
 		}
 		if symbol.Kind == "module" {
 			// The calls attributed to a module are the ones written in its own
 			// body, so a module is its own scope.
-			scope := juliaModuleScope{id: symbol.ID, name: juliaScopeName(symbol)}
-			scopes[symbol.ID] = scope
-			return scope
+			scopes[symbol.ID] = symbol.ID
+			return symbol.ID
 		}
-		var scope juliaModuleScope
+		var scope string
 		// The depth bound is belt and braces: container links form a tree, but a
 		// malformed one must not spin here. A symbol inside no module at all
 		// keeps the zero scope, which reaches nothing module-scoped -- the
@@ -1960,14 +1923,25 @@ func juliaModuleScopesByID(symbolsByID map[string]SymbolRecord) map[string]julia
 // juliaCallerModuleScope is the scope lookup with a fallback for a caller the
 // index does not carry: the immediate container, which IS the module for every
 // definition written directly in one.
-func juliaCallerModuleScope(from SymbolRecord, moduleScopeByID map[string]juliaModuleScope) juliaModuleScope {
+func juliaCallerModuleScope(from SymbolRecord, moduleScopeByID map[string]string) string {
 	if scope, ok := moduleScopeByID[from.ID]; ok {
 		return scope
 	}
-	return juliaModuleScope{id: juliaCallerScope(from), name: juliaScopeName(from)}
+	return juliaCallerScope(from)
 }
 
-func juliaModuleScopedTargetReachable(from, to SymbolRecord, moduleScopeByID map[string]juliaModuleScope) bool {
+// juliaModuleScopedTargetReachable keeps the Julia arm of nameCallMayTargetMethod
+// honest. Admitting methods let bare `name(args...)` — Julia's only call form —
+// reach module-scoped definitions, but `module M ... end` is a hard namespace
+// boundary: from outside M, its definitions are reachable only as `M.name(...)`.
+// Without this, one file holding two modules resolved a bare call to whichever
+// same-named definition happened to be declared nearest, and a top-level call
+// reached into a module it cannot see.
+//
+// The gate is deliberately narrow — method kind, and only within Julia — so it
+// can only withdraw candidates the method arm itself introduced, never a target
+// that resolved before it.
+func juliaModuleScopedTargetReachable(from, to SymbolRecord, moduleScopeByID map[string]string) bool {
 	if from.Language != "Julia" || to.Kind != "method" {
 		return true
 	}
@@ -1985,17 +1959,26 @@ func juliaModuleScopedTargetReachable(from, to SymbolRecord, moduleScopeByID map
 	// call in module B bind a globally unique method of module A purely because
 	// their files differed.
 	//
-	// Module NAMES are compared rather than container ids, because a Julia
-	// module routinely spans files through `include` and each file gives it a
-	// different container id while it stays one namespace.
+	// Module IDENTITY is compared, not module NAME. Comparing names was meant
+	// to survive a module spanning files through `include`, but it does not
+	// have to: an `include`d file carries BARE definitions, which are recorded
+	// with no container at all, so they never reach a name comparison. What
+	// name equality did admit was two INDEPENDENT packages that each declare
+	// `module Utils` -- distinct namespaces in Julia, where a second
+	// `module M ... end` defines a new module rather than reopening the first
+	// -- letting a bare call in one package bind a globally unique method of
+	// the other. A module symbol's ID carries its file, so identity separates
+	// them.
 	scope := juliaCallerModuleScope(from, moduleScopeByID)
-	if toModule := containerName(to.QualifiedName); toModule != "" && toModule != scope.name {
-		return false
-	}
-	if to.FilePath != from.FilePath {
+	if to.ContainerID == scope {
 		return true
 	}
-	return to.ContainerID == scope.id
+	// A target written at a file's top level names no module of its own: it is
+	// either genuinely top-level or the body of an `include`d file spliced into
+	// whichever module included it. Cross-file, that is the only bare-call
+	// target left to accept; within one file the container check above has
+	// already settled it.
+	return containerName(to.QualifiedName) == "" && to.FilePath != from.FilePath
 }
 
 // juliaModuleOwnBlock returns a module's block with its nested definitions blanked
@@ -2493,7 +2476,7 @@ func juliaArgumentListEnd(scan string, from int) int {
 	return -1
 }
 
-func resolveCallTargets(name string, from SymbolRecord, candidates, sameFile []SymbolRecord, importsByName map[string][]string, juliaModuleScopeByID map[string]juliaModuleScope, allowMethodTargets bool) []resolvedCallTarget {
+func resolveCallTargets(name string, from SymbolRecord, candidates, sameFile []SymbolRecord, importsByName map[string][]string, juliaModuleScopeByID map[string]string, allowMethodTargets bool) []resolvedCallTarget {
 	var local []resolvedCallTarget
 	for _, to := range sameFile {
 		// A bare `name()` call resolves to a function, not a class method (methods

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -1987,7 +1987,11 @@ func juliaModuleOwnBlock(from SymbolRecord, block string, fileSymbols []SymbolRe
 // Depth is counted over Julia's block openers, because a definition may contain
 // them and the FIRST `end` is then not its own.
 func juliaMaskLongFormDefinition(block, name string) string {
-	head := regexp.MustCompile(`\bfunction\s+` + regexp.QuoteMeta(name) + `\b`)
+	// `macro name(...) ... end` is a definition with a body exactly like
+	// `function`, and Julia closes both with the same `end`. Leaving it out
+	// left a one-line macro's body unmasked, crediting the enclosing module
+	// with every call the macro makes.
+	head := regexp.MustCompile(`\b(?:function|macro)\s+` + regexp.QuoteMeta(name) + `\b`)
 	openers := regexp.MustCompile(`\b(function|if|for|while|begin|let|do|try|quote|struct|module|macro)\b`)
 	end := regexp.MustCompile(`\bend\b`)
 	// Block tokens are matched against a copy whose STRING and COMMENT bodies are
@@ -2051,6 +2055,10 @@ func juliaMaskDefinitionHeads(block string, names []string) string {
 		quoted := regexp.QuoteMeta(name)
 		for _, pattern := range []string{
 			`\bfunction\s+` + quoted + `\b`,
+			// A macro definition head reads as a call: `macro mymac(x)`
+			// contains `mymac(x)`. Unmasked, the module was credited with
+			// calling its own macro.
+			`\bmacro\s+` + quoted + `\b`,
 			// Short form, masked THROUGH ITS RIGHT-HAND SIDE. `f() = helper()`
 			// occupies one line, so no body line is blanked for it, and masking
 			// only the head left `helper()` in the module's block -- crediting

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -1936,17 +1936,54 @@ func juliaModuleScopedTargetReachable(from, to SymbolRecord) bool {
 // is scanned when its turn comes.
 func juliaModuleOwnBlock(from SymbolRecord, block string, fileSymbols []SymbolRecord) string {
 	lines := strings.Split(block, "\n")
+	var childNames []string
 	for _, child := range fileSymbols {
 		if child.ID == from.ID || child.ContainerID != from.ID {
 			continue
 		}
-		for line := child.StartLine; line <= child.EndLine; line++ {
+		childNames = append(childNames, child.Name)
+		// The child's BODY is blanked, but not the line its definition starts
+		// on. A one-line module -- `module M; setup() = 1; setup(); end` -- puts
+		// the child, the module and a real module-level call on that same line,
+		// so blanking it whole deleted the very call this function exists to
+		// keep. Line numbers are all a SymbolRecord carries, so the head line is
+		// handled textually below instead.
+		for line := child.StartLine + 1; line <= child.EndLine; line++ {
 			if index := line - from.StartLine; index >= 0 && index < len(lines) {
 				lines[index] = ""
 			}
 		}
 	}
-	return strings.Join(lines, "\n")
+	return juliaMaskDefinitionHeads(strings.Join(lines, "\n"), childNames)
+}
+
+// juliaMaskDefinitionHeads blanks the definition HEADS of the given names, leaving
+// calls to those same names in place.
+//
+// A definition reads like a call to a name scanner -- `function setup(` and the
+// short form `setup() = 1` both put the name in front of a parenthesis -- which is
+// why a container was never credited with calling its own children. Blanking the
+// heads says the same thing without also deleting whatever else shares the line.
+func juliaMaskDefinitionHeads(block string, names []string) string {
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		quoted := regexp.QuoteMeta(name)
+		for _, pattern := range []string{
+			`\bfunction\s+` + quoted + `\b`,
+			// Short form, and only where a single `=` assigns: `setup() == x` is
+			// a comparison, not a definition.
+			`\b` + quoted + `\s*\([^()]*\)\s*=(?:[^=]|$)`,
+		} {
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				continue
+			}
+			block = replacePatternSameLength(block, re, "")
+		}
+	}
+	return block
 }
 
 func resolveCallTargets(name string, from SymbolRecord, candidates, sameFile []SymbolRecord, importsByName map[string][]string, allowMethodTargets bool) []resolvedCallTarget {

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -2028,6 +2028,104 @@ func juliaMaskSiblingDefinitionHeads(from SymbolRecord, block string, fileSymbol
 	return juliaMaskDefinitionHeads(block, names)
 }
 
+// juliaMaskGeneratorClauses blanks the `for` of a comprehension or generator --
+// and the `if` filter that may follow it -- because Julia closes those with the
+// BRACKET they sit in, never with `end`.
+//
+// The block-token scans read every `for` as an `end`-delimited opener, so
+// `[g(i) for i in xs]` and `sum(g(i) for i in xs)` each raised the synthetic
+// depth by a block that never closes. The `end` that really closed the
+// definition was then spent rebalancing, the scan ran past it, and trailing
+// module-level code stayed attributed to the definition -- `function f();
+// sum(x for x in xs); end; setup()` kept `setup()` inside f and lost it from the
+// module -- or was masked away with the definition entirely.
+//
+// A `for` belongs to a generator when the innermost construct still open at that
+// point is a BRACKET rather than a block. That distinction is what keeps a
+// genuine loop written inside an argument counted: in
+// `f(map(xs) do x; for i in ys; g(i); end; end)` the innermost open construct at
+// the `for` is the `do` block, not the paren, so it stays an opener.
+//
+// The comprehension's `if` filter is masked only once a generator `for` has been
+// seen in the SAME bracket, so an `if` EXPRESSION passed as an argument --
+// `f(if c; 1; else; 2; end)`, which really does close with `end` -- keeps its
+// depth.
+//
+// An `end` reached with a bracket innermost is an index -- `xs[end]`, the last
+// element -- and not a terminator, so it is blanked too rather than allowed to
+// close a block that is still open. Comprehensions index that way constantly
+// (`sum(xs[end] for x in xs)`), so the generator fix is only whole with it.
+//
+// Masked keywords become spaces, preserving length, so an offset found by a
+// caller still indexes the same byte in the original.
+func juliaMaskGeneratorClauses(scan string) string {
+	out := []byte(scan)
+	// Each frame is one open construct: a bracket, or a block awaiting `end`.
+	type frame struct {
+		bracket   bool
+		generator bool
+	}
+	var stack []frame
+	for _, at := range juliaScanTokens.FindAllStringIndex(scan, -1) {
+		switch token := scan[at[0]:at[1]]; token {
+		case "(", "[", "{":
+			stack = append(stack, frame{bracket: true})
+		case ")", "]", "}":
+			// Pop through any block frames left unclosed inside the bracket
+			// rather than trusting them to balance.
+			for len(stack) > 0 {
+				top := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				if top.bracket {
+					break
+				}
+			}
+		case "end":
+			if len(stack) == 0 || !stack[len(stack)-1].bracket {
+				// A real terminator: it closes the innermost block, and when
+				// nothing is open the scan began inside a block whose opener
+				// this text does not hold, so it is left for the caller's depth.
+				if len(stack) > 0 {
+					stack = stack[:len(stack)-1]
+				}
+				continue
+			}
+			// An index, not a terminator.
+			for i := at[0]; i < at[1]; i++ {
+				out[i] = ' '
+			}
+		case "for", "if":
+			if len(stack) > 0 && stack[len(stack)-1].bracket &&
+				(token == "for" || stack[len(stack)-1].generator) {
+				stack[len(stack)-1].generator = true
+				for i := at[0]; i < at[1]; i++ {
+					out[i] = ' '
+				}
+				continue
+			}
+			stack = append(stack, frame{})
+		default:
+			stack = append(stack, frame{})
+		}
+	}
+	return string(out)
+}
+
+// juliaScanTokens matches everything juliaMaskGeneratorClauses has to track: the
+// block openers, `end`, and the brackets that tell a generator's `for` from a
+// loop's.
+var juliaScanTokens = regexp.MustCompile(
+	`\b(?:function|if|for|while|begin|let|do|try|quote|struct|module|macro|end)\b|[\[\](){}]`)
+
+// juliaBlockScanText is the copy the block-depth scans read: string and comment
+// bodies blanked so an `end` inside either terminates nothing, and generator
+// clauses blanked so a `for` that no `end` closes does not open a block. Every
+// step preserves length, so an offset found in the result indexes the same byte
+// in the original.
+func juliaBlockScanText(text string) string {
+	return juliaMaskGeneratorClauses(maskJuliaBlockComments(stripCodeLiteralsAndComments(text)))
+}
+
 // juliaBlankAfterClosingEnd is the counterpart to juliaBlankThroughClosingEnd,
 // applied to a definition's OWN block: it blanks whatever follows the `end`
 // that closes the definition on its last line.
@@ -2045,7 +2143,7 @@ func juliaBlankAfterClosingEnd(block string) string {
 	// The whole block is scanned, not just its last line: the `end` that closes
 	// the definition returns the scan to depth zero, and only a scan that has
 	// seen the opening `function` knows where that is.
-	scan := maskJuliaBlockComments(stripCodeLiteralsAndComments(block))
+	scan := juliaBlockScanText(block)
 	openers := regexp.MustCompile(`\b(function|if|for|while|begin|let|do|try|quote|struct|module|macro)\b`)
 	end := regexp.MustCompile(`\bend\b`)
 	depth, cursor := 0, 0
@@ -2109,7 +2207,7 @@ func juliaBlankAfterClosingEnd(block string) string {
 // strippers preserve length, so an offset found here indexes the same byte in
 // the original.
 func juliaBlankThroughClosingEnd(line string, openDepth int) string {
-	scan := maskJuliaBlockComments(stripCodeLiteralsAndComments(line))
+	scan := juliaBlockScanText(line)
 	openers := regexp.MustCompile(`\b(function|if|for|while|begin|let|do|try|quote|struct|module|macro)\b`)
 	end := regexp.MustCompile(`\bend\b`)
 	depth := openDepth
@@ -2139,7 +2237,7 @@ func juliaBlankThroughClosingEnd(line string, openDepth int) string {
 // blanked copy as the scans it feeds, so an `end` inside a string or a comment
 // does not close anything.
 func juliaOpenBlockDepth(text string) int {
-	scan := maskJuliaBlockComments(stripCodeLiteralsAndComments(text))
+	scan := juliaBlockScanText(text)
 	openers := regexp.MustCompile(`\b(function|if|for|while|begin|let|do|try|quote|struct|module|macro)\b`)
 	end := regexp.MustCompile(`\bend\b`)
 	depth := 0
@@ -2291,7 +2389,7 @@ func juliaMaskLongFormDefinition(block, name string) string {
 	// one ended the mask early and left the rest of the definition -- every call
 	// in it -- attributed to the enclosing module. The stripper preserves length,
 	// so an offset found here indexes the same byte in the original.
-	scan := maskJuliaBlockComments(stripCodeLiteralsAndComments(block))
+	scan := juliaBlockScanText(block)
 	for {
 		where := head.FindStringIndex(scan)
 		if where == nil {

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -2021,6 +2021,40 @@ func juliaModuleOwnBlock(from SymbolRecord, block string, fileSymbols []SymbolRe
 //
 // Depth is counted over Julia's block openers, because a definition may contain
 // them and the FIRST `end` is then not its own.
+// maskJuliaBlockComments blanks the bodies of Julia's `#= ... =#` comments,
+// preserving length so an offset found in the result indexes the same byte in
+// the original.
+//
+// The generic stripper does not know this form, so `function f(); #= end =#;
+// helper(); end` still carried an `end` inside a comment, and the block-token
+// scan below counted it as the definition's terminator: the mask stopped early
+// and left `helper()` credited to the enclosing module.
+//
+// Julia block comments NEST -- `#= a #= b =# c =#` is one comment -- so this
+// tracks depth rather than stopping at the first `=#`.
+func maskJuliaBlockComments(text string) string {
+	out := []byte(text)
+	depth := 0
+	for i := 0; i < len(out); i++ {
+		if i+1 < len(out) && out[i] == '#' && out[i+1] == '=' {
+			depth++
+			out[i], out[i+1] = ' ', ' '
+			i++
+			continue
+		}
+		if depth > 0 && i+1 < len(out) && out[i] == '=' && out[i+1] == '#' {
+			depth--
+			out[i], out[i+1] = ' ', ' '
+			i++
+			continue
+		}
+		if depth > 0 && out[i] != '\n' {
+			out[i] = ' '
+		}
+	}
+	return string(out)
+}
+
 func juliaMaskLongFormDefinition(block, name string) string {
 	// `macro name(...) ... end` is a definition with a body exactly like
 	// `function`, and Julia closes both with the same `end`. Leaving it out
@@ -2034,7 +2068,7 @@ func juliaMaskLongFormDefinition(block, name string) string {
 	// one ended the mask early and left the rest of the definition -- every call
 	// in it -- attributed to the enclosing module. The stripper preserves length,
 	// so an offset found here indexes the same byte in the original.
-	scan := stripCodeLiteralsAndComments(block)
+	scan := maskJuliaBlockComments(stripCodeLiteralsAndComments(block))
 	for {
 		where := head.FindStringIndex(scan)
 		if where == nil {
@@ -2111,7 +2145,20 @@ func juliaMaskDefinitionHeads(block string, names []string) string {
 			// the line end would swallow it.
 			//
 			// The `=` must be a single one: `f() == x` is a comparison.
-			`\b` + quoted + `\s*\([^()]*\)[^=;\n]*=([^=;\n][^;\n]*)?`,
+			// Go's regexp is RE2 and has no lookahead, so "not followed by
+			// another `=`" cannot be asserted directly. Making the suffix
+			// OPTIONAL was the bug: it let the match end right after the first
+			// `=` of `==`, which is exactly the case the guard was for, and a
+			// genuine module-scope `f(2) == 3` was masked away with the real
+			// `M -> M.f` edge in it. Requiring the suffix makes the next
+			// character prove itself.
+			`\b` + quoted + `\s*\([^()]*\)[^=;\n]*=[^=;\n][^;\n]*`,
+			// A short form may also put its body on the NEXT line
+			// (`f(x) =` then an indented body), which the required suffix above
+			// cannot match. `(?m)$` is zero-width, so the newline survives and
+			// line numbering is unchanged; only spaces or tabs may sit between,
+			// so this still cannot reach the second `=` of `==`.
+			`(?m)\b` + quoted + `\s*\([^()]*\)[^=;\n]*=[ \t]*$`,
 		} {
 			re, err := regexp.Compile(pattern)
 			if err != nil {

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -2067,8 +2067,14 @@ func juliaBlankAfterClosingEnd(block string) string {
 		}
 		// Past the closing `end`. Anything after it on the SAME line belongs to
 		// the enclosing scope, not to this definition.
+		// LastIndexByte returns -1 when the block holds no newline at all, and
+		// the +1 turns that into 0 -- which is the CORRECT start of the only
+		// line. Rejecting 0 treated a one-line definition as unlocatable, so
+		// `function f(); end; setup()` kept `setup()` in f's own scan and
+		// emitted a false `f -> setup` for code belonging to the enclosing
+		// scope.
 		lineStart := strings.LastIndexByte(scan[:cursor], '\n') + 1
-		if lineStart <= 0 || len(lines[last]) == 0 {
+		if len(lines[last]) == 0 {
 			return block
 		}
 		if strings.Count(scan[:cursor], "\n") != last {

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -2102,23 +2102,28 @@ func juliaBlankAfterClosingEnd(block string) string {
 }
 
 // juliaBlankThroughClosingEnd blanks a child's final line up to and including
-// the `end` that closes it, and preserves whatever follows.
+// the `end` that closes it, and preserves whatever follows. `openDepth` is how
+// many blocks the child's EARLIER lines leave open -- at least one, the child's
+// own definition.
 //
 // Depth is counted rather than stopping at the first `end`, because that `end`
 // may close a block nested inside the child (`  if c; helper(); end; end; g()`)
 // and stopping there would credit the enclosing module with the child's own
-// calls. Counting reaches the `end` that returns to depth zero -- the child's --
-// so only the text after it survives.
+// calls. The nesting is not all visible on this line: a multi-line child ending
+// `end; helper(); end; g()` opens its `if` on an earlier one, so counting from a
+// fixed depth of one cut at the `if`'s `end` and handed `helper()` -- the
+// child's own call -- to the module. Counting down from `openDepth` reaches the
+// `end` that closes the child, so only the text after it survives.
 //
 // The scan runs on a copy whose string and comment bodies are blanked, so an
 // `end` inside `"..."` or `#= ... =#` is not read as a terminator; both
 // strippers preserve length, so an offset found here indexes the same byte in
 // the original.
-func juliaBlankThroughClosingEnd(line string) string {
+func juliaBlankThroughClosingEnd(line string, openDepth int) string {
 	scan := maskJuliaBlockComments(stripCodeLiteralsAndComments(line))
 	openers := regexp.MustCompile(`\b(function|if|for|while|begin|let|do|try|quote|struct|module|macro)\b`)
 	end := regexp.MustCompile(`\bend\b`)
-	depth := 0
+	depth := openDepth
 	cursor := 0
 	for cursor < len(scan) {
 		nextOpen := openers.FindStringIndex(scan[cursor:])
@@ -2131,18 +2136,67 @@ func juliaBlankThroughClosingEnd(line string) string {
 			cursor += nextOpen[1]
 			continue
 		}
-		if depth == 0 {
-			cut := cursor + nextEnd[1]
-			return sameLengthReplacement("", cut) + line[cut:]
-		}
 		depth--
 		cursor += nextEnd[1]
+		if depth <= 0 {
+			return sameLengthReplacement("", cursor) + line[cursor:]
+		}
 	}
 	return sameLengthReplacement("", len(line))
 }
 
+// juliaOpenBlockDepth counts the block openers `text` leaves unclosed, so a scan
+// resuming on a later line knows which `end` closes what. It reads the same
+// blanked copy as the scans it feeds, so an `end` inside a string or a comment
+// does not close anything.
+func juliaOpenBlockDepth(text string) int {
+	scan := maskJuliaBlockComments(stripCodeLiteralsAndComments(text))
+	openers := regexp.MustCompile(`\b(function|if|for|while|begin|let|do|try|quote|struct|module|macro)\b`)
+	end := regexp.MustCompile(`\bend\b`)
+	depth := 0
+	cursor := 0
+	for cursor < len(scan) {
+		nextOpen := openers.FindStringIndex(scan[cursor:])
+		nextEnd := end.FindStringIndex(scan[cursor:])
+		switch {
+		case nextOpen == nil && nextEnd == nil:
+			cursor = len(scan)
+		case nextEnd == nil || (nextOpen != nil && nextOpen[0] < nextEnd[0]):
+			depth++
+			cursor += nextOpen[1]
+		default:
+			depth--
+			cursor += nextEnd[1]
+		}
+	}
+	if depth < 1 {
+		return 1
+	}
+	return depth
+}
+
+// juliaJoinLines joins lines[start:stop) with the out-of-range ends clamped away,
+// so a child whose recorded span runs past the block it was cut from still yields
+// the text that is actually there.
+func juliaJoinLines(lines []string, start, stop int) string {
+	if start < 0 {
+		start = 0
+	}
+	if stop > len(lines) {
+		stop = len(lines)
+	}
+	if start >= stop {
+		return ""
+	}
+	return strings.Join(lines[start:stop], "\n")
+}
+
 func juliaModuleOwnBlock(from SymbolRecord, block string, fileSymbols []SymbolRecord) string {
 	lines := strings.Split(block, "\n")
+	// The closing-end scan below needs the child's earlier lines to know how deep
+	// it already is, and `lines` is blanked as children are processed, so the
+	// depth is measured against an untouched copy.
+	original := strings.Split(block, "\n")
 	var childNames []string
 	var oneLineChildren []string
 	for _, child := range fileSymbols {
@@ -2174,8 +2228,11 @@ func juliaModuleOwnBlock(from SymbolRecord, block string, fileSymbols []SymbolRe
 				// blanking the line whole deleted a real module-to-setup call
 				// (and left the same call inside the child's own block, so it
 				// was credited to the child instead). A SymbolRecord carries no
-				// column, so the cut point is found by scanning.
-				lines[index] = juliaBlankThroughClosingEnd(lines[index])
+				// column, so the cut point is found by scanning -- from the depth
+				// the child's earlier lines leave open, because an `end` on this
+				// line may close one of THOSE blocks rather than the child.
+				lines[index] = juliaBlankThroughClosingEnd(lines[index],
+					juliaOpenBlockDepth(juliaJoinLines(original, child.StartLine-from.StartLine, child.EndLine-from.StartLine)))
 				continue
 			}
 			lines[index] = ""

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -1887,6 +1887,13 @@ func juliaCallerScope(from SymbolRecord) string {
 // its container for an ordinary definition, and itself for a module.
 func juliaScopeName(symbol SymbolRecord) string {
 	if symbol.Kind == "module" {
+		// The QUALIFIED name, because a child of a nested module records its
+		// container qualified too: `Outer.Inner`, not `Inner`. Comparing the
+		// short name rejected every module-body call to a child of a nested
+		// module before the same-container check could accept it.
+		if symbol.QualifiedName != "" {
+			return symbol.QualifiedName
+		}
 		return symbol.Name
 	}
 	return containerName(symbol.QualifiedName)
@@ -1972,9 +1979,12 @@ func juliaMaskDefinitionHeads(block string, names []string) string {
 		quoted := regexp.QuoteMeta(name)
 		for _, pattern := range []string{
 			`\bfunction\s+` + quoted + `\b`,
-			// Short form, and only where a single `=` assigns: `setup() == x` is
-			// a comparison, not a definition.
-			`\b` + quoted + `\s*\([^()]*\)\s*=(?:[^=]|$)`,
+			// Short form, masked THROUGH ITS RIGHT-HAND SIDE. `f() = helper()`
+			// occupies one line, so no body line is blanked for it, and masking
+			// only the head left `helper()` in the module's block -- crediting
+			// the module with every call the child's body makes. The `=` must be
+			// a single one: `f() == x` is a comparison, not a definition.
+			`\b` + quoted + `\s*\([^()]*\)\s*=([^=][^\n]*)?`,
 		} {
 			re, err := regexp.Compile(pattern)
 			if err != nil {

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -1884,10 +1884,36 @@ func juliaCallerScope(from SymbolRecord) string {
 // withdraw candidates the method arm itself introduced, never a target that
 // resolved before it.
 func juliaModuleScopedTargetReachable(from, to SymbolRecord) bool {
-	if from.Language != "Julia" || to.Kind != "method" || to.FilePath != from.FilePath {
+	if from.Language != "Julia" || to.Kind != "method" {
+		return true
+	}
+	// The method arm exists so a bare Julia call can reach a Julia
+	// module-scoped definition. The global fallback it draws on is
+	// language-agnostic, so without this an unresolved `runTask()` bound to a
+	// globally unique JAVA or C# method of that name -- a call Julia cannot
+	// make, and one the method arm itself introduced.
+	if to.Language != from.Language {
+		return false
+	}
+	if to.FilePath != from.FilePath {
 		return true
 	}
 	return to.ContainerID == juliaCallerScope(from)
+}
+
+// juliaModuleEmitsNameCalls reports whether a symbol's own block is a place
+// Julia call names may be attributed to it.
+//
+// A `module M ... end` block spans every nested definition, so a scan of the
+// module's own text sees the call names written inside its FUNCTIONS. Those
+// calls belong to the functions, which emit them already. Crediting the module
+// too produced a second edge from a symbol that never made the call: the same
+// `runTask()` appeared as both `M.go -> runTask` and `M -> runTask`. The
+// existing childNamesByContainer guard does not cover this, because it only
+// skips names the module DECLARES, and a call out of the module is not one of
+// them.
+func juliaModuleEmitsNameCalls(from SymbolRecord) bool {
+	return !(from.Language == "Julia" && from.Kind == "module")
 }
 
 func resolveCallTargets(name string, from SymbolRecord, candidates, sameFile []SymbolRecord, importsByName map[string][]string, allowMethodTargets bool) []resolvedCallTarget {
@@ -3370,6 +3396,9 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 				}
 				for _, name := range sortedKeysOf(callNames) {
 					if name == from.Name {
+						continue
+					}
+					if !juliaModuleEmitsNameCalls(from) {
 						continue
 					}
 					// A container's block spans its members' definition lines, which

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -1861,13 +1861,42 @@ func nameCallMayTargetMethod(lang string) bool {
 	return implicitReceiverLanguage(lang) || lang == "Rust" || lang == "Julia"
 }
 
+// juliaCallerScope returns the ID of the scope a symbol's own code is written
+// in. For an ordinary definition that is its container; for a container symbol
+// itself — a `module M ... end` block — it is the symbol, because the calls
+// attributed to it are the ones written in its body.
+func juliaCallerScope(from SymbolRecord) string {
+	if from.Kind == "module" {
+		return from.ID
+	}
+	return from.ContainerID
+}
+
+// juliaModuleScopedTargetReachable keeps the Julia arm of nameCallMayTargetMethod
+// honest. Admitting methods let bare `name(args...)` — Julia's only call form —
+// reach module-scoped definitions, but `module M ... end` is a hard namespace
+// boundary: from outside M, its definitions are reachable only as `M.name(...)`.
+// Without this, one file holding two modules resolved a bare call to whichever
+// same-named definition happened to be declared nearest, and a top-level call
+// reached into a module it cannot see.
+//
+// The gate is deliberately narrow — same file, method kind — so it can only
+// withdraw candidates the method arm itself introduced, never a target that
+// resolved before it.
+func juliaModuleScopedTargetReachable(from, to SymbolRecord) bool {
+	if from.Language != "Julia" || to.Kind != "method" || to.FilePath != from.FilePath {
+		return true
+	}
+	return to.ContainerID == juliaCallerScope(from)
+}
+
 func resolveCallTargets(name string, from SymbolRecord, candidates, sameFile []SymbolRecord, importsByName map[string][]string, allowMethodTargets bool) []resolvedCallTarget {
 	var local []resolvedCallTarget
 	for _, to := range sameFile {
 		// A bare `name()` call resolves to a function, not a class method (methods
 		// require a receiver and are resolved by receiverCallRelations) — matching
 		// a same-named method here is a false edge.
-		if to.ID == from.ID || to.Name != name || !callableTargetKind(to.Kind) || (to.Kind == "method" && !nameCallMayTargetMethod(from.Language) && !allowMethodTargets) || !localReachable(from, to) {
+		if to.ID == from.ID || to.Name != name || !callableTargetKind(to.Kind) || (to.Kind == "method" && !nameCallMayTargetMethod(from.Language) && !allowMethodTargets) || !localReachable(from, to) || !juliaModuleScopedTargetReachable(from, to) {
 			continue
 		}
 		local = append(local, resolvedCallTarget{
@@ -1959,7 +1988,7 @@ func resolveCallTargets(name string, from SymbolRecord, candidates, sameFile []S
 
 	var remaining []SymbolRecord
 	for _, to := range candidates {
-		if to.ID != from.ID && callableTargetKind(to.Kind) && (to.Kind != "method" || nameCallMayTargetMethod(from.Language) || allowMethodTargets) && localReachable(from, to) {
+		if to.ID != from.ID && callableTargetKind(to.Kind) && (to.Kind != "method" || nameCallMayTargetMethod(from.Language) || allowMethodTargets) && localReachable(from, to) && juliaModuleScopedTargetReachable(from, to) {
 			remaining = append(remaining, to)
 		}
 	}

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -1976,6 +1976,102 @@ func juliaMaskSiblingDefinitionHeads(from SymbolRecord, block string, fileSymbol
 	return juliaMaskDefinitionHeads(block, names)
 }
 
+// juliaBlankAfterClosingEnd is the counterpart to juliaBlankThroughClosingEnd,
+// applied to a definition's OWN block: it blanks whatever follows the `end`
+// that closes the definition on its last line.
+//
+// The two halves are the same line-granularity problem seen from either side.
+// `end; setup()` puts a module-level call on a function's final line, so the
+// module's block has to keep it -- and the function's block has to give it up,
+// or one call is credited to both.
+func juliaBlankAfterClosingEnd(block string) string {
+	lines := strings.Split(block, "\n")
+	if len(lines) == 0 {
+		return block
+	}
+	last := len(lines) - 1
+	// The whole block is scanned, not just its last line: the `end` that closes
+	// the definition returns the scan to depth zero, and only a scan that has
+	// seen the opening `function` knows where that is.
+	scan := maskJuliaBlockComments(stripCodeLiteralsAndComments(block))
+	openers := regexp.MustCompile(`\b(function|if|for|while|begin|let|do|try|quote|struct|module|macro)\b`)
+	end := regexp.MustCompile(`\bend\b`)
+	depth, cursor := 0, 0
+	for cursor < len(scan) {
+		nextOpen := openers.FindStringIndex(scan[cursor:])
+		nextEnd := end.FindStringIndex(scan[cursor:])
+		if nextEnd == nil {
+			return block
+		}
+		if nextOpen != nil && nextOpen[0] < nextEnd[0] {
+			depth++
+			cursor += nextOpen[1]
+			continue
+		}
+		cursor += nextEnd[1]
+		depth--
+		if depth > 0 {
+			continue
+		}
+		// Past the closing `end`. Anything after it on the SAME line belongs to
+		// the enclosing scope, not to this definition.
+		lineStart := strings.LastIndexByte(scan[:cursor], '\n') + 1
+		if lineStart <= 0 || len(lines[last]) == 0 {
+			return block
+		}
+		if strings.Count(scan[:cursor], "\n") != last {
+			return block
+		}
+		offset := cursor - lineStart
+		if offset >= len(lines[last]) {
+			return block
+		}
+		lines[last] = lines[last][:offset] + sameLengthReplacement("", len(lines[last])-offset)
+		return strings.Join(lines, "\n")
+	}
+	return block
+}
+
+// juliaBlankThroughClosingEnd blanks a child's final line up to and including
+// the `end` that closes it, and preserves whatever follows.
+//
+// Depth is counted rather than stopping at the first `end`, because that `end`
+// may close a block nested inside the child (`  if c; helper(); end; end; g()`)
+// and stopping there would credit the enclosing module with the child's own
+// calls. Counting reaches the `end` that returns to depth zero -- the child's --
+// so only the text after it survives.
+//
+// The scan runs on a copy whose string and comment bodies are blanked, so an
+// `end` inside `"..."` or `#= ... =#` is not read as a terminator; both
+// strippers preserve length, so an offset found here indexes the same byte in
+// the original.
+func juliaBlankThroughClosingEnd(line string) string {
+	scan := maskJuliaBlockComments(stripCodeLiteralsAndComments(line))
+	openers := regexp.MustCompile(`\b(function|if|for|while|begin|let|do|try|quote|struct|module|macro)\b`)
+	end := regexp.MustCompile(`\bend\b`)
+	depth := 0
+	cursor := 0
+	for cursor < len(scan) {
+		nextOpen := openers.FindStringIndex(scan[cursor:])
+		nextEnd := end.FindStringIndex(scan[cursor:])
+		if nextEnd == nil {
+			return sameLengthReplacement("", len(line))
+		}
+		if nextOpen != nil && nextOpen[0] < nextEnd[0] {
+			depth++
+			cursor += nextOpen[1]
+			continue
+		}
+		if depth == 0 {
+			cut := cursor + nextEnd[1]
+			return sameLengthReplacement("", cut) + line[cut:]
+		}
+		depth--
+		cursor += nextEnd[1]
+	}
+	return sameLengthReplacement("", len(line))
+}
+
 func juliaModuleOwnBlock(from SymbolRecord, block string, fileSymbols []SymbolRecord) string {
 	lines := strings.Split(block, "\n")
 	var childNames []string
@@ -1999,9 +2095,21 @@ func juliaModuleOwnBlock(from SymbolRecord, block string, fileSymbols []SymbolRe
 		// keep. Line numbers are all a SymbolRecord carries, so the head line is
 		// handled textually below instead.
 		for line := child.StartLine + 1; line <= child.EndLine; line++ {
-			if index := line - from.StartLine; index >= 0 && index < len(lines) {
-				lines[index] = ""
+			index := line - from.StartLine
+			if index < 0 || index >= len(lines) {
+				continue
 			}
+			if line == child.EndLine {
+				// The child's LAST line may carry module-level code after the
+				// `end` that closes it -- `end; setup()` is valid Julia -- and
+				// blanking the line whole deleted a real module-to-setup call
+				// (and left the same call inside the child's own block, so it
+				// was credited to the child instead). A SymbolRecord carries no
+				// column, so the cut point is found by scanning.
+				lines[index] = juliaBlankThroughClosingEnd(lines[index])
+				continue
+			}
+			lines[index] = ""
 		}
 	}
 	masked := strings.Join(lines, "\n")
@@ -3530,6 +3638,7 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 					blockIsOwnBody = true
 				}
 				if from.Language == "Julia" && from.Kind != "module" {
+					callBlock = juliaBlankAfterClosingEnd(callBlock)
 					callBlock = juliaMaskSiblingDefinitionHeads(from, callBlock, currentFileSymbols)
 				}
 				if file.Language == "Rust" {

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -1899,7 +1899,75 @@ func juliaScopeName(symbol SymbolRecord) string {
 	return containerName(symbol.QualifiedName)
 }
 
-func juliaModuleScopedTargetReachable(from, to SymbolRecord) bool {
+// juliaModuleScope identifies the module a Julia symbol's own code is written
+// in: the module symbol's ID, for comparing scopes inside one file, and its
+// NAME, for the namespace comparison that has to survive a module spanning
+// several files through `include`.
+type juliaModuleScope struct {
+	id   string
+	name string
+}
+
+// juliaModuleScopesByID maps every Julia symbol to the module its code is
+// written in, found by walking the CONTAINER CHAIN to the nearest module rather
+// than reading the immediate container.
+//
+// The immediate container is not always the module. A Julia inner constructor is
+// contained by its struct -- `struct Boxed; Boxed(x) = new(check(x)); end` emits
+// `Boxed.Boxed` under `Boxed`, which is under the module -- so the immediate
+// container made the caller's scope `Boxed` and dropped every call it makes to
+// its own module's definitions.
+//
+// Stopping at the nearest module, rather than accepting any ancestor, is the
+// other half of the rule: a nested `module Inner` inside `module Outer` does NOT
+// see Outer's names in Julia, so `Inner.f` resolves in Inner and must keep
+// failing to reach `Outer.g`. A module ancestor ends the walk; a struct or
+// function ancestor does not.
+//
+// Built once over the whole symbol pass because the walk is otherwise repeated
+// per candidate call target.
+func juliaModuleScopesByID(symbolsByID map[string]SymbolRecord) map[string]juliaModuleScope {
+	scopes := make(map[string]juliaModuleScope, len(symbolsByID))
+	var resolve func(symbol SymbolRecord, depth int) juliaModuleScope
+	resolve = func(symbol SymbolRecord, depth int) juliaModuleScope {
+		if scope, ok := scopes[symbol.ID]; ok {
+			return scope
+		}
+		if symbol.Kind == "module" {
+			// The calls attributed to a module are the ones written in its own
+			// body, so a module is its own scope.
+			scope := juliaModuleScope{id: symbol.ID, name: juliaScopeName(symbol)}
+			scopes[symbol.ID] = scope
+			return scope
+		}
+		var scope juliaModuleScope
+		// The depth bound is belt and braces: container links form a tree, but a
+		// malformed one must not spin here. A symbol inside no module at all
+		// keeps the zero scope, which reaches nothing module-scoped -- the
+		// pre-existing behaviour for a top-level definition.
+		if parent, ok := symbolsByID[symbol.ContainerID]; ok && depth < len(symbolsByID) {
+			scope = resolve(parent, depth+1)
+		}
+		scopes[symbol.ID] = scope
+		return scope
+	}
+	for _, symbol := range symbolsByID {
+		resolve(symbol, 0)
+	}
+	return scopes
+}
+
+// juliaCallerModuleScope is the scope lookup with a fallback for a caller the
+// index does not carry: the immediate container, which IS the module for every
+// definition written directly in one.
+func juliaCallerModuleScope(from SymbolRecord, moduleScopeByID map[string]juliaModuleScope) juliaModuleScope {
+	if scope, ok := moduleScopeByID[from.ID]; ok {
+		return scope
+	}
+	return juliaModuleScope{id: juliaCallerScope(from), name: juliaScopeName(from)}
+}
+
+func juliaModuleScopedTargetReachable(from, to SymbolRecord, moduleScopeByID map[string]juliaModuleScope) bool {
 	if from.Language != "Julia" || to.Kind != "method" {
 		return true
 	}
@@ -1920,13 +1988,14 @@ func juliaModuleScopedTargetReachable(from, to SymbolRecord) bool {
 	// Module NAMES are compared rather than container ids, because a Julia
 	// module routinely spans files through `include` and each file gives it a
 	// different container id while it stays one namespace.
-	if toModule := containerName(to.QualifiedName); toModule != "" && toModule != juliaScopeName(from) {
+	scope := juliaCallerModuleScope(from, moduleScopeByID)
+	if toModule := containerName(to.QualifiedName); toModule != "" && toModule != scope.name {
 		return false
 	}
 	if to.FilePath != from.FilePath {
 		return true
 	}
-	return to.ContainerID == juliaCallerScope(from)
+	return to.ContainerID == scope.id
 }
 
 // juliaModuleOwnBlock returns a module's block with its nested definitions blanked
@@ -2287,13 +2356,13 @@ func juliaMaskDefinitionHeads(block string, names []string) string {
 	return block
 }
 
-func resolveCallTargets(name string, from SymbolRecord, candidates, sameFile []SymbolRecord, importsByName map[string][]string, allowMethodTargets bool) []resolvedCallTarget {
+func resolveCallTargets(name string, from SymbolRecord, candidates, sameFile []SymbolRecord, importsByName map[string][]string, juliaModuleScopeByID map[string]juliaModuleScope, allowMethodTargets bool) []resolvedCallTarget {
 	var local []resolvedCallTarget
 	for _, to := range sameFile {
 		// A bare `name()` call resolves to a function, not a class method (methods
 		// require a receiver and are resolved by receiverCallRelations) — matching
 		// a same-named method here is a false edge.
-		if to.ID == from.ID || to.Name != name || !callableTargetKind(to.Kind) || (to.Kind == "method" && !nameCallMayTargetMethod(from.Language) && !allowMethodTargets) || !localReachable(from, to) || !juliaModuleScopedTargetReachable(from, to) {
+		if to.ID == from.ID || to.Name != name || !callableTargetKind(to.Kind) || (to.Kind == "method" && !nameCallMayTargetMethod(from.Language) && !allowMethodTargets) || !localReachable(from, to) || !juliaModuleScopedTargetReachable(from, to, juliaModuleScopeByID) {
 			continue
 		}
 		local = append(local, resolvedCallTarget{
@@ -2385,7 +2454,7 @@ func resolveCallTargets(name string, from SymbolRecord, candidates, sameFile []S
 
 	var remaining []SymbolRecord
 	for _, to := range candidates {
-		if to.ID != from.ID && callableTargetKind(to.Kind) && (to.Kind != "method" || nameCallMayTargetMethod(from.Language) || allowMethodTargets) && localReachable(from, to) && juliaModuleScopedTargetReachable(from, to) {
+		if to.ID != from.ID && callableTargetKind(to.Kind) && (to.Kind != "method" || nameCallMayTargetMethod(from.Language) || allowMethodTargets) && localReachable(from, to) && juliaModuleScopedTargetReachable(from, to, juliaModuleScopeByID) {
 			remaining = append(remaining, to)
 		}
 	}
@@ -3008,6 +3077,7 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 	needsGlobalSymbolsByFile := needsGlobalSymbolsByShortName
 	symbolsByShortName := map[string][]SymbolRecord{}
 	symbolsByFile := map[string][]SymbolRecord{}
+	juliaSymbolsByID := map[string]SymbolRecord{}
 	childNamesByContainer := map[string]map[string]bool{}
 	methodsByContainer := map[string]map[string]SymbolRecord{}
 	fieldsByContainer := map[string]map[string]SymbolRecord{}
@@ -3157,6 +3227,12 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 			if needsGlobalSymbolsByFile {
 				symbolsByFile[symbol.FilePath] = append(symbolsByFile[symbol.FilePath], symbol)
 			}
+			// Julia call resolution needs a caller's enclosing MODULE, which is
+			// reached by following container links; index the symbols the walk
+			// has to step through. Julia-only, so every other repo pays nothing.
+			if symbol.Language == "Julia" {
+				juliaSymbolsByID[symbol.ID] = symbol
+			}
 			if symbol.ContainerID != "" && (needsCallScan || needsReceiverCalls || needsFields || needsOverrides) {
 				if childNamesByContainer[symbol.ContainerID] == nil {
 					childNamesByContainer[symbol.ContainerID] = map[string]bool{}
@@ -3199,6 +3275,7 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 			}
 		}
 	}
+	juliaModuleScopeByID := juliaModuleScopesByID(juliaSymbolsByID)
 	// PHP declares return types in docblocks far more often than in native
 	// hints (WordPress uses docblocks exclusively), and the signature pass
 	// above cannot see them. Harvest '@return Type' from the docblock
@@ -3803,7 +3880,7 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 							return terminal == from.Name || childNamesByContainer[from.ID][terminal]
 						})
 					} else {
-						targets = resolveCallTargets(name, from, symbolsByShortName[name], currentFileSymbols, callImportsByName, false)
+						targets = resolveCallTargets(name, from, symbolsByShortName[name], currentFileSymbols, callImportsByName, juliaModuleScopeByID, false)
 					}
 					for _, to := range targets {
 						// A bare identifier passed as an argument may be a callback, but
@@ -3888,7 +3965,7 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 					if name == from.Name {
 						continue
 					}
-					for _, to := range resolveCallTargets(name, from, symbolsByShortName[name], currentFileSymbols, importsByName, false) {
+					for _, to := range resolveCallTargets(name, from, symbolsByShortName[name], currentFileSymbols, importsByName, juliaModuleScopeByID, false) {
 						if typeLikeKind(to.Kind) {
 							continue // construction, not an async call
 						}
@@ -3919,7 +3996,7 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 					if flow.Name == from.Name {
 						continue
 					}
-					for _, to := range resolveCallTargets(flow.Name, from, symbolsByShortName[flow.Name], currentFileSymbols, importsByName, true) {
+					for _, to := range resolveCallTargets(flow.Name, from, symbolsByShortName[flow.Name], currentFileSymbols, importsByName, juliaModuleScopeByID, true) {
 						if flow.Direction == "caller_to_callee" && to.Resolution == "name_only" {
 							continue
 						}
@@ -4208,7 +4285,7 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 						// to exclude, so the terminal fallback is unguarded.
 						targets = resolveJSNamespaceCallChain(name, fileSource, currentFileSymbols, jsSymbolNamespaces, symbolsByShortName, foreignJSNamespaceOf, nil)
 					} else {
-						targets = resolveCallTargets(name, fileSource, symbolsByShortName[name], currentFileSymbols, importsByName, false)
+						targets = resolveCallTargets(name, fileSource, symbolsByShortName[name], currentFileSymbols, importsByName, juliaModuleScopeByID, false)
 					}
 					for _, to := range targets {
 						if jsCallableArgumentOnly[name] && typeLikeKind(to.Kind) {

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -2356,61 +2356,141 @@ func juliaMaskDefinitionHeads(block string, names []string) string {
 			continue
 		}
 		quoted := regexp.QuoteMeta(name)
-		for _, pattern := range []string{
-			`\bfunction\s+` + quoted + `\b`,
-			// A macro definition head reads as a call: `macro mymac(x)`
-			// contains `mymac(x)`. Unmasked, the module was credited with
-			// calling its own macro.
-			`\bmacro\s+` + quoted + `\b`,
-			// Short form, masked THROUGH ITS RIGHT-HAND SIDE. `f() = helper()`
-			// occupies one line, so no body line is blanked for it, and masking
-			// only the head left `helper()` in the module's block -- crediting
-			// the module with every call the child's body makes.
-			//
-			// Anything but `=`, `;` or a newline may sit between the argument
-			// list and the `=`, because Julia writes a return type or a
-			// constraint there: `f(x)::Int = ...` and `f(x) where T = ...` are
-			// both definitions, and requiring `=` to follow the parenthesis
-			// immediately left them in the module's block.
-			//
-			// The mask stops at `;` as well as at the line end, because that is
-			// where the definition stops: `module M; setup() = 1; setup(); end`
-			// puts a real module-level call after the semicolon, and running to
-			// the line end would swallow it.
-			//
-			// The `=` must be an ASSIGNMENT, which is not the same as "not
-			// followed by another `=`". Julia spells many operators with a
-			// trailing `=` -- `>=`, `<=`, `!=`, `~=`, and every update operator
-			// (`+=`, `*=`, ...) -- and `=>` is the Pair constructor. Excluding
-			// only a following `=` caught `f(2) == 3` but still masked
-			// `f(2) >= 3` and `f(2) => v` as definitions, silently dropping the
-			// real module-to-`f` edge in each. RE2 has no lookaround, so the
-			// character on EITHER side of the `=` has to prove itself: the one
-			// before it may not be an operator character, and the one after it
-			// may be neither `=` nor `>`.
-			// Go's regexp is RE2 and has no lookahead, so "not followed by
-			// another `=`" cannot be asserted directly. Making the suffix
-			// OPTIONAL was the bug: it let the match end right after the first
-			// `=` of `==`, which is exactly the case the guard was for, and a
-			// genuine module-scope `f(2) == 3` was masked away with the real
-			// `M -> M.f` edge in it. Requiring the suffix makes the next
-			// character prove itself.
-			`\b` + quoted + `\s*\([^()]*\)(?:[^=;\n]*[^=;\n<>!~+\-*/\\^%&|])?=[^=;\n>][^;\n]*`,
+		// Long form. The mask runs from the keyword THROUGH the argument list,
+		// not just through the name: Julia writes default values in the
+		// signature, and `function f(x = helper())` left `(x = helper())` on the
+		// head line -- the one line of a multi-line definition the module's block
+		// deliberately keeps -- so the module was credited with calling helper
+		// alongside the real `M.f -> M.helper` edge.
+		block = juliaMaskDefinitionAt(block, regexp.MustCompile(`\b(?:function|macro)\s+`+quoted+`\b`), nil)
+		// Short form, masked THROUGH ITS RIGHT-HAND SIDE. `f() = helper()`
+		// occupies one line, so no body line is blanked for it, and masking
+		// only the head left `helper()` in the module's block -- crediting
+		// the module with every call the child's body makes.
+		//
+		// Anything but `=`, `;` or a newline may sit between the argument
+		// list and the `=`, because Julia writes a return type or a
+		// constraint there: `f(x)::Int = ...` and `f(x) where T = ...` are
+		// both definitions, and requiring `=` to follow the parenthesis
+		// immediately left them in the module's block.
+		//
+		// The mask stops at `;` as well as at the line end, because that is
+		// where the definition stops: `module M; setup() = 1; setup(); end`
+		// puts a real module-level call after the semicolon, and running to
+		// the line end would swallow it.
+		//
+		// The `=` must be an ASSIGNMENT, which is not the same as "not
+		// followed by another `=`". Julia spells many operators with a
+		// trailing `=` -- `>=`, `<=`, `!=`, `~=`, and every update operator
+		// (`+=`, `*=`, ...) -- and `=>` is the Pair constructor. Excluding
+		// only a following `=` caught `f(2) == 3` but still masked
+		// `f(2) >= 3` and `f(2) => v` as definitions, silently dropping the
+		// real module-to-`f` edge in each. RE2 has no lookaround, so the
+		// character on EITHER side of the `=` has to prove itself: the one
+		// before it may not be an operator character, and the one after it
+		// may be neither `=` nor `>`. Making that suffix OPTIONAL was the
+		// earlier bug: the match could end right after the first `=` of `==`,
+		// which is exactly the case the guard was for.
+		//
+		// No PARENTHESIS may sit between the argument list and the `=` either.
+		// A return type or a `where` clause never closes one, but a default
+		// value does: in `g(x = other(1)) = other(x)` the inner `other(1)` is
+		// followed by `) = `, and reading that as a short-form head masked the
+		// line from the default value onwards -- destroying `g`'s own argument
+		// list before the mask for `g` could balance it.
+		reference := regexp.MustCompile(`\b` + quoted + `\b`)
+		for _, tail := range []*regexp.Regexp{
+			regexp.MustCompile(`(?:[^=;()\n]*[^=;()\n<>!~+\-*/\\^%&|])?=[^=;\n>][^;\n]*`),
 			// A short form may also put its body on the NEXT line
 			// (`f(x) =` then an indented body), which the required suffix above
 			// cannot match. `(?m)$` is zero-width, so the newline survives and
 			// line numbering is unchanged; only spaces or tabs may sit between,
 			// so this still cannot reach the second `=` of `==`.
-			`(?m)\b` + quoted + `\s*\([^()]*\)(?:[^=;\n]*[^=;\n<>!~+\-*/\\^%&|])?=[ \t]*$`,
+			regexp.MustCompile(`(?m)(?:[^=;()\n]*[^=;()\n<>!~+\-*/\\^%&|])?=[ \t]*$`),
 		} {
-			re, err := regexp.Compile(pattern)
-			if err != nil {
-				continue
-			}
-			block = replacePatternSameLength(block, re, "")
+			block = juliaMaskDefinitionAt(block, reference, tail)
 		}
 	}
 	return block
+}
+
+// juliaMaskDefinitionAt blanks every definition that opens with `head`, running
+// from the head through its BALANCED argument list and then through `tail` when
+// one is given (the right-hand side of a short form). A head whose argument list
+// does not balance on its line, or whose tail does not match immediately after
+// it, is left alone -- it is a call, not a definition.
+//
+// Balancing is what the old `\([^()]*\)` could not do. Julia puts expressions in
+// a signature -- `f(x = g()) = helper()`, `f(x = (1, 2)) = helper()` -- and a
+// pattern that stopped at the first `)` did not match those definitions at all,
+// so the module's block kept the whole line: the head read as a call to the
+// child, and the right-hand side's calls were credited to the module as well.
+//
+// Offsets are found on a copy whose string and comment bodies are blanked, so a
+// parenthesis inside `"f(x) = 1"` neither opens an argument list nor balances
+// one; the strippers preserve length, so an offset found there indexes the same
+// byte in the original. The copy is taken per call because earlier masks have
+// already blanked their own spans.
+func juliaMaskDefinitionAt(block string, head *regexp.Regexp, tail *regexp.Regexp) string {
+	scan := maskJuliaBlockComments(stripCodeLiteralsAndComments(block))
+	cursor := 0
+	for cursor < len(scan) {
+		where := head.FindStringIndex(scan[cursor:])
+		if where == nil {
+			return block
+		}
+		from, nameEnd := cursor+where[0], cursor+where[1]
+		cursor = nameEnd
+		stop := juliaArgumentListEnd(scan, nameEnd)
+		if stop < 0 {
+			if tail != nil {
+				// A short form without an argument list is not a definition
+				// this mask recognises; `NAME` alone is just a reference.
+				continue
+			}
+			// `function f end` declares an empty generic function: no argument
+			// list to mask, but the head still must not read as a call.
+			stop = nameEnd
+		}
+		if tail != nil {
+			match := tail.FindStringIndex(scan[stop:])
+			if match == nil || match[0] != 0 {
+				continue
+			}
+			stop += match[1]
+		}
+		block = maskRangeKeepingNewlines(block, from, stop)
+		scan = maskRangeKeepingNewlines(scan, from, stop)
+		cursor = stop
+	}
+	return block
+}
+
+// juliaArgumentListEnd returns the offset just past the balanced argument list
+// opening at or after `from` on the same line, or -1 when none opens there.
+func juliaArgumentListEnd(scan string, from int) int {
+	cursor := from
+	for cursor < len(scan) && (scan[cursor] == ' ' || scan[cursor] == '\t') {
+		cursor++
+	}
+	if cursor >= len(scan) || scan[cursor] != '(' {
+		return -1
+	}
+	depth := 0
+	for ; cursor < len(scan); cursor++ {
+		switch scan[cursor] {
+		case '\n':
+			return -1
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return cursor + 1
+			}
+		}
+	}
+	return -1
 }
 
 func resolveCallTargets(name string, from SymbolRecord, candidates, sameFile []SymbolRecord, importsByName map[string][]string, juliaModuleScopeByID map[string]juliaModuleScope, allowMethodTargets bool) []resolvedCallTarget {

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -1982,9 +1982,15 @@ func juliaMaskDefinitionHeads(block string, names []string) string {
 			// Short form, masked THROUGH ITS RIGHT-HAND SIDE. `f() = helper()`
 			// occupies one line, so no body line is blanked for it, and masking
 			// only the head left `helper()` in the module's block -- crediting
-			// the module with every call the child's body makes. The `=` must be
-			// a single one: `f() == x` is a comparison, not a definition.
-			`\b` + quoted + `\s*\([^()]*\)\s*=([^=][^\n]*)?`,
+			// the module with every call the child's body makes.
+			//
+			// The mask stops at `;` as well as at the line end, because that is
+			// where the definition stops: `module M; setup() = 1; setup(); end`
+			// puts a real module-level call after the semicolon, and running to
+			// the line end would swallow it.
+			//
+			// The `=` must be a single one: `f() == x` is a comparison.
+			`\b` + quoted + `\s*\([^()]*\)\s*=([^=;\n][^;\n]*)?`,
 		} {
 			re, err := regexp.Compile(pattern)
 			if err != nil {

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -1883,6 +1883,15 @@ func juliaCallerScope(from SymbolRecord) string {
 // The gate is deliberately narrow — same file, method kind — so it can only
 // withdraw candidates the method arm itself introduced, never a target that
 // resolved before it.
+// juliaScopeName is the name of the module a symbol's own code is written in:
+// its container for an ordinary definition, and itself for a module.
+func juliaScopeName(symbol SymbolRecord) string {
+	if symbol.Kind == "module" {
+		return symbol.Name
+	}
+	return containerName(symbol.QualifiedName)
+}
+
 func juliaModuleScopedTargetReachable(from, to SymbolRecord) bool {
 	if from.Language != "Julia" || to.Kind != "method" {
 		return true
@@ -1895,25 +1904,49 @@ func juliaModuleScopedTargetReachable(from, to SymbolRecord) bool {
 	if to.Language != from.Language {
 		return false
 	}
+	// A module is a hard namespace boundary in EVERY file, not only in the one
+	// it is declared in: from outside M, its definitions are reachable as
+	// `M.name(...)` and no other way. Exempting cross-file targets let a bare
+	// call in module B bind a globally unique method of module A purely because
+	// their files differed.
+	//
+	// Module NAMES are compared rather than container ids, because a Julia
+	// module routinely spans files through `include` and each file gives it a
+	// different container id while it stays one namespace.
+	if toModule := containerName(to.QualifiedName); toModule != "" && toModule != juliaScopeName(from) {
+		return false
+	}
 	if to.FilePath != from.FilePath {
 		return true
 	}
 	return to.ContainerID == juliaCallerScope(from)
 }
 
-// juliaModuleEmitsNameCalls reports whether a symbol's own block is a place
-// Julia call names may be attributed to it.
+// juliaModuleOwnBlock returns a module's block with its nested definitions blanked
+// out, leaving the expressions written directly in the module body.
 //
-// A `module M ... end` block spans every nested definition, so a scan of the
-// module's own text sees the call names written inside its FUNCTIONS. Those
-// calls belong to the functions, which emit them already. Crediting the module
-// too produced a second edge from a symbol that never made the call: the same
-// `runTask()` appeared as both `M.go -> runTask` and `M -> runTask`. The
-// existing childNamesByContainer guard does not cover this, because it only
-// skips names the module DECLARES, and a call out of the module is not one of
-// them.
-func juliaModuleEmitsNameCalls(from SymbolRecord) bool {
-	return !(from.Language == "Julia" && from.Kind == "module")
+// A `module M ... end` block spans every definition under it, so scanning it whole
+// credited the module with the calls its FUNCTIONS make. Refusing the module outright
+// fixed that and took a real edge with it: `module M; setup(); end` runs `setup()` at
+// module scope, and that call has no other symbol to belong to. Removing the children
+// keeps both -- the module owns what its own body runs, and nothing else.
+//
+// Lines are blanked rather than deleted so the remaining text keeps its offsets, and
+// only DIRECT children are removed: a nested module is itself a child, and its own body
+// is scanned when its turn comes.
+func juliaModuleOwnBlock(from SymbolRecord, block string, fileSymbols []SymbolRecord) string {
+	lines := strings.Split(block, "\n")
+	for _, child := range fileSymbols {
+		if child.ID == from.ID || child.ContainerID != from.ID {
+			continue
+		}
+		for line := child.StartLine; line <= child.EndLine; line++ {
+			if index := line - from.StartLine; index >= 0 && index < len(lines) {
+				lines[index] = ""
+			}
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 func resolveCallTargets(name string, from SymbolRecord, candidates, sameFile []SymbolRecord, importsByName map[string][]string, allowMethodTargets bool) []resolvedCallTarget {
@@ -3265,6 +3298,16 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 				}
 			} else if fileNeedsCallScan && !typeLikeKind(from.Kind) {
 				callBlock := block
+				// A Julia module's block spans its definitions, so its own body is what
+				// is left once they are removed. Narrowing it also RETIRES the
+				// child-name guard below for this symbol: that guard exists because a
+				// definition line reads like a call, and there are no definition lines
+				// left here -- while `module M; setup(); end` calls a child for real.
+				blockIsOwnBody := false
+				if from.Language == "Julia" && from.Kind == "module" {
+					callBlock = juliaModuleOwnBlock(from, callBlock, currentFileSymbols)
+					blockIsOwnBody = true
+				}
 				if file.Language == "Rust" {
 					callBlock = stripRustCodegenMacroBodies(block)
 				}
@@ -3398,14 +3441,11 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 					if name == from.Name {
 						continue
 					}
-					if !juliaModuleEmitsNameCalls(from) {
-						continue
-					}
 					// A container's block spans its members' definition lines, which
 					// look like calls (e.g. `def validate(self):`). Skip the names of
 					// direct children so a class is not credited with calling its own
 					// methods; the real call site lives in the calling function.
-					if childNamesByContainer[from.ID][name] {
+					if childNamesByContainer[from.ID][name] && !blockIsOwnBody {
 						continue
 					}
 					var targets []resolvedCallTarget

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -1941,6 +1941,41 @@ func juliaModuleScopedTargetReachable(from, to SymbolRecord) bool {
 // Lines are blanked rather than deleted so the remaining text keeps its offsets, and
 // only DIRECT children are removed: a nested module is itself a child, and its own body
 // is scanned when its turn comes.
+// juliaMaskSiblingDefinitionHeads removes the definition heads of a symbol's
+// SIBLINGS from its call-scan block.
+//
+// A block is line-granular -- SymbolRecord carries StartLine and EndLine and
+// nothing finer -- so two definitions written on ONE line each take that whole
+// line as their block and read the other's head as a call. For
+// `module M; helper()=1; function f(); helper(); end; end` the snapshot emitted
+// `M.helper -> M.f`, because `function f` sits inside helper's block.
+//
+// Sub-line spans are the real fix and are not reachable from here. Masking the
+// heads is, and it cannot hide a call site: the patterns match `function NAME`,
+// `macro NAME` and a short-form `NAME(...) = ...`, all definition-shaped, so a
+// genuine `NAME()` elsewhere in the block still registers.
+//
+// Only siblings are masked -- same container, not `from` itself. A nested
+// definition's head is inside its parent's block legitimately, and masking a
+// short form there would take its right-hand side with it, changing which
+// symbol owns those calls.
+func juliaMaskSiblingDefinitionHeads(from SymbolRecord, block string, fileSymbols []SymbolRecord) string {
+	var names []string
+	for _, other := range fileSymbols {
+		if other.ID == from.ID || other.ContainerID != from.ContainerID {
+			continue
+		}
+		if other.StartLine > from.EndLine || other.EndLine < from.StartLine {
+			continue
+		}
+		names = append(names, other.Name)
+	}
+	if len(names) == 0 {
+		return block
+	}
+	return juliaMaskDefinitionHeads(block, names)
+}
+
 func juliaModuleOwnBlock(from SymbolRecord, block string, fileSymbols []SymbolRecord) string {
 	lines := strings.Split(block, "\n")
 	var childNames []string
@@ -3446,6 +3481,9 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 				if from.Language == "Julia" && from.Kind == "module" {
 					callBlock = juliaModuleOwnBlock(from, callBlock, currentFileSymbols)
 					blockIsOwnBody = true
+				}
+				if from.Language == "Julia" && from.Kind != "module" {
+					callBlock = juliaMaskSiblingDefinitionHeads(from, callBlock, currentFileSymbols)
 				}
 				if file.Language == "Rust" {
 					callBlock = stripRustCodegenMacroBodies(block)

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -1990,15 +1990,21 @@ func juliaMaskLongFormDefinition(block, name string) string {
 	head := regexp.MustCompile(`\bfunction\s+` + regexp.QuoteMeta(name) + `\b`)
 	openers := regexp.MustCompile(`\b(function|if|for|while|begin|let|do|try|quote|struct|module|macro)\b`)
 	end := regexp.MustCompile(`\bend\b`)
+	// Block tokens are matched against a copy whose STRING and COMMENT bodies are
+	// blanked, because `println("end")` is not a block terminator. Counting it as
+	// one ended the mask early and left the rest of the definition -- every call
+	// in it -- attributed to the enclosing module. The stripper preserves length,
+	// so an offset found here indexes the same byte in the original.
+	scan := stripCodeLiteralsAndComments(block)
 	for {
-		where := head.FindStringIndex(block)
+		where := head.FindStringIndex(scan)
 		if where == nil {
 			return block
 		}
 		depth, cursor := 0, where[0]
-		for cursor < len(block) {
-			nextOpen := openers.FindStringIndex(block[cursor:])
-			nextEnd := end.FindStringIndex(block[cursor:])
+		for cursor < len(scan) {
+			nextOpen := openers.FindStringIndex(scan[cursor:])
+			nextEnd := end.FindStringIndex(scan[cursor:])
 			if nextEnd == nil {
 				// Unterminated: mask to the end rather than leave the body.
 				return maskRangeKeepingNewlines(block, where[0], len(block))

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -1845,13 +1845,20 @@ func implicitReceiverLanguage(lang string) bool {
 // methods must NOT be excluded from name-match resolution for that language:
 //   - implicit-receiver languages: bare `name()` means `this.name()`;
 //   - Rust: `Type::name()` / `Trait::name()` path calls and associated
-//     functions are written explicitly and resolve to the method by name.
+//     functions are written explicitly and resolve to the method by name;
+//   - Julia: the "method" kind does not mean a receiver-dispatched member. A
+//     Julia definition inside `module M ... end` is namespace-qualified to
+//     `M.name` and therefore emitted as a method, but Julia has no receiver
+//     call form at all — `name(args...)` is the only way to call anything.
+//     Excluding methods here meant that idiomatic Julia (a package is a
+//     module) produced zero same-file CALLS while `capabilities --json`
+//     advertised CALLS for Julia.
 //
 // In Go/Python/JS/TS a method call always carries an explicit `.`-receiver and
 // is handled by receiverCallRelations instead, so methods stay excluded there.
 // (Ported from fix/rust-call-resolution ad6ca4d onto the current gate shape.)
 func nameCallMayTargetMethod(lang string) bool {
-	return implicitReceiverLanguage(lang) || lang == "Rust"
+	return implicitReceiverLanguage(lang) || lang == "Rust" || lang == "Julia"
 }
 
 func resolveCallTargets(name string, from SymbolRecord, candidates, sameFile []SymbolRecord, importsByName map[string][]string, allowMethodTargets bool) []resolvedCallTarget {

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -2050,13 +2050,19 @@ func juliaMaskDefinitionHeads(block string, names []string) string {
 			// only the head left `helper()` in the module's block -- crediting
 			// the module with every call the child's body makes.
 			//
+			// Anything but `=`, `;` or a newline may sit between the argument
+			// list and the `=`, because Julia writes a return type or a
+			// constraint there: `f(x)::Int = ...` and `f(x) where T = ...` are
+			// both definitions, and requiring `=` to follow the parenthesis
+			// immediately left them in the module's block.
+			//
 			// The mask stops at `;` as well as at the line end, because that is
 			// where the definition stops: `module M; setup() = 1; setup(); end`
 			// puts a real module-level call after the semicolon, and running to
 			// the line end would swallow it.
 			//
 			// The `=` must be a single one: `f() == x` is a comparison.
-			`\b` + quoted + `\s*\([^()]*\)\s*=([^=;\n][^;\n]*)?`,
+			`\b` + quoted + `\s*\([^()]*\)[^=;\n]*=([^=;\n][^;\n]*)?`,
 		} {
 			re, err := regexp.Compile(pattern)
 			if err != nil {

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -2252,7 +2252,16 @@ func juliaMaskDefinitionHeads(block string, names []string) string {
 			// puts a real module-level call after the semicolon, and running to
 			// the line end would swallow it.
 			//
-			// The `=` must be a single one: `f() == x` is a comparison.
+			// The `=` must be an ASSIGNMENT, which is not the same as "not
+			// followed by another `=`". Julia spells many operators with a
+			// trailing `=` -- `>=`, `<=`, `!=`, `~=`, and every update operator
+			// (`+=`, `*=`, ...) -- and `=>` is the Pair constructor. Excluding
+			// only a following `=` caught `f(2) == 3` but still masked
+			// `f(2) >= 3` and `f(2) => v` as definitions, silently dropping the
+			// real module-to-`f` edge in each. RE2 has no lookaround, so the
+			// character on EITHER side of the `=` has to prove itself: the one
+			// before it may not be an operator character, and the one after it
+			// may be neither `=` nor `>`.
 			// Go's regexp is RE2 and has no lookahead, so "not followed by
 			// another `=`" cannot be asserted directly. Making the suffix
 			// OPTIONAL was the bug: it let the match end right after the first
@@ -2260,13 +2269,13 @@ func juliaMaskDefinitionHeads(block string, names []string) string {
 			// genuine module-scope `f(2) == 3` was masked away with the real
 			// `M -> M.f` edge in it. Requiring the suffix makes the next
 			// character prove itself.
-			`\b` + quoted + `\s*\([^()]*\)[^=;\n]*=[^=;\n][^;\n]*`,
+			`\b` + quoted + `\s*\([^()]*\)(?:[^=;\n]*[^=;\n<>!~+\-*/\\^%&|])?=[^=;\n>][^;\n]*`,
 			// A short form may also put its body on the NEXT line
 			// (`f(x) =` then an indented body), which the required suffix above
 			// cannot match. `(?m)$` is zero-width, so the newline survives and
 			// line numbering is unchanged; only spaces or tabs may sit between,
 			// so this still cannot reach the second `=` of `==`.
-			`(?m)\b` + quoted + `\s*\([^()]*\)[^=;\n]*=[ \t]*$`,
+			`(?m)\b` + quoted + `\s*\([^()]*\)(?:[^=;\n]*[^=;\n<>!~+\-*/\\^%&|])?=[ \t]*$`,
 		} {
 			re, err := regexp.Compile(pattern)
 			if err != nil {

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12867,6 +12867,103 @@ end
 		}
 	}
 }
+func TestJuliaEqualModuleNamesInDifferentFilesAreDifferentNamespaces(t *testing.T) {
+	// The cross-file half of the module gate compared module NAMES, on the
+	// reasoning that a Julia module spans files through `include` and each file
+	// gives it a different container id while it stays one namespace. The first
+	// clause does not follow from the second: an `include`d file carries BARE
+	// definitions, recorded with no container at all, so the include case never
+	// reached a name comparison. What name equality did admit was two unrelated
+	// packages that each declare `module Utils` -- distinct namespaces in Julia,
+	// where a second `module M ... end` binds a NEW module rather than reopening
+	// the first -- so a bare call in one package fabricated a CALLS edge to a
+	// globally unique method of the other.
+	//
+	// Both directions are pinned: a module spanning files through `include`
+	// still resolves across them, and two same-named but distinct modules do
+	// not resolve into each other.
+	repo := t.TempDir()
+	// Two independent packages, each declaring `module Utils`. Only pkgA
+	// defines `helper`, so it is globally unique and the name-only fallback is
+	// the branch under test.
+	writeFile(t, repo, "pkgA/src/Utils.jl", `module Utils
+
+function helper(x)
+    return x + 1
+end
+
+end
+`)
+	writeFile(t, repo, "pkgB/src/Utils.jl", `module Utils
+
+function localHelper(x)
+    return x - 1
+end
+
+function run(y)
+    return helper(y) + localHelper(y)
+end
+
+end
+`)
+	// A module that genuinely spans files: declared once, its body extended by
+	// an `include`d file of bare definitions.
+	writeFile(t, repo, "pkgC/src/MyPkg.jl", `module MyPkg
+
+include("shared.jl")
+
+function invoke(z)
+    return sharedHelper(z)
+end
+
+end
+`)
+	writeFile(t, repo, "pkgC/src/shared.jl", `function sharedHelper(x)
+    return x * 2
+end
+`)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Last-segment matching cannot tell the two `Utils` modules apart, so match
+	// on the file a symbol is defined in as well as its qualified name.
+	symbolsByID := map[string]SymbolRecord{}
+	for _, symbol := range snapshot.Symbols {
+		symbolsByID[symbol.ID] = symbol
+	}
+	type site struct{ file, qualified string }
+	calls := relationsOfType(snapshot.Relations, "CALLS")
+	hasCall := func(from, to site) bool {
+		for _, relation := range calls {
+			fromSymbol, fromOK := symbolsByID[relation.FromID]
+			toSymbol, toOK := symbolsByID[relation.ToID]
+			if !fromOK || !toOK {
+				continue
+			}
+			if fromSymbol.FilePath == from.file && fromSymbol.QualifiedName == from.qualified &&
+				toSymbol.FilePath == to.file && toSymbol.QualifiedName == to.qualified {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Same-named, genuinely distinct modules must NOT resolve into each other.
+	if hasCall(site{"pkgB/src/Utils.jl", "Utils.run"}, site{"pkgA/src/Utils.jl", "Utils.helper"}) {
+		t.Errorf("bare call in pkgB's Utils must not reach pkgA's same-named Utils: %#v", calls)
+	}
+	// ...while the gate stays narrow: the caller's own module still resolves.
+	if !hasCall(site{"pkgB/src/Utils.jl", "Utils.run"}, site{"pkgB/src/Utils.jl", "Utils.localHelper"}) {
+		t.Errorf("missing in-module Julia CALLS Utils.run->Utils.localHelper: %#v", calls)
+	}
+	// A module spanning files through `include` still resolves across them.
+	if !hasCall(site{"pkgC/src/MyPkg.jl", "MyPkg.invoke"}, site{"pkgC/src/shared.jl", "sharedHelper"}) {
+		t.Errorf("missing include-spanned Julia CALLS MyPkg.invoke->sharedHelper: %#v", calls)
+	}
+}
+
 func TestJuliaCallScopeIsTheEnclosingModuleNotTheImmediateContainer(t *testing.T) {
 	// The module gate asks whether a bare call can see a module-scoped
 	// definition, and the answer depends on the module the CALLER's code is

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12768,6 +12768,110 @@ end
 		}
 	}
 }
+func TestJuliaCallScopeIsTheEnclosingModuleNotTheImmediateContainer(t *testing.T) {
+	// The module gate asks whether a bare call can see a module-scoped
+	// definition, and the answer depends on the module the CALLER's code is
+	// written in -- which is not always the caller's immediate container. A
+	// Julia inner constructor is contained by its STRUCT (`Boxed.Boxed` under
+	// `struct Boxed`), so reading the immediate container made its scope
+	// `Boxed`, and every call it makes to its own module's definitions was
+	// dropped.
+	//
+	// Walking to the nearest MODULE is the fix, and walking no further is the
+	// other half of it: a nested `module` does not inherit its parent's names in
+	// Julia, so an ancestor-prefix rule would wrongly admit `NestInner.innerCaller
+	// -> NestOuter.outerHelper`. Both directions are pinned here, along with the
+	// cross-module guard the gate exists for.
+	repo := t.TempDir()
+	writeFile(t, repo, "src/Ctor.jl", `module Ctor
+
+function check(v)
+    return v
+end
+
+struct Boxed
+    x::Int
+    Boxed(x) = new(check(x))
+end
+
+end
+`)
+	writeFile(t, repo, "src/Nest.jl", `module NestOuter
+
+function outerHelper(x)
+    return x
+end
+
+module NestInner
+
+function innerCaller(y)
+    return outerHelper(y)
+end
+
+end
+
+end
+`)
+	writeFile(t, repo, "src/Guard.jl", `module GuardA
+
+function guardTarget(x)
+    return 1
+end
+
+end
+
+module GuardB
+
+function guardCaller(y)
+    return guardTarget(y)
+end
+
+end
+`)
+	writeFile(t, repo, "src/Flat.jl", `module Flat
+
+function flatHelper(x)
+    return x
+end
+
+function flatOuter(y)
+    function flatInner(z)
+        return flatHelper(z)
+    end
+    return flatInner(y)
+end
+
+end
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := relationsOfType(snapshot.Relations, "CALLS")
+	for _, want := range [][2]string{
+		// An inner constructor sits under the struct, and the struct under the
+		// module: its calls still reach the module's own definitions.
+		{"Boxed.Boxed", "Ctor.check"},
+		// A function nested in another function is recorded flat under the
+		// module, and must keep reaching it.
+		{"Flat.flatInner", "Flat.flatHelper"},
+	} {
+		if !hasRelationByLastSegment(snapshot.Relations, "CALLS", want[0], want[1]) {
+			t.Errorf("missing in-module Julia CALLS %s->%s: %#v", want[0], want[1], calls)
+		}
+	}
+	for _, forbidden := range [][2]string{
+		// A nested module does NOT see its parent's names.
+		{"NestInner.innerCaller", "NestOuter.outerHelper"},
+		// The guard the gate was added for: a bare call in one module must not
+		// bind a globally unique method of another.
+		{"GuardB.guardCaller", "GuardA.guardTarget"},
+	} {
+		if hasRelationByLastSegment(snapshot.Relations, "CALLS", forbidden[0], forbidden[1]) {
+			t.Errorf("cross-module Julia CALLS %s->%s must not resolve: %#v", forbidden[0], forbidden[1], calls)
+		}
+	}
+}
 
 func TestClojureSemanticExtraction(t *testing.T) {
 	// Clojure was promoted from inventory to the semantic tier (vendored

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12606,6 +12606,46 @@ func TestJuliaClosingEndScanCountsDepthAndIgnoresLiterals(t *testing.T) {
 	}
 }
 
+func TestJuliaOperatorsEndingInEqualsAreNotShortFormDefinitions(t *testing.T) {
+	// Julia spells many operators with a trailing `=` -- `>=`, `<=`, `!=`, the
+	// update operators -- and `=>` builds a Pair. Requiring only that the `=` not
+	// be FOLLOWED by another `=` still masked all of those as definitions, and
+	// each one silently took the real module-to-`f` edge with it.
+	for _, op := range []string{">=", "<=", "!=", "==", "=>", "+="} {
+		repo := t.TempDir()
+		writeFile(t, repo, "src/M.jl", "module M\nfunction f(x); x; end\nf(2) "+op+" 3\nend\n")
+		snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+		if err != nil {
+			t.Fatalf("build snapshot: %v", err)
+		}
+		if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "M", "M.f") {
+			t.Errorf("`f(2) %s 3` was masked as a definition, losing CALLS M->M.f: %#v",
+				op, relationsOfType(snapshot.Relations, "CALLS"))
+		}
+	}
+}
+
+func TestJuliaShortFormDefinitionFormsStayMasked(t *testing.T) {
+	// The counterpart: tightening the `=` guard must not stop a real short form
+	// being masked, including the forms that put a return type or a constraint
+	// between the argument list and the `=`.
+	for _, def := range []string{"g(x) = helper(x)", "g(x)::Int = helper(x)", "g(x) where T = helper(x)"} {
+		repo := t.TempDir()
+		writeFile(t, repo, "src/M.jl", "module M\n"+def+"\nfunction helper(y); y; end\nend\n")
+		snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+		if err != nil {
+			t.Fatalf("build snapshot: %v", err)
+		}
+		calls := relationsOfType(snapshot.Relations, "CALLS")
+		if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "M.g", "M.helper") {
+			t.Errorf("%q lost its own body call: %#v", def, calls)
+		}
+		if hasRelationByLastSegment(snapshot.Relations, "CALLS", "M", "M.helper") {
+			t.Errorf("%q left its body in the module's block: %#v", def, calls)
+		}
+	}
+}
+
 func TestJuliaModuleIsNotCreditedWithItsOwnMacros(t *testing.T) {
 	// A module's block spans its members' definition lines, and a macro's head
 	// reads as a call: `macro mymac(x)` contains `mymac(x)`. The module-own-block

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12652,6 +12652,59 @@ end
 	}
 }
 
+func TestJuliaShortFormWithParenthesesInItsArgumentListStaysMasked(t *testing.T) {
+	// The short-form mask required an argument list with NO nested parentheses,
+	// so an ordinary default value -- `g(x = (1, 2)) = other(x)`, `g(x = h(1)) =
+	// other(x)` -- matched nothing and the whole line stayed in the module's
+	// block: the definition head read as a module-to-`g` call, and the
+	// right-hand side's calls were credited to the module as well.
+	for _, def := range []string{"g(x = (1, 2)) = other(x)", "g(x = (1, 2))::Int = other(x)", "g(x = other(1)) = other(x)"} {
+		repo := t.TempDir()
+		writeFile(t, repo, "src/M.jl", "module M\nfunction other(y); y; end\n"+def+"\nend\n")
+		snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+		if err != nil {
+			t.Fatalf("build snapshot: %v", err)
+		}
+		calls := relationsOfType(snapshot.Relations, "CALLS")
+		if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "M.g", "M.other") {
+			t.Errorf("%q lost its own body call: %#v", def, calls)
+		}
+		if hasRelationByLastSegment(snapshot.Relations, "CALLS", "M", "M.other") {
+			t.Errorf("%q left its right-hand side in the module's block: %#v", def, calls)
+		}
+		if hasRelationByLastSegment(snapshot.Relations, "CALLS", "M", "M.g") {
+			t.Errorf("%q left its own definition head in the module's block, read as a call: %#v", def, calls)
+		}
+	}
+}
+
+func TestJuliaLongFormSignatureIsNotTheModuleBody(t *testing.T) {
+	// A multi-line definition's body lines are blanked from the module's block
+	// but its HEAD line is deliberately kept, and only `function NAME` was masked
+	// there. Julia writes default values in the signature, so `function f(x =
+	// helper(1))` left `(x = helper(1))` behind and the module was credited with
+	// calling helper beside the real `M.f -> M.helper` edge.
+	repo := t.TempDir()
+	writeFile(t, repo, "src/M.jl", `module M
+function helper(y); y; end
+function f(x = helper(1))
+    return x
+end
+end
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatalf("build snapshot: %v", err)
+	}
+	calls := relationsOfType(snapshot.Relations, "CALLS")
+	if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "M.f", "M.helper") {
+		t.Errorf("the definition lost the call in its own signature: %#v", calls)
+	}
+	if hasRelationByLastSegment(snapshot.Relations, "CALLS", "M", "M.helper") {
+		t.Errorf("a default argument in a definition's signature was credited to the module: %#v", calls)
+	}
+}
+
 func TestJuliaOperatorsEndingInEqualsAreNotShortFormDefinitions(t *testing.T) {
 	// Julia spells many operators with a trailing `=` -- `>=`, `<=`, `!=`, the
 	// update operators -- and `=>` builds a Pair. Requiring only that the `=` not

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12499,6 +12499,66 @@ func TestJuliaDefinitionsSharingOneLineDoNotCrossAttribute(t *testing.T) {
 	}
 }
 
+func TestJuliaBlockCommentDoesNotTerminateADefinitionMask(t *testing.T) {
+	// Julia block comments nest and the generic stripper does not know the form,
+	// so `#= end =#` left an `end` for the block-token scan to count as the
+	// definition's terminator: the mask stopped inside the comment and left the
+	// rest of the body -- and every call in it -- credited to the module.
+	if got := juliaMaskLongFormDefinition("function f(); #= end =#; helper(); end", "f"); strings.TrimSpace(got) != "" {
+		t.Errorf("the mask stopped at an `end` inside a comment: %q", got)
+	}
+	if got := maskJuliaBlockComments("a #= x #= y =# z =# b"); got != "a                   b" {
+		t.Errorf("nested block comment not fully masked: %q", got)
+	}
+}
+
+func TestJuliaComparisonIsNotMaskedAsAShortFormDefinition(t *testing.T) {
+	// The single-`=` guard was expressed as an OPTIONAL suffix, so the match
+	// could end right after the first `=` of `==` -- exactly the case the guard
+	// was for. A genuine module-scope `f(2) == 3` was masked away, taking the
+	// real `M -> M.f` edge with it.
+	repo := t.TempDir()
+	writeFile(t, repo, "src/M.jl", `module M
+function f(x); x; end
+f(2) == 3
+end
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatalf("build snapshot: %v", err)
+	}
+	calls := relationsOfType(snapshot.Relations, "CALLS")
+	if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "M", "M.f") {
+		t.Fatalf("a module-scope comparison was masked as a definition, losing CALLS M->M.f: %#v", calls)
+	}
+}
+
+func TestJuliaShortFormDefinitionsStayMasked(t *testing.T) {
+	// The counterpart to the above: tightening the guard must not stop real
+	// short forms being masked, including one whose body is on the next line.
+	repo := t.TempDir()
+	writeFile(t, repo, "src/M.jl", `module M
+g(x) = helper(x)
+h(x) =
+    helper(x)
+function helper(y); y; end
+end
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatalf("build snapshot: %v", err)
+	}
+	calls := relationsOfType(snapshot.Relations, "CALLS")
+	for _, want := range [][2]string{{"M.g", "M.helper"}, {"M.h", "M.helper"}} {
+		if !hasRelationByLastSegment(snapshot.Relations, "CALLS", want[0], want[1]) {
+			t.Fatalf("missing real short-form body CALLS %s->%s: %#v", want[0], want[1], calls)
+		}
+	}
+	if hasRelationByLastSegment(snapshot.Relations, "CALLS", "M", "M.helper") {
+		t.Fatalf("a short form's body was credited to the module: %#v", calls)
+	}
+}
+
 func TestJuliaModuleIsNotCreditedWithItsOwnMacros(t *testing.T) {
 	// A module's block spans its members' definition lines, and a macro's head
 	// reads as a call: `macro mymac(x)` contains `mymac(x)`. The module-own-block

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12435,6 +12435,49 @@ end
 	}
 }
 
+func TestJuliaModuleScopedCallsResolve(t *testing.T) {
+	// Idiomatic Julia wraps a package's definitions in `module ... end`, which
+	// makes every definition module-qualified and therefore emitted with kind
+	// "method" rather than "function". A bare `callee(...)` — the only call
+	// syntax Julia has — must still resolve to it: Julia has no receiver call
+	// form, so excluding methods from name resolution left real packages with
+	// zero same-file CALLS while `capabilities --json` advertised CALLS for
+	// Julia.
+	repo := t.TempDir()
+	writeFile(t, repo, "src/Geo.jl", `module Geo
+
+struct Point
+    x::Int
+    y::Int
+end
+
+function add(a, b)
+    return a + b
+end
+
+function point_sum(p::Point)
+    return add(p.x, p.y)
+end
+
+scaled(p::Point) = point_sum(p) * 2
+
+end
+`)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range [][2]string{
+		{"Geo.point_sum", "Geo.add"},
+		{"Geo.scaled", "Geo.point_sum"},
+	} {
+		if !hasRelationByLastSegment(snapshot.Relations, "CALLS", want[0], want[1]) {
+			t.Fatalf("missing Julia module-scoped CALLS %s->%s: %#v", want[0], want[1], relationsOfType(snapshot.Relations, "CALLS"))
+		}
+	}
+}
+
 func TestClojureSemanticExtraction(t *testing.T) {
 	// Clojure was promoted from inventory to the semantic tier (vendored
 	// grammar). tree-sitter-clojure only produces generic list_lit nodes, so

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12771,6 +12771,87 @@ end
 	}
 }
 
+func TestJuliaGeneratorForIsNotAnEndDelimitedOpener(t *testing.T) {
+	// Julia's comprehensions and generators put a `for` -- and optionally an `if`
+	// filter -- inside a bracket, and close it with that bracket, never with
+	// `end`. The block-depth scans counted every `for` as an `end`-delimited
+	// opener, so each generator raised the depth by a block that never closes:
+	// the `end` that really closed the definition was spent rebalancing, the scan
+	// ran past it, and `end; setup()` left a module-level call credited to the
+	// function instead of the module -- or masked away with the function.
+	for _, body := range []string{
+		"sum(x for x in xs)",
+		"[g(i) for i in 1:3]",
+		"[i for i in 1:9 if iseven(i)]",
+		"sum(xs[end] for x in xs)",
+		"Dict{Int,Int}(i => i for i in 1:3)",
+	} {
+		for _, src := range []string{
+			"module M\nfunction setup(); 1; end\nfunction f()\n    " + body + "\nend; setup()\nend\n",
+			"module M\nfunction setup(); 1; end\nfunction f(); " + body + "; end; setup()\nend\n",
+		} {
+			repo := t.TempDir()
+			writeFile(t, repo, "src/M.jl", src)
+			snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+			if err != nil {
+				t.Fatalf("build snapshot: %v", err)
+			}
+			calls := relationsOfType(snapshot.Relations, "CALLS")
+			if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "M", "M.setup") {
+				t.Errorf("%q: a generator `for` inflated the depth, so the module lost the call after the child's `end`: %#v", src, calls)
+			}
+			if hasRelationByLastSegment(snapshot.Relations, "CALLS", "M.f", "M.setup") {
+				t.Errorf("%q: module-level code after the child's `end` stayed in the child's own scan: %#v", src, calls)
+			}
+		}
+	}
+}
+
+func TestJuliaBlockOpenersInsideBracketsAreStillOpeners(t *testing.T) {
+	// The counterpart: a `for` or an `if` inside a bracket is only a generator's
+	// when the innermost construct still open is the BRACKET. A real loop written
+	// in an argument's `do` block, and an `if` EXPRESSION passed as an argument,
+	// both close with `end` and must keep their depth -- otherwise the scan
+	// under-counts and cuts the definition short instead.
+	for _, tc := range []struct{ in, want string }{
+		// generator clauses: closed by the bracket, so the definition's own
+		// `end` is the cut and `setup()` belongs to the enclosing scope.
+		{"function f(); sum(x for x in xs); end; setup()",
+			"function f(); sum(x for x in xs); end         "},
+		{"function f(); [i for i in 1:9 if iseven(i)]; end; setup()",
+			"function f(); [i for i in 1:9 if iseven(i)]; end         "},
+		// `end` as an index is not a terminator either.
+		{"function f(); sum(xs[end] for x in xs); end; setup()",
+			"function f(); sum(xs[end] for x in xs); end         "},
+		{"function f(); h(xs[begin:end]); end; setup()",
+			"function f(); h(xs[begin:end]); end         "},
+		// real blocks inside brackets, which DO close with `end`.
+		{"function f(); g(map(ys) do y; for i in 1:3; h(i); end; end); end; setup()",
+			"function f(); g(map(ys) do y; for i in 1:3; h(i); end; end); end         "},
+		{"function f(); g(if c; 1; else; 2; end); end; setup()",
+			"function f(); g(if c; 1; else; 2; end); end         "},
+	} {
+		if got := juliaBlankAfterClosingEnd(tc.in); got != tc.want {
+			t.Errorf("juliaBlankAfterClosingEnd(%q)\n got %q\nwant %q", tc.in, got, tc.want)
+		}
+	}
+	// The depth a child's earlier lines leave open feeds the closing-end scan, so
+	// a generator there mis-sets the cut on the last line as surely as one on it.
+	for _, tc := range []struct {
+		in   string
+		want int
+	}{
+		{"function f()\n    sum(x for x in xs)", 1},
+		{"function f()\n    [i for i in 1:9 if iseven(i)]", 1},
+		{"function f()\n    map(ys) do y; g(y); end", 1},
+		{"function f()\n    g(map(ys) do y; for i in 1:3; h(i); end", 2},
+	} {
+		if got := juliaOpenBlockDepth(tc.in); got != tc.want {
+			t.Errorf("juliaOpenBlockDepth(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestJuliaModuleIsNotCreditedWithItsOwnMacros(t *testing.T) {
 	// A module's block spans its members' definition lines, and a macro's head
 	// reads as a call: `macro mymac(x)` contains `mymac(x)`. The module-own-block

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12478,6 +12478,89 @@ end
 	}
 }
 
+func TestJuliaBareCallsStayInsideTheirModule(t *testing.T) {
+	// `module M ... end` is a hard namespace boundary in Julia: from outside M,
+	// its definitions are reachable only as `M.name(...)`. Resolving bare calls
+	// to module-scoped definitions must therefore stay inside the caller's own
+	// module, or one file holding two modules resolves a bare call to whichever
+	// same-named definition happens to be declared nearest, and a top-level call
+	// reaches into a module it cannot see.
+	repo := t.TempDir()
+	writeFile(t, repo, "src/Two.jl", `module A
+
+function target(x)
+    return 1
+end
+
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+# padding
+
+function caller(y)
+    return target(y)
+end
+
+end
+
+module B
+
+function target(x)
+    return 2
+end
+
+end
+
+function toplevel(z)
+    return target(z)
+end
+`)
+
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := relationsOfType(snapshot.Relations, "CALLS")
+	// The call sits nearer to B's declaration than to its own module's, so the
+	// lexically-nearest tiebreak picks B without a module-scope gate.
+	if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "A.caller", "A.target") {
+		t.Fatalf("missing in-module Julia CALLS A.caller->A.target: %#v", calls)
+	}
+	for _, forbidden := range [][2]string{
+		{"A.caller", "B.target"},
+		{"toplevel", "A.target"},
+		{"toplevel", "B.target"},
+	} {
+		if hasRelationByLastSegment(snapshot.Relations, "CALLS", forbidden[0], forbidden[1]) {
+			t.Fatalf("cross-module Julia CALLS %s->%s must not resolve: %#v", forbidden[0], forbidden[1], calls)
+		}
+	}
+}
+
 func TestClojureSemanticExtraction(t *testing.T) {
 	// Clojure was promoted from inventory to the semantic tier (vendored
 	// grammar). tree-sitter-clojure only produces generic list_lit nodes, so

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12478,6 +12478,27 @@ end
 	}
 }
 
+func TestJuliaDefinitionsSharingOneLineDoNotCrossAttribute(t *testing.T) {
+	// A call-scan block is line-granular: SymbolRecord carries StartLine and
+	// EndLine and nothing finer, so two definitions written on ONE line each take
+	// that whole line as their block and read the other's definition head as a
+	// call. `helper`'s block contains `function f`, which the name scanner read as
+	// a call, emitting a `M.helper -> M.f` that is not in the source.
+	repo := t.TempDir()
+	writeFile(t, repo, "src/M.jl", "module M; helper()=1; function f(); helper(); end; end\n")
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatalf("build snapshot: %v", err)
+	}
+	calls := relationsOfType(snapshot.Relations, "CALLS")
+	if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "M.f", "M.helper") {
+		t.Fatalf("missing the real CALLS M.f->M.helper: %#v", calls)
+	}
+	if hasRelationByLastSegment(snapshot.Relations, "CALLS", "M.helper", "M.f") {
+		t.Fatalf("a definition head on a shared line was read as a call: %#v", calls)
+	}
+}
+
 func TestJuliaModuleIsNotCreditedWithItsOwnMacros(t *testing.T) {
 	// A module's block spans its members' definition lines, and a macro's head
 	// reads as a call: `macro mymac(x)` contains `mymac(x)`. The module-own-block

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12595,14 +12595,60 @@ func TestJuliaClosingEndScanCountsDepthAndIgnoresLiterals(t *testing.T) {
 	// one: an `end` closing a block nested inside the child would hand the
 	// child's own calls to the module. An `end` inside a string is not a
 	// terminator at all.
-	for _, tc := range []struct{ in, want string }{
-		{"end; setup()", "   ; setup()"},
-		{"  if c; helper(); end; end; g()", "                          ; g()"},
-		{`  x = "end"; end; g()`, "                ; g()"},
+	for _, tc := range []struct {
+		in        string
+		openDepth int
+		want      string
+	}{
+		{"end; setup()", 1, "   ; setup()"},
+		{"  if c; helper(); end; end; g()", 1, "                          ; g()"},
+		{`  x = "end"; end; g()`, 1, "                ; g()"},
+		// The nesting need not start on this line: a child that opened an `if`
+		// earlier reaches its last line already two blocks deep, and counting
+		// from one cut at the `if`'s `end`, handing the child's own call to the
+		// enclosing module.
+		{"    end; helper(); end; setup()", 2, "                      ; setup()"},
 	} {
-		if got := juliaBlankThroughClosingEnd(tc.in); got != tc.want {
-			t.Errorf("juliaBlankThroughClosingEnd(%q) = %q, want %q", tc.in, got, tc.want)
+		if got := juliaBlankThroughClosingEnd(tc.in, tc.openDepth); got != tc.want {
+			t.Errorf("juliaBlankThroughClosingEnd(%q, %d) = %q, want %q", tc.in, tc.openDepth, got, tc.want)
 		}
+	}
+}
+
+func TestJuliaNestingFromEarlierLinesSurvivesToTheClosingEndScan(t *testing.T) {
+	// The cut on a child's last line is the `end` that closes the CHILD, and the
+	// blocks it has to count through are not all on that line. `end; helper();
+	// end; setup()` closes an `if` opened two lines earlier before it closes the
+	// function, and a scan that started from a fixed depth of one stopped at the
+	// `if`'s `end` -- handing `helper()`, a call inside the function's own body,
+	// to the enclosing module.
+	repo := t.TempDir()
+	writeFile(t, repo, "src/M.jl", `module M
+function setup()
+    1
+end
+function helper()
+    2
+end
+function f()
+    if true
+        3
+    end; helper(); end; setup()
+end
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatalf("build snapshot: %v", err)
+	}
+	calls := relationsOfType(snapshot.Relations, "CALLS")
+	if hasRelationByLastSegment(snapshot.Relations, "CALLS", "M", "M.helper") {
+		t.Errorf("an `end` closing a block opened on an earlier line was read as the child's, crediting the module with the child's call: %#v", calls)
+	}
+	if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "M.f", "M.helper") {
+		t.Errorf("the child lost its own body call: %#v", calls)
+	}
+	if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "M", "M.setup") {
+		t.Errorf("module-level code after the child's real closing `end` was blanked: %#v", calls)
 	}
 }
 

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12745,6 +12745,32 @@ func TestJuliaShortFormDefinitionFormsStayMasked(t *testing.T) {
 	}
 }
 
+func TestJuliaOneLineDefinitionGivesUpTrailingModuleCode(t *testing.T) {
+	// The counterpart to TestJuliaCodeAfterAChildsEndBelongsToTheModule for a
+	// definition written entirely on ONE line. Locating the closing `end`'s line
+	// used LastIndexByte, which returns -1 when the block holds no newline; the
+	// +1 makes that 0, the correct start of the only line, but the guard rejected
+	// 0 as "not found" and bailed out. `function f(); end; setup()` therefore kept
+	// `setup()` inside f's own scan and emitted a false `f -> setup`.
+	repo := t.TempDir()
+	writeFile(t, repo, "src/M.jl", `module M
+function setup(); 1; end
+function f(); end; setup()
+end
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatalf("build snapshot: %v", err)
+	}
+	calls := relationsOfType(snapshot.Relations, "CALLS")
+	if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "M", "M.setup") {
+		t.Errorf("the module lost the call written after the one-line definition: %#v", calls)
+	}
+	if hasRelationByLastSegment(snapshot.Relations, "CALLS", "M.f", "M.setup") {
+		t.Errorf("a one-line definition kept trailing module-level code in its own scan: %#v", calls)
+	}
+}
+
 func TestJuliaModuleIsNotCreditedWithItsOwnMacros(t *testing.T) {
 	// A module's block spans its members' definition lines, and a macro's head
 	// reads as a call: `macro mymac(x)` contains `mymac(x)`. The module-own-block

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12559,6 +12559,53 @@ end
 	}
 }
 
+func TestJuliaCodeAfterAChildsEndBelongsToTheModule(t *testing.T) {
+	// `end; setup()` is valid Julia: a function's closing line can carry
+	// module-level code. Blanking the child's lines through EndLine deleted that
+	// call from the module's block, while the child's own block still contained
+	// it -- so one real module-to-setup call was lost from the module and
+	// credited to the function instead. A SymbolRecord carries no column, so both
+	// halves find the cut by counting block depth to the `end` that closes the
+	// child.
+	repo := t.TempDir()
+	writeFile(t, repo, "src/M.jl", `module M
+function setup()
+    1
+end
+function f()
+    2
+end; setup()
+end
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatalf("build snapshot: %v", err)
+	}
+	calls := relationsOfType(snapshot.Relations, "CALLS")
+	if !hasRelationByLastSegment(snapshot.Relations, "CALLS", "M", "M.setup") {
+		t.Fatalf("module-level code after a child's `end` was blanked, losing CALLS M->M.setup: %#v", calls)
+	}
+	if hasRelationByLastSegment(snapshot.Relations, "CALLS", "M.f", "M.setup") {
+		t.Fatalf("module-level code after a child's `end` was also credited to the child: %#v", calls)
+	}
+}
+
+func TestJuliaClosingEndScanCountsDepthAndIgnoresLiterals(t *testing.T) {
+	// The cut is the `end` that returns the scan to depth zero, not the first
+	// one: an `end` closing a block nested inside the child would hand the
+	// child's own calls to the module. An `end` inside a string is not a
+	// terminator at all.
+	for _, tc := range []struct{ in, want string }{
+		{"end; setup()", "   ; setup()"},
+		{"  if c; helper(); end; end; g()", "                          ; g()"},
+		{`  x = "end"; end; g()`, "                ; g()"},
+	} {
+		if got := juliaBlankThroughClosingEnd(tc.in); got != tc.want {
+			t.Errorf("juliaBlankThroughClosingEnd(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestJuliaModuleIsNotCreditedWithItsOwnMacros(t *testing.T) {
 	// A module's block spans its members' definition lines, and a macro's head
 	// reads as a call: `macro mymac(x)` contains `mymac(x)`. The module-own-block

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12478,6 +12478,46 @@ end
 	}
 }
 
+func TestJuliaModuleIsNotCreditedWithItsOwnMacros(t *testing.T) {
+	// A module's block spans its members' definition lines, and a macro's head
+	// reads as a call: `macro mymac(x)` contains `mymac(x)`. The module-own-block
+	// mask blanks child BODIES by line range -- which covers a multi-line macro --
+	// but the head line is deliberately kept (a one-line module puts a real call
+	// there), and a one-line macro has no body line to blank at all. Both mask
+	// helpers therefore have to know `macro`, not just `function`, or the module
+	// gains a fabricated call to each macro plus every call a one-line macro makes.
+	repo := t.TempDir()
+	writeFile(t, repo, "src/M.jl", `module M
+
+function helper(x)
+    return x
+end
+
+macro mymac(x)
+    helper(x)
+end
+
+macro oneline(x) helper(x) end
+
+end
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatalf("build snapshot: %v", err)
+	}
+	calls := relationsOfType(snapshot.Relations, "CALLS")
+	for _, want := range [][2]string{{"M.mymac", "M.helper"}, {"M.oneline", "M.helper"}} {
+		if !hasRelationByLastSegment(snapshot.Relations, "CALLS", want[0], want[1]) {
+			t.Fatalf("missing real macro-body CALLS %s->%s: %#v", want[0], want[1], calls)
+		}
+	}
+	for _, forbidden := range [][2]string{{"M", "M.mymac"}, {"M", "M.oneline"}, {"M", "M.helper"}} {
+		if hasRelationByLastSegment(snapshot.Relations, "CALLS", forbidden[0], forbidden[1]) {
+			t.Fatalf("module credited with its own macro CALLS %s->%s: %#v", forbidden[0], forbidden[1], calls)
+		}
+	}
+}
+
 func TestJuliaBareCallsStayInsideTheirModule(t *testing.T) {
 	// `module M ... end` is a hard namespace boundary in Julia: from outside M,
 	// its definitions are reachable only as `M.name(...)`. Resolving bare calls


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/120
<!-- entire-trail-link-end -->

## Impact

Every function defined inside a Julia `module ... end` — i.e. essentially every
function in every Julia package — produced **zero CALLS edges**, silently.
`capabilities --json` advertises `CALLS` for Julia, `entire graph neighbors`
and `entire graph impact` return nothing for those symbols, and no warning or
partial-failure is reported. The identical code written at file top level does
emit CALLS, which is why the existing Julia call test never caught it.

## Repro

```julia
# Geo.jl
module Geo
function add(a, b)
    return a + b
end
function point_sum(x, y)
    return add(x, y)   # <- no CALLS edge
end
end
```

```
$ entire graph edges --repo . --format ndjson --relation CALLS
graph: 0 edge(s) matched
```

Delete the `module Geo` / `end` wrapper and the same file emits
`CALLS point_sum -> add`. `DATA_FLOWS point_sum -> add` is emitted in *both*
cases, so the call site is found — only the CALLS edge is dropped.

## Root cause

A Julia definition inside a module is namespace-qualified by the parser
(`parser.go`, `case "function_definition"` / `case "assignment"`):

```go
if scope != "" && !strings.Contains(name, ".") {
    kind = "method"
    name = qualify(scope, name)
}
```

so `Geo.add` is emitted with `Kind == "method"`. `resolveCallTargets` then
rejects it, because a bare `name()` call is not allowed to bind to a method
unless the language says otherwise:

```go
if ... || (to.Kind == "method" && !nameCallMayTargetMethod(from.Language) && !allowMethodTargets) ...
```

`nameCallMayTargetMethod` covered implicit-receiver languages and Rust, but not
Julia. That gate exists to stop `name()` from resolving to a receiver-dispatched
member — a distinction Julia does not have: `f(args...)` is the only call syntax
in the language, and the `method` kind here means "module-scoped", not "member".

## Fix

Add Julia to `nameCallMayTargetMethod`, with the reasoning recorded next to the
other two entries. One predicate, no parser or symbol-shape change, so stable
symbol IDs and every other language are untouched.

## Regression test

`TestJuliaModuleScopedCallsResolve` builds a snapshot over a module-wrapped file
and requires `CALLS Geo.point_sum -> Geo.add` and `CALLS Geo.scaled ->
Geo.point_sum` (long-form and short-form definitions).

Mutation verification:

- Before the fix: FAIL — `missing Julia module-scoped CALLS Geo.point_sum->Geo.add: []`.
- With the fix mutated to `lang == "JuliaMUTANT"`: FAIL, same assertion.
- With the fix: PASS.

## Verification run locally

`gofmt -l .`, `go build ./...`, `go vet ./...` and `go test ./internal/sem/`
(2771 tests) all green. The full `-race` gate (`mise run check`) was **not**
completed locally: this machine is running several parallel workloads and both
`internal/cli` and `internal/sem` exceed Go's default 10-minute per-package
timeout regardless of branch — an unmodified `origin/main` worktree times out on
`go test -timeout 9m ./internal/cli/` at 540.7s, identically. CI should run the
full gate on a clean runner.
