### PR TITLE
fix(sem): stop C-family tag references becoming struct definitions

### DIFF
--- a/internal/sem/parser.go
+++ b/internal/sem/parser.go
@@ -4933,12 +4933,18 @@ func entityFromNode(node *sitter.Node, src []byte, language, scope string) (Enti
 		if language == "Objective-C" && node.Type() == "struct_declaration" {
 			return Entity{}, false
 		}
+		if cFamilyTagReference(node, language) {
+			return Entity{}, false
+		}
 		kind = "struct"
 		name = nodeName(node, src)
 	case "enum_item", "enum_declaration", "enum_specifier":
 		// Same as struct_declaration: Zig enums are anonymous literals named by
 		// the enclosing variable_declaration.
 		if language == "Zig" {
+			return Entity{}, false
+		}
+		if cFamilyTagReference(node, language) {
 			return Entity{}, false
 		}
 		kind = "enum"
@@ -7837,6 +7843,28 @@ func goReceiverName(node *sitter.Node, src []byte) string {
 		name = name[index+1:]
 	}
 	return strings.TrimSpace(name)
+}
+
+// cFamilyTagReference reports whether a C-family struct/enum specifier NAMES a
+// tag rather than defining one. In C the tag name is part of the type syntax, so
+// `struct Ledger *l` and `enum Mode m` parse to the same struct_specifier /
+// enum_specifier node type as the definition does — the definition is the one
+// carrying a body. Without this check every mention of a type produced another
+// "definition" of it: a three-line C file that declares `struct Ledger` once and
+// uses it twice emitted three struct symbols at three different lines, and a
+// header whose only content is prototypes emitted a phantom definition for each
+// parameter type.
+//
+// A body-less specifier at file scope is a forward declaration
+// (`struct Ledger;`) — an incomplete type, not a definition either — so it is
+// skipped on the same rule.
+func cFamilyTagReference(node *sitter.Node, language string) bool {
+	switch language {
+	case "C", "C++", "Objective-C":
+	default:
+		return false
+	}
+	return !validNode(node.ChildByFieldName("body"))
 }
 
 func qualify(scope, name string) string {

--- a/internal/sem/parser_c_macro_regression_test.go
+++ b/internal/sem/parser_c_macro_regression_test.go
@@ -1,6 +1,7 @@
 package sem
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -256,8 +257,12 @@ int tail_fn(void)
 	if countEntity(entities, "struct", "Curl_addrinfo") == 0 {
 		t.Errorf("struct Curl_addrinfo missing: %+v", entities)
 	}
-	if countEntity(entities, "struct", "FOO") == 0 {
-		t.Errorf("struct tag FOO must not be blanked: %+v", entities)
+	// `struct FOO bar` names a tag, it does not define one, so it is correctly
+	// not a symbol. Assert the mask guard directly on the masked source instead:
+	// the declarator heuristics must not mistake the tag for an attribute macro
+	// and blank it.
+	if masked := maskCUnsupportedSyntax(src); !strings.Contains(masked, "struct FOO bar") {
+		t.Errorf("struct tag FOO must not be blanked:\n%s", masked)
 	}
 	if countEntity(entities, "function", "tail_fn") != 1 {
 		t.Errorf("tail_fn missing: %+v", entities)

--- a/internal/sem/parser_c_tag_reference_test.go
+++ b/internal/sem/parser_c_tag_reference_test.go
@@ -1,0 +1,89 @@
+package sem
+
+import "testing"
+
+// TestCTagReferencesAreNotDefinitions pins the phantom definitions that a
+// C-family struct or enum tag used to produce. In C the tag name is part of the
+// type syntax, so `struct Ledger *l` parses to the same struct_specifier node
+// type as `struct Ledger { ... }` — the definition is the one carrying a body.
+// Extracting both meant every mention of a type produced another "definition"
+// of it, at a different line, competing with the real one in search results and
+// in `def`.
+func TestCTagReferencesAreNotDefinitions(t *testing.T) {
+	t.Parallel()
+	entities, language := TreeSitterParser{}.Parse("ledger.c", `struct Ledger {
+    int total;
+};
+
+enum Mode {
+    MODE_FAST,
+};
+
+int ledger_add(struct Ledger *ledger, int amount) {
+    return ledger->total + amount;
+}
+
+int ledger_run(enum Mode mode) {
+    struct Ledger ledger = {0};
+    return ledger_add(&ledger, (int)mode);
+}
+`)
+	if language != "C" {
+		t.Fatalf("language = %q, want C", language)
+	}
+	counts := map[string]int{}
+	for _, entity := range entities {
+		counts[entity.Kind+":"+entity.Name]++
+	}
+	if got := counts["struct:Ledger"]; got != 1 {
+		t.Errorf("struct Ledger has %d records, want exactly 1 (the definition): %#v", got, counts)
+	}
+	if got := counts["enum:Mode"]; got != 1 {
+		t.Errorf("enum Mode has %d records, want exactly 1 (the definition): %#v", got, counts)
+	}
+}
+
+// TestCHeaderPrototypesEmitNoPhantomStructs covers the shape that made this
+// worst: a public header is mostly prototypes, so nearly every struct mention
+// in it is a parameter type. Each one used to become a struct "definition"
+// anchored on the prototype's line.
+func TestCHeaderPrototypesEmitNoPhantomStructs(t *testing.T) {
+	t.Parallel()
+	entities, _ := TreeSitterParser{}.Parse("ledger.h", `struct Ledger;
+
+int ledger_add(struct Ledger *ledger, int amount);
+int ledger_reset(struct Ledger *ledger);
+`)
+	for _, entity := range entities {
+		if entity.Kind == "struct" {
+			t.Errorf("header with no struct body emitted a struct definition at line %d: %#v", entity.StartLine, entity)
+		}
+	}
+}
+
+// TestCPlusPlusTagReferencesAreNotDefinitions checks the same rule for C++,
+// whose grammar shares the specifier nodes.
+func TestCPlusPlusTagReferencesAreNotDefinitions(t *testing.T) {
+	t.Parallel()
+	entities, language := TreeSitterParser{}.Parse("point.cpp", `struct Point {
+    int x;
+};
+
+int sum(struct Point p) {
+    struct Point other = p;
+    return other.x;
+}
+`)
+	if language != "C++" {
+		t.Fatalf("language = %q, want C++", language)
+	}
+	structs := 0
+	for _, entity := range entities {
+		if entity.Kind == "struct" && entity.Name == "Point" {
+			structs++
+		}
+	}
+	if structs != 1 {
+		t.Errorf("struct Point has %d records, want exactly 1 (the definition)", structs)
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/132
<!-- entire-trail-link-end -->

## The defect

In C the tag name is part of the type syntax. `struct Ledger *l` and `enum Mode m` parse to the same `struct_specifier` / `enum_specifier` node type as `struct Ledger { … }` does — the definition is the one carrying a body. Both were extracted as definitions.

So every *mention* of a type produced another "definition" of it:

```
struct   Ledger   L1-3   <- the definition
struct   Ledger   L5-5   <- `struct Ledger *l` in a parameter list
struct   Ledger   L10-10 <- `struct Ledger l = {0}` in a body
```

The shape that makes it worst is a public C header: it is mostly prototypes, so nearly every struct mention in it is a parameter type. A header containing one forward declaration and two prototypes emitted three struct "definitions" and zero function symbols. Those phantoms then compete with the real definition in search results and in `def`.

## The fix

Skip a body-less struct/enum specifier for C, C++ and Objective-C. A file-scope `struct Ledger;` is a forward declaration — an incomplete type, not a definition either — and is skipped on the same rule.

## One test changed

`TestCMaskInterDeclarationAnnotations` used the presence of a `struct FOO` entity as a proxy for "the C attribute-macro mask did not blank the tag `FOO` in `struct FOO bar = { 0 };`". That entity only ever existed because of this bug, so the guard now asserts the mask output directly — which is what it was actually about.

Found by the per-language extraction audit; the fixture matrix in #171 covers C and C++.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .`, full `go test ./...` (3759 tests) green.