### PR TITLE
fix(sem): honor .graphignore and the secret rules in the semantic diff

### DIFF
--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -122,11 +122,23 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 	// graph never indexes still produced entity changes here. A consumer that
 	// builds its index from `snapshot` and updates it from `diff` received
 	// symbols for files that its index has no record of and never will.
-	basePolicy, headPolicy, err := newDiffIndexPolicies(ctx, objectRepo, pinnedBase, pinnedHead, rootRelativeNames, changed)
+	basePolicy, headPolicy, err := newDiffIndexPolicies(ctx, objectRepo, pinnedBase, pinnedHead, rootRelativeNames, changed, overBudget)
 	if err != nil {
 		return Result{}, err
 	}
-	policyWarnings := indexPolicyChangeWarnings(changed, basePolicy)
+	policySource := changed
+	if len(paths) > 0 {
+		// A pathspec narrows what Git reports, but not what an exclusion rule
+		// decides: a root .gitignore edited outside the requested scope still
+		// changes membership inside it, and the scoped list cannot show that.
+		// Ask Git for the policy files directly, anchored at the repository root
+		// with :(top) so the caller's cwd does not narrow them a second time.
+		policySource, err = gitutil.ChangedFiles(ctx, repo, pinnedBase, pinnedHead, indexPolicyPathspecs)
+		if err != nil {
+			return Result{}, err
+		}
+	}
+	policyWarnings := indexPolicyChangeWarnings(policySource, basePolicy)
 	changed = admitChangedFiles(changed, basePolicy, headPolicy)
 	emitProgress("parse", 0, len(changed))
 	parser := TreeSitterParser{}
@@ -485,6 +497,11 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 // to apply and fires rules that were not, which silently drops indexed files.
 // There is no prefix to recover, because a tree object does not know its own
 // path, so the only correct answer for a subtree range is to apply no policy.
+// maxRevisionPeels bounds how many trailing ^{...} groups are stripped while
+// deciding whether a label bottoms out at a commit. Each step costs a git
+// subprocess, and no real revision expression stacks more than a couple.
+const maxRevisionPeels = 4
+
 // labelSelectsTreePath reports whether a revision label reaches INTO a tree
 // rather than naming a revision.
 //
