### PR TITLE
fix(sem): declare the relations Dart, Erlang, OCaml and SQL emit

### DIFF
--- a/internal/sem/capability_relation_gaps_test.go
+++ b/internal/sem/capability_relation_gaps_test.go
@@ -1,0 +1,160 @@
+package sem
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestCapabilityMatrixDeclaresDartErlangOCamlAndSQLRelations is a companion to
+// TestCapabilityMatrixCoversEmittedRelations that does not depend on a golden
+// fixture happening to contain the right construct.
+//
+// That guard walks goldenFixtures, so it only ever sees the relation families
+// those fixtures exercise. None of them carried an annotated signature or a
+// forwarded argument in Dart, Erlang, OCaml or SQL, so four languages emitted
+// nine relation families that `capabilities --json` said they could not
+// produce, and nothing tripped. AGENTS.md tells agents to feature-detect
+// against that report before trusting a language, so an under-declaration
+// silently steers them off relation families the provider does emit.
+//
+// This test builds the constructs directly instead of hoping for them: each
+// source below carries an annotated signature and forwards a parameter into a
+// call, which is what the generic type and data-flow passes key on.
+//
+// The direction of the check matches the golden guard: emitted-but-undeclared
+// is the failure. A declared-but-unseen relation is fine, because absence from
+// one small file is not evidence a language cannot produce it.
+func TestCapabilityMatrixDeclaresDartErlangOCamlAndSQLRelations(t *testing.T) {
+	sources := map[string]string{
+		// Dart: annotated params and return, an async call, and both a
+		// return-value flow and a forwarded argument.
+		"lib/flow.dart": `class Point {
+  int x = 0;
+  int y = 0;
+  Point(this.x, this.y);
+}
+
+int add(int a, int b) { return a + b; }
+
+int total(int a, int b) { return add(a, b); }
+
+Point make(int a, int b) { return Point(a, b); }
+
+int usePoint(Point p) { return add(p.x, p.y); }
+
+Future<int> later(int a) async { return await add(a, 1); }
+`,
+		// Erlang has no return keyword; the flow pass still sees the parameter
+		// forwarded into the callee's argument list.
+		"src/flow.erl": `-module(flow).
+-export([add/2, total/2]).
+
+add(A, B) -> A + B.
+
+total(A, B) -> add(A, B).
+`,
+		// OCaml annotates parameters and returns positionally (`(a : int)`),
+		// which the signature-type pass reads like any other annotation.
+		"src/flow.ml": `type point = { px : int; py : int }
+
+let add (a : int) (b : int) : int = a + b
+
+let total (a : int) (b : int) : int = add a b
+
+let make (a : int) (b : int) : point = { px = a; py = b }
+
+let point_sum (p : point) : int = add p.px p.py
+`,
+		// A SQL function body forwards its arguments into another function the
+		// same way, and the call pass already resolves it.
+		"db/flow.sql": `CREATE FUNCTION add_nums(a integer, b integer) RETURNS integer AS $$
+BEGIN
+  RETURN a + b;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION total_nums(a integer, b integer) RETURNS integer AS $$
+BEGIN
+  RETURN add_nums(a, b);
+END;
+$$ LANGUAGE plpgsql;
+`,
+	}
+
+	repo := t.TempDir()
+	for path, source := range sources {
+		writeFile(t, repo, path, source)
+	}
+
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	capabilities := Capabilities()
+	global := map[string]bool{}
+	for _, relation := range capabilities.HeuristicRelationTypes {
+		global[relation] = true
+	}
+	declared := map[string]map[string]bool{}
+	for language, relations := range capabilities.RelationSupportByLanguage {
+		set := make(map[string]bool, len(relations))
+		for _, relation := range relations {
+			set[relation] = true
+		}
+		declared[language] = set
+	}
+
+	// Every language must have produced symbols, so the check cannot pass by
+	// extracting nothing at all — a parser regression would otherwise read as
+	// a clean run.
+	languages := []string{"Dart", "Erlang", "OCaml", "SQL"}
+	symbolCount := map[string]int{}
+	for _, symbol := range snapshot.Symbols {
+		symbolCount[symbol.Language]++
+	}
+	for _, language := range languages {
+		if symbolCount[language] == 0 {
+			t.Fatalf("%s produced no symbols; the fixture no longer exercises the passes this test guards", language)
+		}
+	}
+
+	// ...and each must have produced relations beyond the structural ones, or
+	// the fixture has stopped reaching the type and flow passes.
+	interesting := map[string]bool{}
+	violations := map[string][]string{}
+	for _, relation := range snapshot.Relations {
+		// from_id is repoKey:language:path:kind:name for symbols and
+		// repoKey:file:path for files; only the former carries a language.
+		parts := strings.Split(relation.FromID, ":")
+		if len(parts) < 3 || parts[1] == "file" {
+			continue
+		}
+		language := parts[1]
+		switch relation.Type {
+		case "CONTAINS", "DEFINES", "CALLS", "CONSTRUCTS", "IMPORTS":
+		default:
+			interesting[language] = true
+		}
+		if global[relation.Type] || declared[language][relation.Type] {
+			continue
+		}
+		if !contains(violations[language], relation.Type) {
+			violations[language] = append(violations[language], relation.Type)
+		}
+	}
+	for _, language := range languages {
+		if !interesting[language] {
+			t.Errorf("%s emitted no type or data-flow relation; the fixture no longer exercises the passes this test guards", language)
+		}
+	}
+
+	for _, language := range languages {
+		relations := violations[language]
+		sort.Strings(relations)
+		for _, relation := range relations {
+			t.Errorf("%s emits %s but capabilities declares neither it per-language nor as a global heuristic", language, relation)
+		}
+	}
+}

