### PR TITLE
test(sem): assert every semantic language extracts symbols and relations

### DIFF
--- a/docs/language-support.md
+++ b/docs/language-support.md
@@ -58,6 +58,20 @@ Current generated counts:
 - Zig
 - Zsh
 
+Every language in this list has a minimal fixture under
+`internal/sem/testdata/langmatrix/` and is asserted by
+`TestLanguageExtractionMatrix` to extract real symbols and relations. A grammar
+that loads and parses without error but yields nothing is invisible in
+aggregate symbol counts, so the per-language assertion is the only thing that
+catches it. `TestLanguageMatrixCoversEverySemanticLanguage` keeps that fixture
+set in lockstep with the registry, and `TestDocumentedLanguageListsMatchTheRegistry`
+keeps both lists on this page in lockstep with the registry.
+
+Languages that advertise `CALLS` but extract none from their fixture's
+idiomatic call site are pinned in `languageMatrix` with the reason. That list is
+enforced in both directions: a language going dark fails, and so does a fix
+landing without the audited gap being retired.
+
 Protocol Buffers support covers proto3 and legacy proto2 declarations,
 including files that omit the syntax declaration, proto2 field labels, and
 groups. Compatibility parsing preserves original source locations, signatures,

--- a/internal/sem/language_matrix_test.go
+++ b/internal/sem/language_matrix_test.go
@@ -24,8 +24,28 @@ type languageFixture struct {
 	// callsGap documents a language whose capability report advertises CALLS
 	// while this fixture's idiomatic call form produces none. It is an audited
 	// defect list, not a licence: closing one of these fails this test until the
-	// entry is removed, and adding a new one requires justifying it here.
+	// entry retires (by removal, or by callsGapHolds below reporting the gap's
+	// cause gone), and adding a new one requires justifying it here.
 	callsGap string
+	// callsGapHolds, when non-nil, is the condition callsGap's stated cause
+	// reduces to, evaluated against the extractor on every run: the gap is
+	// claimed only while it reports true. It makes an audited gap
+	// self-verifying rather than a hand-maintained literal, and it tightens the
+	// assertion in both directions. The entry then claims a cause rather than
+	// restating its effect, so naming the wrong cause fails here; and the commit
+	// that closes the gap retires the entry by flipping the condition, which is
+	// what keeps this test order-independent. A literal gap silently disagrees
+	// with an extractor fix that lands on a different branch — the two merge
+	// cleanly and only the merged tree fails — whereas a condition read from the
+	// extractor at run time cannot go stale that way.
+	//
+	// It receives the fixture's own extraction result, because the two shapes a
+	// cause takes need different evidence: a resolution rule is a predicate over
+	// the provider, while a missing symbol is only visible in what the fixture
+	// produced. Leave it nil for a gap that reduces to neither — an absent
+	// scanner or an uninferred type has no witness beyond the missing CALLS
+	// itself — and that gap is asserted unconditionally, exactly as before.
+	callsGapHolds func(got languageMatrixResult) bool
 }
 
 // languageMatrix covers every language in Capabilities().SemanticLanguages.
@@ -77,6 +97,11 @@ var languageMatrix = []languageFixture{
 		// method, so a module-scoped package produces no same-file CALLS.
 		relations: []string{"DEFINES", "CONTAINS", "CONSTRUCTS", "PARAM_TYPE", "USES_TYPE"},
 		callsGap:  "a Julia definition inside `module ... end` is emitted as a method, and bare calls are barred from resolving to methods",
+		// The whole gap reduces to one rule: bare-call resolution skips method
+		// targets for Julia. Reading it here rather than restating its
+		// consequence means the fix that admits Julia retires this entry on its
+		// own, and that a wrong diagnosis is caught instead of recorded.
+		callsGapHolds: func(languageMatrixResult) bool { return !nameCallMayTargetMethod("Julia") },
 	},
 	{dir: "kotlin", symbols: []string{"class:Ledger", "field:total", "method:add", "function:ledgerDouble"}, relations: []string{"DEFINES", "CONTAINS", "CALLS", "CONSTRUCTS"}},
 	{dir: "lua", symbols: []string{"function:new", "function:add", "function:ledger_double"}, relations: []string{"DEFINES", "CALLS"}},
@@ -208,6 +233,13 @@ func TestLanguageExtractionMatrix(t *testing.T) {
 // call site. Both directions are failures worth knowing about: a new entry
 // means a language went dark, and a stale entry means a fix landed without the
 // audited gap list being retired with it.
+//
+// The audit is read from the extractor wherever a gap reduces to a checkable
+// condition (see callsGapHolds), so a gap closes itself in the same commit that
+// closes it in the extractor. That is what makes the assertion safe to state
+// exactly: a gap pinned only as a literal disagrees with a fix that lands on a
+// different branch, and because the two touch different files they merge
+// cleanly and fail only afterwards, on a tree neither author tested.
 func TestLanguageMatrixCallsGapsAreExactlyAsAudited(t *testing.T) {
 	t.Parallel()
 	claimsCalls := map[string]bool{}
@@ -229,10 +261,20 @@ func TestLanguageMatrixCallsGapsAreExactlyAsAudited(t *testing.T) {
 				return
 			}
 			got := runLanguageFixture(t, fixture.dir)
+			auditedGap := fixture.callsGap
+			if auditedGap != "" && fixture.callsGapHolds != nil && !fixture.callsGapHolds(got) {
+				// The gap's stated cause no longer holds, so the entry has
+				// retired itself and the language is now held to the same
+				// standard as every other language that advertises CALLS.
+				auditedGap = ""
+			}
 			switch {
-			case got.relations["CALLS"] && fixture.callsGap != "":
-				t.Fatalf("%s now extracts CALLS; remove its audited gap (%s) from languageMatrix", language, fixture.callsGap)
-			case !got.relations["CALLS"] && fixture.callsGap == "":
+			case got.relations["CALLS"] && auditedGap != "":
+				t.Fatalf("%s now extracts CALLS; remove its audited gap (%s) from languageMatrix", language, auditedGap)
+			case !got.relations["CALLS"] && auditedGap == "":
+				if fixture.callsGap != "" {
+					t.Fatalf("%s still extracts no CALLS, but its audited gap (%s) reports itself closed; callsGapHolds names the wrong cause", language, fixture.callsGap)
+				}
 				t.Fatalf("%s advertises CALLS but extracted none from its fixture; relations seen: %v", language, matrixSortedKeys(got.relations))
 			}
 		})

