### PR TITLE
fix(sem): emit every name a C multi-declarator typedef binds

### DIFF
--- a/internal/sem/c_multi_declarator_typedef_test.go
+++ b/internal/sem/c_multi_declarator_typedef_test.go
@@ -1,0 +1,136 @@
+package sem
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// typeNamesIn returns the sorted names of every `type` symbol in a repository
+// built from one C-family source file.
+func typedefSymbolsFor(t *testing.T, path, source string) (types []string, all []string, snapshot ProviderSnapshot) {
+	t.Helper()
+	repo := t.TempDir()
+	writeFile(t, repo, path, source)
+	snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, symbol := range snapshot.Symbols {
+		all = append(all, symbol.Kind+":"+symbol.Name)
+		if symbol.Kind == "type" {
+			types = append(types, symbol.Name)
+		}
+	}
+	sort.Strings(types)
+	sort.Strings(all)
+	return types, all, snapshot
+}
+
+// A C typedef may bind several names in one declaration. `typedef struct {…}
+// A, B;` is the ordinary way to give a type two names, and `typedef int I1,
+// I2;` is the same shape without a struct.
+//
+// entityFromNode returns a single Entity, and the name it picked came from
+// cFamilyTypedefNameRe, whose `$` anchor can only match the LAST declarator —
+// so every name but one was silently dropped. `A` was not a symbol: search
+// could not find it, and a parameter declared `A a` had no definition to
+// resolve against. The function-pointer form failed in the other direction
+// (the regex matches nothing, so the nodeName fallback kept the FIRST name and
+// dropped the rest), which is why this pins both ends.
+func TestCMultiDeclaratorTypedefEmitsEveryName(t *testing.T) {
+	source := `typedef struct {int v;} A, B;
+typedef int I1, I2;
+typedef struct {int w;} *H1, H2[4];
+typedef int (*F1)(int), (*F2)(int);
+typedef struct Node {int v;} NodeAlias, *NodeP;
+typedef enum {RED, GREEN} C1, C2;
+`
+	// C and C++ share this extraction path; both grammars put every declarator
+	// on a `declarator` field, so both must behave identically.
+	for _, path := range []string{"src/t.c", "src/t.cpp"} {
+		t.Run(path, func(t *testing.T) {
+			types, _, _ := typedefSymbolsFor(t, path, source)
+			counts := map[string]int{}
+			for _, name := range types {
+				counts[name]++
+			}
+			for _, want := range []string{
+				"A", "B", // anonymous struct, two plain declarators
+				"I1", "I2", // no struct at all
+				"H1", "H2", // pointer and array declarators
+				"F1", "F2", // function-pointer declarators
+				"NodeAlias", "NodeP", // tagged struct, plain + pointer
+				"C1", "C2", // anonymous enum
+			} {
+				// Exactly once, not merely present: the primary declarator is
+				// emitted by entityFromNode and must not be emitted a second
+				// time as its own alias.
+				if counts[want] != 1 {
+					t.Errorf("typedef name %q produced %d type symbols, want exactly 1; got types %v", want, counts[want], types)
+				}
+			}
+		})
+	}
+}
+
+// The counterweight: a typedef that binds ONE name must still emit exactly one
+// type symbol. A fix that emitted a symbol per declarator unconditionally, or
+// that stopped deduplicating, would double-count these.
+func TestCSingleDeclaratorTypedefEmitsExactlyOneName(t *testing.T) {
+	source := `typedef unsigned long ULong;
+typedef struct {int z;} Solo;
+typedef struct Tagged {int q;} TaggedAlias;
+typedef int (*Callback)(int);
+`
+	for _, path := range []string{"src/t.c", "src/t.cpp"} {
+		t.Run(path, func(t *testing.T) {
+			types, _, _ := typedefSymbolsFor(t, path, source)
+			counts := map[string]int{}
+			for _, name := range types {
+				counts[name]++
+			}
+			for _, want := range []string{"ULong", "Solo", "TaggedAlias", "Callback"} {
+				if counts[want] != 1 {
+					t.Errorf("single-declarator typedef %q produced %d type symbols, want exactly 1 (types %v)", want, counts[want], types)
+				}
+			}
+		})
+	}
+}
+
+// The names are not just present, they are usable: a parameter declared with a
+// dropped alias now resolves to a definition. This is the reason the missing
+// symbols mattered — before the fix `use_a` had a parameter whose type was
+// invisible to the graph, so no PARAM_TYPE edge could be built for it.
+func TestCMultiDeclaratorTypedefAliasResolvesAsAParameterType(t *testing.T) {
+	source := `typedef struct {int v;} A, B;
+
+int use_a(A a) { return a.v; }
+
+int use_b(B b) { return b.v; }
+`
+	_, _, snapshot := typedefSymbolsFor(t, "src/t.c", source)
+	byID := map[string]SymbolRecord{}
+	for _, symbol := range snapshot.Symbols {
+		byID[symbol.ID] = symbol
+	}
+	seen := map[string]bool{}
+	for _, relation := range snapshot.Relations {
+		if relation.Type != "PARAM_TYPE" {
+			continue
+		}
+		seen[byID[relation.FromID].Name+"->"+byID[relation.ToID].Name] = true
+	}
+	// B was always reachable; A is the one the defect dropped.
+	for _, want := range []string{"use_a->A", "use_b->B"} {
+		if !seen[want] {
+			var got []string
+			for edge := range seen {
+				got = append(got, edge)
+			}
+			sort.Strings(got)
+			t.Errorf("missing PARAM_TYPE %s; got %s", want, strings.Join(got, ", "))
+		}
+	}
+}

