### PR TITLE
fix(sem): name an Objective-C typedef by its alias, not by its source

### DIFF
--- a/internal/sem/parser.go
+++ b/internal/sem/parser.go
@@ -3384,6 +3384,19 @@ var cFamilyNonFunctionNames = map[string]bool{
 	"while":   true,
 }
 
+// cFamilyTypedefLanguage reports whether a language's grammar spells a typedef
+// as C does, so that a `type_definition` node's name must be read from its
+// declarator rather than by descending to the first identifier. Objective-C is
+// a strict C superset and shares the node, so it shares the naming rule.
+func cFamilyTypedefLanguage(language string) bool {
+	switch language {
+	case "C", "C++", "Objective-C":
+		return true
+	default:
+		return false
+	}
+}
+
 func cFamilyTypedefAliasName(node *sitter.Node, src []byte) string {
 	text := strings.TrimSpace(stripCodeLiteralsAndComments(node.Content(src)))
 	if !strings.HasPrefix(text, "typedef ") {
@@ -4852,7 +4865,19 @@ func entityFromNode(node *sitter.Node, src []byte, language, scope string) (Enti
 			// *_type_defn child; the generic name descent would instead latch onto
 			// a leading attribute ([<CustomEquality>] type SemVerInfo -> "CustomEquality").
 			name = fsharpTypeName(node, src)
-		} else if (language == "C" || language == "C++") && node.Type() == "type_definition" {
+		} else if cFamilyTypedefLanguage(language) && node.Type() == "type_definition" {
+			// Objective-C belongs here with C and C++: its grammar is a C
+			// superset and emits the same type_definition node. Left out of
+			// this branch it fell through to nodeName, which finds no `name`
+			// field on a typedef and descends to the first identifier in
+			// pre-order — the SOURCE of the alias, never the alias. So every
+			// Objective-C typedef was published under the wrong name:
+			// `typedef struct {int v;} A, B;` became `type:v` (a field),
+			// `typedef struct Node {int q;} NodeAlias;` became `type:Node`
+			// (the tag), `typedef enum {RED, GREEN} Color;` became `type:RED`
+			// (an enum constant), and `typedef NSInteger MyInt;` became
+			// `type:NSInteger` — a phantom definition of a framework type this
+			// file does not define, while `MyInt` was not a symbol at all.
 			if alias := cFamilyTypedefAliasName(node, src); alias != "" {
 				name = alias
 			} else {

--- a/internal/sem/parser_objc_typedef_test.go
+++ b/internal/sem/parser_objc_typedef_test.go
@@ -1,0 +1,81 @@
+package sem
+
+import (
+	"sort"
+	"testing"
+)
+
+// Objective-C's grammar is a C superset, so a typedef parses to the same
+// `type_definition` node C uses. entityFromNode's naming branch for that node
+// was gated to C and C++ only, so Objective-C fell through to nodeName —
+// which finds no `name` field on a typedef and descends to the first
+// identifier in pre-order. That identifier is always part of the type being
+// aliased, never the alias, so every Objective-C typedef was published under
+// a name that belongs to something else:
+//
+//	typedef struct {int v;} A, B;          -> type:v          (a field)
+//	typedef struct Node {int q;} NodeAlias; -> type:Node      (the struct tag)
+//	typedef enum {RED, GREEN} Color;        -> type:RED       (an enum constant)
+//	typedef NSInteger MyInt;                -> type:NSInteger (a framework type)
+//
+// Both directions are wrong. The declared name is not a symbol, so searching
+// for it finds nothing and a declaration using it has no definition to resolve
+// against; and the name that IS emitted is a phantom definition pointing at
+// the typedef line — for `MyInt` the graph claimed this file defines
+// `NSInteger`, a type it only mentions.
+//
+// C parses the identical source correctly, so the fix is parity: the C naming
+// rule covers Objective-C. This asserts name-by-name rather than on the whole
+// symbol set, so it stays orthogonal to the anonymous-specifier and
+// multi-declarator work on the same node.
+func TestObjCTypedefIsNamedByItsAliasNotItsSource(t *testing.T) {
+	source := `typedef struct {int v;} A, B;
+typedef struct {int w;} P;
+typedef struct Node {int q;} NodeAlias;
+typedef enum {RED, GREEN} Color;
+typedef NSInteger MyInt;
+typedef int I1;
+typedef unsigned long long ULL;
+typedef void (^Handler)(int);
+typedef int (*FnPtr)(int);
+`
+	// The declared names the typedefs above bind. `A` is deliberately absent:
+	// a multi-declarator typedef keeping only its last name is a separate
+	// defect on this node, shared with C.
+	wantTypes := []string{"B", "P", "NodeAlias", "Color", "MyInt", "I1", "ULL", "Handler", "FnPtr"}
+	// Names that appear in the source but name the aliased type, not the
+	// alias. None may be emitted as a `type`.
+	wantAbsentTypes := []string{"v", "w", "q", "Node", "RED", "GREEN", "NSInteger"}
+
+	// C is the control: it already reports this source correctly, and
+	// Objective-C must not diverge from it.
+	for _, path := range []string{"src/typedefs.m", "src/typedefs.c"} {
+		t.Run(path, func(t *testing.T) {
+			repo := t.TempDir()
+			writeFile(t, repo, path, source)
+			snapshot, err := BuildProviderSnapshot(t.Context(), repo, "test-version")
+			if err != nil {
+				t.Fatal(err)
+			}
+			types := map[string]bool{}
+			var all []string
+			for _, symbol := range snapshot.Symbols {
+				all = append(all, symbol.Kind+":"+symbol.Name)
+				if symbol.Kind == "type" {
+					types[symbol.Name] = true
+				}
+			}
+			sort.Strings(all)
+			for _, name := range wantTypes {
+				if !types[name] {
+					t.Errorf("typedef %q is not a type symbol; got %#v", name, all)
+				}
+			}
+			for _, name := range wantAbsentTypes {
+				if types[name] {
+					t.Errorf("%q is part of an aliased type, not a typedef name, but was emitted as a type; got %#v", name, all)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/141
<!-- entire-trail-link-end -->

Objective-C's grammar is a C superset, so a typedef parses to the same
`type_definition` node C uses. `entityFromNode`'s naming branch for that node was
gated to C and C++ only, so Objective-C fell through to `nodeName` — which finds
no `name` field on a typedef and descends to the first identifier in pre-order.
That identifier always belongs to the type being aliased, never to the alias.

Measured on `origin/main`, the same source in a `.c` and a `.m` file:

| source | `.c` | `.m` (before) | `.m` (after) |
|---|---|---|---|
| `typedef struct {int v;} A, B;` | `type:B` | `type:v` — a field | `type:B` |
| `typedef struct {int w;} P;` | `type:P` | `type:w` — a field | `type:P` |
| `typedef struct Node {int q;} NodeAlias;` | `type:NodeAlias` | `type:Node` — the tag | `type:NodeAlias` |
| `typedef enum {RED, GREEN} Color;` | `type:Color` | `type:RED` — an enum constant | `type:Color` |
| `typedef NSInteger MyInt;` | `type:MyInt` | `type:NSInteger` — a framework type | `type:MyInt` |

Both directions are wrong. The declared name was not a symbol at all, so a search
for it found nothing and a declaration using it had no definition to resolve
against. And the name that *was* emitted is a phantom definition sitting on the
typedef line: for `MyInt` the graph claimed this file defines `NSInteger`, a type
it only mentions — so "where is `NSInteger` defined?" answered with an unrelated
alias in the user's own repo.

C parses the identical source correctly, so the fix is parity. The language set
moves into `cFamilyTypedefLanguage` and Objective-C joins it. No other behaviour
changes: `.c` and `.cpp` output is byte-identical, and the forms the alias regex
cannot match (`typedef void (^Handler)(int);`, `typedef int (*FnPtr)(int);`) keep
their existing `nodeName` fallback, which already named them correctly.

Objective-C++ (`.mm`) is inventory-only and unaffected.

## Test

`TestObjCTypedefIsNamedByItsAliasNotItsSource` builds a provider snapshot from one
file of typedefs, run twice: once as `.m`, once as `.c` as the control. It asserts
name by name — every alias is present as a `type`, and no field, tag, enum
constant or aliased-type name is — rather than on the whole symbol set, so it
stays orthogonal to the other open work on this node.

## Verification (local — see note below)

- New test fails on `origin/main`, passes with the fix.
- Mutation, both compiling:
  - drop `"Objective-C"` from `cFamilyTypedefLanguage` → 10 assertion failures, `.m` subtest fails. Caught.
  - drop `"C", "C++"` from it → `.c` control subtest fails, `.m` passes. Caught.
- Full `go test ./internal/sem/` green (75s), `gofmt -s`, `go vet ./internal/sem/`, `go build ./cmd/entire-graph` all clean.

CI may not start on this PR — the Actions billing limit was reached on 2026-08-29.
A red or missing check should be read as "the workflow could not run", not as a
failure. The gate above was run locally.

## Relationship to the other open work on this node

Independent of, and non-overlapping with, both:

- **#182** (multi-declarator typedefs) adds a new function and a call site in
  `walkEntitiesScoped`; this changes the language gate in `entityFromNode`.
  Different hunks, no textual conflict. Note for #182: its
  `cFamilyTypedefAliasEntities` carries its own `language != "C" && language != "C++"`
  gate, so once both land Objective-C will still keep only the last declarator of
  `typedef struct {…} A, B;`. Adopting `cFamilyTypedefLanguage` there on rebase
  closes that remaining gap. This PR deliberately leaves it alone — `A` is absent
  in C on main today too, so it is #182's finding, not this one's. The test here
  asserts `B` present and `v` absent, and stays green either way.
- **#179** (anonymous specifiers) suppresses the `struct_specifier` /
  `enum_specifier` entity. It does not touch `type_definition`, so it does not
  cover this: with #179 applied the bogus `struct:v` goes away but `type:v`
  remains. This test asserts only on `type` symbols, so it is unaffected by #179
  landing.
