### PR TITLE
fix(sem): scope Julia module bare calls

### DIFF
--- a/internal/sem/julia_bindings.go
+++ b/internal/sem/julia_bindings.go
@@ -1,0 +1,133 @@
+package sem
+
+import (
+	"context"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// juliaLocalBindingNames returns every name that Julia's syntax binds inside
+// one callable. The same-container CALLS fallback is intentionally fail-closed:
+// a parse failure returns nil, which disables that fallback for the callable.
+func juliaLocalBindingNames(source string) map[string]struct{} {
+	sourceBytes := []byte(source)
+	headerSource := maskJuliaLiteralsAndComments(source)
+	spec, ok := languageForPath("scope.jl")
+	if !ok {
+		return nil
+	}
+	parser := sitter.NewParser()
+	defer parser.Close()
+	parser.SetLanguage(spec.grammar)
+	ctx, cancel := context.WithTimeout(context.Background(), treeSitterParseTimeout)
+	defer cancel()
+	tree, err := parser.ParseCtx(ctx, nil, sourceBytes)
+	if tree != nil {
+		defer tree.Close()
+	}
+	if err != nil || ctx.Err() != nil || tree == nil {
+		return nil
+	}
+	root := tree.RootNode()
+	if !validNode(root) || root.HasError() {
+		return nil
+	}
+
+	type walkItem struct {
+		node    *sitter.Node
+		binding bool
+	}
+	bindings := map[string]struct{}{}
+	stack := []walkItem{{node: root}}
+	pushChildren := func(node *sitter.Node, start int, binding func(int, *sitter.Node) bool) {
+		for i := int(node.NamedChildCount()) - 1; i >= start; i-- {
+			child := node.NamedChild(i)
+			stack = append(stack, walkItem{node: child, binding: binding != nil && binding(i, child)})
+		}
+	}
+	for len(stack) > 0 {
+		item := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		node := item.node
+		if !validNode(node) {
+			continue
+		}
+		if item.binding {
+			switch node.Type() {
+			case "identifier":
+				if name := strings.TrimSpace(node.Content(sourceBytes)); name != "" {
+					bindings[name] = struct{}{}
+				}
+				continue
+			case "typed_expression":
+				stack = append(stack, walkItem{node: node.NamedChild(0), binding: true})
+				continue
+			case "argument_list", "open_tuple", "parenthesized_expression", "splat_expression", "tuple_expression":
+				pushChildren(node, 0, func(int, *sitter.Node) bool { return true })
+				continue
+			}
+		}
+		switch node.Type() {
+		case "assignment", "compound_assignment_expression", "for_binding", "let_binding":
+			pushChildren(node, 1, nil)
+			stack = append(stack, walkItem{node: node.NamedChild(0), binding: true})
+			continue
+		case "catch_clause", "let_statement":
+			keyword := strings.TrimSuffix(node.Type(), "_statement")
+			keyword = strings.TrimSuffix(keyword, "_clause")
+			headerEnd := juliaHeaderBindingEnd(node, headerSource, keyword)
+			pushChildren(node, 0, func(_ int, child *sitter.Node) bool {
+				return int(child.StartByte()) < headerEnd
+			})
+			continue
+		case "local_statement":
+			pushChildren(node, 0, func(_ int, child *sitter.Node) bool {
+				return child.Type() != "assignment" && child.Type() != "compound_assignment_expression"
+			})
+			continue
+		case "do_clause", "arrow_function_expression":
+			pushChildren(node, 1, nil)
+			stack = append(stack, walkItem{node: node.NamedChild(0), binding: true})
+			continue
+		}
+		pushChildren(node, 0, nil)
+	}
+	return bindings
+}
+
+// juliaHeaderBindingEnd separates comma-continued catch/let headers from
+// their flattened bodies. Literal/comment masking makes delimiters in comments
+// harmless while preserving tree-sitter byte offsets.
+func juliaHeaderBindingEnd(node *sitter.Node, source, keyword string) int {
+	cursor := int(node.StartByte()) + len(keyword)
+	headerEnd := 0
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		child := node.NamedChild(i)
+		if strings.Contains(child.Type(), "comment") {
+			continue
+		}
+		start := int(child.StartByte())
+		if cursor < 0 || cursor > start || start > len(source) {
+			break
+		}
+		gap := source[cursor:start]
+		if headerEnd == 0 {
+			if strings.ContainsAny(gap, ";\r\n") {
+				break
+			}
+		} else {
+			comma := strings.IndexByte(gap, ',')
+			semicolon := strings.IndexByte(gap, ';')
+			if comma < 0 || semicolon >= 0 && semicolon < comma {
+				break
+			}
+		}
+		headerEnd = int(child.EndByte())
+		cursor = headerEnd
+		if keyword == "catch" {
+			break
+		}
+	}
+	return headerEnd
+}

