### PR TITLE
ci: build a nightly release the way cli does

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,51 @@
+name: nightly
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # 06:00 UTC daily
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  nightly-tag:
+    name: tag and release
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Create nightly tag
+        id: tag
+        run: |
+          set -euo pipefail
+          TAG=$(scripts/create-nightly-tag.sh) && EXIT=0 || EXIT=$?
+          if [ "$EXIT" -eq 2 ]; then
+            echo "Skipping — HEAD already has a nightly tag."
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            exit 0
+          elif [ "$EXIT" -ne 0 ] || [ -z "$TAG" ]; then
+            echo "::error::Failed to generate nightly tag"
+            exit 1
+          fi
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      # A tag pushed with GITHUB_TOKEN does not trigger `on: push: tags`, so
+      # dispatch the release explicitly. Dispatching with --ref <tag> sets
+      # github.ref to refs/tags/<tag>, which is what release.yml's publish job
+      # requires.
+      - name: Build and publish the release for that tag
+        if: steps.tag.outputs.tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG"

--- a/scripts/create-nightly-tag.sh
+++ b/scripts/create-nightly-tag.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Calculate the next nightly tag from the latest stable tag and HEAD.
+# Prints the tag to stdout. Exits 2 (not an error) when HEAD already has one.
+#
+# Tag format: v<major>.<minor>.<patch+1>-nightly.<YYYYMMDDhhmm>.<short-commit>
+# Usage: scripts/create-nightly-tag.sh
+
+SHORT_COMMIT=$(git rev-parse --short HEAD)
+
+if git tag -l "v*-nightly.*.${SHORT_COMMIT}" | grep -q .; then
+  echo "Nightly tag already exists for commit ${SHORT_COMMIT}, skipping." >&2
+  exit 2
+fi
+
+LATEST_STABLE=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*-*' 2>/dev/null || true)
+if [ -z "$LATEST_STABLE" ]; then
+  echo "::error::No stable version tag found" >&2
+  exit 1
+fi
+
+MAJOR=$(echo "$LATEST_STABLE" | sed 's/^v//' | cut -d. -f1)
+MINOR=$(echo "$LATEST_STABLE" | sed 's/^v//' | cut -d. -f2)
+PATCH=$(echo "$LATEST_STABLE" | sed 's/^v//' | cut -d. -f3)
+NEXT_PATCH=$((PATCH + 1))
+
+DATE=$(TZ=UTC0 date +%Y%m%d%H%M)
+TAG="v${MAJOR}.${MINOR}.${NEXT_PATCH}-nightly.${DATE}.${SHORT_COMMIT}"
+
+if git rev-parse "${TAG}" >/dev/null 2>&1; then
+  echo "Tag ${TAG} already exists, skipping." >&2
+  exit 2
+fi
+
+echo "${TAG}"


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/144
<!-- entire-trail-link-end -->

entire-graph had no nightly build. cli tags a nightly at 06:00 UTC and lets `release.yml` build it; graph's `release.yml` already listens on `v*` and its publish job gates on `refs/tags/`, so the only missing piece was the tag.

## What this adds

- **`scripts/create-nightly-tag.sh`** — mirrors cli's: bump the latest stable tag's patch, stamp `-nightly.<UTCstamp>.<short-sha>`, exit 2 (a skip, not a failure) when HEAD already carries one. Verified live: `v0.4.0` → `v0.4.1-nightly.202608301815.c5620ed6`, and a second run on the same commit exits 2.
- **`.github/workflows/nightly.yml`** — 06:00 UTC daily plus `workflow_dispatch`.

## The one departure from cli, and why

cli pushes its tag with a **GitHub App token**, because a tag pushed with the default `GITHUB_TOKEN` does **not** trigger `on: push: tags`. That app is scoped to `cli` (`repositories: cli`), and `entire-graph` has no repo secrets — so copying cli's shape verbatim would have produced a tag that silently never built.

Instead this pushes the tag and then dispatches the release explicitly:

```
gh workflow run release.yml --ref "$TAG"
```

Dispatching with `--ref <tag>` sets `github.ref` to `refs/tags/<tag>`, which is precisely what `release.yml`'s `publish` job requires (`if: startsWith(github.ref, 'refs/tags/')`). No app, no PAT, no new secret.

## Not claimed

The end-to-end path has not been exercised — the first real run is the proof. If the dispatch turns out not to satisfy the publish gate, the fallback is the app-token approach, which needs the app granted access to `entire-graph`.