### PR TITLE
fix(sem): keep a repository's own exclusions from vanishing silently

### DIFF
--- a/docs/trust-and-security.md
+++ b/docs/trust-and-security.md
@@ -76,7 +76,10 @@ other is installation.
   Caller-supplied ignore inputs are bounded to 1 MiB per file and 64 KiB per rule
   line. One listing retains at most 16,384 parsed external rules and observes at
   most 512 nested `.gitignore` files. A limit refusal is reported instead of
-  truncating the policy and silently changing the indexed corpus. Nested
+  truncating the policy and silently changing the indexed corpus, and so is a
+  `.git` this process cannot read while resolving `info/exclude`: absence of a
+  git directory degrades to "no exclude list", but a failure to READ one that is
+  there is refused rather than dropping the repository's own exclusions. Nested
   worktree ignore files are confined to the repository and are not followed
   through a symlink that escapes it. When Git cannot enumerate a worktree, the
   bounded filesystem fallback applies the ignore files it can observe and emits

--- a/internal/sem/cache_ignore_inputs_test.go
+++ b/internal/sem/cache_ignore_inputs_test.go
@@ -246,7 +246,10 @@ func TestWorktreeSnapshotAppliesGitInfoExcludeWithoutCaching(t *testing.T) {
 		t.Fatal("cold snapshot did not include app.go")
 	}
 
