### PR TITLE
fix(sem): qualify recovered Objective-C methods by their container

### DIFF
--- a/internal/sem/parser.go
+++ b/internal/sem/parser.go
@@ -7099,8 +7099,24 @@ func objectiveCMethodEntities(content string) []Entity {
 	}
 
 	var entities []Entity
+	scope := ""
 	for i := 0; i < len(lines); i++ {
 		trimmed := strings.TrimSpace(lines[i])
+		// Track the enclosing @interface/@implementation/@protocol so a
+		// recovered method carries the same qualified name the tree-sitter walk
+		// gives it. Without the scope every method the walk DID find gained an
+		// unqualified twin here: appendMissingEntities keys on kind+name, so
+		// `Ledger.add` and `add` were two different symbols at one source
+		// location, duplicating the method in the symbol table, duplicating
+		// every call edge into it, and pairing it with itself as SIMILAR_TO.
+		if declared, ok := objectiveCContainerName(trimmed); ok {
+			scope = declared
+			continue
+		}
+		if trimmed == "@end" {
+			scope = ""
+			continue
+		}
 		if !strings.HasPrefix(trimmed, "- (") && !strings.HasPrefix(trimmed, "+ (") {
 			continue
 		}
@@ -7129,7 +7145,7 @@ func objectiveCMethodEntities(content string) []Entity {
 			continue
 		}
 		header := strings.Join(headerParts, " ")
-		name := objectiveCMethodHeaderName(header)
+		name := qualify(scope, objectiveCMethodHeaderName(header))
 		if name == "" {
 			continue
 		}
@@ -7156,6 +7172,33 @@ func objectiveCMethodEntities(content string) []Entity {
 	}
 	return entities
 }
