### PR TITLE
fix(sem): stop inventory-only files emitting call relations

### DIFF
--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -724,7 +724,25 @@ func supportsCallExtraction(spec languageSpec) bool {
 	if spec.inventoryOnly {
 		return false
 	}
-	switch spec.language {
+	return callExtractionLanguage(spec.language)
+}
+
+// callExtractionLanguage is the single source of truth for "this language's
+// call syntax is extracted". It backs BOTH the capability report and the
+// runtime gate on the call scan (fileNeedsCallScan), so the two cannot drift:
+// a language the report says has no CALLS is a language the scanner does not
+// run on.
+//
+// They used to be independent. The report was this list; the scanner ran on
+// every file with any symbol, including the single `document` symbol an
+// inventory-only filetype gets, whose block is the whole file. A `.patch`, a
+// `.coffee` or a `.ino` therefore emitted CALLS into unrelated languages'
+// symbols through the globally-unique-name fallback — false edges in
+// `neighbors`, `impact` and search ranking, from filetypes
+// docs/language-support.md promises are "without claiming call/type/data-flow
+// analysis".
+func callExtractionLanguage(language string) bool {
+	switch language {
 	case "Bash", "C", "C++", "C#", "Clojure", "ClojureScript", "Dart", "Elixir", "Erlang", "F#", "Go", "Groovy", "Haskell", "Java", "JavaScript", "Julia", "Kotlin", "Lua", "Objective-C", "OCaml", "Perl", "PHP", "Python", "R", "Ruby", "Rust", "Scala", "SQL", "Swift", "TypeScript", "Zig", "Zsh":
 		return true
 	default:
@@ -3064,7 +3082,11 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 		}
 		lines := strings.Split(content, "\n")
 		currentFileSymbols := recordsByFile[file.Path]
-		fileNeedsCallScan := needsCallScan && !skipFastCFamilyCallScan(spec, file.Language)
+		// callExtractionLanguage keeps the scan inside the set `capabilities
+		// --json` declares CALLS for. Without it the scan also ran over
+		// inventory-only `document` symbols (whose block is the whole file) and
+		// over data/markup languages, inventing cross-language call edges.
+		fileNeedsCallScan := needsCallScan && callExtractionLanguage(file.Language) && !skipFastCFamilyCallScan(spec, file.Language)
 		fileNeedsRouteScan := spec.emits("HANDLES_ROUTE") && routeScanLanguage(file.Language)
 		fileNeedsHTTPScan := spec.emits("HTTP_CALLS") && httpScanLanguage(file.Language)
 		fileNeedsServiceScan := needsServiceRelations && serviceScanLanguage(file.Language)
@@ -3642,7 +3664,12 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 					}
 				}
 			}
-			if spec.callResolution == "full" {
+			// The receiver pass resolves `recv.method(...)` and is a second
+			// producer of CALLS, so it takes the same language gate as the
+			// bare-name scan above: without it an inventory-only `document`
+			// symbol still reached it and matched a `x.y(...)` shape anywhere
+			// in the file against another language's methods.
+			if spec.callResolution == "full" && callExtractionLanguage(file.Language) {
 				for _, r := range receiverCallRelations(from, block, methodsByContainer, superContainerByID, implementersByContainer, symbolsByShortName, returnTypesBySymbolNameAndFile, returnTypesBySymbolNameAndDir, importsByName, manifestImports.goModule, pkgVarTypesByDir[filepath.ToSlash(filepath.Dir(file.Path))], phpPropTypes, kotlinPropTypes, typeScriptPropTypes, fieldsByContainer, swiftTypes) {
 					emit(r)
 				}

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -1771,6 +1771,69 @@ fn main() {}
 	}
 }
 
