### PR TITLE
fix(sem): extract HCL top-level attributes as settings

### DIFF
--- a/internal/sem/parser.go
+++ b/internal/sem/parser.go
@@ -4997,6 +4997,26 @@ func entityFromNode(node *sitter.Node, src []byte, language, scope string) (Enti
 	case "block":
 		kind = "block"
 		name = hclBlockName(node, src)
+	case "attribute":
+		// HCL top-level attribute (`region = "us-west-2"`). A Terraform
+		// variables file (`.tfvars`, `*.auto.tfvars`) contains nothing else —
+		// the format rejects blocks — so extracting only `block` nodes left
+		// every such file with zero symbols and zero relations while HCL was
+		// advertised as a semantic language. Hand-written Consul/Nomad/Vault
+		// `.hcl` configs carry the same top-level settings. Attributes nested
+		// inside a block are that block's body and stay folded into the block
+		// symbol, which keeps a Terraform module from fanning out one symbol
+		// per argument. The node type is HCL-only in this grammar set, but the
+		// gate is explicit so another language's `attribute` node cannot leak
+		// into this case.
+		if language != "HCL" || !hclTopLevelAttribute(node) {
+			return Entity{}, false
+		}
+		name = hclAttributeName(node, src)
+		if name == "" {
+			return Entity{}, false
+		}
+		kind = "setting"
 	case "field":
 		kind = "field"
 		name = cueFieldName(node, src)
@@ -7747,6 +7767,29 @@ func hclBlockName(node *sitter.Node, src []byte) string {
 		}
 	}
 	return strings.Join(parts, ".")
+}
+
+// hclTopLevelAttribute reports whether an `attribute` node sits directly in the
+// file body rather than inside a block. tree-sitter-hcl nests every attribute
+// under a `body`, so the distinguishing parent is the body's own parent:
+// `config_file` for a top-level setting, `block` for a block argument.
+func hclTopLevelAttribute(node *sitter.Node) bool {
+	body := node.Parent()
+	if !validNode(body) || body.Type() != "body" {
+		return false
+	}
+	root := body.Parent()
+	return validNode(root) && root.Type() == "config_file"
+}
+
+// hclAttributeName returns the name an HCL attribute binds — the identifier on
+// the left of the `=`.
+func hclAttributeName(node *sitter.Node, src []byte) string {
+	identifier := firstNamedChildOfType(node, "identifier")
+	if !validNode(identifier) {
+		return ""
+	}
+	return strings.TrimSpace(identifier.Content(src))
 }
 
 func hclBlockPart(node *sitter.Node, src []byte) string {

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -1801,6 +1801,60 @@ resource "aws_subnet" "web" {
 	}
 }
 
