### PR TITLE
docs: adopt the session before committing from a scratch worktree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,37 @@ mise run check   # fmt + vet + race tests + build
 
 Contract rules that must not break: schema `1.x` is frozen and additive-only (`docs/adr/0001-ga-schema-contract.md`); the provider is **no-egress** (never add remote fetches, hosted API calls, telemetry, or runtime grammar downloads); `compound-v1` symbol IDs must stay stable across ordinary edits; unsupported/unparseable files must surface as machine-readable partial failures, never silent drops. All logic lives under `internal/` (`sem` = parsing/graph/search, `cli` = hand-rolled dispatch, `gitutil` = git subprocess); `cmd/entire-graph/main.go` is a thin entry point. The plugin manifest (`entire-plugin.yml`) registers the subcommand `graph`, so users type `entire graph ...`. This project was **previously named `entire-sem`** — do not reintroduce the old name. **Entire Brain** (`entire-brain`) is the separate downstream consumer of this provider's NDJSON — not an old name for this project.
 
+### Working in a scratch worktree: adopt the session first
+
+Entire binds an agent session to the worktree it started in, and links a commit to
+that session through a `Entire-Checkpoint:` trailer added by its git hooks. Commits
+made in a DIFFERENT worktree are not linked: no checkpoint, no trailer, and the
+work is absent from `entire checkpoint list` even though the hooks are healthy and
+`entire doctor` reports nothing wrong.
+
+That is easy to hit precisely because reviewing a pull request should happen in a
+scratch worktree rather than the primary one. Before the first commit in it, run
+from inside the scratch worktree:
+
+```sh
+entire session adopt <session-id> --from /path/to/primary/worktree
+```
+
+`entire session current` shows the id, and `entire session info <id>` shows which
+worktree a session is bound to and how many checkpoints it has. A session that has
+made commits but reports `Checkpoints: 0` is the symptom.
+
+If it is already too late, `entire session attach <session-id>` builds a checkpoint
+from the transcript and links it to the last commit. Two cautions:
+
+- It attaches to the last commit **of the current branch**, so make sure that
+  branch is up to date first. A primary worktree that has only ever fetched still
+  points at whatever it was on when the session started.
+- Do not pass `--force` on a branch whose tip is already pushed: that flag amends
+  the last commit to add the trailer, which rewrites published history. Without it
+  the checkpoint is still created and the trailer is printed to paste into a later
+  commit instead.
+
 <!-- entire-graph:begin -->
 This repo has the entire-graph code graph installed. Before exploring code with
 grep/find/whole-file reads, read .entire/graph-agent.md — resolution-first guidance


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/143
<!-- entire-trail-link-end -->

## Problem

Entire binds an agent session to the worktree it started in, and links a commit to that session through the `Entire-Checkpoint:` trailer its git hooks add. Commits made in a **different** worktree are not linked — no checkpoint, no trailer, and the work missing from `entire checkpoint list`.

Nothing fails loudly. `entire doctor` reports hooks OK, the metadata branch stays in sync with origin, and `git push` even prints `[entire] Pushing entire/checkpoints/v1 to origin.... done`. The only visible symptom is a session with commits behind it and `Checkpoints: 0`.

It went unnoticed here for seven commits across three merged pull requests. The trailers cannot be added retroactively, because those commits are on `main` and stamping them would rewrite published history.

## Why it is easy to hit

Reviewing a pull request belongs in a scratch worktree rather than the primary one. Following that advice is exactly what breaks the capture, so the two pieces of guidance quietly work against each other unless the session is adopted first:

```sh
entire session adopt <session-id> --from /path/to/primary/worktree
```

One command, before the first commit in the scratch worktree.

## Also documented: the recovery path, and its two traps

`entire session attach <session-id>` builds a checkpoint from the transcript when it is already too late. Both ways it can go wrong are recorded, because both were hit while writing this:

- It attaches to the last commit **of the current branch**. A primary worktree that has only ever fetched still points at whatever it was on when the session started — here that was the commit the session *began* from, which would have linked the session to work that predates it.
- `--force` amends that commit to add the trailer. On a branch whose tip is already pushed, that rewrites published history. Without the flag the checkpoint is still created and the trailer is printed to paste into a later commit.

## Verification

This PR's own commit carries `Entire-Checkpoint: effc0f5849d5`, and `entire checkpoint list` now resolves it:

```
● effc0f5849d5  "Review PR 167\n\n## 0. Ground rules..."
  08-30 07:51 (8d2138a) docs: adopt the session before committing from a scratch worktree
```

Documentation only — no code, no test surface touched. The generated `entire-graph:begin/end` block at the end of AGENTS.md is untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to AGENTS.md; no runtime, schema, or test surface affected.
> 
> **Overview**
> Adds a **Working in a scratch worktree** subsection to `AGENTS.md` so agents know Entire ties sessions and `Entire-Checkpoint:` trailers to the worktree where the session started—commits from another worktree (e.g. a PR review checkout) can look healthy in `entire doctor` but show **Checkpoints: 0** and never appear in `entire checkpoint list`.
> 
> The new guidance tells readers to run **`entire session adopt <session-id> --from /path/to/primary/worktree`** before the first commit in the scratch tree, and points to **`entire session current`** / **`entire session info`** for diagnosis. It also documents **`entire session attach`** as recovery, including warnings about attaching to the branch tip (stale primary worktrees) and avoiding **`--force`** on already-pushed tips because it amends history.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d2138a10a3d4bc7c5b3b1c9a88660ced1c78827. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->