+func TestInventoryOnlyFilesEmitNoCallRelations(t *testing.T) {
+	// An inventory-only filetype gets a single `document` symbol whose block is
+	// the whole file. The generic `name(` call scanner ran over it like any
+	// other symbol body, so a unified diff, a CoffeeScript file or an Arduino
+	// sketch could emit a CALLS edge into an unrelated language's symbol
+	// through the globally-unique-name fallback. docs/language-support.md
+	// promises the opposite: inventory-only coverage is file and document
+	// symbols "without claiming call/type/data-flow analysis", and
+	// `capabilities --json` declares only CONTAINS/DEFINES for these languages.
+	repo := t.TempDir()
+	writeFile(t, repo, "svc/service.go", `package svc
+
+type Stage struct{}
+
+func (s Stage) Advance() int {
+	return 1
+}
+
+func RunPipeline() int {
+	return 1
+}
+`)
+	writeFile(t, repo, "notes/change.patch", `--- a/x
++++ b/x
+@@ -1 +1 @@
+-old
++RunPipeline()
+`)
+	writeFile(t, repo, "sketch/blink.ino", `void loop() {
+  RunPipeline();
+}
+`)
+	// A receiver-shaped call exercises the second CALLS producer
+	// (receiverCallRelations), which is gated separately from the bare-name scan.
+	writeFile(t, repo, "web/app.coffee", `run = -> Stage.Advance()
+`)
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	languageByID := map[string]string{}
+	for _, symbol := range snapshot.Symbols {
+		languageByID[symbol.ID] = symbol.Language
+	}
+	inventory := map[string]bool{"Patch": true, "Diff": true, "Arduino": true, "CoffeeScript": true}
+	for _, relation := range snapshot.Relations {
+		switch relation.Type {
+		case "CALLS", "CONSTRUCTS", "ASYNC_CALLS":
+		default:
+			continue
+		}
+		if inventory[languageByID[relation.FromID]] {
+			t.Fatalf("inventory-only %s symbol emitted %s: %s -> %s",
+				languageByID[relation.FromID], relation.Type, relation.FromID, relation.ToID)
+		}
+	}
+	// The semantic side of the same repository is untouched.
+	if !hasSymbolNamed(snapshot.Symbols, "RunPipeline") {
+		t.Fatalf("Go symbol missing: %#v", snapshot.Symbols)
+	}
+}
+
 func TestResourceDependsOnGraph(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, repo, "main.tf", `resource "aws_vpc" "main" {


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/124
<!-- entire-trail-link-end -->

## Impact

Inventory-only filetypes emitted **CALLS edges into other languages' symbols**.

`docs/language-support.md` states that inventory-only coverage is file discovery
and document symbols "without claiming call/type/data-flow analysis", and
`capabilities --json` declares only `CONTAINS`/`DEFINES` for these languages.
The provider did not honour that: an inventory-only file gets one `document`
symbol whose block is the entire file, and the generic `name(` call scanner ran
over it like any other symbol body. Names that hit the globally-unique-name
fallback produced confident-looking, wholly invented edges.

Observed on a fixture repository covering every registered extension:

| from | to |
|---|---|
| `notes/change.patch` (a unified diff) | Go `func Run` |
| `sketch/blink.ino` | Objective-C `addValues` |
| `web/app.coffee` | Scala `Point.sum` |
| `fix.idr`, `fix.lean`, `fix.re`, `fix.res` | Haskell `pointSum` |
| `fix.raku`, `fix.wren` | Rust `Point::new` |
| `fix.mm` | Objective-C `addValues` |

Eleven inventory-only languages produced CALLS in a single fixture pass. These
edges reach `entire graph neighbors`, `entire graph impact` (blast radius) and
graph-neighbour search ranking, all of which present them as real. `.patch` and
`.diff` files are common in ordinary repositories, so is a vendored `.coffee`
tree, so this is not a synthetic condition.

## Repro

```
repo/
  svc/service.go     func RunPipeline() int { return 1 }
  sketch/blink.ino   void loop() { RunPipeline(); }
```

```
$ entire graph edges --repo . --format ndjson --relation CALLS
... "from_id":"...:Arduino:sketch/blink.ino:document:blink",
    "to_id":"...:Go:svc/service.go:function:RunPipeline",
    "type":"CALLS","confidence":0.68,
    "reason":"direct call expression matched globally unique symbol name"
```

Arduino is declared `["CONTAINS","DEFINES"]` by `capabilities --json`.

## Root cause

Two independent decisions about the same question.

- The **capability report** answers "does this language have call extraction?"
  with `supportsCallExtraction`, a hard-coded language list.
- The **scanner** answered it with
  `fileNeedsCallScan := needsCallScan && !skipFastCFamilyCallScan(...)`, which
  consults only the profile and a C-family fast-path exception — no language
  tier at all.

So the scan ran on every file that produced any symbol.
`TestCapabilityMatrixCoversEmittedRelations` is the guard for exactly this, but
it is fixture-driven, and no golden fixture pairs an inventory-only file with a
uniquely-named symbol elsewhere in the repo, so nothing ever tripped it.

## Fix

Make the two agree by construction. `supportsCallExtraction`'s language list is
lifted into `callExtractionLanguage(language string)`, and both CALLS producers
gate on it:

- `fileNeedsCallScan` (the bare-name scan and the top-level complement), and
- the `receiverCallRelations` / `importedReceiverCallRelations` pass, which is a
  separate producer and accounted for the last three false edges
  (`.coffee` -> Scala `Point.sum`, `.raku`/`.wren` -> Rust `Point::new`).

The capability report and the scanners now read the same predicate, so a
language the report says has no CALLS is a language the scanner does not run on.
No language in the list changes behaviour.

Measured on the fixture repository (uncached, `--worktree`): CALLS drops from 86
to 75 — exactly the eleven inventory-only false edges — and no semantic-language
CALLS edge is lost.

## Regression test

`TestInventoryOnlyFilesEmitNoCallRelations` builds a repo with a Go
`RunPipeline` plus a `.patch`, an `.ino` and a `.coffee` file that each mention
`RunPipeline()`, and fails if any `CALLS`/`CONSTRUCTS`/`ASYNC_CALLS` relation
originates from an inventory-only symbol. It also asserts the Go symbol is still
extracted, so the test cannot pass by the snapshot coming out empty.

Mutation verification (each gate is bound independently):

- Before the fix: FAIL — `inventory-only Arduino symbol emitted CALLS: ...:Arduino:sketch/blink.ino:document:blink -> ...:Go:svc/service.go:function:RunPipeline`.
- Removing `callExtractionLanguage` from `fileNeedsCallScan`: FAIL on the Arduino edge.
- Removing it from the `receiverCallRelations` gate: FAIL on the CoffeeScript edge.
- With the fix: PASS.

## Verification run locally

`gofmt -l .`, `go build ./...`, `go vet ./...` and `go test ./internal/sem/`
(2771 tests) all green. The full `-race` gate (`mise run check`) was **not**
completed locally: this machine is running several parallel workloads and both
`internal/cli` and `internal/sem` exceed Go's default 10-minute per-package
timeout regardless of branch — an unmodified `origin/main` worktree times out on
`go test -timeout 9m ./internal/cli/` at 540.7s, identically. CI should run the
full gate on a clean runner.