--- a/internal/sem/parser.go
+++ b/internal/sem/parser.go
@@ -3401,6 +3401,76 @@ func cFamilyTypedefAliasName(node *sitter.Node, src []byte) string {
 	return name
 }
 
+// cFamilyTypedefDeclaratorNames returns every name a C/C++ typedef binds, in
+// source order. One typedef can declare several — `typedef struct {…} A, B;`
+// is ordinary C, and so are `typedef int I1, I2;` and mixed forms like
+// `typedef struct {…} *H1, H2[4];`. Each declarator is an independent type
+// name that code refers to on its own, so each needs its own symbol.
+//
+// The grammar puts every one of them on a `declarator` field of the
+// type_definition, so this reads the AST rather than extending
+// cFamilyTypedefNameRe, whose `$` anchor can only ever see the last one. The
+// declarator is not always a bare identifier (`*H1`, `H2[4]`, `(*F1)(int)`),
+// so the name comes from firstNameDescendant, which unwraps pointer, array and
+// function declarators alike.
+func cFamilyTypedefDeclaratorNames(node *sitter.Node, src []byte) []string {
+	if !validNode(node) || node.Type() != "type_definition" {
+		return nil
+	}
+	var names []string
+	seen := map[string]bool{}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		if node.FieldNameForChild(i) != "declarator" {
+			continue
+		}
+		name := firstNameDescendant(node.Child(i), src)
+		if name == "" || cFamilyNonFunctionNames[name] || seen[name] {
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	return names
+}
+
+// cFamilyTypedefAliasEntities returns the typedef names entityFromNode did not
+// emit. entityFromNode returns a single Entity, so a multi-declarator typedef
+// kept exactly one name and silently dropped the rest: `typedef struct {int v;}
+// A, B;` produced only `type:B`, so a search for `A` found nothing and a
+// parameter typed `A` had no definition to resolve against.
+//
+// The name entityFromNode chose stays the primary entity — it is what scopes
+// the struct's fields — and these are emitted as its peers, so no existing
+// symbol moves and only the missing names are added.
+func cFamilyTypedefAliasEntities(node *sitter.Node, src []byte, language string, primary Entity) []Entity {
+	if language != "C" && language != "C++" {
+		return nil
+	}
+	if primary.Kind != "type" || !validNode(node) || node.Type() != "type_definition" {
+		return nil
+	}
+	names := cFamilyTypedefDeclaratorNames(node, src)
+	if len(names) < 2 {
+		return nil
+	}
+	block := node.Content(src)
+	var aliases []Entity
+	for _, name := range names {
+		if name == primary.Name {
+			continue
+		}
+		alias := primary
+		alias.Name = name
+		// Recompute rather than copy: for a single-line declaration the
+		// fingerprint is the signature with the entity's own name blanked out,
+		// so sharing the primary's would make every alias look like the same
+		// entity to change detection.
+		alias.Fingerprint = hash(normalize(entityFingerprintSource(Entity{Name: name, Signature: primary.Signature}, block)))
+		aliases = append(aliases, alias)
+	}
+	return aliases
+}
+
 func fastCFamilyEntities(path, content, language string) []Entity {
 	_ = path
 	_ = language
@@ -3695,6 +3765,9 @@ func walkEntitiesScoped(node *sitter.Node, src []byte, language, scope string, i
 			entity.Local = true // nested inside another function
 		}
 		*entities = append(*entities, entity)
+		// A C/C++ typedef can bind several names at once; entityFromNode
+		// returns one entity, so the remaining declarators are emitted here.
+		*entities = append(*entities, cFamilyTypedefAliasEntities(node, src, language, entity)...)
 		if scopesChildren(language, entity.Kind) {
 			childScope = entity.Name
 		}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/140
<!-- entire-trail-link-end -->

This is the residue #179 identified and deliberately left: *"`typedef struct {int v;} A, B;` emits only `type:B` — a typedef with multiple declarators loses every name but the last. Not touched here; it is a different code path (the `type_definition` arm, not the specifier arm) and wants its own change."*

This is that change. It branches off `main`, not #179, and touches a different function, so the two do not conflict.

## The defect

`typedef struct {int v;} A, B;` is the ordinary way to give a C type two names. Only `B` became a symbol. `A` did not exist in the graph at all — a search for it found nothing, and a parameter declared `A a` had no definition to resolve against, so no `PARAM_TYPE` edge could be built for it.

The same shape hits every multi-declarator typedef, with or without a struct:

| source | emitted before | dropped |
|---|---|---|
| `typedef struct {int v;} A, B;` | `type:B` | `A` |
| `typedef int I1, I2;` | `type:I2` | `I1` |
| `typedef struct {int w;} *H1, H2[4];` | `type:H2` | `H1` |
| `typedef struct Node {…} NodeAlias, *NodeP;` | `type:NodeP` | `NodeAlias` |
| `typedef enum {RED, GREEN} C1, C2;` | `type:C2` | `C1` |
| `typedef int (*F1)(int), (*F2)(int);` | `type:F1` | `F2` |

Note the last row fails in the **other direction**. `entityFromNode` returns a single Entity, and the name it chose came from `cFamilyTypedefNameRe`, whose `$` anchor can only ever match the last declarator — except for the function-pointer form, where the regex matches nothing and the `nodeName` fallback keeps the *first* name instead. Either way every name but one is silently lost, so the test pins both ends.

## The fix

The grammar already puts every declarator on a `declarator` field of the `type_definition` node:

```
type_definition "typedef struct {int v;} A, B;"
  child[1] field="type"       struct_specifier
  child[2] field="declarator" type_identifier "A"
  child[4] field="declarator" type_identifier "B"
```

So read them from the AST rather than extending a regex anchored to the end of the text. Declarators are not always bare identifiers (`*H1`, `H2[4]`, `(*F1)(int)`), so names come from `firstNameDescendant`, which already unwraps pointer, array and function declarators — verified identical on both the C and C++ grammars.

**The name `entityFromNode` already chose stays the primary entity** — it is what scopes the struct's fields — and the others are emitted as its peers. No existing symbol moves, changes container, or disappears. The diff is **73 inserted lines and zero deleted**, and no golden fixture moved.

Alias fingerprints are recomputed rather than copied: `entityFingerprintSource` blanks the entity's own name out of the signature for a single-line declaration, so sharing the primary's fingerprint would make every alias look like the same entity to change detection.

## Verification

Three tests, and the third is the one that shows why the missing symbols mattered rather than just that they were missing:

- `TestCMultiDeclaratorTypedefEmitsEveryName` — every name above, run over **both** `.c` and `.cpp`, asserting each appears **exactly once** (not merely present).
- `TestCSingleDeclaratorTypedefEmitsExactlyOneName` — the counterweight: `typedef unsigned long ULong;` and friends must still emit exactly one type symbol, so a fix that emitted per-declarator unconditionally would be caught.
- `TestCMultiDeclaratorTypedefAliasResolvesAsAParameterType` — `int use_a(A a)` now produces `PARAM_TYPE use_a -> A`. Before the fix that edge could not exist.

### Mutations

| mutation | compiles | result |
|---|---|---|
| call site removed (fix reverted) | yes | FAIL — 6 names missing on `.c` and 6 on `.cpp`, plus `missing PARAM_TYPE use_a->A` |
| primary-name dedup removed | yes | FAIL — `B`/`I2`/`H2`/`F1` each produce 2 type symbols |
| C/C++ language guard removed | yes | **not caught** — see below |

The language guard is honestly defensive rather than load-bearing: no other language in the corpus currently has a multi-declarator `type_definition`, so removing it breaks nothing today. It is kept because it matches how every other C-family helper in this file is gated and bounds the blast radius if another grammar starts producing that node.

### Live CLI check

```
$ entire graph symbols --repo . --worktree     # typedef struct {int v;} A, B; + typedef int I1, I2;
   type A     type B     type I1     type I2     struct v     function use_a
$ entire graph edges --repo . --worktree | grep PARAM_TYPE
   use_a -> A
```

## Local gate

CI may not start (the org's Actions billing limit was hit), so this was gated locally:

- `go test ./internal/sem -count=1` — **2806 passed** (2801 on `main` + the 5 new subtests); no golden fixture moved
- `go test ./internal/cli -count=1` — 748 passed
- `go vet ./...` clean, `gofmt -s -l` clean, `go build ./cmd/entire-graph` OK

## Adjacent, not fixed here

`.h` maps to the **C** language spec, so headers are covered by this change. **`.m` (Objective-C) is not**, and it is worse there — it never reaches the C/C++ branch of the `type_definition` arm, so it falls through to `nodeName`:

```
typedef struct {int v;} A, B;   ->  Objective-C  type:v     (a FIELD name; A and B both lost)
typedef int I1, I2;             ->  Objective-C  type:I1    (I2 lost)
```

That is this defect and #179's anonymous-specifier defect at once, on a third code path. Left alone deliberately — it wants its own change, and fixing it here would mean changing Objective-C's primary-name selection too.