-	exclude := gitInfoExcludePath(repo)
+	exclude, err := gitInfoExcludePath(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if exclude == "" {
 		t.Fatal("test repository did not resolve info/exclude")
 	}

--- a/internal/sem/ignore.go
+++ b/internal/sem/ignore.go
@@ -389,7 +389,11 @@ func loadWorktreeIgnoreMatcher(repo string, ignoreFiles, includeFiles []string) 
 	// is a regular file holding "gitdir: <path>", so that join names a path under a
 	// non-directory: os.Stat returns ENOTDIR rather than ErrNotExist, and treating
 	// that as fatal aborted the entire search with zero results in every worktree.
-	if exclude := gitInfoExcludePath(repo); exclude != "" {
+	exclude, err := gitInfoExcludePath(repo)
+	if err != nil {
+		return ignoreMatcher{}, err
+	}
+	if exclude != "" {
 		if err := matcher.loadOptionalSameVolume(repo, exclude, false); err != nil {
 			return ignoreMatcher{}, err
 		}
@@ -442,27 +446,52 @@ func (m *ignoreMatcher) loadExplicit(repo string, ignoreFiles, includeFiles []st
 // worktree, where it holds "gitdir: <path to .git/worktrees/<name>>". Git shares
 // info/ across worktrees via that gitdir's commondir pointer, so the exclude file
 // lives under the common directory, not under <repo>/.git.
-func gitInfoExcludePath(repo string) string {
+//
+// ABSENCE and UNREADABILITY are different answers. info/exclude is the
+// repository's own private exclude list and carries the same authority as
+// .gitignore, so returning "" for a `.git` this process may not read silently
+// drops the whole list and admits every file it names — the one failure mode a
+// caller cannot see in the output. Only "there is nothing here" degrades to
+// ("", nil): a missing `.git`, and the same-volume guard's deliberate refusals,
+// which are policy decisions about where this process will look rather than
+// failures to read what is there. Everything else — a permission denial, an I/O
+// error, a `.git` this process cannot stat — is returned.
+//
+// A repository root this process cannot read AT ALL is a third case and stays
+// silent here: nothing can be said to have been dropped when the entry naming it
+// was never visible, and the listing preflight owns that repository and refuses
+// the whole operation. nestedIgnoreStack.directoryReadable draws the same line
+// one level down.
+//
+// The limit worth naming: the indirection past this point (gitCommonDir, the
+// gitdir handle) still reports absence and unreadability as the same "".
+func gitInfoExcludePath(repo string) (string, error) {
 	dotGit := filepath.Join(repo, ".git")
 	opened, resolvedDotGit, err := openSameVolumePath(repo, dotGit)
 	if err != nil {
-		return ""
+		if gitDirAbsent(err) || !repoRootReadable(repo) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read git directory %q: %w", dotGit, err)
 	}
 	defer opened.Close()
 	info, err := opened.Stat()
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("read git directory %q: %w", dotGit, err)
 	}
 	if info.IsDir() {
 		common, ok := gitCommonDir(resolvedDotGit)
 		if !ok {
-			return ""
+			return "", nil
 		}
-		return filepath.Join(common, "info", "exclude")
+		return filepath.Join(common, "info", "exclude"), nil
 	}
 	regular, err := openedFileIsRegular(opened, info)
-	if err != nil || !regular || info.Size() > maxGitFileBytes {
-		return ""
+	if err != nil {
+		return "", fmt.Errorf("read git directory %q: %w", dotGit, err)
+	}
+	if !regular || info.Size() > maxGitFileBytes {
+		return "", nil
 	}
 	// One reader and one byte rule for both pointer files, in provider.go: git
 	// applies read_gitfile_gently() here too, so a `.git` text file git refuses
@@ -473,11 +502,11 @@ func gitInfoExcludePath(repo string) string {
 	// about which directory a worktree's `.git` names.
 	gitDir, ok := readGitDirPointerFromOpened(opened, info.Size())
 	if !ok {
-		return ""
+		return "", nil
 	}
 	gitDir = filepath.FromSlash(gitDir)
 	if !gitTargetPathValid(gitDir) {
-		return ""
+		return "", nil
 	}
 	if absoluteGitDir, absolute := gitAbsolutePath(repo, gitDir); absolute {
 		gitDir = absoluteGitDir
@@ -485,11 +514,11 @@ func gitInfoExcludePath(repo string) string {
 		gitDir = gitJoinRelative(repo, gitDir)
 	}
 	if !sameVolume(gitDir, repo) {
-		return ""
+		return "", nil
 	}
 	gitDirHandle, resolvedGitDir, err := openSameVolumePath(repo, gitDir)
 	if err != nil {
-		return ""
+		return "", nil
 	}
 	_ = gitDirHandle.Close()
 	// commondir points at the shared .git that owns info/; it may be relative to
@@ -508,10 +537,46 @@ func gitInfoExcludePath(repo string) string {
 	// top-level check ever ran.
 	common, ok := gitCommonDir(resolvedGitDir)
 	if !ok {
-		return ""
+		return "", nil
 	}
 	gitDir = filepath.Clean(common)
-	return filepath.Join(gitDir, "info", "exclude")
+	return filepath.Join(gitDir, "info", "exclude"), nil
+}
+
+// gitDirAbsent reports the errors from resolving <repo>/.git that mean "there is
+// no git directory to consult here" rather than "there is one and this process
+// could not read it".
+//
+// Absence is the missing path itself, including the ENOTDIR a join past a
+// non-directory produces. The same-volume guard's refusals are grouped with it
+// deliberately: an off-volume symlink chain, a crossed mount point, an
+// uninspectable redirect, and a platform with no safe mount inventory are all
+// decisions not to look, taken before any read is attempted, and each already
+// has a repository layout that depends on continuing without info/exclude.
+func gitDirAbsent(err error) bool {
+	return isMissingPathError(err) ||
+		errors.Is(err, errSymlinkChainOffVolume) ||
+		errors.Is(err, errPathRedirectUnreadable) ||
+		errors.Is(err, errPathMountGuardUnsupported)
+}
+
+// repoRootReadable reports whether this process can list the repository root at
+// all. It separates "the `.git` entry could not be read" — a dropped exclude
+// policy the caller must hear about — from "the repository root could not be
+// read", where the listing that follows cannot run either and refuses on its own
+// terms. Enumeration is the probe rather than a mode test, because a mode is a
+// request: the effective answer depends on the filesystem, the platform and the
+// user.
+func repoRootReadable(repo string) bool {
+	opened, err := os.Open(repo)
+	if err != nil {
+		return false
+	}
+	defer opened.Close()
+	if _, err := opened.ReadDir(1); err != nil && !errors.Is(err, io.EOF) {
+		return false
+	}
+	return true
 }
 
 func (m *ignoreMatcher) loadOptional(file string, includeMode bool) error {
@@ -1199,8 +1264,11 @@ func (m ignoreMatcher) MayIncludeDescendant(rel string) bool {
 // first-party. An erlang.mk/rebar monorepo gitignores fetched dependencies
 // (`/deps/*`) but negates its own applications (`!/deps/rabbit/`), so the
 // vendored-directory-name heuristic must not skip the tree wholesale; the
-// ignore rules themselves keep the fetched dependencies out. Basename-only
-// negations (e.g. `!.keep`) carry no path and are not treated as a signal.
+// ignore rules themselves keep the fetched dependencies out. A basename-only
+// negation (e.g. `!.keep`) carries no path of its own; at the repository root
+// there is nothing to resolve it against, so it is not treated as a signal (see
+// negationPathScope for the nested case, where the ignore file's own directory
+// supplies that path).
 func (m ignoreMatcher) ReincludesDescendant(rel string) bool {
 	return m.reincludesDescendantUnder("", rel)
 }
@@ -1208,8 +1276,6 @@ func (m ignoreMatcher) ReincludesDescendant(rel string) bool {
 // reincludesDescendantUnder is ReincludesDescendant for an ignore file that lives
 // in dir rather than at the repository root: its patterns are relative to dir, so
 // each literal prefix is resolved against dir before being compared to rel.
-// Basename-only negations carry no path in either position and are skipped in
-// both, exactly as before.
 func (m ignoreMatcher) reincludesDescendantUnder(dir, rel string) bool {
 	rel = cleanIgnorePath(rel)
 	if rel == "" {
@@ -1217,21 +1283,50 @@ func (m ignoreMatcher) reincludesDescendantUnder(dir, rel string) bool {
 	}
 	dir = cleanIgnorePath(dir)
 	for _, rule := range m.rules {
-		if rule.ignore || rule.includeFile || rule.basenameOnly {
+		if rule.ignore || rule.includeFile {
 			continue
 		}
-		prefix := literalPatternPrefix(rule.pattern)
-		if prefix == "" {
+		prefix, ok := negationPathScope(rule, dir)
+		if !ok {
 			continue
-		}
-		if dir != "" {
-			prefix = dir + "/" + prefix
 		}
 		if prefix == rel || strings.HasPrefix(prefix, rel+"/") {
 			return true
 		}
 	}
 	return false
+}
+
+// negationPathScope returns the repository-relative path a negation rule speaks
+// about, given the repository-relative directory dir of the ignore file it was
+// read from ("" for the repository root).
+//
+// A negation that carries a literal path prefix (`!/deps/rabbit/`) names that
+// path, resolved against dir. A negation that carries none — a basename-only
+// rule such as `!lib.py`, or a leading-glob rule such as `!**/lib.py` — names no
+// path OF ITS OWN, but a nested ignore file supplies the missing context: it can
+// only re-include something inside its own directory, so dir is the path it
+// speaks for. Skipping those made a `vendor/.gitignore` holding `*` and the
+// ordinary unanchored `!mypkg/` report that nothing under vendor was
+// first-party, and the vendored-directory heuristic then dropped Git-tracked
+// source from the corpus with no warning.
+//
+// At the repository root there is no such context — `!.keep` genuinely names
+// nowhere — so a pathless negation there is still no signal, and the caller's
+// comparison keeps this scoped to dir itself: a negation is evidence about the
+// tree it lives in, never about a sibling.
+func negationPathScope(rule ignoreRule, dir string) (string, bool) {
+	prefix := literalPatternPrefix(rule.pattern)
+	if prefix == "" {
+		return dir, dir != ""
+	}
+	if rule.basenameOnly {
+		return dir, dir != ""
+	}
+	if dir != "" {
+		prefix = dir + "/" + prefix
+	}
+	return prefix, true
 }
 
 func (r ignoreRule) matchKind(rel string, isDir bool) ignoreMatchKind {

--- a/internal/sem/ignore_scope_test.go
+++ b/internal/sem/ignore_scope_test.go
@@ -1,0 +1,132 @@
+package sem
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A negation in a NESTED ignore file carries the path context of the directory
+// that file lives in, so a basename-only negation there is not the pathless
+// signal a basename-only negation at the repository root is. Skipping it made
+// the vendored-directory heuristic answer "nothing here is first-party" for a
+// tree whose own .gitignore reopens part of it, and Git-tracked source was
+// dropped from the corpus without a warning.
+func TestNestedIgnoreNegationReincludesUnderItsOwnDirectory(t *testing.T) {
+	t.Parallel()
+
+	rules := newNestedIgnoreRules(ignoreMatcher{})
+	// vendor/.gitignore excludes everything and reopens one package, spelled the
+	// ordinary unanchored way.
+	if err := rules.addFile("vendor/.gitignore", "*\n!mypkg/\n"); err != nil {
+		t.Fatal(err)
+	}
+	// A deeper file whose own negation names a bare filename.
+	if err := rules.addFile("third_party/pkg/.gitignore", "*\n!lib.py\n"); err != nil {
+		t.Fatal(err)
+	}
+
+	if !rules.ReincludesDescendant("vendor") {
+		t.Error("vendor: a negation in vendor/.gitignore must count as a re-included descendant")
+	}
+	if !rules.ReincludesDescendant("third_party") {
+		t.Error("third_party: a negation in third_party/pkg/.gitignore must count as a re-included descendant")
+	}
+	// Path-scoped: the negation speaks for its own directory, not for the whole
+	// repository. A tree that holds no such ignore file keeps no re-inclusion.
+	if rules.ReincludesDescendant("build") {
+		t.Error("build: a negation elsewhere in the tree must not re-include an unrelated directory")
+	}
+
+	// At the repository root there is no directory to supply the missing path,
+	// so a basename-only negation still carries no signal.
+	var root ignoreMatcher
+	if err := root.loadContent("*\n!.keep\n", false); err != nil {
+		t.Fatal(err)
+	}
+	if root.ReincludesDescendant("vendor") {
+		t.Error("vendor: a root basename-only negation names no path and must not re-include a tree")
+	}
+}
+
+// `.git/info/exclude` is the repository's own private exclude list, and the
+// graph reads it with the same authority as .gitignore. A linked worktree
+// reaches it through the `.git` POINTER FILE, and every failure to read that
+// pointer was reported as "there is no git directory here" — so a pointer this
+// process may not read silently dropped the whole exclude list and admitted the
+// files it names. Absence must degrade; a read failure must not.
+func TestLoadWorktreeIgnoreMatcherRefusesAnUnreadableGitPointer(t *testing.T) {
+	root := t.TempDir()
+	repo := filepath.Join(root, "wt")
+	gitDir := filepath.Join(root, "main", ".git", "worktrees", "wt")
+	commonDir := filepath.Join(root, "main", ".git")
+	for _, dir := range []string{repo, gitDir, filepath.Join(commonDir, "info")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "commondir"), []byte("../..\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(commonDir, "info", "exclude"), []byte("secret.txt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pointer := filepath.Join(repo, ".git")
+	if err := os.WriteFile(pointer, []byte("gitdir: "+gitDir+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Readable: the exclude list is found and applied.
+	matcher, err := loadWorktreeIgnoreMatcher(repo, nil, nil)
+	if err != nil {
+		t.Fatalf("readable pointer: %v", err)
+	}
+	if !matcher.Ignored("secret.txt", false) {
+		t.Fatal("readable pointer: the shared info/exclude was not applied")
+	}
+
+	unreadableFileOrSkip(t, pointer)
+
+	if _, err := loadWorktreeIgnoreMatcher(repo, nil, nil); err == nil {
+		t.Fatal("an unreadable .git pointer was reported as \"no git directory\": " +
+			"the repository's info/exclude was skipped and its excluded files admitted, silently")
+	}
+}
+
+// The other side of that line. A repository ROOT this process cannot read is not
+// a dropped exclude policy — the entry naming one was never visible, and the
+// listing preflight refuses the whole operation on its own terms
+// (TestExecuteOnlyRepositoryRootIsRefusedByTheListingPreflight). Reporting it
+// here instead would make every such repository fail with the wrong reason.
+func TestLoadWorktreeIgnoreMatcherStaysSilentForAnUnlistableRepositoryRoot(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, ".git"), []byte("gitdir: elsewhere\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Execute-only: names inside can still be looked up, so the earlier
+	// .gitignore probe passes and the `.git` resolution is what fails. That is
+	// the layout the openSource preflight test uses.
+	unlistableButSearchableOrSkip(t, repo)
+
+	if _, err := loadWorktreeIgnoreMatcher(repo, nil, nil); err != nil {
+		t.Fatalf("an unlistable repository root must not be reported as a dropped exclude policy: %v", err)
+	}
+}
+
+// unlistableButSearchableOrSkip makes dir execute-only and confirms the process
+// really lost enumeration while keeping lookup, because a chmod is a request:
+// root ignores the mode and so does a filesystem mounted without it.
+func unlistableButSearchableOrSkip(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.Chmod(dir, 0o111); err != nil {
+		t.Skipf("cannot make this directory execute-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+	if opened, err := os.Open(dir); err == nil {
+		_ = opened.Close()
+		t.Skip("this process lists a mode-0111 directory anyway (root, or a filesystem that ignores the mode)")
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".git")); err != nil {
+		t.Skipf("this filesystem does not grant lookup without read: %v", err)
+	}
+}

--- a/internal/sem/ignore_worktree_test.go
+++ b/internal/sem/ignore_worktree_test.go
@@ -83,7 +83,11 @@ func TestGitInfoExcludePath(t *testing.T) {
 			t.Fatal(err)
 		}
 		want = filepath.Join(resolvedParent, filepath.Base(want))
-		if got := gitInfoExcludePath(repo); got != want {
+		got, err := gitInfoExcludePath(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != want {
 			t.Errorf("got %q want %q", got, want)
 		}
 	})
@@ -109,14 +113,22 @@ func TestGitInfoExcludePath(t *testing.T) {
 			t.Fatal(err)
 		}
 		want = filepath.Join(resolvedParent, filepath.Base(want))
-		if got := gitInfoExcludePath(repo); got != want {
+		got, err := gitInfoExcludePath(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != want {
 			t.Errorf("got %q want %q", got, want)
 		}
 	})
 
 	t.Run("no git dir at all", func(t *testing.T) {
 		t.Parallel()
-		if got := gitInfoExcludePath(t.TempDir()); got != "" {
+		got, err := gitInfoExcludePath(t.TempDir())
+		if err != nil {
+			t.Fatalf("a directory that is not a repository must not be an error: %v", err)
+		}
+		if got != "" {
 			t.Errorf("non-git directory: got %q want \"\"", got)
 		}
 	})

--- a/internal/sem/provider_gitdir_unc_windows_test.go
+++ b/internal/sem/provider_gitdir_unc_windows_test.go
@@ -298,7 +298,10 @@ func TestGitInfoExcludePathAcceptsACaseDifferentCommonDirVolume(t *testing.T) {
 	lowerVolume := strings.ToLower(filepath.VolumeName(gitDir)) + gitDir[len(filepath.VolumeName(gitDir)):]
 	writeFile(t, repo, ".realgit/commondir", lowerVolume+"\n")
 
-	got := gitInfoExcludePath(repo)
+	got, err := gitInfoExcludePath(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if got == "" {
 		t.Fatal("gitInfoExcludePath(repo) = empty: a commondir differing only in drive-letter case was treated as a different volume")
 	}
@@ -462,8 +465,9 @@ func TestGitInfoExcludePathRejectsAUNCCommonDirWithoutTouchingTheNetwork(t *test
 
 	done := make(chan struct{})
 	var got string
+	var gotErr error
 	go func() {
-		got = gitInfoExcludePath(repo)
+		got, gotErr = gitInfoExcludePath(repo)
 		close(done)
 	}()
 	select {
@@ -471,6 +475,9 @@ func TestGitInfoExcludePathRejectsAUNCCommonDirWithoutTouchingTheNetwork(t *test
 	case <-time.After(5 * time.Second):
 		t.Fatal("gitInfoExcludePath did not return within 5s: a UNC commondir target must be rejected by" +
 			" volume before any caller's os.Stat attempts to resolve it over the network")
+	}
+	if gotErr != nil {
+		t.Fatalf("a UNC commondir target must be refused by volume, not reported as unreadable: %v", gotErr)
 	}
 	if got != "" {
 		t.Errorf("gitInfoExcludePath(repo) = %q, want \"\": a UNC commondir target is never on the repository's own volume", got)
@@ -770,7 +777,11 @@ func TestGitInfoExcludePathRejectsWin32TrimAlias(t *testing.T) {
 	repo := t.TempDir()
 	writeFile(t, repo, ".git", "gitdir:   \n")
 	writeFile(t, repo, "info/exclude", "secret.go\n")
-	if got := gitInfoExcludePath(repo); got != "" {
+	got, err := gitInfoExcludePath(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
 		t.Fatalf("gitInfoExcludePath = %q, want empty for Git-rejected Win32 trim alias", got)
 	}
 }

--- a/internal/sem/provider_gitfile_parse_test.go
+++ b/internal/sem/provider_gitfile_parse_test.go
@@ -89,7 +89,11 @@ func TestGitInfoExcludePathIgnoresAGitfileGitRejects(t *testing.T) {
 			t.Parallel()
 			repo := t.TempDir()
 			writeFile(t, repo, ".git", content)
-			if got := gitInfoExcludePath(repo); got != "" {
+			got, err := gitInfoExcludePath(repo)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != "" {
 				t.Errorf("gitInfoExcludePath = %q, want \"\" for a gitfile git rejects", got)
 			}
 		})


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/162
<!-- entire-trail-link-end -->

Two findings on `internal/sem/ignore.go` where the ignore layer could change what a search can see without reporting it. Both reproduce on `main`; both regression tests fail on a compile-clean revert of the fix alone.

## A nested negation that carries no path was discarded

`reincludesDescendantUnder` skipped every basename-only negation, in both the root and the nested position. At the repository root that is right — `!.keep` names nowhere. In a nested `.gitignore` it is not: the file can only re-include something inside its own directory, so that directory is the path the negation speaks for.

The result was that `vendor/.gitignore` holding `*` and the ordinary unanchored `!mypkg/` reported that nothing under `vendor` was first-party. The vendored-directory heuristic then skipped the whole tree, and Git-tracked source left both the working-tree and the committed-tree corpus with no warning — the exact case the `nestedIgnoreRules` doc comment says the type exists to prevent, still live for the unanchored spelling.

`negationPathScope` now resolves a pathless negation against the directory of the ignore file it came from. The containment test is unchanged and stays path-scoped (`prefix == rel || strings.HasPrefix(prefix, rel+"/")`): a negation is evidence about the tree it lives in, never about a sibling, and never a blanket re-admission of an ancestor's subtree.

Fails without the fix:

    ignore_scope_test.go:30: vendor: a negation in vendor/.gitignore must count as a re-included descendant
    ignore_scope_test.go:33: third_party: a negation in third_party/pkg/.gitignore must count as a re-included descendant

Mutation check on the new helper, both directions:

- pathless negations never count (the pre-fix behavior) — `TestNestedIgnoreNegationReincludesUnderItsOwnDirectory` fails.
- literal prefix discarded, every negation scoped to its file's directory — `TestAnalyzeGitRangeReportsReincludedVendorTree`, `TestAnalyzeGitRangeDependentsIncludeReincludedVendorCallers`, `TestCommittedSubdirectoryReadsRootAndNestedIgnoreFiles` and `TestOpenSourceBindsListingContentAndGitignoreToExactRevision` fail.

## An unreadable `.git` pointer was reported as "no git directory"

`gitInfoExcludePath` returned `""` for every failure to resolve `<repo>/.git`. `.git/info/exclude` is the repository's own private exclude list and is read with the same authority as `.gitignore`, so a pointer file this process may not read silently dropped the entire list and admitted every file it names — with nothing in the output to say so.

Absence and unreadability are now different answers:

- missing `.git` (including the ENOTDIR from joining past a non-directory) still degrades to `("", nil)`;
- the same-volume guard's refusals — off-volume symlink chain, crossed mount point, uninspectable redirect, no safe mount inventory on this platform — still degrade, because each is a decision not to look taken before any read, and existing repository layouts depend on continuing without `info/exclude`;
- a permission denial, an I/O error, or a `.git` that cannot be stat'd is returned.

A repository root that cannot be listed at all is a third case and stays silent. Nothing can be said to have been dropped when the entry naming it was never visible, and the listing preflight already refuses such a repository on its own terms (`TestExecuteOnlyRepositoryRootIsRefusedByTheListingPreflight`, which pins that refusal, still passes). `nestedIgnoreStack.directoryReadable` draws the same line one level down.

Fails without the fix:

    ignore_scope_test.go:91: an unreadable .git pointer was reported as "no git directory": the repository's info/exclude was skipped and its excluded files admitted, silently

Mutation check, both directions:

- `gitDirAbsent` always true — the unreadable-pointer test fails; always false — `TestGitInfoExcludePath/no_git_dir_at_all` fails (a plain directory becomes an error).
- `repoRootReadable` always true — `TestExecuteOnlyRepositoryRootIsRefusedByTheListingPreflight` and `TestLoadWorktreeIgnoreMatcherStaysSilentForAnUnlistableRepositoryRoot` fail; always false — the unreadable-pointer test fails.

`gitInfoExcludePath` now returns `(string, error)`; its callers in `ignore_worktree_test.go`, `cache_ignore_inputs_test.go`, `provider_gitfile_parse_test.go` and `provider_gitdir_unc_windows_test.go` were updated with it, and the UNC test additionally asserts that a UNC commondir is refused by volume rather than reported as unreadable.

`docs/trust-and-security.md` records the new refusal beside the existing ignore-policy limit refusals.

## Tests

New in `internal/sem/ignore_scope_test.go`:

- `TestNestedIgnoreNegationReincludesUnderItsOwnDirectory`
- `TestLoadWorktreeIgnoreMatcherRefusesAnUnreadableGitPointer`
- `TestLoadWorktreeIgnoreMatcherStaysSilentForAnUnlistableRepositoryRoot`

They run in the `test` job of `.github/workflows/test.yml` (ubuntu-latest and macos-latest), which executes `go test -timeout 30m ./...`, and in the Windows shard job that compiles and runs the same package. The two permission tests probe their fixture and skip when the platform or user ignores the mode, so a root-owned or Windows runner skips rather than failing.

`gofmt -l -s .` clean, `go vet ./...` clean, `go test ./... -count=1` exit 0.