+
+// objectiveCContainerName returns the type an @interface, @implementation or
+// @protocol line declares, matching how the tree-sitter walk names the same
+// node: a category (`@implementation Foo (Bar)`) still names Foo, and a
+// superclass or protocol conformance list is not part of the name.
+func objectiveCContainerName(trimmed string) (string, bool) {
+	for _, keyword := range []string{"@interface", "@implementation", "@protocol"} {
+		if !strings.HasPrefix(trimmed, keyword) {
+			continue
+		}
+		rest := strings.TrimSpace(trimmed[len(keyword):])
+		if rest == "" {
+			// `@interface` with the name on the next line is not a shape the
+			// recovery scanner can attribute; leave the scope untouched rather
+			// than guessing at it.
+			return "", false
+		}
+		name := objectiveCContainerNamePattern.FindString(rest)
+		if name == "" {
+			return "", false
+		}
+		return name, true
+	}
+	return "", false
+}
+
+var objectiveCContainerNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*`)
 
 func objectiveCMethodHeaderName(header string) string {
 	closeReturnType := strings.IndexByte(header, ')')

--- a/internal/sem/parser_objc_recovery_test.go
+++ b/internal/sem/parser_objc_recovery_test.go
@@ -1,0 +1,85 @@
+package sem
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestObjectiveCRecoveredMethodsAreQualifiedByTheirContainer pins the
+// duplication that the recovery scanner used to cause. It supplements the
+// tree-sitter walk for implementation methods the walk misses, but it named
+// them by their bare selector while the walk names them `Class.selector`.
+// appendMissingEntities keys on kind+name, so the two never collided: every
+// method the walk DID find gained a second, unqualified record at the same
+// source location.
+//
+// The cost was not cosmetic. The symbol table reported each method twice, each
+// call into the method produced two CALLS edges, and the pair matched itself as
+// a SIMILAR_TO near-clone.
+func TestObjectiveCRecoveredMethodsAreQualifiedByTheirContainer(t *testing.T) {
+	t.Parallel()
+	entities, language := TreeSitterParser{}.Parse("Ledger.m", `@interface Ledger : NSObject
+- (int)add:(int)amount;
+@end
+
+@implementation Ledger
+
+- (int)add:(int)amount {
+    return amount;
+}
+
+- (int)twice:(int)amount {
+    return [self add:amount] * 2;
+}
+
+@end
+`)
+	if language != "Objective-C" {
+		t.Fatalf("language = %q, want Objective-C", language)
+	}
+
+	counts := map[string]int{}
+	for _, entity := range entities {
+		if entity.Kind == "method" {
+			counts[entity.Name]++
+		}
+	}
+	for _, want := range []string{"Ledger.add", "Ledger.twice"} {
+		if counts[want] != 1 {
+			t.Errorf("method %q has %d records, want exactly 1: %#v", want, counts[want], counts)
+		}
+	}
+	for name := range counts {
+		if !strings.Contains(name, ".") {
+			t.Errorf("method %q is not qualified by its container: %#v", name, counts)
+		}
+	}
+}
+
+// TestObjectiveCRecoveredMethodsUseCategoryOwner checks that a category
+// (`@implementation Foo (Bar)`) attributes its methods to Foo, matching how the
+// tree-sitter walk names the same class_implementation node, and that a method
+// written outside any container is still recovered rather than dropped.
+func TestObjectiveCRecoveredMethodsUseCategoryOwner(t *testing.T) {
+	t.Parallel()
+	entities, _ := TreeSitterParser{}.Parse("Ledger+Math.m", `@implementation Ledger (Math)
+
+- (int)square:(int)amount {
+    return amount * amount;
+}
+
+@end
+
+static int Helper(int amount) { return amount; }
+`)
+	found := map[string]bool{}
+	for _, entity := range entities {
+		found[entity.Kind+":"+entity.Name] = true
+	}
+	if !found["method:Ledger.square"] {
+		t.Errorf("category method should be attributed to Ledger: %#v", found)
+	}
+	if found["method:square"] {
+		t.Errorf("category method should not also appear unqualified: %#v", found)
+	}
+}

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -13924,8 +13924,21 @@ func TestObjectiveCMethodFallbackExtractsColonSelectors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !snapshotHasSymbol(snapshot, "invalidateSessionCancelingTasks") {
+	// The method is qualified by its @implementation, exactly as the
+	// tree-sitter walk names it. The recovery scanner used to emit an
+	// unqualified twin instead, so this method existed twice at one source
+	// location; count the records so that cannot come back.
+	if !snapshotHasSymbol(snapshot, "AFURLSessionManager.invalidateSessionCancelingTasks") {
 		t.Fatalf("missing Objective-C colon selector method: %#v", snapshot.Symbols)
+	}
+	records := 0
+	for _, symbol := range snapshot.Symbols {
+		if strings.HasSuffix(symbol.QualifiedName, "invalidateSessionCancelingTasks") {
+			records++
+		}
+	}
+	if records != 1 {
+		t.Fatalf("expected exactly one record for invalidateSessionCancelingTasks, got %d: %#v", records, snapshot.Symbols)
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/131
<!-- entire-trail-link-end -->

## The defect

`objectiveCMethodEntities` is a recovery scanner: it supplements the tree-sitter walk with implementation methods the walk misses. It named them by their bare selector (`add`) while the walk names them `Class.selector` (`Ledger.add`), and `appendMissingEntities` dedupes on `kind + name` — so the two never collided.

The result: **every Objective-C method the walk already found gained a second, unqualified record** at the same file, the same lines, the same signature, and the same container.

```
method   add   qn=Ledger.add   L6-6  sig="- (int)add:(int)amount"  container=…:class:Ledger
method   add   qn=add          L6-6  sig="- (int)add:(int)amount"  container=…:class:Ledger
```

This is not cosmetic:

- the symbol table reports each method twice;
- each call into a method produces two `CALLS` edges (`CALLS(twice->add)` twice on a three-line file);
- the duplicate pair matches itself as a `SIMILAR_TO` near-clone.

The repository's own `TestObjectiveCMethodFallbackExtractsColonSelectors` was asserting on the *duplicate* — it looked for the unqualified name, which only ever existed because of this bug.

## The fix

Track the enclosing `@interface` / `@implementation` / `@protocol` while scanning and qualify the recovered name with it, matching the walk. A category (`@implementation Foo (Bar)`) attributes to `Foo`, exactly as the walk names the same `class_implementation` node, and a method written outside any container is still recovered unqualified rather than dropped.

The existing fallback test now asserts the qualified name and counts the records, so the duplication cannot come back.

Found by the per-language extraction audit; the fixture matrix in #171 covers Objective-C.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .`, full `go test ./...` (3759 tests) green.