--- a/internal/sem/language_matrix_test.go
+++ b/internal/sem/language_matrix_test.go
@@ -1,0 +1,330 @@
+package sem
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// languageFixture pins what one semantic language must extract from a minimal
+// fixture that contains a handful of unmistakable definitions: a function, a
+// type, and a member. It exists because a zero-symbol language is invisible in
+// aggregate counts — a grammar can keep loading, keep parsing without error,
+// and keep being advertised in `capabilities --json` while producing nothing at
+// all. Only a per-language assertion catches that.
+type languageFixture struct {
+	// dir is the fixture directory under testdata/langmatrix.
+	dir string
+	// symbols are entity records that must appear, written "kind:name".
+	symbols []string
+	// relations are relation types that must appear at least once.
+	relations []string
+	// callsGap documents a language whose capability report advertises CALLS
+	// while this fixture's idiomatic call form produces none. It is an audited
+	// defect list, not a licence: closing one of these fails this test until the
+	// entry is removed, and adding a new one requires justifying it here.
+	callsGap string
+}
+
+// languageMatrix covers every language in Capabilities().SemanticLanguages.
+// TestLanguageMatrixCoversEverySemanticLanguage enforces that, so a language
+// added to the registry cannot ship without a fixture, and a language whose
+// extraction goes dark fails here instead of going unnoticed.
+var languageMatrix = []languageFixture{
+	{dir: "bash", symbols: []string{"function:ledger_add", "function:ledger_double"}, relations: []string{"DEFINES", "CALLS"}},
+	{dir: "c", symbols: []string{"struct:Ledger", "function:ledger_add", "function:ledger_double"}, relations: []string{"DEFINES", "CALLS", "PARAM_TYPE", "USES_TYPE"}},
+	{dir: "clojure", symbols: []string{"class:Ledger", "function:ledger-add", "function:ledger-double"}, relations: []string{"DEFINES", "CALLS"}},
+	{dir: "clojurescript", symbols: []string{"class:Ledger", "function:ledger-add", "function:ledger-double"}, relations: []string{"DEFINES", "CALLS"}},
+	{
+		dir:     "cpp",
+		symbols: []string{"class:Ledger", "function:LedgerDouble"},
+		// A stack-allocated receiver (`Ledger ledger;` — C++'s default
+		// construction syntax) is not type-inferred, so `ledger.Add(amount)`
+		// resolves to nothing. `Ledger l = Ledger();` and `new Ledger()` both do
+		// resolve, so this is a hole in declaration parsing, not in C++ receiver
+		// resolution as a whole.
+		relations: []string{"DEFINES", "CONTAINS", "USES_TYPE"},
+		callsGap:  "a default-constructed C++ stack receiver (`Ledger ledger;`) carries no inferred type, so its method calls resolve to nothing",
+	},
+	{dir: "csharp", symbols: []string{"class:Ledger", "class:LedgerHelper", "field:Total", "method:Add", "method:Double"}, relations: []string{"DEFINES", "CONTAINS", "CALLS", "CONSTRUCTS"}},
+	{dir: "cue", symbols: []string{"field:#Ledger", "field:#Add", "field:ledger"}, relations: []string{"DEFINES", "CONTAINS"}},
+	{dir: "dart", symbols: []string{"class:Ledger", "method:add", "function:ledgerDouble"}, relations: []string{"DEFINES", "CONTAINS", "CALLS", "CONSTRUCTS"}},
+	{dir: "elixir", symbols: []string{"module:Ledger", "method:add", "method:double"}, relations: []string{"DEFINES", "CONTAINS", "CALLS"}},
+	{dir: "erlang", symbols: []string{"module:ledger", "struct:ledger", "function:add", "function:double"}, relations: []string{"DEFINES", "CALLS"}},
+	{
+		dir:     "fsharp",
+		symbols: []string{"module:Ledger", "type:Ledger", "function:add", "function:double"},
+		// F# applies functions by juxtaposition (`add ledger amount`), which no
+		// scanner reads: the dotted scanners need a `.` and the generic scanner
+		// needs `name(`. Resolving it needs an application parser.
+		relations: []string{"DEFINES", "CONTAINS", "PARAM_TYPE", "USES_TYPE"},
+		callsGap:  "F# function application by juxtaposition (`add ledger amount`) has no scanner, so idiomatic F# call sites are invisible",
+	},
+	{dir: "go", symbols: []string{"type:Ledger", "field:Total", "method:Add", "function:LedgerDouble"}, relations: []string{"DEFINES", "CONTAINS", "CALLS", "USES_TYPE", "READS_FIELD"}},
+	{dir: "groovy", symbols: []string{"class:Ledger", "field:total", "method:add", "function:ledgerDouble"}, relations: []string{"DEFINES", "CONTAINS", "CALLS", "CONSTRUCTS"}},
+	{dir: "haskell", symbols: []string{"type:Ledger", "function:add", "function:double"}, relations: []string{"DEFINES", "CALLS", "PARAM_TYPE", "USES_TYPE"}},
+	{dir: "hcl", symbols: []string{"block:region", "block:ledger", "block:ledger_bucket"}, relations: []string{"DEFINES", "CONFIGURES", "RESOURCE_DEPENDS_ON"}},
+	{dir: "java", symbols: []string{"class:Ledger", "field:total", "method:add", "method:ledgerDouble"}, relations: []string{"DEFINES", "CONTAINS", "CALLS", "CONSTRUCTS"}},
+	{dir: "javascript", symbols: []string{"class:Ledger", "method:constructor", "method:add", "function:ledgerDouble"}, relations: []string{"DEFINES", "CONTAINS", "CALLS", "CONSTRUCTS"}},
+	{
+		dir:     "julia",
+		symbols: []string{"module:Ledgers", "struct:Ledger", "method:add", "method:double"},
+		// Idiomatic Julia wraps a package in `module ... end`, which makes every
+		// definition module-qualified and therefore emitted as a method. Bare
+		// `add(...)` — Julia's only call syntax — is excluded from resolving to a
+		// method, so a module-scoped package produces no same-file CALLS.
+		relations: []string{"DEFINES", "CONTAINS", "CONSTRUCTS", "PARAM_TYPE", "USES_TYPE"},
+		callsGap:  "a Julia definition inside `module ... end` is emitted as a method, and bare calls are barred from resolving to methods",
+	},
+	{dir: "kotlin", symbols: []string{"class:Ledger", "field:total", "method:add", "function:ledgerDouble"}, relations: []string{"DEFINES", "CONTAINS", "CALLS", "CONSTRUCTS"}},
+	{dir: "lua", symbols: []string{"function:new", "function:add", "function:ledger_double"}, relations: []string{"DEFINES", "CALLS"}},
+	{
+		dir:     "objc",
+		symbols: []string{"class:Ledger", "method:add", "function:LedgerDouble"},
+		// A message send to `self` resolves, but a send to any other receiver
+		// does not: the local's declared type (`Ledger *ledger = ...`) is never
+		// inferred, so `[ledger add:amount]` — the only way to call a method on
+		// another object — binds to nothing.
+		relations: []string{"DEFINES", "CONTAINS"},
+		callsGap:  "an Objective-C local's declared type is not inferred, so a message send to anything but `self` resolves to nothing",
+	},
+	{dir: "ocaml", symbols: []string{"type:ledger", "module:Ledgers", "function:add", "function:double"}, relations: []string{"DEFINES", "CONTAINS", "CALLS", "USES_TYPE"}},
+	{dir: "perl", symbols: []string{"module:Ledger", "function:new", "function:add", "function:ledger_double"}, relations: []string{"DEFINES", "CALLS"}},
+	{dir: "php", symbols: []string{"class:Ledger", "method:add", "function:ledgerDouble"}, relations: []string{"DEFINES", "CONTAINS", "CALLS", "CONSTRUCTS"}},
+	{dir: "protobuf", symbols: []string{"message:Ledger", "message:AddRequest", "service:LedgerService", "rpc:Add"}, relations: []string{"DEFINES", "CONTAINS", "HANDLES_GRPC"}},
+	{dir: "python", symbols: []string{"class:Ledger", "method:__init__", "method:add", "function:ledger_double"}, relations: []string{"DEFINES", "CONTAINS", "CALLS", "CONSTRUCTS"}},
+	{dir: "r", symbols: []string{"function:make_ledger", "function:ledger_add", "function:ledger_double"}, relations: []string{"DEFINES", "CALLS"}},
+	{dir: "ruby", symbols: []string{"class:Ledger", "method:initialize", "method:add", "function:ledger_double"}, relations: []string{"DEFINES", "CONTAINS", "CALLS"}},
+	{dir: "rust", symbols: []string{"struct:Ledger", "field:total", "method:add", "function:ledger_double"}, relations: []string{"DEFINES", "CONTAINS", "CALLS", "READS_FIELD"}},
+	{dir: "scala", symbols: []string{"class:Ledger", "class:LedgerApp", "method:add", "method:ledgerDouble"}, relations: []string{"DEFINES", "CONTAINS", "CALLS", "CONSTRUCTS"}},
+	{dir: "sql", symbols: []string{"table:ledger", "view:ledger_totals", "function:ledger_add", "function:ledger_double"}, relations: []string{"DEFINES", "CALLS"}},
+	{dir: "swift", symbols: []string{"struct:Ledger", "field:total", "method:add", "function:ledgerDouble"}, relations: []string{"DEFINES", "CONTAINS", "CALLS", "CONSTRUCTS", "IMPORTS"}},
+	{dir: "typescript", symbols: []string{"class:Ledger", "field:total", "method:add", "function:ledgerDouble"}, relations: []string{"DEFINES", "CONTAINS", "CALLS", "CONSTRUCTS", "READS_FIELD"}},
+	{dir: "yaml", symbols: []string{"section:service", "section:routes"}, relations: []string{"DEFINES"}},
+	{dir: "zig", symbols: []string{"struct:Ledger", "method:add", "function:ledgerDouble"}, relations: []string{"DEFINES", "CONTAINS", "CALLS", "PARAM_TYPE", "USES_TYPE"}},
+	{dir: "zsh", symbols: []string{"function:ledger_add", "function:ledger_double"}, relations: []string{"DEFINES", "CALLS"}},
+}
+
+// languageMatrixLanguages maps each fixture directory to the language label the
+// provider must report for it. A fixture that silently reroutes to another
+// language (or to inventory) would otherwise pass its symbol assertions while
+// the language under test is not exercised at all.
+var languageMatrixLanguages = map[string]string{
+	"bash": "Bash", "c": "C", "clojure": "Clojure", "clojurescript": "ClojureScript",
+	"cpp": "C++", "csharp": "C#", "cue": "CUE", "dart": "Dart", "elixir": "Elixir",
+	"erlang": "Erlang", "fsharp": "F#", "go": "Go", "groovy": "Groovy", "haskell": "Haskell",
+	"hcl": "HCL", "java": "Java", "javascript": "JavaScript", "julia": "Julia",
+	"kotlin": "Kotlin", "lua": "Lua", "objc": "Objective-C", "ocaml": "OCaml",
+	"perl": "Perl", "php": "PHP", "protobuf": "Protocol Buffers", "python": "Python",
+	"r": "R", "ruby": "Ruby", "rust": "Rust", "scala": "Scala", "sql": "SQL",
+	"swift": "Swift", "typescript": "TypeScript", "yaml": "YAML", "zig": "Zig",
+	"zsh": "Zsh",
+}
+
+type languageMatrixResult struct {
+	language  string
+	symbols   map[string]bool
+	relations map[string]bool
+	symbolLen int
+}
+
+func runLanguageFixture(t *testing.T, dir string) languageMatrixResult {
+	t.Helper()
+	repo := t.TempDir()
+	src := filepath.Join("testdata", "langmatrix", dir)
+	files, err := os.ReadDir(src)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", dir, err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("fixture %s has no files", dir)
+	}
+	for _, file := range files {
+		content, err := os.ReadFile(filepath.Join(src, file.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(repo, file.Name()), content, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	out := languageMatrixResult{symbols: map[string]bool{}, relations: map[string]bool{}}
+	err = StreamSnapshot(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true}, func(record any) error {
+		switch rec := record.(type) {
+		case SymbolRecord:
+			out.symbols[rec.Kind+":"+rec.Name] = true
+			out.symbolLen++
+		case RelationRecord:
+			out.relations[rec.Type] = true
+		case FileRecord:
+			if rec.Language != "" {
+				out.language = rec.Language
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("snapshot %s: %v", dir, err)
+	}
+	return out
+}
+
+// TestLanguageExtractionMatrix asserts that every semantic language extracts
+// real symbols and real relations from a minimal fixture. The failure mode it
+// guards against is a grammar that loads, parses without error, and yields
+// nothing: aggregate symbol counts across a repository never reveal it, and
+// `capabilities --json` keeps advertising the language regardless.
+func TestLanguageExtractionMatrix(t *testing.T) {
+	t.Parallel()
+	for _, fixture := range languageMatrix {
+		t.Run(fixture.dir, func(t *testing.T) {
+			t.Parallel()
+			got := runLanguageFixture(t, fixture.dir)
+
+			if want := languageMatrixLanguages[fixture.dir]; got.language != want {
+				t.Fatalf("fixture %s parsed as language %q, want %q", fixture.dir, got.language, want)
+			}
+			if got.symbolLen == 0 {
+				t.Fatalf("fixture %s produced no symbols at all: the grammar loads but extracts nothing", fixture.dir)
+			}
+			for _, want := range fixture.symbols {
+				if !got.symbols[want] {
+					t.Errorf("fixture %s is missing symbol %q; got %v", fixture.dir, want, matrixSortedKeys(got.symbols))
+				}
+			}
+			for _, want := range fixture.relations {
+				if !got.relations[want] {
+					t.Errorf("fixture %s is missing relation %q; got %v", fixture.dir, want, matrixSortedKeys(got.relations))
+				}
+			}
+		})
+	}
+}
+
+// TestLanguageMatrixCallsGapsAreExactlyAsAudited pins the languages that
+// advertise CALLS in `capabilities --json` yet extract none from an idiomatic
+// call site. Both directions are failures worth knowing about: a new entry
+// means a language went dark, and a stale entry means a fix landed without the
+// audited gap list being retired with it.
+func TestLanguageMatrixCallsGapsAreExactlyAsAudited(t *testing.T) {
+	t.Parallel()
+	claimsCalls := map[string]bool{}
+	for language, relations := range relationSupportByLanguage() {
+		for _, relation := range relations {
+			if relation == "CALLS" {
+				claimsCalls[language] = true
+			}
+		}
+	}
+	for _, fixture := range languageMatrix {
+		t.Run(fixture.dir, func(t *testing.T) {
+			t.Parallel()
+			language := languageMatrixLanguages[fixture.dir]
+			if !claimsCalls[language] {
+				if fixture.callsGap != "" {
+					t.Fatalf("%s does not advertise CALLS, so it cannot have an audited CALLS gap", language)
+				}
+				return
+			}
+			got := runLanguageFixture(t, fixture.dir)
+			switch {
+			case got.relations["CALLS"] && fixture.callsGap != "":
+				t.Fatalf("%s now extracts CALLS; remove its audited gap (%s) from languageMatrix", language, fixture.callsGap)
+			case !got.relations["CALLS"] && fixture.callsGap == "":
+				t.Fatalf("%s advertises CALLS but extracted none from its fixture; relations seen: %v", language, matrixSortedKeys(got.relations))
+			}
+		})
+	}
+}
+
+// TestLanguageMatrixCoversEverySemanticLanguage keeps the fixture set and the
+// parser registry in lockstep. Without it a language could be registered,
+// counted in `capabilities --json`, documented as supported, and never once be
+// shown to extract anything.
+func TestLanguageMatrixCoversEverySemanticLanguage(t *testing.T) {
+	t.Parallel()
+	covered := map[string]bool{}
+	for _, fixture := range languageMatrix {
+		language, ok := languageMatrixLanguages[fixture.dir]
+		if !ok {
+			t.Fatalf("fixture %q has no entry in languageMatrixLanguages", fixture.dir)
+		}
+		if covered[language] {
+			t.Fatalf("language %q has more than one matrix fixture", language)
+		}
+		covered[language] = true
+	}
+	for _, language := range Capabilities().SemanticLanguages {
+		if !covered[language] {
+			t.Errorf("semantic language %q has no fixture in testdata/langmatrix; add one so it cannot go dark unnoticed", language)
+		}
+		delete(covered, language)
+	}
+	for language := range covered {
+		t.Errorf("matrix fixture covers %q, which is not a semantic language", language)
+	}
+}
+
+// TestDocumentedLanguageListsMatchTheRegistry reconciles both lists in
+// docs/language-support.md with the parser registry. The two drifted apart in
+// peregrine — Kotlin stayed documented as tier-1 support long after its
+// extractor stopped producing symbols — and a docs list that is not checked is
+// a list that will drift. The inventory-only list is checked too: it is the
+// larger of the two, and the tier a language is documented under is what tells
+// a reader whether call/type analysis is claimed for it at all.
+func TestDocumentedLanguageListsMatchTheRegistry(t *testing.T) {
+	t.Parallel()
+	capabilities := Capabilities()
+	for _, tier := range []struct {
+		heading    string
+		registered []string
+	}{
+		{"## Semantic Languages", capabilities.SemanticLanguages},
+		{"## Inventory-Only Languages", capabilities.InventoryOnlyLanguages},
+	} {
+		documented := documentedLanguages(t, tier.heading)
+		if len(documented) == 0 {
+			t.Fatalf("docs/language-support.md has no %q list", tier.heading)
+		}
+		for _, language := range tier.registered {
+			if !documented[language] {
+				t.Errorf("language %q is registered under %q but undocumented", language, tier.heading)
+			}
+			delete(documented, language)
+		}
+		for language := range documented {
+			t.Errorf("docs/language-support.md lists %q under %q, but it is not registered there", language, tier.heading)
+		}
+	}
+}
+
+func documentedLanguages(t *testing.T, heading string) map[string]bool {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "..", "docs", "language-support.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := map[string]bool{}
+	inSection := false
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "## ") {
+			inSection = strings.TrimSpace(line) == heading
+			continue
+		}
+		if inSection && strings.HasPrefix(line, "- ") {
+			out[strings.TrimSpace(strings.TrimPrefix(line, "- "))] = true
+		}
+	}
+	return out
+}
+
+func matrixSortedKeys(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for key := range set {
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/sem/testdata/langmatrix/bash/ledger.sh
+++ b/internal/sem/testdata/langmatrix/bash/ledger.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+ledger_add() {
+  local amount="$1"
+  echo $(( amount + 1 ))
+}
+
+ledger_double() {
+  local amount="$1"
+  ledger_add "$amount"
+}
+
+ledger_double 2

--- a/internal/sem/testdata/langmatrix/c/ledger.c
+++ b/internal/sem/testdata/langmatrix/c/ledger.c
@@ -1,0 +1,14 @@
+#include <stddef.h>
+
+struct Ledger {
+    int total;
+};
+
+int ledger_add(struct Ledger *ledger, int amount) {
+    return ledger->total + amount;
+}
+
+int ledger_double(int amount) {
+    struct Ledger ledger = {0};
+    return ledger_add(&ledger, amount) * 2;
+}

--- a/internal/sem/testdata/langmatrix/clojure/ledger.clj
+++ b/internal/sem/testdata/langmatrix/clojure/ledger.clj
@@ -1,0 +1,9 @@
+(ns fixtures.ledger)
+
+(defrecord Ledger [total])
+
+(defn ledger-add [ledger amount]
+  (+ (:total ledger) amount))
+
+(defn ledger-double [amount]
+  (* 2 (ledger-add (->Ledger 0) amount)))

--- a/internal/sem/testdata/langmatrix/clojurescript/ledger.cljs
+++ b/internal/sem/testdata/langmatrix/clojurescript/ledger.cljs
@@ -1,0 +1,9 @@
+(ns fixtures.ledger)
+
+(defrecord Ledger [total])
+
+(defn ledger-add [ledger amount]
+  (+ (:total ledger) amount))
+
+(defn ledger-double [amount]
+  (* 2 (ledger-add (->Ledger 0) amount)))

--- a/internal/sem/testdata/langmatrix/cpp/ledger.cpp
+++ b/internal/sem/testdata/langmatrix/cpp/ledger.cpp
@@ -1,0 +1,18 @@
+#include <string>
+
+class Ledger {
+public:
+    int Add(int amount) const;
+
+private:
+    int total_ = 0;
+};
+
+int Ledger::Add(int amount) const {
+    return total_ + amount;
+}
+
+int LedgerDouble(int amount) {
+    Ledger ledger;
+    return ledger.Add(amount) * 2;
+}

--- a/internal/sem/testdata/langmatrix/csharp/Ledger.cs
+++ b/internal/sem/testdata/langmatrix/csharp/Ledger.cs
@@ -1,0 +1,21 @@
+namespace Fixtures
+{
+    public class Ledger
+    {
+        public int Total { get; set; }
+
+        public int Add(int amount)
+        {
+            return Total + amount;
+        }
+    }
+
+    public static class LedgerHelper
+    {
+        public static int Double(int amount)
+        {
+            var ledger = new Ledger();
+            return ledger.Add(amount) * 2;
+        }
+    }
+}

--- a/internal/sem/testdata/langmatrix/cue/ledger.cue
+++ b/internal/sem/testdata/langmatrix/cue/ledger.cue
@@ -1,0 +1,16 @@
+package fixtures
+
+#Ledger: {
+	total: int
+	name:  string
+}
+
+ledger: #Ledger & {
+	total: 0
+	name:  "primary"
+}
+
+#Add: {
+	amount: int
+	out:    int
+}

--- a/internal/sem/testdata/langmatrix/dart/ledger.dart
+++ b/internal/sem/testdata/langmatrix/dart/ledger.dart
@@ -1,0 +1,12 @@
+class Ledger {
+  int total = 0;
+
+  int add(int amount) {
+    return total + amount;
+  }
+}
+
+int ledgerDouble(int amount) {
+  final ledger = Ledger();
+  return ledger.add(amount) * 2;
+}

--- a/internal/sem/testdata/langmatrix/elixir/ledger.ex
+++ b/internal/sem/testdata/langmatrix/elixir/ledger.ex
@@ -1,0 +1,11 @@
+defmodule Fixtures.Ledger do
+  defstruct total: 0
+
+  def add(ledger, amount) do
+    ledger.total + amount
+  end
+
+  def double(amount) do
+    add(%Fixtures.Ledger{}, amount) * 2
+  end
+end

--- a/internal/sem/testdata/langmatrix/erlang/ledger.erl
+++ b/internal/sem/testdata/langmatrix/erlang/ledger.erl
@@ -1,0 +1,10 @@
+-module(ledger).
+-export([add/2, double/1]).
+
+-record(ledger, {total = 0}).
+
+add(Ledger, Amount) ->
+    Ledger#ledger.total + Amount.
+
+double(Amount) ->
+    add(#ledger{}, Amount) * 2.

--- a/internal/sem/testdata/langmatrix/fsharp/Ledger.fs
+++ b/internal/sem/testdata/langmatrix/fsharp/Ledger.fs
@@ -1,0 +1,9 @@
+module Fixtures.Ledger
+
+type Ledger = { Total: int }
+
+let add (ledger: Ledger) (amount: int) : int =
+    ledger.Total + amount
+
+let double (amount: int) : int =
+    add { Total = 0 } amount * 2

--- a/internal/sem/testdata/langmatrix/go/ledger.go
+++ b/internal/sem/testdata/langmatrix/go/ledger.go
@@ -1,0 +1,14 @@
+package fixtures
+
+type Ledger struct {
+	Total int
+}
+
+func (l Ledger) Add(amount int) int {
+	return l.Total + amount
+}
+
+func LedgerDouble(amount int) int {
+	ledger := Ledger{}
+	return ledger.Add(amount) * 2
+}

--- a/internal/sem/testdata/langmatrix/groovy/Ledger.groovy
+++ b/internal/sem/testdata/langmatrix/groovy/Ledger.groovy
@@ -1,0 +1,12 @@
+class Ledger {
+    int total = 0
+
+    int add(int amount) {
+        return total + amount
+    }
+}
+
+int ledgerDouble(int amount) {
+    def ledger = new Ledger()
+    return ledger.add(amount) * 2
+}

--- a/internal/sem/testdata/langmatrix/haskell/Ledger.hs
+++ b/internal/sem/testdata/langmatrix/haskell/Ledger.hs
@@ -1,0 +1,9 @@
+module Fixtures.Ledger where
+
+data Ledger = Ledger { total :: Int }
+
+add :: Ledger -> Int -> Int
+add ledger amount = total ledger + amount
+
+double :: Int -> Int
+double amount = add (Ledger 0) amount * 2

--- a/internal/sem/testdata/langmatrix/hcl/main.tf
+++ b/internal/sem/testdata/langmatrix/hcl/main.tf
@@ -1,0 +1,12 @@
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+
+resource "aws_s3_bucket" "ledger" {
+  bucket = "ledger-${var.region}"
+}
+
+output "ledger_bucket" {
+  value = aws_s3_bucket.ledger.bucket
+}

--- a/internal/sem/testdata/langmatrix/java/Ledger.java
+++ b/internal/sem/testdata/langmatrix/java/Ledger.java
@@ -1,0 +1,14 @@
+package fixtures;
+
+public class Ledger {
+    private int total;
+
+    public int add(int amount) {
+        return total + amount;
+    }
+
+    public static int ledgerDouble(int amount) {
+        Ledger ledger = new Ledger();
+        return ledger.add(amount) * 2;
+    }
+}

--- a/internal/sem/testdata/langmatrix/javascript/ledger.js
+++ b/internal/sem/testdata/langmatrix/javascript/ledger.js
@@ -1,0 +1,14 @@
+export class Ledger {
+  constructor() {
+    this.total = 0;
+  }
+
+  add(amount) {
+    return this.total + amount;
+  }
+}
+
+export function ledgerDouble(amount) {
+  const ledger = new Ledger();
+  return ledger.add(amount) * 2;
+}

--- a/internal/sem/testdata/langmatrix/julia/Ledger.jl
+++ b/internal/sem/testdata/langmatrix/julia/Ledger.jl
@@ -1,0 +1,15 @@
+module Ledgers
+
+struct Ledger
+    total::Int
+end
+
+function add(ledger::Ledger, amount::Int)
+    return ledger.total + amount
+end
+
+function double(amount::Int)
+    return add(Ledger(0), amount) * 2
+end
+
+end

--- a/internal/sem/testdata/langmatrix/kotlin/Ledger.kt
+++ b/internal/sem/testdata/langmatrix/kotlin/Ledger.kt
@@ -1,0 +1,12 @@
+package fixtures
+
+class Ledger(var total: Int = 0) {
+    fun add(amount: Int): Int {
+        return total + amount
+    }
+}
+
+fun ledgerDouble(amount: Int): Int {
+    val ledger = Ledger()
+    return ledger.add(amount) * 2
+}

--- a/internal/sem/testdata/langmatrix/lua/ledger.lua
+++ b/internal/sem/testdata/langmatrix/lua/ledger.lua
@@ -1,0 +1,17 @@
+local Ledger = {}
+Ledger.__index = Ledger
+
+function Ledger.new()
+  return setmetatable({ total = 0 }, Ledger)
+end
+
+function Ledger.add(self, amount)
+  return self.total + amount
+end
+
+local function ledger_double(amount)
+  local ledger = Ledger.new()
+  return Ledger.add(ledger, amount) * 2
+end
+
+return ledger_double

--- a/internal/sem/testdata/langmatrix/objc/Ledger.m
+++ b/internal/sem/testdata/langmatrix/objc/Ledger.m
@@ -1,0 +1,19 @@
+#import <Foundation/Foundation.h>
+
+@interface Ledger : NSObject
+@property (nonatomic) NSInteger total;
+- (NSInteger)add:(NSInteger)amount;
+@end
+
+@implementation Ledger
+
+- (NSInteger)add:(NSInteger)amount {
+    return self.total + amount;
+}
+
+@end
+
+NSInteger LedgerDouble(NSInteger amount) {
+    Ledger *ledger = [[Ledger alloc] init];
+    return [ledger add:amount] * 2;
+}

--- a/internal/sem/testdata/langmatrix/ocaml/ledger.ml
+++ b/internal/sem/testdata/langmatrix/ocaml/ledger.ml
@@ -1,0 +1,9 @@
+type ledger = { total : int }
+
+let add ledger amount = ledger.total + amount
+
+let double amount = add { total = 0 } amount * 2
+
+module Ledgers = struct
+  let empty = { total = 0 }
+end

--- a/internal/sem/testdata/langmatrix/perl/Ledger.pl
+++ b/internal/sem/testdata/langmatrix/perl/Ledger.pl
@@ -1,0 +1,21 @@
+package Ledger;
+
+sub new {
+    my ($class) = @_;
+    return bless { total => 0 }, $class;
+}
+
+sub add {
+    my ($self, $amount) = @_;
+    return $self->{total} + $amount;
+}
+
+package main;
+
+sub ledger_double {
+    my ($amount) = @_;
+    my $ledger = Ledger->new();
+    return $ledger->add($amount) * 2;
+}
+
+1;

--- a/internal/sem/testdata/langmatrix/php/Ledger.php
+++ b/internal/sem/testdata/langmatrix/php/Ledger.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Fixtures;
+
+class Ledger
+{
+    private int $total = 0;
+
+    public function add(int $amount): int
+    {
+        return $this->total + $amount;
+    }
+}
+
+function ledgerDouble(int $amount): int
+{
+    $ledger = new Ledger();
+    return $ledger->add($amount) * 2;
+}

--- a/internal/sem/testdata/langmatrix/protobuf/ledger.proto
+++ b/internal/sem/testdata/langmatrix/protobuf/ledger.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package fixtures;
+
+message Ledger {
+  int32 total = 1;
+}
+
+message AddRequest {
+  int32 amount = 1;
+}
+
+service LedgerService {
+  rpc Add(AddRequest) returns (Ledger);
+}

--- a/internal/sem/testdata/langmatrix/python/ledger.py
+++ b/internal/sem/testdata/langmatrix/python/ledger.py
@@ -1,0 +1,11 @@
+class Ledger:
+    def __init__(self) -> None:
+        self.total = 0
+
+    def add(self, amount: int) -> int:
+        return self.total + amount
+
+
+def ledger_double(amount: int) -> int:
+    ledger = Ledger()
+    return ledger.add(amount) * 2

--- a/internal/sem/testdata/langmatrix/r/ledger.r
+++ b/internal/sem/testdata/langmatrix/r/ledger.r
@@ -1,0 +1,11 @@
+make_ledger <- function() {
+  list(total = 0)
+}
+
+ledger_add <- function(ledger, amount) {
+  ledger$total + amount
+}
+
+ledger_double <- function(amount) {
+  ledger_add(make_ledger(), amount) * 2
+}

--- a/internal/sem/testdata/langmatrix/ruby/ledger.rb
+++ b/internal/sem/testdata/langmatrix/ruby/ledger.rb
@@ -1,0 +1,16 @@
+class Ledger
+  attr_accessor :total
+
+  def initialize
+    @total = 0
+  end
+
+  def add(amount)
+    @total + amount
+  end
+end
+
+def ledger_double(amount)
+  ledger = Ledger.new
+  ledger.add(amount) * 2
+end

--- a/internal/sem/testdata/langmatrix/rust/ledger.rs
+++ b/internal/sem/testdata/langmatrix/rust/ledger.rs
@@ -1,0 +1,14 @@
+pub struct Ledger {
+    pub total: i32,
+}
+
+impl Ledger {
+    pub fn add(&self, amount: i32) -> i32 {
+        self.total + amount
+    }
+}
+
+pub fn ledger_double(amount: i32) -> i32 {
+    let ledger = Ledger { total: 0 };
+    ledger.add(amount) * 2
+}

--- a/internal/sem/testdata/langmatrix/scala/Ledger.scala
+++ b/internal/sem/testdata/langmatrix/scala/Ledger.scala
@@ -1,0 +1,12 @@
+package fixtures
+
+class Ledger(var total: Int = 0) {
+  def add(amount: Int): Int = total + amount
+}
+
+object LedgerApp {
+  def ledgerDouble(amount: Int): Int = {
+    val ledger = new Ledger()
+    ledger.add(amount) * 2
+  }
+}

--- a/internal/sem/testdata/langmatrix/sql/ledger.sql
+++ b/internal/sem/testdata/langmatrix/sql/ledger.sql
@@ -1,0 +1,15 @@
+CREATE TABLE ledger (
+    id integer PRIMARY KEY,
+    total integer NOT NULL
+);
+
+CREATE VIEW ledger_totals AS
+    SELECT id, total FROM ledger;
+
+CREATE FUNCTION ledger_add(amount integer) RETURNS integer AS $$
+    SELECT total + amount FROM ledger LIMIT 1;
+$$ LANGUAGE sql;
+
+CREATE FUNCTION ledger_double(amount integer) RETURNS integer AS $$
+    SELECT ledger_add(amount) * 2;
+$$ LANGUAGE sql;

--- a/internal/sem/testdata/langmatrix/swift/Ledger.swift
+++ b/internal/sem/testdata/langmatrix/swift/Ledger.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct Ledger {
+    var total: Int = 0
+
+    func add(_ amount: Int) -> Int {
+        return total + amount
+    }
+}
+
+func ledgerDouble(_ amount: Int) -> Int {
+    let ledger = Ledger()
+    return ledger.add(amount) * 2
+}

--- a/internal/sem/testdata/langmatrix/typescript/ledger.ts
+++ b/internal/sem/testdata/langmatrix/typescript/ledger.ts
@@ -1,0 +1,12 @@
+export class Ledger {
+  total = 0;
+
+  add(amount: number): number {
+    return this.total + amount;
+  }
+}
+
+export function ledgerDouble(amount: number): number {
+  const ledger = new Ledger();
+  return ledger.add(amount) * 2;
+}

--- a/internal/sem/testdata/langmatrix/yaml/ledger.yaml
+++ b/internal/sem/testdata/langmatrix/yaml/ledger.yaml
@@ -1,0 +1,8 @@
+service:
+  name: ledger
+  port: 8080
+  limits:
+    memory: 512Mi
+routes:
+  - path: /add
+    handler: ledgerAdd

--- a/internal/sem/testdata/langmatrix/zig/ledger.zig
+++ b/internal/sem/testdata/langmatrix/zig/ledger.zig
@@ -1,0 +1,14 @@
+const std = @import("std");
+
+pub const Ledger = struct {
+    total: i32,
+
+    pub fn add(self: Ledger, amount: i32) i32 {
+        return self.total + amount;
+    }
+};
+
+pub fn ledgerDouble(amount: i32) i32 {
+    const ledger = Ledger{ .total = 0 };
+    return ledger.add(amount) * 2;
+}

--- a/internal/sem/testdata/langmatrix/zsh/ledger.zsh
+++ b/internal/sem/testdata/langmatrix/zsh/ledger.zsh
@@ -1,0 +1,13 @@
+#!/usr/bin/env zsh
+
+ledger_add() {
+  local amount="$1"
+  print $(( amount + 1 ))
+}
+
+ledger_double() {
+  local amount="$1"
+  ledger_add "$amount"
+}
+
+ledger_double 2


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/130
<!-- entire-trail-link-end -->

## Why

A grammar that loads, parses without a syntax error, and yields nothing is invisible. Aggregate symbol counts across a repository never show it, and `capabilities --json` keeps advertising the language regardless. Nothing in the suite asserted that any given language extracts anything at all — 10 of the 36 semantic languages had golden coverage; the other 26 were unverified.

This matters more now that entire-graph is proposed as the org's single symbol producer (#146): a language that silently yields nothing would then yield nothing for every consumer.

## What

One minimal fixture per semantic language — a function, a type, a member, and a call between them — under `internal/sem/testdata/langmatrix/`, plus four assertions:

| test | guards against |
|---|---|
| `TestLanguageExtractionMatrix` | a language extracting nothing, or the wrong things, from unmistakable definitions |
| `TestLanguageMatrixCoversEverySemanticLanguage` | a language registered and counted in `capabilities --json` with no evidence it extracts anything |
| `TestDocumentedLanguageListsMatchTheRegistry` | either tier list in `docs/language-support.md` drifting away from the registry |
| `TestLanguageMatrixCallsGapsAreExactlyAsAudited` | a language advertising `CALLS` while extracting none — and a fix landing without its audited gap being retired |

## Audited CALLS gaps

Four languages advertise `CALLS` in the capability report and extract none from their fixture's idiomatic call site. They are pinned by name with the reason rather than papered over, and the test fails if the list grows *or* goes stale:

- **C++** — a default-constructed stack receiver (`Ledger ledger;`) carries no inferred type, so its method calls resolve to nothing. `Ledger l = Ledger();` and `new Ledger()` both do resolve, so this is a hole in declaration parsing rather than in C++ receiver resolution.
- **F#** — application by juxtaposition (`add ledger amount`) has no scanner: the dotted scanners need a `.` and the generic one needs `name(`. (#163 covers the forward-pipe form.)
- **Julia** — a definition inside `module ... end` is emitted as a method, and bare calls are barred from resolving to methods. (#161 addresses this.)
- **Objective-C** — a local's declared type is not inferred, so `[ledger add:amount]` resolves to nothing; only `[self …]` binds.

## Reconciliation result

No docs/registry disagreement was found in either direction. Both the semantic list (36) and the inventory-only list (149) match the registry exactly, and the counts stated in the doc (185 / 36 / 149) match `capabilities --json`.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .`, and the full `go test ./...` (3833 tests) are green. This branch and #172/#173/#174 merge together cleanly; the combined tree passes 3841 tests.