--- a/internal/sem/language_matrix_test.go
+++ b/internal/sem/language_matrix_test.go
@@ -102,21 +102,7 @@ var languageMatrix = []languageFixture{
 	{dir: "hcl", symbols: []string{"block:region", "block:ledger", "block:ledger_bucket"}, relations: []string{"DEFINES", "CONFIGURES", "RESOURCE_DEPENDS_ON"}},
 	{dir: "java", symbols: []string{"class:Ledger", "field:total", "method:add", "method:ledgerDouble"}, relations: []string{"DEFINES", "CONTAINS", "CALLS", "CONSTRUCTS"}},
 	{dir: "javascript", symbols: []string{"class:Ledger", "method:constructor", "method:add", "function:ledgerDouble"}, relations: []string{"DEFINES", "CONTAINS", "CALLS", "CONSTRUCTS"}},
-	{
-		dir:     "julia",
-		symbols: []string{"module:Ledgers", "struct:Ledger", "method:add", "method:double"},
-		// Idiomatic Julia wraps a package in `module ... end`, which makes every
-		// definition module-qualified and therefore emitted as a method. Bare
-		// `add(...)` — Julia's only call syntax — is excluded from resolving to a
-		// method, so a module-scoped package produces no same-file CALLS.
-		relations: []string{"DEFINES", "CONTAINS", "CONSTRUCTS", "PARAM_TYPE", "USES_TYPE"},
-		callsGap:  "a Julia definition inside `module ... end` is emitted as a method, and bare calls are barred from resolving to methods",
-		// The whole gap reduces to one rule: bare-call resolution skips method
-		// targets for Julia. Reading it here rather than restating its
-		// consequence means the fix that admits Julia retires this entry on its
-		// own, and that a wrong diagnosis is caught instead of recorded.
-		callsGapHolds: func(languageMatrixResult) bool { return !nameCallMayTargetMethod("Julia") },
-	},
+	{dir: "julia", symbols: []string{"module:Ledgers", "struct:Ledger", "method:add", "method:double"}, relations: []string{"DEFINES", "CONTAINS", "CALLS", "CONSTRUCTS", "PARAM_TYPE", "USES_TYPE"}},
 	{dir: "kotlin", symbols: []string{"class:Ledger", "field:total", "method:add", "function:ledgerDouble"}, relations: []string{"DEFINES", "CONTAINS", "CALLS", "CONSTRUCTS"}},
 	{dir: "lua", symbols: []string{"function:new", "function:add", "function:ledger_double"}, relations: []string{"DEFINES", "CALLS"}},
 	{

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -2042,6 +2042,58 @@ func nameCallMayTargetMethod(lang string) bool {
 	return implicitReceiverLanguage(lang) || lang == "Rust"
 }
 
+// resolveJuliaSameContainerMethodCallTargets is a conservative fallback for
+// module-scoped Julia definitions, which the parser represents as methods.
+// found distinguishes "no module candidate" from ambiguous overloads, while
+// blocked prevents a shadowed name from falling through to an external edge.
+func resolveJuliaSameContainerMethodCallTargets(name string, from SymbolRecord, sameFile []SymbolRecord) (targets []resolvedCallTarget, found, blocked bool) {
+	if from.Language != "Julia" || from.Kind != "method" || from.Local || from.ContainerID == "" {
+		return nil, false, false
+	}
+	parameters := symbolFlowParameterNames(from)
+	if !from.parameterNamesKnown {
+		// A short-form signature includes its RHS; stop at the first balanced
+		// argument list so calls on the RHS are not mistaken for parameters.
+		if open := strings.Index(from.Signature, "("); open >= 0 {
+			if close := matchingParen(from.Signature, open); close > open {
+				parameters = parameterNames(from.Signature[:close+1])
+			}
+		}
+	}
+	if parameters[name] {
+		return nil, true, true
+	}
+	hasNestedCallable := false
+	for _, to := range sameFile {
+		if to.ID != from.ID && to.FilePath == from.FilePath && to.Local && callableTargetKind(to.Kind) &&
+			from.StartLine <= to.StartLine && to.EndLine <= from.EndLine {
+			hasNestedCallable = true
+		}
+		if to.ID == from.ID || to.FilePath != from.FilePath || to.Language != from.Language || to.Name != name ||
+			to.Kind != "method" || to.ContainerID != from.ContainerID || !localReachable(from, to) {
+			continue
+		}
+		found = true
+		if to.Local {
+			return nil, true, true
+		}
+		targets = append(targets, resolvedCallTarget{
+			SymbolRecord: to,
+			Confidence:   0.92,
+			Reason:       "direct Julia call expression resolved to same-container symbol",
+			Resolution:   "exact",
+			Scope:        "file",
+		})
+	}
+	if hasNestedCallable {
+		return nil, false, false
+	}
+	if len(targets) != 1 {
+		return nil, found, false
+	}
+	return targets, true, false
+}
+
 func resolveCallTargets(name string, from SymbolRecord, candidates, sameFile []SymbolRecord, importsByName map[string][]string, allowMethodTargets bool) []resolvedCallTarget {
 	var local []resolvedCallTarget
 	for _, to := range sameFile {
@@ -3392,7 +3444,7 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 				return
 			}
 			block := symbolBlockFromLines(lines, from)
-			if file.Language == "JavaScript" || file.Language == "TypeScript" {
+			if file.Language == "JavaScript" || file.Language == "TypeScript" || file.Language == "Julia" {
 				if exact, ok := exactSymbolSource(content, from); ok {
 					block = exact
 				}
@@ -3582,6 +3634,7 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 						continue
 					}
 					var targets []resolvedCallTarget
+					suppressExternal := false
 					if _, namespaceCall := jsNamespaceCalls[name]; namespaceCall {
 						// Same-file namespace members first, then members of a
 						// merged same-file value declaration, then the terminal-name
@@ -3595,6 +3648,16 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 						})
 					} else {
 						targets = resolveCallTargets(name, from, symbolsByShortName[name], currentFileSymbols, callImportsByName, false)
+						juliaTargets, found, blocked := resolveJuliaSameContainerMethodCallTargets(name, from, currentFileSymbols)
+						genericSameContainerType := len(targets) == 1 && typeLikeKind(targets[0].Kind) &&
+							targets[0].FilePath == from.FilePath && targets[0].ContainerID == from.ContainerID
+						if blocked {
+							targets = nil
+							suppressExternal = true
+						} else if found && !genericSameContainerType {
+							targets = juliaTargets
+							suppressExternal = len(juliaTargets) == 0
+						}
 					}
 					for _, to := range targets {
 						// A bare identifier passed as an argument may be a callback, but
@@ -3663,7 +3726,7 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 							continue
 						}
 					}
-					if len(targets) == 0 {
+					if len(targets) == 0 && !suppressExternal {
 						for _, relation := range importedExternalCallRelationsForName(from, name, callImportsByName[name]) {
 							emit(relation)
 						}

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -2067,7 +2067,9 @@ func resolveJuliaSameContainerMethodCallTargets(name string, from SymbolRecord, 
 		return nil, true, true
 	}
 	if _, shadowed := localBindings[name]; shadowed {
-		return nil, true, true
+		// Decline only this additive Julia-method fallback. Existing generic
+		// targets and external resolution must retain their pre-PR behavior.
+		return nil, false, false
 	}
 	hasNestedCallable := false
 	for _, to := range sameFile {

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -2046,8 +2046,11 @@ func nameCallMayTargetMethod(lang string) bool {
 // module-scoped Julia definitions, which the parser represents as methods.
 // found distinguishes "no module candidate" from ambiguous overloads, while
 // blocked prevents a shadowed name from falling through to an external edge.
-func resolveJuliaSameContainerMethodCallTargets(name string, from SymbolRecord, sameFile []SymbolRecord) (targets []resolvedCallTarget, found, blocked bool) {
+func resolveJuliaSameContainerMethodCallTargets(name string, from SymbolRecord, sameFile []SymbolRecord, localBindings map[string]struct{}) (targets []resolvedCallTarget, found, blocked bool) {
 	if from.Language != "Julia" || from.Kind != "method" || from.Local || from.ContainerID == "" {
+		return nil, false, false
+	}
+	if localBindings == nil {
 		return nil, false, false
 	}
 	parameters := symbolFlowParameterNames(from)
@@ -2061,6 +2064,9 @@ func resolveJuliaSameContainerMethodCallTargets(name string, from SymbolRecord, 
 		}
 	}
 	if parameters[name] {
+		return nil, true, true
+	}
+	if _, shadowed := localBindings[name]; shadowed {
 		return nil, true, true
 	}
 	hasNestedCallable := false
@@ -3507,8 +3513,12 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 				callNames := callLikeIdentifiers(callBlock, file.Language)
 				jsCallableArgumentOnly := map[string]bool{}
 				jsNamespaceCalls := map[string]struct{}{}
+				var juliaLocalBindings map[string]struct{}
 				if file.Language == "Julia" {
 					callNames = juliaCallIdentifiers(callBlock)
+					if len(callNames) > 0 && from.Kind == "method" && !from.Local && from.ContainerID != "" {
+						juliaLocalBindings = juliaLocalBindingNames(callBlock)
+					}
 				}
 				if file.Language == "Rust" {
 					for name := range rustTurbofishCallIdentifiers(callBlock) {
@@ -3648,7 +3658,7 @@ func forEachRelation(repoKey string, files []FileRecord, recordsByFile map[strin
 						})
 					} else {
 						targets = resolveCallTargets(name, from, symbolsByShortName[name], currentFileSymbols, callImportsByName, false)
-						juliaTargets, found, blocked := resolveJuliaSameContainerMethodCallTargets(name, from, currentFileSymbols)
+						juliaTargets, found, blocked := resolveJuliaSameContainerMethodCallTargets(name, from, currentFileSymbols, juliaLocalBindings)
 						genericSameContainerType := len(targets) == 1 && typeLikeKind(targets[0].Kind) &&
 							targets[0].FilePath == from.FilePath && targets[0].ContainerID == from.ContainerID
 						if blocked {

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12746,6 +12746,7 @@ func TestJuliaSameContainerMethodCallTargetsFailClosed(t *testing.T) {
 		wantBlocked bool
 	}{
 		{name: "unique same-container target", candidates: []SymbolRecord{target}, wantID: target.ID, wantFound: true},
+		{name: "local binding blocks resolution", candidates: []SymbolRecord{target}, wantFound: true, wantBlocked: true},
 		{name: "sibling module", candidates: []SymbolRecord{func() SymbolRecord { s := target; s.ContainerID = "module-b"; return s }()}},
 		{name: "different file", candidates: []SymbolRecord{func() SymbolRecord { s := target; s.FilePath = "src/other.jl"; return s }()}},
 		{name: "different language", candidates: []SymbolRecord{func() SymbolRecord { s := target; s.Language = "Java"; return s }()}},
@@ -12756,7 +12757,11 @@ func TestJuliaSameContainerMethodCallTargetsFailClosed(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			targets, found, blocked := resolveJuliaSameContainerMethodCallTargets("target", from, tt.candidates)
+			bindings := map[string]struct{}{}
+			if tt.name == "local binding blocks resolution" {
+				bindings["target"] = struct{}{}
+			}
+			targets, found, blocked := resolveJuliaSameContainerMethodCallTargets("target", from, tt.candidates, bindings)
 			if found != tt.wantFound || blocked != tt.wantBlocked {
 				t.Fatalf("found, blocked = %v, %v; want %v, %v", found, blocked, tt.wantFound, tt.wantBlocked)
 			}
@@ -12770,6 +12775,115 @@ func TestJuliaSameContainerMethodCallTargetsFailClosed(t *testing.T) {
 				t.Fatalf("targets = %#v, want only %q", targets, tt.wantID)
 			}
 		})
+	}
+}
+
+func TestJuliaModuleCallResolutionRejectsLocalBindingShadows(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "src/bindings.jl", `
+module Bound
+helper() = 1
+plain(callback) = (helper = callback; helper())
+function looped(callbacks)
+    for helper in callbacks
+        helper()
+    end
+end
+function caught(callback)
+    try
+        callback()
+    catch helper
+        helper()
+    end
+end
+function lexical(callback)
+    let helper = callback
+        helper()
+    end
+end
+function destructured(callbacks)
+    local (helper::Function, other...) = callbacks
+    helper()
+end
+function closure(callback)
+    map([callback]) do helper
+        helper()
+    end
+end
+function generated(callbacks)
+    [helper() for helper in callbacks]
+end
+function multi_let(callback)
+    let unrelated = callback, helper = callback
+        helper()
+    end
+end
+function multiline_let()
+    let unrelated,
+        helper
+        helper()
+    end
+end
+function commented_let(callback)
+    let #= header comment =# helper = callback
+        helper()
+    end
+end
+function control()
+    unrelated = identity
+    helper()
+end
+function bare_let()
+    let
+        helper
+        helper()
+    end
+end
+function bare_catch()
+    try
+        error()
+    catch
+        helper
+        helper()
+    end
+end
+function inline_let()
+    let; helper; helper(); end
+end
+function inline_catch()
+    try
+    catch; helper; helper(); end
+end
+end
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	helper := symbolByKindAndName(snapshot.Symbols, "method", "Bound.helper")
+	if helper.ID == "" {
+		t.Fatalf("missing Bound.helper: %#v", snapshot.Symbols)
+	}
+	for _, name := range []string{"plain", "looped", "caught", "lexical", "destructured", "closure", "generated", "multi_let", "multiline_let", "commented_let"} {
+		caller := symbolByKindAndName(snapshot.Symbols, "method", "Bound."+name)
+		if caller.ID == "" {
+			t.Fatalf("missing Bound.%s: %#v", name, snapshot.Symbols)
+		}
+		for _, relation := range snapshot.Relations {
+			if relation.Type == "CALLS" && relation.FromID == caller.ID && relation.ToID == helper.ID {
+				t.Fatalf("local binding in Bound.%s resolved to module helper: %#v", name, relation)
+			}
+		}
+	}
+	for _, name := range []string{"control", "bare_let", "bare_catch", "inline_let", "inline_catch"} {
+		caller := symbolByKindAndName(snapshot.Symbols, "method", "Bound."+name)
+		callsHelper := false
+		for _, relation := range snapshot.Relations {
+			callsHelper = callsHelper || relation.Type == "CALLS" && relation.FromID == caller.ID && relation.ToID == helper.ID
+		}
+		if !callsHelper {
+			t.Fatalf("non-shadowing Bound.%s lost its call to Bound.helper: %#v", name, relationsOfType(snapshot.Relations, "CALLS"))
+		}
 	}
 }
 

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12734,6 +12734,139 @@ end
 	}
 }
 
+func TestJuliaSameContainerMethodCallTargetsFailClosed(t *testing.T) {
+	from := SymbolRecord{ID: "caller", Kind: "method", Name: "caller", FilePath: "src/app.jl", Language: "Julia", ContainerID: "module-a", StartLine: 1, EndLine: 100}
+	target := SymbolRecord{ID: "target", Kind: "method", Name: "target", FilePath: from.FilePath, Language: from.Language, ContainerID: from.ContainerID, StartLine: 110, EndLine: 120}
+
+	tests := []struct {
+		name        string
+		candidates  []SymbolRecord
+		wantID      string
+		wantFound   bool
+		wantBlocked bool
+	}{
+		{name: "unique same-container target", candidates: []SymbolRecord{target}, wantID: target.ID, wantFound: true},
+		{name: "sibling module", candidates: []SymbolRecord{func() SymbolRecord { s := target; s.ContainerID = "module-b"; return s }()}},
+		{name: "different file", candidates: []SymbolRecord{func() SymbolRecord { s := target; s.FilePath = "src/other.jl"; return s }()}},
+		{name: "different language", candidates: []SymbolRecord{func() SymbolRecord { s := target; s.Language = "Java"; return s }()}},
+		{name: "type target remains generic", candidates: []SymbolRecord{func() SymbolRecord { s := target; s.Kind = "struct"; return s }()}},
+		{name: "ambiguous overloads", candidates: []SymbolRecord{target, func() SymbolRecord { s := target; s.ID = "target-overload"; return s }()}, wantFound: true},
+		{name: "local declaration blocks resolution", candidates: []SymbolRecord{func() SymbolRecord { s := target; s.Local = true; s.StartLine = 10; s.EndLine = 20; return s }()}, wantFound: true, wantBlocked: true},
+		{name: "nested callable disables fallback", candidates: []SymbolRecord{target, {ID: "inner", Kind: "method", Name: "inner", FilePath: from.FilePath, Language: from.Language, ContainerID: from.ContainerID, Local: true, StartLine: 10, EndLine: 20}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targets, found, blocked := resolveJuliaSameContainerMethodCallTargets("target", from, tt.candidates)
+			if found != tt.wantFound || blocked != tt.wantBlocked {
+				t.Fatalf("found, blocked = %v, %v; want %v, %v", found, blocked, tt.wantFound, tt.wantBlocked)
+			}
+			if tt.wantID == "" {
+				if len(targets) != 0 {
+					t.Fatalf("unsafe targets emitted: %#v", targets)
+				}
+				return
+			}
+			if len(targets) != 1 || targets[0].ID != tt.wantID {
+				t.Fatalf("targets = %#v, want only %q", targets, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestJuliaModuleCallResolutionIsContainerScoped(t *testing.T) {
+	repo := t.TempDir()
+	writeFile(t, repo, "src/scopes.jl", `
+target() = 0
+
+module A
+shared(x::Int) = x
+shared(x::String) = x
+caller() = shared(1)
+end
+
+module B
+only() = 1
+end
+
+module C
+caller() = only()
+end
+
+module D; helper() = 1; function f(); helper(); end; end
+
+module E
+target(x) = x
+caller() = target(1)
+end
+
+module F
+struct Widget end
+Widget(x::Int) = Widget()
+caller() = Widget(1)
+end
+
+module G
+shadow() = 0
+function caller()
+    shadow() = 1
+end
+end
+
+module H
+helper() = 1
+function outer()
+    function inner()
+        helper()
+    end
+end
+end
+
+module I
+helper() = 1
+caller(helper) = helper()
+end
+`)
+	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	symbol := func(kind, name string) SymbolRecord {
+		got := symbolByKindAndName(snapshot.Symbols, kind, name)
+		if got.ID == "" {
+			t.Fatalf("missing %s %s: %#v", kind, name, snapshot.Symbols)
+		}
+		return got
+	}
+	aCaller, cCaller := symbol("method", "A.caller"), symbol("method", "C.caller")
+	dHelper, dF := symbol("method", "D.helper"), symbol("method", "D.f")
+	eTarget, eCaller := symbol("method", "E.target"), symbol("method", "E.caller")
+	fWidget, fCaller := symbol("struct", "Widget"), symbol("method", "F.caller")
+	gCaller, hOuter := symbol("method", "G.caller"), symbol("method", "H.outer")
+	iCaller := symbol("method", "I.caller")
+
+	has := func(relationType string, from, to SymbolRecord) bool {
+		for _, relation := range snapshot.Relations {
+			if relation.Type == relationType && relation.FromID == from.ID && relation.ToID == to.ID {
+				return true
+			}
+		}
+		return false
+	}
+	for _, from := range []SymbolRecord{aCaller, cCaller, dHelper, gCaller, hOuter, iCaller} {
+		for _, relation := range snapshot.Relations {
+			if relation.Type == "CALLS" && relation.FromID == from.ID {
+				t.Fatalf("unsafe Julia CALLS from %s: %#v", from.QualifiedName, relation)
+			}
+		}
+	}
+	if !has("CALLS", dF, dHelper) || !has("CALLS", eCaller, eTarget) {
+		t.Fatalf("missing container-scoped Julia CALLS: %#v", relationsOfType(snapshot.Relations, "CALLS"))
+	}
+	if !has("CONSTRUCTS", fCaller, fWidget) {
+		t.Fatalf("existing Julia constructor resolution changed: %#v", relationsOfType(snapshot.Relations, "CONSTRUCTS"))
+	}
+}
+
 func TestClojureSemanticExtraction(t *testing.T) {
 	// Clojure was promoted from inventory to the semantic tier (vendored
 	// grammar). tree-sitter-clojure only produces generic list_lit nodes, so

--- a/internal/sem/provider_test.go
+++ b/internal/sem/provider_test.go
@@ -12746,7 +12746,7 @@ func TestJuliaSameContainerMethodCallTargetsFailClosed(t *testing.T) {
 		wantBlocked bool
 	}{
 		{name: "unique same-container target", candidates: []SymbolRecord{target}, wantID: target.ID, wantFound: true},
-		{name: "local binding blocks resolution", candidates: []SymbolRecord{target}, wantFound: true, wantBlocked: true},
+		{name: "local binding declines fallback", candidates: []SymbolRecord{target}},
 		{name: "sibling module", candidates: []SymbolRecord{func() SymbolRecord { s := target; s.ContainerID = "module-b"; return s }()}},
 		{name: "different file", candidates: []SymbolRecord{func() SymbolRecord { s := target; s.FilePath = "src/other.jl"; return s }()}},
 		{name: "different language", candidates: []SymbolRecord{func() SymbolRecord { s := target; s.Language = "Java"; return s }()}},
@@ -12758,7 +12758,7 @@ func TestJuliaSameContainerMethodCallTargetsFailClosed(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			bindings := map[string]struct{}{}
-			if tt.name == "local binding blocks resolution" {
+			if tt.name == "local binding declines fallback" {
 				bindings["target"] = struct{}{}
 			}
 			targets, found, blocked := resolveJuliaSameContainerMethodCallTargets("target", from, tt.candidates, bindings)
@@ -12854,6 +12854,13 @@ function inline_catch()
     try
     catch; helper; helper(); end
 end
+struct Widget end
+function constructor_control(callback)
+    Widget()
+    let Widget = callback
+        Widget()
+    end
+end
 end
 `)
 	snapshot, err := BuildProviderSnapshotWithOptions(t.Context(), repo, "test-version", ProviderSnapshotOptions{Worktree: true})
@@ -12884,6 +12891,18 @@ end
 		if !callsHelper {
 			t.Fatalf("non-shadowing Bound.%s lost its call to Bound.helper: %#v", name, relationsOfType(snapshot.Relations, "CALLS"))
 		}
+	}
+	widget := symbolByKindAndName(snapshot.Symbols, "struct", "Widget")
+	constructorControl := symbolByKindAndName(snapshot.Symbols, "method", "Bound.constructor_control")
+	if widget.ID == "" || constructorControl.ID == "" {
+		t.Fatalf("missing constructor-control symbols: %#v", snapshot.Symbols)
+	}
+	constructsWidget := false
+	for _, relation := range snapshot.Relations {
+		constructsWidget = constructsWidget || relation.Type == "CONSTRUCTS" && relation.FromID == constructorControl.ID && relation.ToID == widget.ID
+	}
+	if !constructsWidget {
+		t.Fatalf("local-binding veto removed existing constructor resolution: %#v", relationsOfType(snapshot.Relations, "CONSTRUCTS"))
 	}
 }
 


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/148
<!-- entire-trail-link-end -->

## Summary

- recover bare `CALLS` between Julia functions that the parser represents as methods inside the same module
- leave the existing generic resolver in front and preserve its targets when local-binding uncertainty declines the additive Julia fallback
- require one non-local target in the same file and exact container; fail closed for overloads, parameter or local-binding shadowing, local definitions, and nested callable bodies
- inspect Julia binding syntax with the vendored tree-sitter grammar, including assignment/destructuring, `local`, loop/generator, `catch`, `let`, `do`, and arrow binders
- use exact symbol byte ranges for Julia so definitions sharing one line do not inherit each other's calls
- retire the Julia CALLS gap in the semantic language matrix

## Why this is narrow

This is an intentionally bounded alternative to #161. It does not change the entity parser, the shared `nameCallMayTargetMethod` gate, DATA_FLOWS, or any non-Julia resolver. The complete PR is 477 additions across four files; 212 changed production lines are confined to Julia binding extraction and the Julia resolver path.

Supported here: an unqualified call from one non-local Julia module function to one non-local function in the same source file and exact module container. When any supported local binding shadows that name, this new fallback declines the edge for the whole caller rather than attempting call-site-sensitive Julia scope evaluation; pre-existing generic, constructor, and external resolution remains unchanged. Call-site-sensitive lexical scope, including explicit `global` declarations, is deliberately not inferred, so those cases can remain unresolved rather than produce a false exact edge.

Deliberately not modeled here: cross-file `include`/import resolution, module-body calls, qualified calls, overload dispatch, inner constructors, or nested/local callers.

## Verification

- `go test ./...` (`internal/sem`: 312.3s)
- `go test ./internal/sem -count=1` (320.9s on the final tree)
- `go test -race ./internal/sem -run 'TestJulia|TestLanguageMatrix' -count=1`
- `go vet ./...`
- `go build ./...`
- `git diff --check`

Focused coverage includes the positive language-matrix case plus sibling modules, overload ambiguity, same-name global functions, constructor preservation, one-line definitions, nested definitions, parameter shadowing, assignments, typed/destructured locals, loops/generators, `catch`, single/multiple/multiline/commented `let` headers, `do` binders, and non-shadowing controls.