+func TestHCLTopLevelAttributesEmitSymbols(t *testing.T) {
+	// A Terraform variables file (`.tfvars`, `*.auto.tfvars`) is by definition
+	// nothing but top-level attribute assignments: the format rejects blocks.
+	// Extracting only `block` nodes therefore made every .tfvars file in every
+	// repository produce zero symbols and zero relations, silently — the file
+	// was parsed, HCL is advertised as a semantic language, and nothing was
+	// reported as missing. Top-level attributes in hand-written .hcl configs
+	// (Consul/Nomad/Vault `datacenter = "dc1"`) were invisible for the same
+	// reason. Attributes INSIDE a block stay folded into the block symbol.
+	repo := t.TempDir()
+	writeFile(t, repo, "prod.tfvars", `region         = "us-west-2"
+instance_count = 3
+
+tags = {
+  env = "prod"
+}
+`)
+	writeFile(t, repo, "main.tf", `datacenter = "dc1"
+
+resource "aws_s3_bucket" "logs" {
+  bucket = "app-logs"
+}
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := map[string]string{}
+	for _, symbol := range snapshot.Symbols {
+		if symbol.Language == "HCL" {
+			got[symbol.FilePath+":"+symbol.Name] = symbol.Kind
+		}
+	}
+	for _, want := range []string{
+		"prod.tfvars:region",
+		"prod.tfvars:instance_count",
+		"prod.tfvars:tags",
+		"main.tf:datacenter",
+	} {
+		if got[want] != "setting" {
+			t.Fatalf("HCL top-level attribute %q not extracted as a setting: %#v", want, got)
+		}
+	}
+	if got["main.tf:logs"] != "block" {
+		t.Fatalf("HCL block symbol regressed: %#v", got)
+	}
+	// A nested attribute is part of its block's body, not a symbol of its own.
+	if _, nested := got["main.tf:bucket"]; nested {
+		t.Fatalf("attribute nested in a block must not be extracted: %#v", got)
+	}
+}
+
 func TestDockerfileStageResourceDependencies(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, repo, "Dockerfile", `FROM golang:1.22 AS builder


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/121
<!-- entire-trail-link-end -->

## Impact

`.tfvars` is a registered extension mapped to HCL, a language the provider
advertises in `semantic_languages`. A Terraform variables file consists of
nothing but top-level attribute assignments — the format rejects blocks — and
the HCL walker extracts only `block` nodes. The result: **every `.tfvars` and
`*.auto.tfvars` file in every repository produces zero symbols and zero
relations**, with no warning and no partial failure. The file is read, parsed
and counted as HCL, and nothing comes out. Hand-written Consul/Nomad/Vault
`.hcl` configs lose their top-level settings (`datacenter = "dc1"`,
`data_dir = "/opt/consul"`) for the same reason.

Other config languages already carry key/value symbols: TOML emits `setting`,
JSON/JSON5 and YAML emit `section`, CUE emits `field`. HCL was the outlier.

## Repro

```hcl
# prod.tfvars
region         = "us-west-2"
instance_count = 3
```

```
$ entire graph symbols --repo . --format ndjson | grep prod.tfvars
$ entire graph edges   --repo . --format ndjson | grep prod.tfvars
```

Both empty. The summary record does not even list HCL among the snapshot's
languages when the repository holds only attribute-shaped HCL.

## Root cause

`entityFromNode` (`internal/sem/parser.go`) has a `case "block"` for HCL and no
case for `attribute`, the node type tree-sitter-hcl produces for
`identifier = expression`. There is nothing else to fall back to: HCL is
grammar-backed, so it never reaches `fallbackEntities`.

## Fix

Add `case "attribute"` gated to HCL, emitting `kind: "setting"` (the same kind
TOML uses for a config key) named by the attribute's `identifier` child.

Only **top-level** attributes are extracted. `hclTopLevelAttribute` checks that
the attribute's `body` parent is the `config_file` itself, not a `block`, so an
argument inside a Terraform resource stays folded into the block symbol and a
large module does not fan out into one symbol per argument. That keeps the
change confined to the file class that was returning nothing at all.

`hclResourceDependsOnRelations` and `configTargets` both key on
`Kind == "block"` and are unaffected; RESOURCE_DEPENDS_ON and CONFIGURES output
is byte-identical for existing HCL.

## Regression test

`TestHCLTopLevelAttributesEmitSymbols` asserts:

- `prod.tfvars` emits `setting` symbols for `region`, `instance_count`, `tags`;
- a top-level `datacenter` in a `.tf` file emits one too;
- the `resource "aws_s3_bucket" "logs"` block symbol still comes out as `block`;
- the `bucket` argument *inside* that block does **not** become a symbol.

Mutation verification (both directions bind):

- Before the fix: FAIL — `HCL top-level attribute "prod.tfvars:region" not extracted as a setting: map["main.tf:logs":"block"]`.
- Mutating the guard to `|| true` (never extract): FAIL, same assertion.
- Mutating away the `hclTopLevelAttribute` check (extract every attribute): FAIL — `attribute nested in a block must not be extracted`.
- With the fix: PASS.

## Verification run locally

`gofmt -l .`, `go build ./...`, `go vet ./...` and `go test ./internal/sem/`
(2771 tests) all green. The full `-race` gate (`mise run check`) was **not**
completed locally: this machine is running several parallel workloads and both
`internal/cli` and `internal/sem` exceed Go's default 10-minute per-package
timeout regardless of branch — an unmodified `origin/main` worktree times out on
`go test -timeout 9m ./internal/cli/` at 540.7s, identically. CI should run the
full gate on a clean runner.
