### PR TITLE
fix(bench): require the judge's verdict before counting a LoCoMo record as scored

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -289,6 +289,19 @@ jobs:
       - run: python -B -m pip install --disable-pip-version-check rank-bm25==0.2.2
       - run: python -B -m unittest bench.memory.benchmarks.common.test_bm25_client
 
+  # The LoCoMo nightly's scoreability gate is Python and carries its own suite;
+  # `go test` never runs it, so nothing exercised it until this job.
+  locomo-summary-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: python -B -m unittest bench.memory.ci.test_summarize_run
+
   # The status line is a POSIX shell script with its own shell suite; `go test` never runs it.
   # No windows-latest: the script targets /bin/sh.
   statusline:

--- a/bench/memory/ci/summarize_run.py
+++ b/bench/memory/ci/summarize_run.py
@@ -570,7 +570,23 @@ def audit_question_records(results_dir: str, run_id: str) -> QuestionRecordAudit
                 record_errors.append(
                     "`cutoff_results.top_200.score` must be the number 0 or 1"
                 )
-            if judgment in ("CORRECT", "WRONG") and score_valid:
+            # The judge's rationale is the only field that separates a real
+            # verdict from a judge failure. When every structured judge attempt
+            # fails the harness falls back to an empty payload, which serializes
+            # with exactly the shape of a legitimate negative verdict -- a
+            # generated answer, judgment WRONG, score 0 -- and no rationale.
+            # Accepting that shape counted a judge outage as a scored wrong
+            # answer, so the outage depressed accuracy while the run still
+            # declared itself scoreable, which is the failure this gate exists
+            # to catch. Require the payload the judge only writes when it ran.
+            reason = top_200.get("reason")
+            reason_valid = isinstance(reason, str) and bool(reason.strip())
+            if not reason_valid:
+                record_errors.append(
+                    "`cutoff_results.top_200.reason` must be a non-empty string "
+                    "recording the judge's verdict"
+                )
+            if judgment in ("CORRECT", "WRONG") and score_valid and reason_valid:
                 expected_judgment = "CORRECT" if float(score) == 1.0 else "WRONG"
                 if judgment != expected_judgment:
                     record_errors.append(

--- a/bench/memory/ci/test_summarize_run.py
+++ b/bench/memory/ci/test_summarize_run.py
@@ -211,6 +211,33 @@ class SummarizeRunTest(unittest.TestCase):
         self.assertEqual(status, 1)
         self.assertIn("top_200.generated_answer` must be a non-empty string", output)
 
+    def test_judge_failure_fallback_is_not_counted_as_a_verdict(self) -> None:
+        # Every structured judge attempt failing yields ``{}``, which is
+        # serialized with exactly the shape of a real negative verdict -- a
+        # generated answer, judgment WRONG, score 0 -- and an empty rationale.
+        # Counting that as a scored wrong answer lets a partial judge outage
+        # depress accuracy while the run still declares itself scoreable.
+        for name, mutate in (
+            ("empty reason", lambda top: top.__setitem__("reason", "")),
+            ("blank reason", lambda top: top.__setitem__("reason", "  ")),
+            ("absent reason", lambda top: top.pop("reason")),
+            ("non-string reason", lambda top: top.__setitem__("reason", 0)),
+        ):
+            with self.subTest(name):
+                self.write_aggregate(correct=2, accuracy=2 / 3 * 100)
+                self.write_records([5, 6, 7], scores=[1, 0, 1])
+                record = self.read_record(1)
+                mutate(record["cutoff_results"]["top_200"])
+                self.write_record(1, record)
+
+                status, output = self.run_summary()
+
+                self.assertEqual(status, 1)
+                self.assertIn("valid top_200 judgments: **2/3**", output)
+                self.assertIn(
+                    "top_200.reason` must be a non-empty string", output
+                )
+
     def test_memories_evaluated_must_match_retrieved_context(self) -> None:
         self.write_aggregate()
         self.write_records([5, 6, 7])


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/150
<!-- entire-trail-link-end -->

Follow-up review of the six open findings on trails 109 and 107. Both source PRs (#97, #147) are merged, so every one of these was checked against `main`, not against a branch. Three turned out to be already fixed on `main`, two are live but owned by an open RFD, and one is live and fixed here.

## Fixed here

**`bench/memory/ci/summarize_run.py:563` (`01M0KM4JG5YA`)** — the LoCoMo nightly's scoreability gate accepted a judge outage as a real verdict.

When every structured judge attempt fails, the harness falls back to an empty payload, serialized with exactly the shape of a legitimate negative verdict: a generated answer, `judgment: "WRONG"`, `score: 0`, and an empty `reason`. The gate validated `judgment`, `score`, `generated_answer` and `memories_evaluated` but never `reason`, so it accepted that record, counted it toward `scored`/`correct`, and still printed `### Scoreable`. A partial judge outage depressed accuracy while presenting as a real regression — the exact failure this gate exists to catch.

`reason` is the only field the judge writes solely when it actually ran, so it is now required, and the `scored`/`correct` counters are gated on it alongside `judgment` and `score`.

Reverting the `summarize_run.py` hunk (the reverted file still compiles: `python -m py_compile` exit 0) makes the new test fail on all four shapes with `AssertionError: 0 != 1` — the run is declared scoreable — and the summary reports `valid top_200 judgments: **3/3**` rather than `**2/3**`.

**CI**: `bench/memory/ci/test_summarize_run.py` was never executed by any workflow — `go test` does not run it and no Python job referenced it. Added `locomo-summary-gate` so the regression test protects something.

## Already fixed on `main` — no change needed

All three were closed by 582741a1 (plus d49c3c73 and e29b2490 for the Cargo one), which landed after the review that raised them. Verified by diffing the reviewed tree against `main` at the exact reported lines.

- **`compact_snapshot.go:549` (`01M108H3QZEA`)** — at 582741a1^ line 549 was literally `if relationType == "DEFINES" || relationType == "CONTAINS" { continue }`. `main` now counts a `CONTAINS` whose parent differs from the child's `ContainerID` into `UnsupportedRelationCounts`, and a missing parent into `MissingSourceRelations`. Pinned by `TestSCIPCountsUnrepresentedContainment` and `TestSCIPDoesNotCountDefines` (both PASS).
- **`compact_snapshot.go:543` (`01M0Y4KW0HY1`)** — `IsReference` is now `methodLikeSCIPKind(source.Kind) && methodLikeSCIPKind(targetKind)`, so it is set only for member-level relationships and fails closed on an unknown target kind. Pinned by `TestSCIPIsReferenceOnlyForMemberRelationships` (PASS).
- **`scip_project_version.go:89` (`01M0Y4KW15A8`)** — `parseCargoPackageVersion` follows both `version.workspace = true` and `version = { workspace = true }` to `[workspace.package]`. Checked against a realistic root manifest carrying `[workspace]` with `members`/`resolver`, `[workspace.package]`, `[workspace.dependencies]`, a `[package]` inheriting version/edition/license, `[dependencies]` and `[[bin]]`: resolves correctly, a literal version still wins, and declaring inheritance with no workspace version yields no version rather than a guess. Pinned by `TestScipProjectVersionReadsRootManifests`, `TestCargoWorkspaceInheritanceSyntaxIsConservative` and `TestCargoWorkspaceInheritanceSurvivesATrailingComment` (all PASS).

## Live, but deliberately not changed here

Both rewrite what the export claims, and both already have a written home. Deciding either in a follow-up PR would pre-empt the document that exists to decide it.

- **`compact_snapshot.go:771` → now `scipSymbol` (`01M108H3QHBH`)** — descriptors carry a file descriptor and a leaf descriptor and nothing between. This is verbatim the **fourth** bullet of RFD 0005's open question 2 ("Descriptors omit the container ancestry"), which states that all four sub-decisions "must move together, because each rewrites every symbol's identity". It sits in the same set as the external-symbol identity question (third bullet), which was likewise left alone — nothing adjacent to either behaviour is touched by this PR.
- **`compact_snapshot.go:585` → now the evidence loop (`01M108H3QD2Z`)** — relation evidence is the enclosing symbol's whole declaration span, so every emitted reference occurrence is a positional claim the graph did not measure. This is the entire subject of RFD 0006 (`rfd/reference-positions`, status Proposed, open for comment), which measures it at 18,988/18,988 `CALLS` evidence records equal to the caller's own span and proposes Option A. 582741a1's own message records the deliberate decision to propose it there "rather than decided here".

## Verification

- `go test ./... -count=1` — exit 0
- `python -B -m unittest bench.memory.ci.test_summarize_run` — 37 tests, OK