@@ -553,18 +570,28 @@ func resolveDiffTrees(
 		if _, err := resolve(ctx, repo, objectID+"^{commit}"); err == nil {
 			return true
 		}
-		// A caller who wrote <commit-ish>^{tree} still named a root tree. Peel
-		// the suffix THEY wrote — adding none of our own — and ask again.
-		peeled, found := strings.CutSuffix(label, "^{tree}")
-		if !found {
-			return false
+		// A caller who wrote <commit-ish>^{tree} still named a root tree, and Git
+		// spells that several ways: ^{tree}, ^{tree}^{}, ^{tree}^{object}. Peel
+		// the trailing groups THEY wrote — adding none of our own — and ask again
+		// after each, so any spelling that bottoms out at a commit is recognized.
+		// The peel count is capped because each step costs a subprocess and a
+		// label can carry arbitrarily many groups.
+		peeled := label
+		for range maxRevisionPeels {
+			open := strings.LastIndex(peeled, "^{")
+			if open <= 0 || !strings.HasSuffix(peeled, "}") {
+				return false
+			}
+			peeled = peeled[:open]
+			peeledID, err := resolve(ctx, repo, peeled)
+			if err != nil {
+				continue
+			}
+			if _, err := resolve(ctx, repo, peeledID+"^{commit}"); err == nil {
+				return true
+			}
 		}
-		peeledID, err := resolve(ctx, repo, peeled)
-		if err != nil {
-			return false
-		}
-		_, err = resolve(ctx, repo, peeledID+"^{commit}")
-		return err == nil
+		return false
 	}
 	resolveTree := func(label string) (string, bool, error) {
 		// Resolve the caller's expression exactly before adding syntax of our
@@ -1091,6 +1118,12 @@ func indexPolicyChangeWarnings(changed []gitutil.ChangedFile, policy diffIndexPo
 	return warnings
 }
 
+// indexPolicyPathspecs names every committed file that can decide index
+// membership, anchored at the repository root so a caller's cwd cannot narrow
+// them. Git matches a wildcard pathspec at any depth, which is what nested
+// .gitignore files need.
+var indexPolicyPathspecs = []string{":(top)*.gitignore", ":(top)" + graphIgnoreFileName}
+
 // isIndexPolicyFile reports whether a path is one of the committed files whose
 // contents decide what the graph indexes.
 //
@@ -1131,8 +1164,13 @@ func newDiffIndexPolicies(
 	repo, baseTree, headTree string,
 	rootRelative bool,
 	changed []gitutil.ChangedFile,
+	overBudget func() bool,
 ) (diffIndexPolicy, diffIndexPolicy, error) {
-	if !rootRelative {
+	// Nothing has been parsed yet, so a range that is already over budget will
+	// return an empty result with its budget warnings whatever the policy says.
+	// Listing whole trees to build one would only make the command overshoot the
+	// budget it promised the caller.
+	if !rootRelative || overBudget() {
 		return diffIndexPolicy{}, diffIndexPolicy{}, nil
 	}
 	ignores, err := loadExplicitIgnoreMatcher(repo, nil, nil)
@@ -1153,6 +1191,11 @@ func newDiffIndexPolicies(
 	}
 	base.vendorRules = baseRules
 	base.vendorRulesLoaded = true
+	if overBudget() {
+		// The base listing alone spent what was left. Stop before the second one
+		// and let the caller's budget warnings describe the range.
+		return diffIndexPolicy{}, diffIndexPolicy{}, nil
+	}
 	if headTree == baseTree {
 		head.vendorRules = baseRules
 		head.vendorRulesLoaded = true

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -108,11 +108,24 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 		return Result{}, err
 	}
 
+	// A repo-root .graphignore is honored by every graph command (see the
+	// `index` help text and docs/operations.md). The snapshot/search family
+	// applies it through loadExplicitIgnoreMatcher; the diff family did not, so
+	// a tracked-but-vendored or generated tree that the graph never indexes
+	// still produced entity changes here. A consumer that builds its index from
+	// `snapshot` and updates it from `diff` received symbols for files that its
+	// index has no record of and never will.
+	ignores, err := loadExplicitIgnoreMatcher(objectRepo, nil, nil)
+	if err != nil {
+		return Result{}, err
+	}
+
 	emitProgress("discover", 0, 0)
 	changed, err := gitutil.ChangedFiles(ctx, repo, pinnedBase, pinnedHead, paths)
 	if err != nil {
 		return Result{}, err
 	}
+	changed = dropIgnoredChangedFiles(changed, ignores)
 	emitProgress("parse", 0, len(changed))
 	parser := TreeSitterParser{}
 	baseReader := gitutil.NewLimitedFileReader(ctx, objectRepo, pinnedBase, maxDiffFileBytes)
@@ -797,6 +810,29 @@ const (
 	// rather than guessing.
 	ambiguityMargin = 0.05
 )
+
+// dropIgnoredChangedFiles removes the changed files the graph would never index.
+//
+// ChangedFile.Path is the deciding name for every status: Git's name-status
+// output carries the surviving path for an addition or a modification, the
+// removed path for a deletion, and the destination path for a rename, so it is
+// always the name the graph would hold a record under. A file the graph does
+// not index has no entities on either side, so reporting a change to it
+// describes symbols that no snapshot of this repository contains.
+//
+// Ignored files are omitted rather than warned about, exactly as the snapshot
+// omits them — an ignore rule is a deliberate exclusion, not an input the
+// provider failed to read.
+func dropIgnoredChangedFiles(changed []gitutil.ChangedFile, ignores ignoreMatcher) []gitutil.ChangedFile {
+	kept := changed[:0]
+	for _, file := range changed {
+		if ignores.Ignored(file.Path, false) {
+			continue
+		}
+		kept = append(kept, file)
+	}
+	return kept
+}
 
 // moduleScopeChange builds a synthetic change for a file whose contents changed
 // but where no named symbol changed. Attributing the edit to a module-level

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/entireio/entire-graph/internal/gitutil"
@@ -94,7 +95,7 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 	// When both labels are byte-identical, reuse the first resolution so a ref
 	// advance between subprocesses cannot turn an intended empty diff into an
 	// old-tree/new-tree comparison. Keep the labels below for result provenance.
-	pinnedBase, pinnedHead, err := resolveDiffTrees(ctx, repo, base, head, gitutil.RevParse)
+	pinnedBase, pinnedHead, rootRelativeNames, err := resolveDiffTrees(ctx, repo, base, head, gitutil.RevParse)
 	if err != nil {
 		return Result{}, err
 	}
@@ -108,24 +109,23 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 		return Result{}, err
 	}
 
-	// A repo-root .graphignore is honored by every graph command (see the
-	// `index` help text and docs/operations.md). The snapshot/search family
-	// applies it through loadExplicitIgnoreMatcher; the diff family did not, so
-	// a tracked-but-vendored or generated tree that the graph never indexes
-	// still produced entity changes here. A consumer that builds its index from
-	// `snapshot` and updates it from `diff` received symbols for files that its
-	// index has no record of and never will.
-	ignores, err := loadExplicitIgnoreMatcher(objectRepo, nil, nil)
-	if err != nil {
-		return Result{}, err
-	}
-
 	emitProgress("discover", 0, 0)
 	changed, err := gitutil.ChangedFiles(ctx, repo, pinnedBase, pinnedHead, paths)
 	if err != nil {
 		return Result{}, err
 	}
-	changed = dropIgnoredChangedFiles(changed, ignores)
+	// Every graph command honors a repo-root .graphignore and the vendored-tree
+	// heuristic (see the `index` help text and docs/operations.md). The
+	// snapshot/search family applies both through openSource; the diff family
+	// applied neither, so a tracked-but-vendored or generated tree that the
+	// graph never indexes still produced entity changes here. A consumer that
+	// builds its index from `snapshot` and updates it from `diff` received
+	// symbols for files that its index has no record of and never will.
+	basePolicy, headPolicy, err := newDiffIndexPolicies(ctx, objectRepo, pinnedBase, pinnedHead, rootRelativeNames, changed)
+	if err != nil {
+		return Result{}, err
+	}
+	changed = admitChangedFiles(changed, basePolicy, headPolicy)
 	emitProgress("parse", 0, len(changed))
 	parser := TreeSitterParser{}
 	baseReader := gitutil.NewLimitedFileReader(ctx, objectRepo, pinnedBase, maxDiffFileBytes)
@@ -453,35 +453,74 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 	return result, nil
 }
 
+// resolveDiffTrees pins both revision labels to immutable trees and reports
+// whether ChangedFiles' names for the resulting range are repository-root
+// relative.
+//
+// That last question decides whether any exclusion policy may be applied at all.
+// ChangedFiles passes --no-relative, so a range between two COMMITS is named
+// from the repository root, which is the namespace the root .graphignore and the
+// vendored-tree rules are written in. A tree expression such as HEAD:scope names
+// a subtree, and every emitted name is then relative to THAT tree: matching
+// root-relative rules against those names both misses the rules that were meant
+// to apply and fires rules that were not, which silently drops indexed files.
+// There is no prefix to recover, because a tree object does not know its own
+// path, so the only correct answer for a subtree range is to apply no policy.
 func resolveDiffTrees(
 	ctx context.Context,
 	repo, base, head string,
 	resolve func(context.Context, string, string) (string, error),
-) (string, string, error) {
-	resolveTree := func(label string) (string, error) {
+) (string, string, bool, error) {
+	rootRelative := func(label, objectID string) bool {
+		// Probe the immutable OID rather than the caller's expression, for the
+		// same reason the tree peel below does: appending ^{commit} to
+		// HEAD:scope can select a repository path literally named
+		// scope^{commit}. A commit-ish label resolves through ^{commit}; a tree
+		// expression does not.
+		if _, err := resolve(ctx, repo, objectID+"^{commit}"); err == nil {
+			return true
+		}
+		// A caller who wrote <commit-ish>^{tree} still named a root tree. Peel
+		// the suffix THEY wrote — adding none of our own — and ask again.
+		peeled, found := strings.CutSuffix(label, "^{tree}")
+		if !found {
+			return false
+		}
+		peeledID, err := resolve(ctx, repo, peeled)
+		if err != nil {
+			return false
+		}
+		_, err = resolve(ctx, repo, peeledID+"^{commit}")
+		return err == nil
+	}
+	resolveTree := func(label string) (string, bool, error) {
 		// Resolve the caller's expression exactly before adding syntax of our
 		// own. Appending ^{tree} directly to HEAD:scope can select a different
 		// repository path literally named scope^{tree}; an immutable OID has no
 		// such revision/path ambiguity.
 		objectID, err := resolve(ctx, repo, label)
 		if err != nil {
-			return "", err
+			return "", false, err
 		}
-		return resolve(ctx, repo, objectID+"^{tree}")
+		tree, err := resolve(ctx, repo, objectID+"^{tree}")
+		if err != nil {
+			return "", false, err
+		}
+		return tree, rootRelative(label, objectID), nil
 	}
 
-	pinnedBase, err := resolveTree(base)
+	pinnedBase, baseFromCommit, err := resolveTree(base)
 	if err != nil {
-		return "", "", fmt.Errorf("resolve diff base %q: %w", base, err)
+		return "", "", false, fmt.Errorf("resolve diff base %q: %w", base, err)
 	}
 	if head == base {
-		return pinnedBase, pinnedBase, nil
+		return pinnedBase, pinnedBase, baseFromCommit, nil
 	}
-	pinnedHead, err := resolveTree(head)
+	pinnedHead, headFromCommit, err := resolveTree(head)
 	if err != nil {
-		return "", "", fmt.Errorf("resolve diff head %q: %w", head, err)
+		return "", "", false, fmt.Errorf("resolve diff head %q: %w", head, err)
 	}
-	return pinnedBase, pinnedHead, nil
+	return pinnedBase, pinnedHead, baseFromCommit && headFromCommit, nil
 }
 
 // budgetSkippedFileWarning marks one changed file that was never analyzed
@@ -811,27 +850,174 @@ const (
 	ambiguityMargin = 0.05
 )
 
-// dropIgnoredChangedFiles removes the changed files the graph would never index.
+// diffIndexPolicy answers, for ONE compared tree, the question the committed-tree
+// snapshot asks of its own listing (openSource in provider.go): would the graph
+// index this path? It applies the same two filters in the same order — the
+// vendored-tree heuristic, then the explicit .graphignore and built-in secret
+// matcher — so the diff can neither report an entity for a file no snapshot of
+// that tree contains nor omit one a snapshot does contain.
 //
-// ChangedFile.Path is the deciding name for every status: Git's name-status
-// output carries the surviving path for an addition or a modification, the
-// removed path for a deletion, and the destination path for a rename, so it is
-// always the name the graph would hold a record under. A file the graph does
-// not index has no entities on either side, so reporting a change to it
-// describes symbols that no snapshot of this repository contains.
+// The policy is per-tree rather than per-range because its two halves answer
+// differently on the two sides. The matcher is read from the working tree and so
+// is common to both, but the vendored-tree rules come from each compared tree's
+// own .gitignore files: a project can re-include part of a vendored tree in one
+// revision and not the other, which makes an otherwise unremarkable edit an
+// entry into, or an exit from, the graph.
+type diffIndexPolicy struct {
+	ignores     ignoreMatcher
+	vendorRules vendorIgnoreRules
+	enabled     bool
+}
+
+// indexed reports whether the graph would hold records for rel in this tree.
 //
-// Ignored files are omitted rather than warned about, exactly as the snapshot
-// omits them — an ignore rule is a deliberate exclusion, not an input the
-// provider failed to read.
-func dropIgnoredChangedFiles(changed []gitutil.ChangedFile, ignores ignoreMatcher) []gitutil.ChangedFile {
+// A disabled policy admits everything. That is not a weaker guess, it is the
+// only correct answer available: the names it would be asked about are relative
+// to some subtree, and neither rule set describes that namespace (see
+// resolveDiffTrees).
+func (p diffIndexPolicy) indexed(rel string) bool {
+	if !p.enabled {
+		return true
+	}
+	rel = filepath.ToSlash(rel)
+	if vendoredPath(rel, p.vendorRules) {
+		return false
+	}
+	return !p.ignores.Ignored(rel, false)
+}
+
+// admitChangedFiles rewrites Git's changed-file list into the delta the GRAPH
+// saw, which is not always the delta Git saw.
+//
+// Git reports what happened to a path; this command reports what happened to the
+// index. The two diverge whenever a change crosses the boundary between indexed
+// and unindexed — a rename into a vendored tree, a rename out of one, or a file
+// whose tree re-includes it on one side only. Deciding that from the destination
+// path alone gets both crossings wrong: it discards the removals the base side
+// still owes a consumer, and it reports a body change against a base file that
+// no snapshot contains while never naming the head file's other symbols at all.
+//
+// So each side is decided independently and the status is rewritten to match:
+//
+//	base yes, head yes   unchanged
+//	base yes, head no    a deletion of the base path; its symbols leave the graph
+//	base no,  head yes   an addition of the head path; all of its symbols are new
+//	base no,  head no    dropped
+//
+// Rewriting to "D" and "A" needs no new emission code: both are ordinary
+// name-status inputs, and the loop above already derives its read plan from
+// Status alone. The emitted FileChange.Status is then the graph's truth rather
+// than Git's — a rename out of the index IS a deletion of everything the index
+// held.
+//
+// A copy (status "C") is the one crossing that must never become a deletion: its
+// source still exists and is not part of this delta, so an unindexed destination
+// simply drops. ChangedFiles asks for --find-renames and not --find-copies, so
+// this is a guard against a future flag rather than a path exercised today.
+//
+// Files are omitted rather than warned about, exactly as the snapshot omits them:
+// an exclusion rule is a deliberate choice, not an input the provider failed to
+// read.
+func admitChangedFiles(changed []gitutil.ChangedFile, base, head diffIndexPolicy) []gitutil.ChangedFile {
 	kept := changed[:0]
 	for _, file := range changed {
-		if ignores.Ignored(file.Path, false) {
-			continue
+		oldPath := file.OldPath
+		if oldPath == "" {
+			oldPath = file.Path
 		}
-		kept = append(kept, file)
+		inBase := file.Status != "A" && base.indexed(oldPath)
+		inHead := file.Status != "D" && head.indexed(file.Path)
+		switch {
+		case inBase && inHead:
+			kept = append(kept, file)
+		case inBase:
+			if file.Status == "C" {
+				continue
+			}
+			kept = append(kept, gitutil.ChangedFile{Status: "D", Path: oldPath})
+		case inHead:
+			kept = append(kept, gitutil.ChangedFile{Status: "A", Path: file.Path})
+		}
 	}
 	return kept
+}
+
+// newDiffIndexPolicies builds the base-side and head-side policies for one range.
+//
+// rootRelative gates the whole thing: when the compared trees were not named by
+// commit-ish expressions, ChangedFiles' names are relative to some subtree while
+// both rule sets are written against repository-root paths, and applying one to
+// the other silently omits indexed files. Admitting everything there is exactly
+// what this command did before the policy existed.
+func newDiffIndexPolicies(
+	ctx context.Context,
+	repo, baseTree, headTree string,
+	rootRelative bool,
+	changed []gitutil.ChangedFile,
+) (diffIndexPolicy, diffIndexPolicy, error) {
+	if !rootRelative {
+		return diffIndexPolicy{}, diffIndexPolicy{}, nil
+	}
+	ignores, err := loadExplicitIgnoreMatcher(repo, nil, nil)
+	if err != nil {
+		return diffIndexPolicy{}, diffIndexPolicy{}, err
+	}
+	// ignoreMatcher{} re-includes nothing, which is the correct starting rule set
+	// for a range that touches no vendorable path and the exact set the probe
+	// below is proved against.
+	base := diffIndexPolicy{ignores: ignores, vendorRules: ignoreMatcher{}, enabled: true}
+	head := base
+	if !changedFilesMayBeVendored(changed) {
+		return base, head, nil
+	}
+	baseRules, err := treeVendorIgnoreRules(ctx, repo, baseTree, ignores)
+	if err != nil {
+		return diffIndexPolicy{}, diffIndexPolicy{}, err
+	}
+	base.vendorRules = baseRules
+	if headTree == baseTree {
+		head.vendorRules = baseRules
+		return base, head, nil
+	}
+	headRules, err := treeVendorIgnoreRules(ctx, repo, headTree, ignores)
+	if err != nil {
+		return diffIndexPolicy{}, diffIndexPolicy{}, err
+	}
+	head.vendorRules = headRules
+	return base, head, nil
+}
+
+// changedFilesMayBeVendored reports whether any changed path could be excluded by
+// the vendored-tree heuristic, evaluated against EMPTY re-inclusion rules.
+//
+// The probe is exact rather than approximate. Rules reach the heuristic only
+// through ReincludesDescendant in skipVendoredDir, which can only ever
+// un-vendor a path, so empty rules yield the maximal candidate set and "no
+// candidate here" proves that loading the real rules would change no verdict.
+// That keeps the two tree listings they cost off the overwhelmingly common range
+// that touches nothing vendorable.
+func changedFilesMayBeVendored(changed []gitutil.ChangedFile) bool {
+	for _, file := range changed {
+		if vendoredPath(filepath.ToSlash(file.Path), ignoreMatcher{}) {
+			return true
+		}
+		if file.OldPath != "" && vendoredPath(filepath.ToSlash(file.OldPath), ignoreMatcher{}) {
+			return true
+		}
+	}
+	return false
+}
+
+// treeVendorIgnoreRules loads one compared tree's nested .gitignore rules the way
+// the snapshot loads its own: from that exact tree, through the same bounded
+// reader, so the diff and a snapshot of the same revision cannot disagree about
+// which vendored trees a project meant to keep.
+func treeVendorIgnoreRules(ctx context.Context, repo, tree string, policyBase ignoreMatcher) (vendorIgnoreRules, error) {
+	paths, err := gitutil.ListFiles(ctx, repo, tree)
+	if err != nil {
+		return nil, err
+	}
+	return headVendorIgnoreRules(ctx, repo, tree, paths, policyBase)
 }
 
 // moduleScopeChange builds a synthetic change for a file whose contents changed

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -467,12 +467,38 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 // to apply and fires rules that were not, which silently drops indexed files.
 // There is no prefix to recover, because a tree object does not know its own
 // path, so the only correct answer for a subtree range is to apply no policy.
+// labelSelectsTreePath reports whether a revision label reaches INTO a tree
+// rather than naming a revision.
+//
+// Resolving to a commit object is not sufficient evidence that a label named a
+// commit: a gitlink resolves to one too. `HEAD:sub` on a submodule entry yields
+// that submodule's commit, and a range over its tree is named relative to the
+// SUBMODULE's root, not this repository's — so a superproject rule set matched
+// against those names is the same category error as a subtree range. The probe
+// happens to fail today because the submodule's objects usually are not in the
+// superproject's object database, but an absorbed or fetched submodule puts them
+// there, and correctness here should not rest on which objects a repository
+// happens to hold.
+//
+// `:` is the only object-name syntax that reaches into a tree (`<rev>:<path>`
+// and `:<stage>:<path>`). The single exception is `:/text`, which searches
+// commit messages and so names a commit and nothing else.
+func labelSelectsTreePath(label string) bool {
+	if strings.HasPrefix(label, ":/") {
+		return false
+	}
+	return strings.Contains(label, ":")
+}
+
 func resolveDiffTrees(
 	ctx context.Context,
 	repo, base, head string,
 	resolve func(context.Context, string, string) (string, error),
 ) (string, string, bool, error) {
 	rootRelative := func(label, objectID string) bool {
+		if labelSelectsTreePath(label) {
+			return false
+		}
 		// Probe the immutable OID rather than the caller's expression, for the
 		// same reason the tree peel below does: appending ^{commit} to
 		// HEAD:scope can select a repository path literally named
@@ -920,10 +946,12 @@ func (p diffIndexPolicy) admitFunc() func(string) bool {
 // than Git's — a rename out of the index IS a deletion of everything the index
 // held.
 //
-// A copy (status "C") is the one crossing that must never become a deletion: its
-// source still exists and is not part of this delta, so an unindexed destination
-// simply drops. ChangedFiles asks for --find-renames and not --find-copies, so
-// this is a guard against a future flag rather than a path exercised today.
+// A copy (status "C") is the one entry that is never a comparison at all: its
+// source still exists, so the destination is purely an addition and must never
+// be reported as a deletion of, or a change to, the file it was copied from.
+// ChangedFiles asks for --find-renames and not --find-copies, and Git emits "C"
+// only under --find-copies-harder, so this is a guard against a future flag
+// rather than a path exercised today.
 //
 // Files are omitted rather than warned about, exactly as the snapshot omits them:
 // an exclusion rule is a deliberate choice, not an input the provider failed to
@@ -937,13 +965,21 @@ func admitChangedFiles(changed []gitutil.ChangedFile, base, head diffIndexPolicy
 		}
 		inBase := file.Status != "A" && base.indexed(oldPath)
 		inHead := file.Status != "D" && head.indexed(file.Path)
+		if file.Status == "C" {
+			// A copy's source survives, so it is not part of this delta at all
+			// and the destination is simply new to the graph. That makes a copy
+			// an addition whenever its destination is indexed and nothing
+			// otherwise: never a deletion of a file that still exists, and never
+			// a comparison against a source this change did not touch.
+			if inHead {
+				kept = append(kept, gitutil.ChangedFile{Status: "A", Path: file.Path})
+			}
+			continue
+		}
 		switch {
 		case inBase && inHead:
 			kept = append(kept, file)
 		case inBase:
-			if file.Status == "C" {
-				continue
-			}
 			kept = append(kept, gitutil.ChangedFile{Status: "D", Path: oldPath})
 		case inHead:
 			kept = append(kept, gitutil.ChangedFile{Status: "A", Path: file.Path})

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -446,6 +446,7 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 		},
 		deadline: deadline,
 		budget:   options.MaxDuration,
+		admit:    headPolicy.admitFunc(),
 	}); err != nil {
 		return Result{}, err
 	}
@@ -884,6 +885,15 @@ func (p diffIndexPolicy) indexed(rel string) bool {
 		return false
 	}
 	return !p.ignores.Ignored(rel, false)
+}
+
+// admitFunc exposes indexed to the dependents scan, or nil when this policy has
+// no opinion, which is the scan's own "admit everything" signal.
+func (p diffIndexPolicy) admitFunc() func(string) bool {
+	if !p.enabled {
+		return nil
+	}
+	return p.indexed
 }
 
 // admitChangedFiles rewrites Git's changed-file list into the delta the GRAPH

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -1093,12 +1093,19 @@ func indexPolicyChangeWarnings(changed []gitutil.ChangedFile, policy diffIndexPo
 
 // isIndexPolicyFile reports whether a path is one of the committed files whose
 // contents decide what the graph indexes.
+//
+// The two files are scoped differently, and the warning must follow that rather
+// than match on name alone. Git applies a .gitignore to its own directory and
+// below, and the vendored-tree rules read every one of them in the tree, so any
+// of them can change membership. A .graphignore is only ever read from the
+// repository root (loadExplicitIgnoreMatcher), so `pkg/.graphignore` decides
+// nothing and warning about it would be a false report of incompleteness.
 func isIndexPolicyFile(rel string) bool {
-	switch path.Base(filepath.ToSlash(rel)) {
-	case ".gitignore", graphIgnoreFileName:
+	rel = filepath.ToSlash(rel)
+	if rel == graphIgnoreFileName {
 		return true
 	}
-	return false
+	return path.Base(rel) == ".gitignore"
 }
 
 func indexPolicyChangedWarning(rel string) ProviderWarning {

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -445,9 +445,14 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 
 	// The dependents scan reads the whole head tree, so it needs the head tree's
 	// real rules rather than the ones the changed-file probe was allowed to skip.
-	// Resolve them only when there is something to count.
+	// Resolve them only when there is something to count, and only while the
+	// budget still allows work: resolving lists the whole head tree and reads its
+	// ignore files, and an exhausted range must return with its budget warning
+	// rather than spend more time than the caller asked for. The scan below
+	// re-checks the same deadline and stops immediately, so the policy it would
+	// have used cannot matter then.
 	dependentsPolicy := headPolicy
-	if len(result.Files) > 0 {
+	if len(result.Files) > 0 && !overBudget() {
 		dependentsPolicy, err = headPolicy.resolvedForTree(ctx, objectRepo, pinnedHead)
 		if err != nil {
 			return Result{}, err
@@ -494,11 +499,18 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 // happens to hold.
 //
 // `:` is the only object-name syntax that reaches into a tree (`<rev>:<path>`
-// and `:<stage>:<path>`), but not every colon is that syntax. `:/text` searches
-// commit messages, so it names a commit and every colon after it is part of the
-// text; and a colon inside an `@{...}` selector is data too, because a reflog
-// date such as `HEAD@{2026-08-27 12:34:56 +0000}` names a commit and reaches
-// into no tree. Only a colon outside every such block is the separator.
+// and `:<stage>:<path>`), but not every colon is that syntax. Three forms carry
+// colons that are data:
+//
+//	:/text                            a commit-message search; the colons are text
+//	HEAD@{2026-08-27 12:34:56 +0000}  a reflog date selector
+//	HEAD^{/release: fix}              a commit-message search from a starting point
+//
+// All three name a commit and reach into no tree, so only a colon outside every
+// `@{...}` and `^{...}` block is the separator. Both brace forms are tracked, not
+// just the one that happened to come up first: mistaking a commit for a subtree
+// loses no data, but it silently withdraws the exclusion guarantee for the whole
+// range, which is the kind of failure nothing downstream can notice.
 func labelSelectsTreePath(label string) bool {
 	if strings.HasPrefix(label, ":/") {
 		return false
@@ -506,7 +518,7 @@ func labelSelectsTreePath(label string) bool {
 	depth := 0
 	for index := 0; index < len(label); index++ {
 		switch label[index] {
-		case '@':
+		case '@', '^':
 			if index+1 < len(label) && label[index+1] == '{' {
 				depth++
 				index++

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -125,6 +126,7 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 	if err != nil {
 		return Result{}, err
 	}
+	policyWarnings := indexPolicyChangeWarnings(changed, basePolicy)
 	changed = admitChangedFiles(changed, basePolicy, headPolicy)
 	emitProgress("parse", 0, len(changed))
 	parser := TreeSitterParser{}
@@ -140,6 +142,7 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 	// constructed; every caller (AnalyzeGitRange, AnalyzeCheckpoint, and the
 	// diff/analyze CLI handlers that call through them) inherits it.
 	result := Result{Base: base, Head: head, SchemaVersion: SchemaVersion}
+	result.Warnings = append(result.Warnings, policyWarnings...)
 	var deltas []*fileDelta
 	appendBudgetWarnings := func(start int) {
 		for _, skipped := range changed[start:] {
@@ -1043,6 +1046,58 @@ func admitChangedFiles(changed []gitutil.ChangedFile, base, head diffIndexPolicy
 		}
 	}
 	return kept
+}
+
+// indexPolicyChangeWarnings discloses the one incompleteness a change-based diff
+// cannot close by filtering.
+//
+// A committed exclusion rule decides membership for files it never mentions in a
+// commit. Deleting a `!vendor/pkg/**` re-inclusion drops that whole subtree from
+// the head snapshot while Git reports only `.gitignore` as changed, so the
+// correct delta contains removals for files that appear nowhere in this
+// command's input. Synthesizing them would mean comparing the two trees' entire
+// corpora and could emit an entry per file in a vendored tree — a different and
+// unbounded operation, not a filter over a change list.
+//
+// What is not acceptable is letting a consumer believe the delta is complete
+// when it is not, so the range says so. The check runs on Git's original list,
+// before admission, because the policy file may itself be excluded.
+func indexPolicyChangeWarnings(changed []gitutil.ChangedFile, policy diffIndexPolicy) []ProviderWarning {
+	if !policy.enabled {
+		return nil
+	}
+	var warnings []ProviderWarning
+	for _, file := range changed {
+		for _, candidate := range [...]string{file.Path, file.OldPath} {
+			if candidate == "" || !isIndexPolicyFile(candidate) {
+				continue
+			}
+			warnings = append(warnings, indexPolicyChangedWarning(candidate))
+			break
+		}
+	}
+	return warnings
+}
+
+// isIndexPolicyFile reports whether a path is one of the committed files whose
+// contents decide what the graph indexes.
+func isIndexPolicyFile(rel string) bool {
+	switch path.Base(filepath.ToSlash(rel)) {
+	case ".gitignore", graphIgnoreFileName:
+		return true
+	}
+	return false
+}
+
+func indexPolicyChangedWarning(rel string) ProviderWarning {
+	return ProviderWarning{
+		Code:     "W_INDEX_POLICY_CHANGED",
+		Severity: "warning",
+		FilePath: rel,
+		EffectOnCompleteness: "files that did not change may have entered or left the graph in this range; " +
+			"this delta alone is not sufficient to update an index built from a snapshot",
+		Detail: "an exclusion policy file changed, and it decides index membership for files it does not name",
+	}
 }
 
 // newDiffIndexPolicies builds the base-side and head-side policies for one range.

--- a/internal/sem/analyze.go
+++ b/internal/sem/analyze.go
@@ -440,13 +440,23 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 		})
 	}
 
+	// The dependents scan reads the whole head tree, so it needs the head tree's
+	// real rules rather than the ones the changed-file probe was allowed to skip.
+	// Resolve them only when there is something to count.
+	dependentsPolicy := headPolicy
+	if len(result.Files) > 0 {
+		dependentsPolicy, err = headPolicy.resolvedForTree(ctx, objectRepo, pinnedHead)
+		if err != nil {
+			return Result{}, err
+		}
+	}
 	if err := addDependentCountsWithProgress(ctx, objectRepo, pinnedHead, &result, dependentsScanOptions{
 		progress: func(done, total int, path string) {
 			emitProgressEvent("dependents", done, total, path, path == "")
 		},
 		deadline: deadline,
 		budget:   options.MaxDuration,
-		admit:    headPolicy.admitFunc(),
+		admit:    dependentsPolicy.admitFunc(),
 	}); err != nil {
 		return Result{}, err
 	}
@@ -481,13 +491,34 @@ func AnalyzeGitRangeWithOptions(ctx context.Context, repo, base, head string, pa
 // happens to hold.
 //
 // `:` is the only object-name syntax that reaches into a tree (`<rev>:<path>`
-// and `:<stage>:<path>`). The single exception is `:/text`, which searches
-// commit messages and so names a commit and nothing else.
+// and `:<stage>:<path>`), but not every colon is that syntax. `:/text` searches
+// commit messages, so it names a commit and every colon after it is part of the
+// text; and a colon inside an `@{...}` selector is data too, because a reflog
+// date such as `HEAD@{2026-08-27 12:34:56 +0000}` names a commit and reaches
+// into no tree. Only a colon outside every such block is the separator.
 func labelSelectsTreePath(label string) bool {
 	if strings.HasPrefix(label, ":/") {
 		return false
 	}
-	return strings.Contains(label, ":")
+	depth := 0
+	for index := 0; index < len(label); index++ {
+		switch label[index] {
+		case '@':
+			if index+1 < len(label) && label[index+1] == '{' {
+				depth++
+				index++
+			}
+		case '}':
+			if depth > 0 {
+				depth--
+			}
+		case ':':
+			if depth == 0 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func resolveDiffTrees(
@@ -893,7 +924,33 @@ const (
 type diffIndexPolicy struct {
 	ignores     ignoreMatcher
 	vendorRules vendorIgnoreRules
-	enabled     bool
+	// vendorRulesLoaded distinguishes "this tree really re-includes nothing"
+	// from "nobody has needed the rules yet", which is what makes it safe to
+	// skip loading them for a range that touches nothing vendorable.
+	vendorRulesLoaded bool
+	enabled           bool
+}
+
+// resolvedForTree returns a copy of p holding this tree's real vendored-tree
+// rules, loading them if the changed-file probe skipped them.
+//
+// That probe licenses one question only: whether any of the paths GIT reported
+// could be vendored. The dependents scan asks a different and much larger one —
+// it walks the whole head tree — so a `vendor/...` path the project re-included
+// can turn up there even when nothing vendorable changed. Reusing the probe's
+// policy would then judge that caller by empty rules, drop it, and undercount a
+// dependent the graph really holds.
+func (p diffIndexPolicy) resolvedForTree(ctx context.Context, repo, tree string) (diffIndexPolicy, error) {
+	if !p.enabled || p.vendorRulesLoaded {
+		return p, nil
+	}
+	rules, err := treeVendorIgnoreRules(ctx, repo, tree, p.ignores)
+	if err != nil {
+		return diffIndexPolicy{}, err
+	}
+	p.vendorRules = rules
+	p.vendorRulesLoaded = true
+	return p, nil
 }
 
 // indexed reports whether the graph would hold records for rel in this tree.
@@ -1021,8 +1078,10 @@ func newDiffIndexPolicies(
 		return diffIndexPolicy{}, diffIndexPolicy{}, err
 	}
 	base.vendorRules = baseRules
+	base.vendorRulesLoaded = true
 	if headTree == baseTree {
 		head.vendorRules = baseRules
+		head.vendorRulesLoaded = true
 		return base, head, nil
 	}
 	headRules, err := treeVendorIgnoreRules(ctx, repo, headTree, ignores)
@@ -1030,6 +1089,7 @@ func newDiffIndexPolicies(
 		return diffIndexPolicy{}, diffIndexPolicy{}, err
 	}
 	head.vendorRules = headRules
+	head.vendorRulesLoaded = true
 	return base, head, nil
 }
 

--- a/internal/sem/analyze_indexpolicy_test.go
+++ b/internal/sem/analyze_indexpolicy_test.go
@@ -356,6 +356,14 @@ func TestAdmitChangedFilesRewritesIndexCrossings(t *testing.T) {
 			want: []gitutil.ChangedFile{{Status: "A", Path: "b.go"}},
 		},
 		{
+			// The source is untouched by a copy, so comparing the destination
+			// against it would report a change to a file that did not change.
+			name: "copy between indexed paths is still only an addition",
+			base: indexed, head: indexed,
+			in:   gitutil.ChangedFile{Status: "C", OldPath: "a.go", Path: "b.go"},
+			want: []gitutil.ChangedFile{{Status: "A", Path: "b.go"}},
+		},
+		{
 			name: "a disabled policy admits everything",
 			base: diffIndexPolicy{}, head: diffIndexPolicy{},
 			in:   gitutil.ChangedFile{Status: "M", Path: "a.go"},

--- a/internal/sem/analyze_indexpolicy_test.go
+++ b/internal/sem/analyze_indexpolicy_test.go
@@ -452,3 +452,68 @@ func TestAnalyzeGitRangeWarnsWhenAnIndexPolicyFileChanges(t *testing.T) {
 		}
 	}
 }
+
+// TestAnalyzeGitRangeWarnsAboutPolicyChangesOutsideThePathspec pins that a
+// pathspec narrows what Git reports, not what an exclusion rule decides. A root
+// rule edited outside the requested scope still changes membership inside it,
+// and the scoped changed-file list cannot show that.
+func TestAnalyzeGitRangeWarnsAboutPolicyChangesOutsideThePathspec(t *testing.T) {
+	repo := t.TempDir()
+	initDiffPolicyRepo(t, repo)
+	write(t, repo, ".gitignore", "vendor/*\n!vendor/rootpkg/\n!vendor/rootpkg/**\n")
+	write(t, repo, "vendor/rootpkg/root.go", "package rootpkg\n\nfunc Root() int { return 1 }\n")
+	git(t, repo, "add", "-A", "-f")
+	git(t, repo, "commit", "-m", "initial")
+	base := rev(t, repo, "HEAD")
+
+	write(t, repo, ".gitignore", "vendor/*\n")
+	write(t, repo, "vendor/rootpkg/root.go", "package rootpkg\n\nfunc Root() int { return 2 }\n")
+	git(t, repo, "add", "-A", "-f")
+	git(t, repo, "commit", "-m", "drop the re-inclusion and edit inside it")
+	head := rev(t, repo, "HEAD")
+
+	// Scoped to the subtree, so Git never reports the root rule file at all.
+	result, err := AnalyzeGitRange(context.Background(), repo, base, head, []string{"vendor"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, warning := range result.Warnings {
+		if warning.Code == "W_INDEX_POLICY_CHANGED" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("scoped range went silent about a policy change: %#v", result.Warnings)
+	}
+}
+
+// TestAnalyzeGitRangeAcceptsEveryRootTreeSpelling pins the peel. Git spells "the
+// tree of this commit" several ways, and a spelling this failed to recognize
+// disabled every exclusion rule for the range.
+func TestAnalyzeGitRangeAcceptsEveryRootTreeSpelling(t *testing.T) {
+	repo := t.TempDir()
+	initDiffPolicyRepo(t, repo)
+	write(t, repo, ".graphignore", "vendored/\n")
+	write(t, repo, "keep/k.go", "package keep\n\nfunc Keep() int { return 1 }\n")
+	write(t, repo, "vendored/gen.go", "package vendored\n\nfunc Gen() int { return 1 }\n")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-m", "initial")
+
+	write(t, repo, "keep/k.go", "package keep\n\nfunc Keep() int { return 2 }\n")
+	write(t, repo, "vendored/gen.go", "package vendored\n\nfunc Gen() int { return 2 }\n")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-m", "edit both")
+
+	for _, spelling := range []string{"^{tree}", "^{tree}^{}", "^{tree}^{object}"} {
+		t.Run(spelling, func(t *testing.T) {
+			result, err := AnalyzeGitRange(context.Background(), repo, "HEAD~1"+spelling, "HEAD"+spelling, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if file := onlyFile(t, result); file.Path != "keep/k.go" {
+				t.Fatalf("file = %#v, want only keep/k.go", file)
+			}
+		})
+	}
+}

--- a/internal/sem/analyze_indexpolicy_test.go
+++ b/internal/sem/analyze_indexpolicy_test.go
@@ -422,6 +422,22 @@ func TestAnalyzeGitRangeWarnsWhenAnIndexPolicyFileChanges(t *testing.T) {
 		t.Fatalf("warnings = %#v, want W_INDEX_POLICY_CHANGED for .gitignore", result.Warnings)
 	}
 
+	// A .graphignore outside the repository root decides nothing: the matcher only
+	// ever reads <repo>/.graphignore, so warning about it would be a false report.
+	write(t, repo, "pkg/.graphignore", "generated/\n")
+	git(t, repo, "add", "-A", "-f")
+	git(t, repo, "commit", "-m", "add a nested graphignore")
+	nested, err := AnalyzeGitRange(context.Background(), repo, head, rev(t, repo, "HEAD"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, warning := range nested.Warnings {
+		if warning.Code == "W_INDEX_POLICY_CHANGED" {
+			t.Fatalf("a non-root .graphignore warned about an index policy change: %#v", nested.Warnings)
+		}
+	}
+	head = rev(t, repo, "HEAD")
+
 	// An ordinary range must stay quiet; the warning is a real signal, not noise.
 	write(t, repo, "keep/k.go", "package keep\n\nfunc Keep() int { return 2 }\n")
 	git(t, repo, "add", "-A", "-f")

--- a/internal/sem/analyze_indexpolicy_test.go
+++ b/internal/sem/analyze_indexpolicy_test.go
@@ -384,3 +384,55 @@ func TestAdmitChangedFilesRewritesIndexCrossings(t *testing.T) {
 		})
 	}
 }
+
+// TestAnalyzeGitRangeWarnsWhenAnIndexPolicyFileChanges pins the one
+// incompleteness a change-based diff cannot filter its way out of. A committed
+// exclusion rule decides membership for files it never names, so dropping a
+// re-inclusion removes a whole subtree from the head snapshot while Git reports
+// only the rule file. The delta cannot contain those removals, so it must at
+// least say so rather than read as complete.
+func TestAnalyzeGitRangeWarnsWhenAnIndexPolicyFileChanges(t *testing.T) {
+	repo := t.TempDir()
+	initDiffPolicyRepo(t, repo)
+	write(t, repo, ".gitignore", "vendor/*\n!vendor/rootpkg/\n!vendor/rootpkg/**\n")
+	write(t, repo, "vendor/rootpkg/root.go", "package rootpkg\n\nfunc Root() int { return 1 }\n")
+	write(t, repo, "keep/k.go", "package keep\n\nfunc Keep() int { return 1 }\n")
+	git(t, repo, "add", "-A", "-f")
+	git(t, repo, "commit", "-m", "initial")
+	base := rev(t, repo, "HEAD")
+
+	// The re-inclusion goes away. vendor/rootpkg/root.go does not change, but it
+	// leaves the graph.
+	write(t, repo, ".gitignore", "vendor/*\n")
+	git(t, repo, "add", "-A", "-f")
+	git(t, repo, "commit", "-m", "drop the re-inclusion")
+	head := rev(t, repo, "HEAD")
+
+	result, err := AnalyzeGitRange(context.Background(), repo, base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, warning := range result.Warnings {
+		if warning.Code == "W_INDEX_POLICY_CHANGED" && warning.FilePath == ".gitignore" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("warnings = %#v, want W_INDEX_POLICY_CHANGED for .gitignore", result.Warnings)
+	}
+
+	// An ordinary range must stay quiet; the warning is a real signal, not noise.
+	write(t, repo, "keep/k.go", "package keep\n\nfunc Keep() int { return 2 }\n")
+	git(t, repo, "add", "-A", "-f")
+	git(t, repo, "commit", "-m", "ordinary edit")
+	quiet, err := AnalyzeGitRange(context.Background(), repo, head, rev(t, repo, "HEAD"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, warning := range quiet.Warnings {
+		if warning.Code == "W_INDEX_POLICY_CHANGED" {
+			t.Fatalf("ordinary range warned about an index policy change: %#v", quiet.Warnings)
+		}
+	}
+}

--- a/internal/sem/analyze_indexpolicy_test.go
+++ b/internal/sem/analyze_indexpolicy_test.go
@@ -1,0 +1,378 @@
+package sem
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/entireio/entire-graph/internal/gitutil"
+)
+
+// The semantic diff must report what happened to the GRAPH, not what happened to
+// a path. These tests pin that equivalence directly: whatever the diff says
+// entered or left the index is checked against a snapshot of the same repository,
+// so neither side can drift without a failure here.
+
+func initDiffPolicyRepo(t *testing.T, repo string) {
+	t.Helper()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+}
+
+// snapshotSymbolNames is the graph's own answer for one file at the repository's
+// current state, which is what the diff's additions and removals have to match.
+func snapshotSymbolNames(t *testing.T, repo, file string) map[string]struct{} {
+	t.Helper()
+	snapshot, err := BuildProviderSnapshot(context.Background(), repo, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := map[string]struct{}{}
+	for _, symbol := range snapshot.Symbols {
+		if filepath.ToSlash(symbol.FilePath) == file {
+			names[symbol.Name] = struct{}{}
+		}
+	}
+	return names
+}
+
+func changeNamesByType(file FileChange, changeType string) map[string]struct{} {
+	names := map[string]struct{}{}
+	for _, change := range file.Changes {
+		if change.Type == changeType {
+			names[change.Name] = struct{}{}
+		}
+	}
+	return names
+}
+
+func sameNames(left, right map[string]struct{}) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for name := range left {
+		if _, ok := right[name]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func onlyFile(t *testing.T, result Result) FileChange {
+	t.Helper()
+	if len(result.Files) != 1 {
+		t.Fatalf("files = %#v, want exactly one", result.Files)
+	}
+	return result.Files[0]
+}
+
+// TestAnalyzeGitRangeIndexedToIgnoredRenameRemovesOldSymbols covers a rename OUT
+// of the graph. The base snapshot holds the old path's symbols and the head
+// snapshot holds nothing, so the delta a consumer needs is a removal of every one
+// of them. Deciding from the destination path alone discarded the whole entry and
+// left those symbols in the consumer's index forever.
+func TestAnalyzeGitRangeIndexedToIgnoredRenameRemovesOldSymbols(t *testing.T) {
+	repo := t.TempDir()
+	initDiffPolicyRepo(t, repo)
+	write(t, repo, ".graphignore", "vendored/\n")
+	write(t, repo, "keep/k.go", "package keep\n\nfunc Keep() int { return 1 }\n\nfunc Also() int { return 9 }\n\nfunc Third() int { return 3 }\n")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-m", "initial")
+	base := rev(t, repo, "HEAD")
+
+	wantRemoved := snapshotSymbolNames(t, repo, "keep/k.go")
+	if len(wantRemoved) == 0 {
+		t.Fatal("fixture is wrong: the snapshot indexes no symbol in keep/k.go")
+	}
+
+	if err := os.Remove(filepath.Join(repo, "keep", "k.go")); err != nil {
+		t.Fatal(err)
+	}
+	write(t, repo, "vendored/k.go", "package vendored\n\nfunc Keep() int { return 111 }\n\nfunc Also() int { return 9 }\n\nfunc Third() int { return 3 }\n")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-m", "move the tree out of the graph")
+	head := rev(t, repo, "HEAD")
+
+	if got := snapshotSymbolNames(t, repo, "vendored/k.go"); len(got) != 0 {
+		t.Fatalf("fixture is wrong: the snapshot indexed an ignored file: %#v", got)
+	}
+
+	result, err := AnalyzeGitRange(context.Background(), repo, base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file := onlyFile(t, result)
+	if file.Path != "keep/k.go" || file.Status != "D" {
+		t.Fatalf("file = %#v, want a deletion of keep/k.go", file)
+	}
+	if file.OldPath != "" {
+		t.Fatalf("file = %#v, want no rename provenance: nothing moved inside the graph", file)
+	}
+	if removed := changeNamesByType(file, "removed"); !sameNames(removed, wantRemoved) {
+		t.Fatalf("removed = %#v, want every symbol the base snapshot held: %#v", removed, wantRemoved)
+	}
+	if len(file.Changes) != len(wantRemoved) {
+		t.Fatalf("changes = %#v, want only removals", file.Changes)
+	}
+}
+
+// TestAnalyzeGitRangeIgnoredToIndexedRenameAddsEveryHeadSymbol covers the mirror
+// crossing, INTO the graph. No snapshot contains the base path, so comparing
+// against it reported a body change for a file the graph never held and never
+// named the head file's other symbols at all.
+func TestAnalyzeGitRangeIgnoredToIndexedRenameAddsEveryHeadSymbol(t *testing.T) {
+	repo := t.TempDir()
+	initDiffPolicyRepo(t, repo)
+	write(t, repo, ".graphignore", "vendored/\n")
+	write(t, repo, "anchor.go", "package root\n\nfunc Anchor() int { return 0 }\n")
+	write(t, repo, "vendored/g.go", "package vendored\n\nfunc Gen() int { return 1 }\n\nfunc GenTwo() int { return 2 }\n\nfunc GenThree() int { return 3 }\n")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-m", "initial")
+	base := rev(t, repo, "HEAD")
+
+	if got := snapshotSymbolNames(t, repo, "vendored/g.go"); len(got) != 0 {
+		t.Fatalf("fixture is wrong: the snapshot indexed an ignored file: %#v", got)
+	}
+
+	if err := os.Remove(filepath.Join(repo, "vendored", "g.go")); err != nil {
+		t.Fatal(err)
+	}
+	write(t, repo, "keep/g.go", "package keep\n\nfunc Gen() int { return 111 }\n\nfunc GenTwo() int { return 2 }\n\nfunc GenThree() int { return 3 }\n")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-m", "move the tree into the graph")
+	head := rev(t, repo, "HEAD")
+
+	wantAdded := snapshotSymbolNames(t, repo, "keep/g.go")
+	if len(wantAdded) < 2 {
+		t.Fatalf("fixture is wrong: want several symbols in keep/g.go, got %#v", wantAdded)
+	}
+
+	result, err := AnalyzeGitRange(context.Background(), repo, base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file := onlyFile(t, result)
+	if file.Path != "keep/g.go" || file.Status != "A" {
+		t.Fatalf("file = %#v, want an addition of keep/g.go", file)
+	}
+	if file.OldPath != "" {
+		t.Fatalf("file = %#v, want no provenance from a path no snapshot holds", file)
+	}
+	if added := changeNamesByType(file, "added"); !sameNames(added, wantAdded) {
+		t.Fatalf("added = %#v, want every symbol the head snapshot holds: %#v", added, wantAdded)
+	}
+	if len(file.Changes) != len(wantAdded) {
+		t.Fatalf("changes = %#v, want only additions", file.Changes)
+	}
+}
+
+// TestAnalyzeGitRangeSubtreeRangeAppliesNoIgnorePolicy is the over-rejection
+// guard for the root-relative gate. A subtree range names its files relative to
+// that subtree, so a root-anchored rule matched the wrong names and silently
+// dropped a file the graph does index.
+func TestAnalyzeGitRangeSubtreeRangeAppliesNoIgnorePolicy(t *testing.T) {
+	repo := t.TempDir()
+	initDiffPolicyRepo(t, repo)
+	// Anchored at the repository root: it names top.go, never sub/top.go.
+	write(t, repo, ".graphignore", "/top.go\n")
+	write(t, repo, "top.go", "package top\n\nfunc Top() int { return 1 }\n")
+	write(t, repo, "sub/top.go", "package sub\n\nfunc Top() int { return 1 }\n")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-m", "initial")
+
+	write(t, repo, "top.go", "package top\n\nfunc Top() int { return 2 }\n")
+	write(t, repo, "sub/top.go", "package sub\n\nfunc Top() int { return 2 }\n")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-m", "edit both")
+
+	if got := snapshotSymbolNames(t, repo, "sub/top.go"); len(got) == 0 {
+		t.Fatal("fixture is wrong: the snapshot must index sub/top.go")
+	}
+
+	subtree, err := AnalyzeGitRange(context.Background(), repo, "HEAD~1:sub", "HEAD:sub", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file := onlyFile(t, subtree)
+	if file.Path != "top.go" {
+		t.Fatalf("subtree range file = %#v, want the subtree-relative top.go", file)
+	}
+
+	// The same rule still applies for the ordinary root-relative range, where the
+	// names it was written against are the names Git emits.
+	whole, err := AnalyzeGitRange(context.Background(), repo, "HEAD~1", "HEAD", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file = onlyFile(t, whole)
+	if file.Path != "sub/top.go" {
+		t.Fatalf("root range file = %#v, want only sub/top.go", file)
+	}
+}
+
+// TestAnalyzeGitRangeTreePeeledRangeStillAppliesIgnorePolicy pins the other side
+// of the gate: <commit-ish>^{tree} is a root tree, so its names ARE root
+// relative and the policy must still apply.
+func TestAnalyzeGitRangeTreePeeledRangeStillAppliesIgnorePolicy(t *testing.T) {
+	repo := t.TempDir()
+	initDiffPolicyRepo(t, repo)
+	write(t, repo, ".graphignore", "vendored/\n")
+	write(t, repo, "keep/k.go", "package keep\n\nfunc Keep() int { return 1 }\n")
+	write(t, repo, "vendored/gen.go", "package vendored\n\nfunc Gen() int { return 1 }\n")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-m", "initial")
+
+	write(t, repo, "keep/k.go", "package keep\n\nfunc Keep() int { return 2 }\n")
+	write(t, repo, "vendored/gen.go", "package vendored\n\nfunc Gen() int { return 2 }\n")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-m", "edit both")
+
+	result, err := AnalyzeGitRange(context.Background(), repo, "HEAD~1^{tree}", "HEAD^{tree}", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file := onlyFile(t, result)
+	if file.Path != "keep/k.go" {
+		t.Fatalf("file = %#v, want only keep/k.go", file)
+	}
+}
+
+// TestAnalyzeGitRangeHonorsVendoredTrees covers the other filter the committed
+// snapshot applies. A tracked vendor/ tree is the canonical case: no snapshot
+// contains it, so no diff may report entity changes in it.
+func TestAnalyzeGitRangeHonorsVendoredTrees(t *testing.T) {
+	repo := t.TempDir()
+	initDiffPolicyRepo(t, repo)
+	write(t, repo, "keep/k.go", "package keep\n\nfunc Keep() int { return 1 }\n")
+	write(t, repo, "vendor/v.go", "package vendorpkg\n\nfunc V() int { return 1 }\n")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-m", "initial")
+	base := rev(t, repo, "HEAD")
+
+	write(t, repo, "keep/k.go", "package keep\n\nfunc Keep() int { return 2 }\n")
+	write(t, repo, "vendor/v.go", "package vendorpkg\n\nfunc V() int { return 2 }\n")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-m", "edit both")
+	head := rev(t, repo, "HEAD")
+
+	if got := snapshotSymbolNames(t, repo, "vendor/v.go"); len(got) != 0 {
+		t.Fatalf("fixture is wrong: the snapshot indexed a vendored file: %#v", got)
+	}
+
+	result, err := AnalyzeGitRange(context.Background(), repo, base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if file := onlyFile(t, result); file.Path != "keep/k.go" {
+		t.Fatalf("file = %#v, want only keep/k.go", file)
+	}
+}
+
+// TestAnalyzeGitRangeReportsReincludedVendorTree is the over-rejection guard for
+// the vendored-tree filter. A project that re-includes part of a vendored tree
+// means to keep it, the snapshot indexes it, and so the diff must report it.
+func TestAnalyzeGitRangeReportsReincludedVendorTree(t *testing.T) {
+	repo := t.TempDir()
+	initDiffPolicyRepo(t, repo)
+	write(t, repo, ".gitignore", "vendor/*\n!vendor/rootpkg/\n!vendor/rootpkg/**\n")
+	write(t, repo, "vendor/rootpkg/root.go", "package rootpkg\n\nfunc Root() int { return 1 }\n")
+	git(t, repo, "add", "-A", "-f")
+	git(t, repo, "commit", "-m", "initial")
+	base := rev(t, repo, "HEAD")
+
+	write(t, repo, "vendor/rootpkg/root.go", "package rootpkg\n\nfunc Root() int { return 2 }\n")
+	git(t, repo, "add", "-A", "-f")
+	git(t, repo, "commit", "-m", "edit the re-included tree")
+	head := rev(t, repo, "HEAD")
+
+	if got := snapshotSymbolNames(t, repo, "vendor/rootpkg/root.go"); len(got) == 0 {
+		t.Fatal("fixture is wrong: the snapshot must index a re-included vendor tree")
+	}
+
+	result, err := AnalyzeGitRange(context.Background(), repo, base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if file := onlyFile(t, result); file.Path != "vendor/rootpkg/root.go" {
+		t.Fatalf("file = %#v, want the re-included vendor path reported", file)
+	}
+}
+
+// TestAdmitChangedFilesRewritesIndexCrossings covers the rewrite table directly,
+// including the copy case Git is not currently asked to detect: a copy's source
+// still exists, so an unindexed destination must never be reported as a deletion
+// of it.
+func TestAdmitChangedFilesRewritesIndexCrossings(t *testing.T) {
+	indexed := diffIndexPolicy{ignores: ignoreMatcher{}, vendorRules: ignoreMatcher{}, enabled: true}
+	var ignoredAll ignoreMatcher
+	if err := ignoredAll.loadContent("*\n", false); err != nil {
+		t.Fatal(err)
+	}
+	unindexed := diffIndexPolicy{ignores: ignoredAll, vendorRules: ignoreMatcher{}, enabled: true}
+
+	tests := []struct {
+		name string
+		base diffIndexPolicy
+		head diffIndexPolicy
+		in   gitutil.ChangedFile
+		want []gitutil.ChangedFile
+	}{
+		{
+			name: "indexed both sides is untouched",
+			base: indexed, head: indexed,
+			in:   gitutil.ChangedFile{Status: "R", OldPath: "a.go", Path: "b.go"},
+			want: []gitutil.ChangedFile{{Status: "R", OldPath: "a.go", Path: "b.go"}},
+		},
+		{
+			name: "rename out of the index becomes a deletion of the old path",
+			base: indexed, head: unindexed,
+			in:   gitutil.ChangedFile{Status: "R", OldPath: "a.go", Path: "b.go"},
+			want: []gitutil.ChangedFile{{Status: "D", Path: "a.go"}},
+		},
+		{
+			name: "rename into the index becomes an addition of the new path",
+			base: unindexed, head: indexed,
+			in:   gitutil.ChangedFile{Status: "R", OldPath: "a.go", Path: "b.go"},
+			want: []gitutil.ChangedFile{{Status: "A", Path: "b.go"}},
+		},
+		{
+			name: "unindexed on both sides is dropped",
+			base: unindexed, head: unindexed,
+			in:   gitutil.ChangedFile{Status: "M", Path: "a.go"},
+			want: nil,
+		},
+		{
+			name: "copy to an unindexed destination never deletes its source",
+			base: indexed, head: unindexed,
+			in:   gitutil.ChangedFile{Status: "C", OldPath: "a.go", Path: "b.go"},
+			want: nil,
+		},
+		{
+			name: "copy into the index adds only the destination",
+			base: unindexed, head: indexed,
+			in:   gitutil.ChangedFile{Status: "C", OldPath: "a.go", Path: "b.go"},
+			want: []gitutil.ChangedFile{{Status: "A", Path: "b.go"}},
+		},
+		{
+			name: "a disabled policy admits everything",
+			base: diffIndexPolicy{}, head: diffIndexPolicy{},
+			in:   gitutil.ChangedFile{Status: "M", Path: "a.go"},
+			want: []gitutil.ChangedFile{{Status: "M", Path: "a.go"}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := admitChangedFiles([]gitutil.ChangedFile{test.in}, test.base, test.head)
+			if len(got) != len(test.want) {
+				t.Fatalf("admitted %#v, want %#v", got, test.want)
+			}
+			for index := range got {
+				if got[index] != test.want[index] {
+					t.Fatalf("admitted %#v, want %#v", got, test.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -294,12 +294,20 @@ func TestResolveDiffTreesReusesResolutionForSameLabel(t *testing.T) {
 			return "new-tree", nil
 		}
 	}
-	base, head, err := resolveDiffTrees(t.Context(), "repo", "moving", "moving", resolve)
+	base, head, rootRelative, err := resolveDiffTrees(t.Context(), "repo", "moving", "moving", resolve)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(revisions) != 2 || revisions[0] != "moving" || revisions[1] != "moving-object^{tree}" {
-		t.Fatalf("same ref resolutions = %#v, want exact label then one immutable tree peel", revisions)
+	// The moving label is still resolved exactly once; the two follow-ups both
+	// address the immutable object it resolved to, never the label again.
+	if len(revisions) != 3 ||
+		revisions[0] != "moving" ||
+		revisions[1] != "moving-object^{tree}" ||
+		revisions[2] != "moving-object^{commit}" {
+		t.Fatalf("same ref resolutions = %#v, want exact label then immutable tree and commit peels", revisions)
+	}
+	if !rootRelative {
+		t.Fatal("a commit-ish label must report repository-root relative names")
 	}
 	if base != "old-tree" || head != "old-tree" {
 		t.Fatalf("same ref pinned to %q..%q, want old-tree..old-tree", base, head)

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -314,6 +314,38 @@ func TestResolveDiffTreesReusesResolutionForSameLabel(t *testing.T) {
 	}
 }
 
+// TestResolveDiffTreesRejectsTreePathLabels pins that resolving to a commit is
+// not on its own evidence that a label named one. A gitlink resolves to the
+// submodule's commit, and a range over its tree is named relative to the
+// SUBMODULE's root, so this repository's exclusion rules do not describe those
+// names. The probe happens to fail today only because a submodule's objects are
+// usually absent from the superproject; an absorbed or fetched submodule puts
+// them there, and this must not depend on that.
+func TestResolveDiffTreesRejectsTreePathLabels(t *testing.T) {
+	// Mimics a superproject that DOES hold the submodule's objects: every peel
+	// resolves cleanly, so only the label's shape can rule it out.
+	resolve := func(_ context.Context, _, revision string) (string, error) {
+		return "gitlink-commit", nil
+	}
+	_, _, rootRelative, err := resolveDiffTrees(t.Context(), "repo", "HEAD:sub", "HEAD:sub", resolve)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rootRelative {
+		t.Fatal("a gitlink label must not be treated as repository-root relative")
+	}
+
+	// The commit-message search is the one colon form that names a commit and
+	// reaches into no tree.
+	_, _, rootRelative, err = resolveDiffTrees(t.Context(), "repo", ":/fix the bug", ":/fix the bug", resolve)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rootRelative {
+		t.Fatal(":/text names a commit, so its names are repository-root relative")
+	}
+}
+
 func TestAnalyzeGitRangeSurfacesModuleScopeChange(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -1819,3 +1819,138 @@ func TestAnalyzeGitRangeNoBudgetKeepsFullResult(t *testing.T) {
 		}
 	}
 }
+
+// TestAnalyzeGitRangeHonorsGraphIgnore pins the documented contract that a
+// repo-root .graphignore is honored by every graph command. The snapshot and
+// search family already applied it; the diff family did not, so a tracked but
+// vendored or generated tree that the graph never indexes still produced entity
+// changes — symbols no snapshot of the repository contains.
+func TestAnalyzeGitRangeHonorsGraphIgnore(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	write(t, repo, ".graphignore", "vendored/\n")
+	write(t, repo, "keep/keep.go", "package keep\n\nfunc Keep() int { return 1 }\n")
+	write(t, repo, "vendored/gen.go", "package vendored\n\nfunc Gen() int { return 1 }\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	base := rev(t, repo, "HEAD")
+
+	write(t, repo, "keep/keep.go", "package keep\n\nfunc Keep() int { return 2 }\n")
+	write(t, repo, "vendored/gen.go", "package vendored\n\nfunc Gen() int { return 2 }\n\nfunc Extra() int { return 3 }\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "touch both trees")
+	head := rev(t, repo, "HEAD")
+
+	result, err := AnalyzeGitRange(context.Background(), repo, base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Files) != 1 || result.Files[0].Path != "keep/keep.go" {
+		t.Fatalf("ignored tree reported in the diff: %#v", result.Files)
+	}
+
+	// The same repository's snapshot must agree: whatever the diff reports has
+	// to be something the graph would index.
+	snapshot, err := BuildProviderSnapshot(context.Background(), repo, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, symbol := range snapshot.Symbols {
+		if strings.HasPrefix(symbol.FilePath, "vendored/") {
+			t.Fatalf("snapshot indexed an ignored file, fixture is wrong: %#v", symbol)
+		}
+	}
+}
+
+// TestAnalyzeGitRangeHonorsGraphIgnoreForDeletions covers the base side: a
+// deletion has no head path, so the base path is what decides.
+func TestAnalyzeGitRangeHonorsGraphIgnoreForDeletions(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	write(t, repo, ".graphignore", "vendored/\n")
+	write(t, repo, "keep/keep.go", "package keep\n\nfunc Keep() int { return 1 }\n")
+	write(t, repo, "vendored/gen.go", "package vendored\n\nfunc Gen() int { return 1 }\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	base := rev(t, repo, "HEAD")
+
+	if err := os.Remove(filepath.Join(repo, "vendored/gen.go")); err != nil {
+		t.Fatal(err)
+	}
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-m", "drop the vendored tree")
+	head := rev(t, repo, "HEAD")
+
+	result, err := AnalyzeGitRange(context.Background(), repo, base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Files) != 0 {
+		t.Fatalf("deleting an ignored file produced a delta: %#v", result.Files)
+	}
+}
+
+// TestAnalyzeGitRangeWithoutGraphIgnoreIsUnchanged guards against the filter
+// swallowing ordinary files when no ignore rule exists.
+func TestAnalyzeGitRangeWithoutGraphIgnoreIsUnchanged(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	write(t, repo, "vendored/gen.go", "package vendored\n\nfunc Gen() int { return 1 }\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	base := rev(t, repo, "HEAD")
+
+	write(t, repo, "vendored/gen.go", "package vendored\n\nfunc Gen() int { return 2 }\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "edit")
+	head := rev(t, repo, "HEAD")
+
+	result, err := AnalyzeGitRange(context.Background(), repo, base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Files) != 1 || result.Files[0].Path != "vendored/gen.go" {
+		t.Fatalf("file was dropped without an ignore rule: %#v", result.Files)
+	}
+}
+
+// TestAnalyzeGitRangeHonorsBuiltinSecretRules covers the other half of the same
+// matcher. The provider's built-in secret rules already keep committed
+// credential files out of the snapshot; the diff reported them as entity
+// changes, naming paths the rest of the provider refuses to index.
+func TestAnalyzeGitRangeHonorsBuiltinSecretRules(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	write(t, repo, "app.go", "package app\n\nfunc Run() int { return 1 }\n")
+	write(t, repo, ".env", "API_KEY=first\n")
+	git(t, repo, "add", "-A", "-f")
+	git(t, repo, "commit", "-m", "initial")
+	base := rev(t, repo, "HEAD")
+
+	write(t, repo, "app.go", "package app\n\nfunc Run() int { return 2 }\n")
+	write(t, repo, ".env", "API_KEY=second\n")
+	git(t, repo, "add", "-A", "-f")
+	git(t, repo, "commit", "-m", "rotate")
+	head := rev(t, repo, "HEAD")
+
+	result, err := AnalyzeGitRange(context.Background(), repo, base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range result.Files {
+		if file.Path == ".env" {
+			t.Fatalf("committed credential file reported in the diff: %#v", file)
+		}
+	}
+	if len(result.Files) != 1 || result.Files[0].Path != "app.go" {
+		t.Fatalf("files = %#v, want only app.go", result.Files)
+	}
+}

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -346,6 +346,38 @@ func TestResolveDiffTreesRejectsTreePathLabels(t *testing.T) {
 	}
 }
 
+// TestLabelSelectsTreePath pins which colons are the <rev>:<path> separator and
+// which are data. Rejecting a colon that is not that separator does not lose
+// data, but it silently disables every exclusion rule for the range, so a
+// reflog date selector must not be mistaken for a subtree expression.
+func TestLabelSelectsTreePath(t *testing.T) {
+	tests := []struct {
+		label string
+		want  bool
+	}{
+		{"HEAD", false},
+		{"main", false},
+		{"HEAD~1", false},
+		{"refs/tags/v1.0.0", false},
+		{"HEAD@{2}", false},
+		// A reflog date selector: commit-ish, and full of colons.
+		{"HEAD@{2026-08-27 12:34:56 +0000}", false},
+		{"main@{yesterday 09:00:00}", false},
+		// The commit-message search names a commit; colons after it are text.
+		{":/fix: the bug", false},
+		// These do reach into a tree.
+		{"HEAD:sub", true},
+		{"HEAD~1:sub/dir", true},
+		{":0:conflicted.go", true},
+		{"HEAD@{2}:sub", true},
+	}
+	for _, test := range tests {
+		if got := labelSelectsTreePath(test.label); got != test.want {
+			t.Errorf("labelSelectsTreePath(%q) = %v, want %v", test.label, got, test.want)
+		}
+	}
+}
+
 func TestAnalyzeGitRangeSurfacesModuleScopeChange(t *testing.T) {
 	repo := t.TempDir()
 	git(t, repo, "init")

--- a/internal/sem/analyze_test.go
+++ b/internal/sem/analyze_test.go
@@ -363,13 +363,19 @@ func TestLabelSelectsTreePath(t *testing.T) {
 		// A reflog date selector: commit-ish, and full of colons.
 		{"HEAD@{2026-08-27 12:34:56 +0000}", false},
 		{"main@{yesterday 09:00:00}", false},
-		// The commit-message search names a commit; colons after it are text.
+		// The commit-message searches name a commit; colons in them are text.
 		{":/fix: the bug", false},
+		{"HEAD^{/release: fix}", false},
+		{"main^{/colon: here}~2", false},
+		// The ordinary peels carry no colon but must stay revision-shaped.
+		{"HEAD^{tree}", false},
+		{"HEAD^{commit}", false},
 		// These do reach into a tree.
 		{"HEAD:sub", true},
 		{"HEAD~1:sub/dir", true},
 		{":0:conflicted.go", true},
 		{"HEAD@{2}:sub", true},
+		{"HEAD^{/release fix}:sub", true},
 	}
 	for _, test := range tests {
 		if got := labelSelectsTreePath(test.label); got != test.want {

--- a/internal/sem/dependents.go
+++ b/internal/sem/dependents.go
@@ -27,6 +27,11 @@ type dependentsScanOptions struct {
 	// count.
 	deadline time.Time
 	budget   time.Duration
+	// admit reports whether a candidate file is part of the graph at head, so a
+	// dependent count means "references the graph holds" rather than "textual
+	// references anywhere in the tree". nil admits every candidate, which is
+	// what every caller that has no index policy to offer wants.
+	admit func(rel string) bool
 }
 
 func addDependentCounts(ctx context.Context, repo, head string, result *Result) error {
@@ -94,6 +99,19 @@ func buildReferenceIndexWithProgress(ctx context.Context, repo, head string, nam
 	files, prefiltered, warnings, err := referenceCandidateFiles(ctx, repo, head, names)
 	if err != nil {
 		return nil, nil, err
+	}
+	// Drop candidates the graph does not index before any of them is read. A
+	// caller inside a vendored or .graphignore'd tree is not a dependent the
+	// graph can show: after the diff stopped naming those files, counting them
+	// left a number nothing in the output accounted for.
+	if options.admit != nil {
+		admitted := files[:0]
+		for _, file := range files {
+			if options.admit(file) {
+				admitted = append(admitted, file)
+			}
+		}
+		files = admitted
 	}
 	if options.progress != nil {
 		options.progress(0, len(files), "")
@@ -474,6 +492,11 @@ func grepFallbackWarning(err error) ProviderWarning {
 // file in the tree so a git-grep quirk never silently zeroes out dependent
 // counts, and surface exactly one warning noting the prefilter failure so the
 // fallback (much slower) scan is not silent.
+//
+// The superset guarantee is about TEXT, and the caller may narrow the result
+// afterwards by index membership (dependentsScanOptions.admit). Nothing dropped
+// there is a dependent the graph could ever show, so the guarantee still holds
+// where it is claimed: relative to the files the graph indexes.
 //
 // The prefiltered return reports whether the grep preselection actually ran:
 // true means every returned file already matched a changed name; false means

--- a/internal/sem/dependents_indexpolicy_test.go
+++ b/internal/sem/dependents_indexpolicy_test.go
@@ -1,0 +1,40 @@
+package sem
+
+import (
+	"context"
+	"testing"
+)
+
+// TestAnalyzeGitRangeDependentsExcludeUnindexedCallers pins the count to the
+// graph. Once the diff stopped naming ignored files, counting their references
+// left a number nothing in the output accounted for.
+func TestAnalyzeGitRangeDependentsExcludeUnindexedCallers(t *testing.T) {
+	repo := t.TempDir()
+	initDiffPolicyRepo(t, repo)
+	write(t, repo, ".graphignore", "vendored/\n")
+	write(t, repo, "keep/k.go", "package keep\n\nfunc Keep() int { return 1 }\n")
+	write(t, repo, "other.go", "package other\n\nimport \"x/keep\"\n\nfunc Real() int { return keep.Keep() }\n")
+	write(t, repo, "vendored/callers.go", "package vendored\n\nimport \"x/keep\"\n\nfunc A() int { return keep.Keep() }\nfunc B() int { return keep.Keep() }\nfunc C() int { return keep.Keep() }\n")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-m", "initial")
+	base := rev(t, repo, "HEAD")
+
+	write(t, repo, "keep/k.go", "package keep\n\nfunc Keep() int { return 2 }\n")
+	git(t, repo, "add", "-A")
+	git(t, repo, "commit", "-m", "edit the callee")
+	head := rev(t, repo, "HEAD")
+
+	result, err := AnalyzeGitRange(context.Background(), repo, base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file := onlyFile(t, result)
+	if len(file.Changes) != 1 {
+		t.Fatalf("changes = %#v, want one", file.Changes)
+	}
+	// other.go is the only caller the graph holds; the three in vendored/ are in
+	// no snapshot and so are not dependents the graph can show.
+	if got := file.Changes[0].DependentsCount; got != 1 {
+		t.Fatalf("dependents = %d, want 1 indexed caller", got)
+	}
+}

--- a/internal/sem/dependents_indexpolicy_test.go
+++ b/internal/sem/dependents_indexpolicy_test.go
@@ -38,3 +38,46 @@ func TestAnalyzeGitRangeDependentsExcludeUnindexedCallers(t *testing.T) {
 		t.Fatalf("dependents = %d, want 1 indexed caller", got)
 	}
 }
+
+// TestAnalyzeGitRangeDependentsIncludeReincludedVendorCallers is the
+// over-rejection guard for the same filter, and the reason the head policy is
+// resolved separately for this scan.
+//
+// The changed-file probe may skip loading a tree's vendored-tree rules when
+// nothing vendorable changed. The dependents scan asks about the whole head
+// tree, where a re-included vendor path can still appear, so reusing that
+// probe's policy judged a real caller by empty rules and dropped it.
+func TestAnalyzeGitRangeDependentsIncludeReincludedVendorCallers(t *testing.T) {
+	repo := t.TempDir()
+	initDiffPolicyRepo(t, repo)
+	write(t, repo, ".gitignore", "vendor/*\n!vendor/rootpkg/\n!vendor/rootpkg/**\n")
+	write(t, repo, "keep/k.go", "package keep\n\nfunc Keep() int { return 1 }\n")
+	write(t, repo, "other.go", "package other\n\nimport \"x/keep\"\n\nfunc Real() int { return keep.Keep() }\n")
+	write(t, repo, "vendor/rootpkg/caller.go", "package rootpkg\n\nimport \"x/keep\"\n\nfunc Vendored() int { return keep.Keep() }\n")
+	git(t, repo, "add", "-A", "-f")
+	git(t, repo, "commit", "-m", "initial")
+	base := rev(t, repo, "HEAD")
+
+	// Only an ordinary file changes, so the changed-file probe finds nothing
+	// vendorable and skips the rule load. The caller below still exists.
+	write(t, repo, "keep/k.go", "package keep\n\nfunc Keep() int { return 2 }\n")
+	git(t, repo, "add", "-A", "-f")
+	git(t, repo, "commit", "-m", "edit the callee")
+	head := rev(t, repo, "HEAD")
+
+	if got := snapshotSymbolNames(t, repo, "vendor/rootpkg/caller.go"); len(got) == 0 {
+		t.Fatal("fixture is wrong: the snapshot must index the re-included vendor caller")
+	}
+
+	result, err := AnalyzeGitRange(context.Background(), repo, base, head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file := onlyFile(t, result)
+	if len(file.Changes) != 1 {
+		t.Fatalf("changes = %#v, want one", file.Changes)
+	}
+	if got := file.Changes[0].DependentsCount; got != 2 {
+		t.Fatalf("dependents = %d, want both indexed callers including the re-included vendor one", got)
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/126
<!-- entire-trail-link-end -->

## Problem

`entire graph index --help` states the contract:

> A repo-root `.graphignore` (gitignore syntax) is honored by every graph command, on top of `.gitignore`.

The diff family did not honor it. `snapshot` / `symbols` / `search` apply the matcher through `loadExplicitIgnoreMatcher`; `diff`, `analyze`, `commit`, and `checkpoint` never loaded one.

```
$ cat .graphignore
vendored/

$ entire graph symbols --repo . --format ndjson | grep -c '"file_path":"vendored/'
0

$ entire graph diff --base HEAD~1 --head HEAD
keep/k.go (Go)
  ~ function Keep body changed (0 dependents)

vendored/gen.go (Go)          <-- never indexed, never in any snapshot
  ~ function Gen body changed (0 dependents)
  + function Extra added
```

`.graphignore` exists for tracked-but-vendored or generated sources — the tree-sitter `parser.c` blobs the help text names, plus generated clients, bundled vendor trees, and checked-in build output. Those are exactly the paths that churn, so the diff emitted entity changes for symbols that no snapshot of the repository contains and that no consumer building its index from `snapshot` can resolve.

## Fix

The diff must report what happened to the **index**, not what happened to a **path**. Those are the same thing only while a change stays on one side of the boundary between indexed and unindexed; a filter that asks one question — *is the destination ignored?* — gets both crossings wrong.

So membership is decided per side. `diffIndexPolicy` answers, for **one** compared tree, the question `openSource` asks of its own committed listing — would the graph index this path? — applying the same two filters in the same order. The policy is per-tree because its halves answer differently on the two sides: the `.graphignore` matcher is read from the working tree and is common to both, but the vendored-tree rules come from each compared tree's own `.gitignore` files, so a project can re-include part of a vendored tree in one revision and not the other. Each changed file is then rewritten to the delta the graph saw:

| base indexed | head indexed | emitted |
| --- | --- | --- |
| yes | yes | unchanged |
| yes | no | a deletion of the base path — its symbols leave the graph |
| no | yes | an addition of the head path — all of its symbols are new |
| no | no | dropped |

`D` and `A` are ordinary name-status inputs and the analysis loop already derives its read plan from `Status` alone, so this needs no new emission code. A copy (`C`) is never a comparison at all: its source survives untouched, so the destination is purely an addition — never a deletion of a file that still exists, and never a change reported against the file it was copied from. Git emits `C` only under `--find-copies-harder` and `ChangedFiles` asks for `--find-renames`, so that is a guard against a future flag rather than a path exercised today.

That covers three divergences from the snapshot, not one.

**`.graphignore` and the built-in secret rules.** The original case above, plus committed credential files, which were excluded from the snapshot but named by the diff:

```
$ entire graph diff --base HEAD~1 --head HEAD        # before
.env (Dotenv)
  ~ document .env body changed (0 dependents)

s.go (Go)
  ~ function S body changed (0 dependents)
```

**The vendored-tree heuristic.** `openSource` applies `filterVendoredPaths` *and* `filterIgnoredPaths`; only the second was in scope before. A tracked `vendor/` tree is the canonical tracked-but-vendored case and the one that churns:

```
$ entire graph symbols --repo . --format ndjson | grep -o '"file_path":"[^"]*"'
"file_path":".gitignore"
"file_path":"keep/k.go"

$ entire graph diff --base HEAD~1 --head HEAD        # before
keep/k.go (Go)          ~ function Keep body changed
third_party/t.go (Go)   ~ function T body changed    <-- in no snapshot
vendor/v.go (Go)        ~ function V body changed    <-- in no snapshot
```

Its rules are per-tree and cost a listing, so they load only when some changed path is candidate-vendored under **empty** rules. That probe is exact rather than approximate: rules reach the heuristic only through `ReincludesDescendant`, which can only ever *un*-vendor a path, so an empty-rule probe is the maximal candidate set and "no candidate here" proves the real rules would change no verdict.

**Dependent counts.** The dependents scan reads the whole head tree, so `dependents_count` included references from files no snapshot contains — a count of 4 against one visible caller. Once the diff stopped naming those files the number became unaccountable, so the head-side policy now gates the candidate list before any candidate is read. That scan gets its own resolution of the head rules rather than the changed-file policy: the probe above licenses one question — could any path *Git reported* be vendored — while this scan walks the whole tree, where a re-included `vendor/...` caller can appear even when nothing vendorable changed. Reusing the probe's answer there would drop a real caller and undercount, which is the silent direction.

### Where no policy may be applied at all

`ChangedFiles` passes `--no-relative`, so a range between two **commits** is named from the repository root — the namespace both rule sets are written in. A tree expression such as `HEAD:scope` names a subtree, and every emitted name is then relative to *that* tree, where root-anchored rules both miss what they meant to match and fire on what they did not:

```
$ cat .graphignore
/top.go                                     # the ROOT top.go, not sub/top.go

$ entire graph diff --base HEAD~1:sub --head HEAD:sub
No semantic entity changes detected.        # but sub/top.go IS indexed
```

A tree object cannot know its own path, so there is no prefix to recover. `resolveDiffTrees` now reports whether both labels named a commit — probing the resolved OID rather than the caller's expression, because appending `^{commit}` to `HEAD:scope` can select a path literally named `scope^{commit}`, the same ambiguity the existing `^{tree}` peel avoids — and a range that is not root-relative admits everything, exactly as this command did before any policy existed.

Resolving to a commit **object** is not on its own evidence that a label named a commit: a gitlink resolves to one too. `HEAD:sub` on a submodule entry yields that submodule's commit, and a range over its tree is named relative to the *submodule's* root. That probe happens to fail today only because a submodule's objects are usually absent from the superproject's object database — `git rev-parse HEAD:sub` succeeds there while `^{commit}` on the result does not — but an absorbed or fetched submodule puts them there, so a label that reaches into a tree is rejected on its shape as well. `:` is the only object-name syntax that does that — but not every colon is that syntax. `:/text` searches commit messages, and a colon inside an `@{...}` selector is data too: `HEAD@{2026-08-27 12:34:56 +0000}` is a reflog date that names a commit and reaches into no tree. Only a colon outside every such block is the separator. Getting that wrong loses no data — an unfiltered range over-reports — but it quietly withdraws the guarantee the range was supposed to have.

## Behaviour changes to expect

- **Lockfiles and sourcemaps disappear from `diff` / `commit` output.** `package-lock.json`, `yarn.lock`, `Cargo.lock`, `*.map` and friends are vendored-scan files: no snapshot contains them, so no diff reports them. This is the most visible consequence of the change.
- **A rename across the boundary now emits where nothing was emitted before.** A pure rename produced no entity changes at all, even when it moved a whole tree out of the graph. It is now a deletion of everything the index held, which is the delta a consumer actually needs.
- There is no behaviour change for a repository with no `.graphignore`, no vendored tree, and no secret-rule match.

### The one gap, and why it is disclosed rather than closed

A committed exclusion rule decides membership for files it never names. Deleting a `!vendor/pkg/**` re-inclusion drops that whole subtree from the head snapshot while Git reports only `.gitignore` as changed, so the correct delta contains removals for files that appear nowhere in this command's input. No filter over a change list can produce them: it would take a comparison of the two trees' entire corpora, and could emit an entry per file in a vendored tree — a different and unbounded operation.

That gap predates the index policy, because it is a property of diffing changes rather than corpora. But this command now claims its output agrees with a snapshot, and an unstated exception to that claim is worse than not making it. So a range that changes `.gitignore` or `.graphignore` carries `W_INDEX_POLICY_CHANGED`: unchanged files may have entered or left the graph, and this delta alone is not enough to update an index. A consumer gets a signal to resnapshot instead of silent staleness.

A second, older mismatch is left alone deliberately. `--repo <subdir>` means different things to the two families: `symbols`/`snapshot` treat the subdirectory as the repository, emitting subtree-relative paths and reading that subdirectory's `.graphignore`, while the diff family resolves Git's command root and emits repository-root-relative paths. Pairing a subdirectory-scoped snapshot with a subdirectory-scoped diff therefore compares two different namespaces, in both directions, and it did so before this change too. Reconciling them means deciding what `--repo <subdir>` should mean for the diff family, which changes the paths it prints for every consumer of that flag — a contract change that belongs in its own review, not in this one.

## Tests

Assertions are made against a snapshot of the **same repository**, not against a hand-written symbol list, so the diff and the snapshot cannot drift apart without a failure here.

- `TestAnalyzeGitRangeHonorsGraphIgnore` — a change touching both an indexed and an ignored tree reports only the indexed one.
- `TestAnalyzeGitRangeHonorsGraphIgnoreForDeletions` — deleting an ignored file produces no delta.
- `TestAnalyzeGitRangeWithoutGraphIgnoreIsUnchanged` — with no ignore rule, the same file is still reported.
- `TestAnalyzeGitRangeHonorsBuiltinSecretRules` — a committed credential file is not named.
- `TestAnalyzeGitRangeIndexedToIgnoredRenameRemovesOldSymbols` — the removals equal the base snapshot's symbols for that file.
- `TestAnalyzeGitRangeIgnoredToIndexedRenameAddsEveryHeadSymbol` — the additions equal the head snapshot's symbols, including the ones a rename comparison never mentioned.
- `TestAnalyzeGitRangeSubtreeRangeAppliesNoIgnorePolicy` — a subtree range reports the indexed file a root-anchored rule was dropping.
- `TestAnalyzeGitRangeTreePeeledRangeStillAppliesIgnorePolicy` — `<commit-ish>^{tree}` is still root-relative, so the policy still applies.
- `TestAnalyzeGitRangeHonorsVendoredTrees` — a tracked `vendor/` tree is not reported.
- `TestAnalyzeGitRangeReportsReincludedVendorTree` — a re-included vendor tree **is** reported; the snapshot indexes it.
- `TestAnalyzeGitRangeDependentsExcludeUnindexedCallers` — three callers inside an ignored tree and one indexed caller counts 1.
- `TestAdmitChangedFilesRewritesIndexCrossings` — the rewrite table itself, including all three copy cases.
- `TestResolveDiffTreesRejectsTreePathLabels` — a gitlink label is not root-relative even when every peel resolves; `:/text` still is.
- `TestLabelSelectsTreePath` — which colons are the `<rev>:<path>` separator and which are reflog or search-text data.
- `TestAnalyzeGitRangeDependentsIncludeReincludedVendorCallers` — a re-included vendor caller is still counted when nothing vendorable changed.
- `TestAnalyzeGitRangeWarnsWhenAnIndexPolicyFileChanges` — the range says so when a rule file changed, stays quiet when none did, and does not warn about a non-root `.graphignore`.
- `TestAnalyzeGitRangeWarnsAboutPolicyChangesOutsideThePathspec` — a pathspec narrows what Git reports, not what a rule decides.
- `TestAnalyzeGitRangeAcceptsEveryRootTreeSpelling` — `^{tree}`, `^{tree}^{}` and `^{tree}^{object}` all name a root tree.

Mutation-checked, each against the test that is supposed to catch it: restoring the destination-only filter fails both crossing tests; removing the root-relative gate fails the subtree test; removing the vendored-tree filter fails the vendor test; never loading the re-inclusion rules fails the re-inclusion test; removing the dependents filter restores the inflated count; removing the copy branch fails the copy cases; removing the tree-path guard fails the gitlink test; removing the `^{tree}` peel fails the peeled-range test; treating every colon as a path separator fails the reflog case; reusing the unresolved policy for the dependents scan fails the re-included-caller count; suppressing the policy-change warning fails one half of its test and emitting it for every file fails the other; and widening the policy to drop everything fails all three over-rejection guards.

---

**Local gate**

- `go build ./...`, `go vet ./...`, `gofmt -l` — clean.
- `go test -timeout 40m ./...` — green, every package `ok` (internal/sem 251s, internal/cli 69s).

`mise run check` additionally runs `go test -race ./...`, which did not complete on this machine: Go's default 10-minute per-package timeout is exceeded under the load here. That is a timeout, not a failure, and it is not specific to this branch. Controls on an unmodified `origin/main` worktree: `go test -timeout 9m ./internal/cli/` times out at 540.7s there versus 542.7s on a changed branch, and one pre-existing test, `TestWriteOutputFileDoesNotFollowALinkSwappedInAfterTheCheck`, takes 343s by itself under `-race`. The same suite finishes in about 2 minutes on a clean CI runner, so CI should be the authority for the `-race` gate.