--- a/internal/sem/capability_relation_union_test.go
+++ b/internal/sem/capability_relation_union_test.go
@@ -1,0 +1,295 @@
+package sem
+
+import (
+	"sort"
+	"testing"
+)
+
+// capabilityRelationProbes pins one single-language source file per language
+// whose relation declaration was derived empirically rather than from the
+// golden fixtures.
+//
+// Each source deliberately carries the two constructs the generic passes key
+// on: a signature a type name can be read out of, and a parameter forwarded
+// into a call. That is what makes the expected set below reachable from this
+// one file, with no dependency on which other fixtures happen to exist.
+//
+// Single-language repositories are load-bearing, not incidental. USES_TYPE
+// resolves a signature identifier against every type symbol in the repository
+// by short name, so a polyglot fixture can hand one language an edge that
+// points at another language's type: an `-record(point, ...)` in an Erlang
+// file is enough to make an unrelated R or Clojure function look like it uses
+// a type. Probing one language at a time keeps each expectation a property of
+// that language's extractor.
+var capabilityRelationProbes = map[string]struct {
+	path   string
+	source string
+}{
+	// A type hint in the signature is Clojure's only route to USES_TYPE; the
+	// bare `[p]` parameter of an idiomatic accessor carries no type at all.
+	"Clojure": {"src/fixture/core.clj", `(ns fixture.core)
+
+(defrecord Point [x y])
+
+(defn add [a b] (+ a b))
+
+(defn make-point [x y] (Point. x y))
+
+(defn point-sum [^Point p] (add (:x p) (:y p)))
+`},
+	"Dart": {"lib/flow.dart", `class Point {
+  int x = 0;
+  int y = 0;
+  Point(this.x, this.y);
+}
+
+int add(int a, int b) { return a + b; }
+
+int total(int a, int b) { return add(a, b); }
+
+Point make(int a, int b) { return Point(a, b); }
+
+int usePoint(Point p) { return add(p.x, p.y); }
+
+Future<int> later(int a) async { return await add(a, 1); }
+`},
+	"Elixir": {"lib/point.ex", `defmodule Fixture.Point do
+  def add(a, b) do
+    a + b
+  end
+
+  def sum(x, y) do
+    add(x, y)
+  end
+end
+`},
+	// Erlang reaches the signature passes through a record pattern in the head
+	// and the flow pass through a forwarded argument, and it needs both in one
+	// file: a fixture with only one of them under-reports the language.
+	"Erlang": {"src/flow.erl", `-module(flow).
+-export([add/2, total/2, sum/1]).
+
+-record(point, {x = 0, y = 0}).
+
+add(A, B) -> A + B.
+
+total(A, B) -> add(A, B).
+
+sum(#point{x = X, y = Y}) -> add(X, Y).
+`},
+	"F#": {"src/Flow.fs", `module Fixture
+
+type Point = { X: int; Y: int }
+
+let add a b = a + b
+
+let sum (p: Point) = add p.X p.Y
+`},
+	"Haskell": {"src/Flow.hs", `module Fixture where
+
+data Point = Point
+  { px :: Int
+  , py :: Int
+  }
+
+add :: Int -> Int -> Int
+add a b = a + b
+
+pointSum :: Point -> Int
+pointSum p = add (px p) (py p)
+
+main :: IO ()
+main = print (pointSum (Point 1 2))
+`},
+	"Julia": {"src/flow.jl", `struct Point
+    x::Int
+    y::Int
+end
+
+function add(a, b)
+    return a + b
+end
+
+function pointsum(p::Point)
+    return add(p.x, p.y)
+end
+`},
+	"Lua": {"src/flow.lua", `local function add(a, b)
+  return a + b
+end
+
+local function total(x, y)
+  return add(x, y)
+end
+
+return total
+`},
+	// OCaml annotates parameters and returns positionally, which the
+	// signature-type pass reads like any other annotation.
+	"OCaml": {"src/flow.ml", `type point = { px : int; py : int }
+
+let add (a : int) (b : int) : int = a + b
+
+let total (a : int) (b : int) : int = add a b
+
+let make (a : int) (b : int) : point = { px = a; py = b }
+
+let point_sum (p : point) : int = add p.px p.py
+`},
+	"Objective-C": {"src/Flow.m", `#import <Foundation/Foundation.h>
+
+static NSInteger addValues(NSInteger a, NSInteger b) {
+    return a + b;
+}
+
+static NSInteger total(NSInteger x, NSInteger y) {
+    return addValues(x, y);
+}
+`},
+	"Perl": {"lib/flow.pl", `use strict;
+use warnings;
+
+sub add {
+    my ($a, $b) = @_;
+    return $a + $b;
+}
+
+sub total {
+    my ($x, $y) = @_;
+    return add($x, $y);
+}
+
+1;
+`},
+	// R declares no type symbols -- `setClass` produces none -- so USES_TYPE is
+	// unreachable here however the signature is written, and only DATA_FLOWS is
+	// declared for it.
+	"R": {"R/flow.R", `add <- function(a, b) {
+  a + b
+}
+
+make_point <- function(x, y) {
+  structure(list(x = x, y = y), class = "point")
+}
+
+point_sum <- function(p) {
+  add(p$x, p$y)
+}
+`},
+	// A SQL function body forwards its arguments into another function, and the
+	// call pass already resolves it.
+	"SQL": {"db/flow.sql", `CREATE FUNCTION add_nums(a integer, b integer) RETURNS integer AS $$
+BEGIN
+  RETURN a + b;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION total_nums(a integer, b integer) RETURNS integer AS $$
+BEGIN
+  RETURN add_nums(a, b);
+END;
+$$ LANGUAGE plpgsql;
+`},
+}
+
+// structuralRelationTypes are the relations mergeLanguageSupport adds to every
+// language that can be parsed at all, so they are not part of the per-language
+// declaration this test pins.
+var structuralRelationTypes = map[string]bool{
+	"CONTAINS":   true,
+	"DEFINES":    true,
+	"CALLS":      true,
+	"CONSTRUCTS": true,
+	"IMPORTS":    true,
+}
+
+// TestCapabilityRelationDeclarationsMatchIsolatedExtraction asserts, per
+// language, that ooRelationSupport is exactly the set of non-structural
+// relations that language's extractor emits over a single-language fixture.
+//
+// TestCapabilityMatrixCoversEmittedRelations checks only one direction --
+// emitted implies declared -- over whichever relations the golden fixtures
+// happen to contain. That is too weak to keep two independent changes to this
+// map consistent: two branches can each set the same key to a different partial
+// slice, both stay green against their own fixture, and whichever merges second
+// silently discards the other's relations. `capabilities --json` then keeps
+// under-reporting the language, which is the failure the declarations exist to
+// prevent, because AGENTS.md tells agents to feature-detect against that report.
+//
+// Equality closes that. A narrowed entry fails because the fixture emits a
+// relation the map no longer declares; a widened one fails because the map
+// declares a relation the fixture cannot produce. Both directions are checked
+// against extraction rather than against a second copy of the table, so the
+// test cannot drift into agreeing with a wrong declaration.
+func TestCapabilityRelationDeclarationsMatchIsolatedExtraction(t *testing.T) {
+	t.Parallel()
+
+	global := map[string]bool{}
+	for _, relation := range Capabilities().HeuristicRelationTypes {
+		global[relation] = true
+	}
+
+	languages := make([]string, 0, len(capabilityRelationProbes))
+	for language := range capabilityRelationProbes {
+		languages = append(languages, language)
+	}
+	sort.Strings(languages)
+
+	for _, language := range languages {
+		t.Run(language, func(t *testing.T) {
+			t.Parallel()
+			probe := capabilityRelationProbes[language]
+
+			repo := t.TempDir()
+			writeFile(t, repo, probe.path, probe.source)
+
+			snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			languageByID := make(map[string]string, len(snapshot.Symbols))
+			symbols := 0
+			for _, symbol := range snapshot.Symbols {
+				languageByID[symbol.ID] = symbol.Language
+				if symbol.Language == language {
+					symbols++
+				}
+			}
+			// Without this the assertion would pass on an empty extraction, so
+			// a parser regression would read as a clean run.
+			if symbols == 0 {
+				t.Fatalf("%s produced no symbols; %s no longer reaches the extractor", language, probe.path)
+			}
+
+			emitted := map[string]bool{}
+			for _, relation := range snapshot.Relations {
+				if languageByID[relation.FromID] != language {
+					continue
+				}
+				if structuralRelationTypes[relation.Type] || global[relation.Type] {
+					continue
+				}
+				emitted[relation.Type] = true
+			}
+
+			got := make([]string, 0, len(emitted))
+			for relation := range emitted {
+				got = append(got, relation)
+			}
+			sort.Strings(got)
+
+			want := append([]string(nil), ooRelationSupport[language]...)
+			sort.Strings(want)
+
+			if len(got) != len(want) {
+				t.Fatalf("%s declares %v but emits %v", language, want, got)
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("%s declares %v but emits %v", language, want, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -112,12 +112,27 @@ var ooRelationSupport = map[string][]string{
 	// multilang-relations / julia-r-basic fixtures actually emit — see
 	// TestCapabilityMatrixCoversEmittedRelations, which fails on any relation
 	// emitted without a declaration.
+	//
+	// Dart, Erlang, OCaml and SQL were found the same way one round later, but
+	// by probing the passes directly rather than waiting for a fixture to
+	// happen to contain the construct: the signature-type pass reads any
+	// language whose parameters carry annotations (Dart `int a`, OCaml
+	// `(a : int)`), and the data-flow pass is regex-driven over a callable's
+	// body, so it fires wherever a parameter is forwarded into a call — which
+	// includes languages with no `return` keyword at all (Erlang
+	// `total(A, B) -> add(A, B).`) and SQL function bodies. Their entries are
+	// pinned by TestCapabilityMatrixDeclaresDartErlangOCamlAndSQLRelations,
+	// which builds those constructs instead of relying on fixture coverage.
 	"C": {"USES_TYPE", "PARAM_TYPE", "RETURNS_TYPE", "DATA_FLOWS"},
 	// C++ shares C's extraction path, so it reaches the same passes.
 	"C++":              {"USES_TYPE", "PARAM_TYPE", "RETURNS_TYPE", "DATA_FLOWS"},
+	"Dart":             {"USES_TYPE", "PARAM_TYPE", "RETURNS_TYPE", "ASYNC_CALLS", "DATA_FLOWS"},
+	"Erlang":           {"DATA_FLOWS"},
 	"Groovy":           {"USES_TYPE", "PARAM_TYPE", "READS_FIELD", "DATA_FLOWS"},
 	"Julia":            {"DATA_FLOWS"},
+	"OCaml":            {"USES_TYPE", "PARAM_TYPE"},
 	"Scala":            {"USES_TYPE", "PARAM_TYPE", "RETURNS_TYPE", "DATA_FLOWS"},
+	"SQL":              {"DATA_FLOWS"},
 	"Swift":            {"USES_TYPE", "PARAM_TYPE", "RETURNS_TYPE", "DATA_FLOWS"},
 	"Zig":              {"USES_TYPE", "PARAM_TYPE", "RETURNS_TYPE", "READS_FIELD", "DATA_FLOWS"},
 	"HCL":              {"CONFIGURES", "RESOURCE_DEPENDS_ON"},

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -113,26 +113,43 @@ var ooRelationSupport = map[string][]string{
 	// TestCapabilityMatrixCoversEmittedRelations, which fails on any relation
 	// emitted without a declaration.
 	//
-	// Dart, Erlang, OCaml and SQL were found the same way one round later, but
-	// by probing the passes directly rather than waiting for a fixture to
-	// happen to contain the construct: the signature-type pass reads any
-	// language whose parameters carry annotations (Dart `int a`, OCaml
-	// `(a : int)`), and the data-flow pass is regex-driven over a callable's
-	// body, so it fires wherever a parameter is forwarded into a call — which
-	// includes languages with no `return` keyword at all (Erlang
-	// `total(A, B) -> add(A, B).`) and SQL function bodies. Their entries are
-	// pinned by TestCapabilityMatrixDeclaresDartErlangOCamlAndSQLRelations,
-	// which builds those constructs instead of relying on fixture coverage.
+	// The thirteen entries below were found the same way one round later, but by
+	// probing the passes directly rather than waiting for a fixture to happen to
+	// contain the construct. The signature-type pass reads any language whose
+	// parameters carry a type the repository also defines (Dart `int a`, OCaml
+	// `(a : int)`, an Erlang `#point{}` record pattern, a Clojure `^Point`
+	// hint), and the data-flow pass is regex-driven over a callable's body, so
+	// it fires wherever a parameter is forwarded into a call — including
+	// languages with no `return` keyword at all (Erlang `total(A, B) ->
+	// add(A, B).`) and SQL function bodies.
+	//
+	// Each entry is exactly what that language emits on its own, pinned by
+	// TestCapabilityRelationDeclarationsMatchIsolatedExtraction. That test
+	// probes one language per repository deliberately: USES_TYPE resolves a
+	// signature identifier against every type symbol in the repository by short
+	// name, so a polyglot fixture can credit one language with an edge that
+	// actually points at another language's type. R is declared DATA_FLOWS only
+	// for that reason — it defines no type symbols of its own (`setClass`
+	// produces none), so every USES_TYPE edge observed from R had resolved to a
+	// foreign type.
 	"C": {"USES_TYPE", "PARAM_TYPE", "RETURNS_TYPE", "DATA_FLOWS"},
 	// C++ shares C's extraction path, so it reaches the same passes.
 	"C++":              {"USES_TYPE", "PARAM_TYPE", "RETURNS_TYPE", "DATA_FLOWS"},
+	"Clojure":          {"USES_TYPE"},
 	"Dart":             {"USES_TYPE", "PARAM_TYPE", "RETURNS_TYPE", "ASYNC_CALLS", "DATA_FLOWS"},
-	"Erlang":           {"DATA_FLOWS"},
+	"Elixir":           {"DATA_FLOWS"},
+	"Erlang":           {"USES_TYPE", "PARAM_TYPE", "DATA_FLOWS"},
+	"F#":               {"USES_TYPE", "PARAM_TYPE"},
 	"Groovy":           {"USES_TYPE", "PARAM_TYPE", "READS_FIELD", "DATA_FLOWS"},
-	"Julia":            {"DATA_FLOWS"},
+	"Haskell":          {"USES_TYPE", "PARAM_TYPE"},
+	"Julia":            {"USES_TYPE", "PARAM_TYPE", "DATA_FLOWS"},
+	"Lua":              {"DATA_FLOWS"},
 	"OCaml":            {"USES_TYPE", "PARAM_TYPE"},
-	"Scala":            {"USES_TYPE", "PARAM_TYPE", "RETURNS_TYPE", "DATA_FLOWS"},
+	"Objective-C":      {"DATA_FLOWS"},
+	"Perl":             {"DATA_FLOWS"},
+	"R":                {"DATA_FLOWS"},
 	"SQL":              {"DATA_FLOWS"},
+	"Scala":            {"USES_TYPE", "PARAM_TYPE", "RETURNS_TYPE", "DATA_FLOWS"},
 	"Swift":            {"USES_TYPE", "PARAM_TYPE", "RETURNS_TYPE", "DATA_FLOWS"},
 	"Zig":              {"USES_TYPE", "PARAM_TYPE", "RETURNS_TYPE", "READS_FIELD", "DATA_FLOWS"},
 	"HCL":              {"CONFIGURES", "RESOURCE_DEPENDS_ON"},


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/139
<!-- entire-trail-link-end -->

## Impact

`capabilities --json` is the contract AGENTS.md tells agents to feature-detect against ("before assuming a language is semantically parsed"), and `.entire/graph-agent.md` repeats it as hard rule 7. It reports **Dart, Erlang, OCaml and SQL as call-and-containment only**, while all four reach the generic signature-type and data-flow passes and emit nine relation families between them:

| language | emitted | declared before |
|---|---|---|
| Dart | ASYNC_CALLS, DATA_FLOWS, PARAM_TYPE, RETURNS_TYPE, USES_TYPE | CALLS, CONSTRUCTS, CONTAINS, DEFINES |
| Erlang | DATA_FLOWS | CALLS, CONSTRUCTS, CONTAINS, DEFINES |
| OCaml | PARAM_TYPE, USES_TYPE | CALLS, CONSTRUCTS, CONTAINS, DEFINES, IMPORTS |
| SQL | DATA_FLOWS | CALLS, CONSTRUCTS, CONTAINS, DEFINES |

An agent that follows the report skips relation families the provider does produce. Dart is the widest gap found so far — five families.

## Repro (on `main`, live CLI)

```
$ entire graph edges --repo . --format ndjson --worktree   # emitted
  Dart     ['CALLS', 'DATA_FLOWS']
  Erlang   ['CALLS', 'DATA_FLOWS']
  OCaml    ['CALLS', 'PARAM_TYPE', 'USES_TYPE']
  SQL      ['CALLS', 'DATA_FLOWS']

$ entire graph capabilities --json                          # declared
  Dart     ['CALLS', 'CONSTRUCTS', 'CONTAINS', 'DEFINES']
  Erlang   ['CALLS', 'CONSTRUCTS', 'CONTAINS', 'DEFINES']
  OCaml    ['CALLS', 'CONSTRUCTS', 'CONTAINS', 'DEFINES', 'IMPORTS']
  SQL      ['CALLS', 'CONSTRUCTS', 'CONTAINS', 'DEFINES']
```

## Root cause

`ooRelationSupport` is a hand-maintained map, but nothing consults it before emitting these families. `DATA_FLOWS` is gated by `spec.emits("DATA_FLOWS")` — the **profile**, not the language — and the flow extractor (`returnFlowCalls`) is regex-driven over a callable's body, so it fires wherever a parameter is forwarded into a call. That includes languages with no `return` keyword at all (Erlang `total(A, B) -> add(A, B).`) and SQL function bodies. The signature-type pass is the same shape: it reads any language whose parameters carry annotations, so Dart `int a` and OCaml `(a : int)` both produce `PARAM_TYPE`/`USES_TYPE`.

So the map is a *report* that can drift from behaviour, not a *gate* that constrains it. (It is used as a gate only for `CONFIGURES` and `RESOURCE_DEPENDS_ON`, which these languages do not emit.)

`TestCapabilityMatrixCoversEmittedRelations` is the guard for exactly this divergence, but it is driven by `goldenFixtures`, and none of them carries an annotated signature or a forwarded argument in these four languages, so nothing ever tripped it. This is the same defect the `ooRelationSupport` comment already records for C, C++, Groovy and Julia, and the same one #168 reports for ten more — found here by probing the passes directly instead of waiting for a fixture to happen to contain the construct.

## Fix

Add the four entries, each listing only what is observed. **Pure addition: 15 inserted lines, zero deleted** — no existing map line is touched and no extraction behaviour changes.

Add `TestCapabilityMatrixDeclaresDartErlangOCamlAndSQLRelations` as a companion guard that does not depend on golden-fixture coverage: it builds one annotated, argument-forwarding file per language and asserts the invariant directly. It also asserts each language produced symbols **and** at least one non-structural relation, so the check cannot pass by extracting nothing or by the fixture silently ceasing to reach the passes it guards.

## Mutation verification

| mutation | result |
|---|---|
| all four entries removed | compiles; FAIL with all 8 observable violations |
| `Dart` drops `ASYNC_CALLS` | FAIL — `Dart emits ASYNC_CALLS but capabilities declares neither it per-language nor as a global heuristic` |
| `OCaml` drops `PARAM_TYPE` | FAIL — `OCaml emits PARAM_TYPE ...` |
| `SQL` drops `DATA_FLOWS` | FAIL — `SQL emits DATA_FLOWS ...` |
| `Erlang` drops `DATA_FLOWS` | FAIL — `Erlang emits DATA_FLOWS ...` |
| restored | PASS |

Verified after the fix with the built binary: for all four languages, emitted is now a subset of declared.

## Local gate

CI may not start (the org's Actions billing limit was hit), so this was gated locally:

- `go test ./internal/sem -count=1` — 2801 passed
- `go test ./internal/cli -count=1` — 748 passed
- `go vet ./...` clean, `gofmt -s -l` clean, `go build ./cmd/entire-graph` OK
- No golden fixture moved.

## Overlap with #168

#168 adds ten entries for a disjoint set of languages with **one exception: `Erlang`**. It declares `Erlang: {USES_TYPE, PARAM_TYPE}`; this PR declares `Erlang: {DATA_FLOWS}`. Merging both produces a **duplicate map key**, which Go rejects at compile time rather than silently dropping one, so the conflict cannot land unnoticed — whichever merges second should resolve to the union `{USES_TYPE, PARAM_TYPE, DATA_FLOWS}`. The other three languages here (Dart, OCaml, SQL) appear in neither #168 nor any other open PR.