### PR TITLE
feat: add graph changeset risk analysis

### DIFF
--- a/BUILDATHON.md
+++ b/BUILDATHON.md
@@ -1,0 +1,135 @@
+# Entire Graph Risk Intelligence
+
+## One-sentence summary
+
+Entire Graph Risk Intelligence adds deterministic, changeset-level risk analysis to a large open-source developer tool, then optionally makes the resulting evidence queryable in Databricks Delta tables.
+
+## Problem, intended user and why it matters
+
+Developers reviewing a change in a large repository can see a text diff but cannot reliably see its downstream blast radius or the tests most likely to matter. The intended user is a developer or reviewer who needs a bounded, evidence-backed risk assessment before shipping a change.
+
+## Selected Entire track and why Entire is essential
+
+**Selected track: Large Open Source Repository (Track 2).**
+
+This is a contribution to [Entire Graph](https://github.com/entireio/entire-graph), an open-source Entire CLI plugin. Entire is essential rather than incidental: the new `entire graph risk` command composes Entire Graph's semantic Git diff, persistent code graph, impact analysis, and checkpoint-aware workflow. A plain Git diff cannot supply the direct callers, type consumers, affected tests, or explicit graph-evidence limitations reported by the command.
+
+## Repository, branch, and submission commits
+
+- GitHub fork: <https://github.com/Yashwanthk06/entire-graph>
+- Upstream pull request: <https://github.com/entireio/entire-graph/pull/235>
+- Submission branch: `track2-risk`
+- Risk-analysis feature commit: [`d760c2929bd409a63a320b76e0a7de09b97bd4d9`](https://github.com/Yashwanthk06/entire-graph/commit/d760c2929bd409a63a320b76e0a7de09b97bd4d9)
+- Databricks integration commit: [`15e7e1782c79958ebd2e27a7d730d3ee8db1fb99`](https://github.com/Yashwanthk06/entire-graph/commit/15e7e1782c79958ebd2e27a7d730d3ee8db1fb99)
+- Entire mirror/project URL: **not available from this local checkout.** Add the exact shared Entire project or mirror URL here before submission if the form requires one.
+
+## Architecture and main workflow
+
+1. `entire graph risk` semantically compares `--base` and `--head`, or reads an Entire checkpoint.
+2. It builds/loads the current committed-tree graph and resolves bounded dependency impact for changed entities.
+3. It emits deterministic `high`, `medium`, or `low` risk, graph evidence, affected-test paths, and limitations in text or JSON.
+4. The optional Databricks job ingests the JSON report into a Unity Catalog Delta table, one row per changed entity, for team-wide querying and trend analysis.
+
+The main implementation is [`internal/cli/risk.go`](internal/cli/risk.go), with behavior covered by [`internal/cli/risk_test.go`](internal/cli/risk_test.go). The Databricks integration is isolated under [`databricks/`](databricks/) and therefore does not alter local CLI behavior or send source code to a service.
+
+## Entire Graph findings and verification
+
+The key graph finding is that risk should be determined from semantic relationships, not text-file churn. For each changed entity, the command resolves direct callers, transitive callers, type consumers, callees, and graph-related test paths. A signature change with resolved callers/type consumers is classified conservatively above an isolated body-only change. When the requested revision is not the current graph snapshot, the command deliberately omits misleading graph evidence and reports a limitation.
+
+Verification is represented in the risk-command tests: they cover flag validation, deterministic risk classification, JSON output, bounded entity analysis, affected test selection, and degraded/non-current graph evidence. The command's output keeps graph facts separate from the tool's risk inference.
+
+## Noon Curveball: what changed and how we adapted
+
+The curveball was the need to demonstrate Databricks value without compromising Entire Graph's local-only and no-egress runtime contract. We adapted by keeping the primary analysis entirely local and adding an **optional, separately deployed** Databricks bundle that consumes only the explicit JSON report chosen by the user. This preserves the core command's deterministic, offline behavior while enabling governed analytics after a report is intentionally exported.
+
+The isolation is demonstrated by the separate bundle files and by the existing Go tests for `entire graph risk`; no Go production path imports a Databricks SDK or contacts a workspace.
+
+## Checkpoint links and what each checkpoint proves
+
+**Submission blocker: no Entire checkpoints are present on the current local submission branch.** `entire checkpoint list` reported `0` checkpoints in this checkout. Do not submit placeholder links.
+
+Before submitting, create or recover the required checkpoints from the tracked agent session and replace this section with their real Entire URLs:
+
+| Checkpoint | URL | What it proves |
+| --- | --- | --- |
+| Risk-analysis implementation | `ADD REAL ENTIRE CHECKPOINT URL` | The semantic-diff, graph-impact, risk classification, and tests were created on the tracked branch. |
+| Databricks integration | `ADD REAL ENTIRE CHECKPOINT URL` | The optional bundle, notebook, documentation, and review of the no-egress boundary were completed. |
+
+Use `entire checkpoint list` and `entire checkpoint explain <id>` from the tracked submission branch to obtain and verify the records. If the checkpoints live on another existing branch/session, switch to it and use the URLs returned there rather than creating fictitious replacements.
+
+## Setup, run and test instructions
+
+Prerequisites: Git 2.36+, Go 1.26 with CGO enabled, the Entire CLI, and the Entire Graph plugin build dependencies. `mise` is optional but pins the repository toolchain.
+
+```sh
+git clone https://github.com/Yashwanthk06/entire-graph.git
+cd entire-graph
+git checkout track2-risk
+
+# Build and install the plugin locally.
+go build -o entire-graph ./cmd/entire-graph
+entire plugin install ./entire-graph --force
+entire graph version
+
+# Run the product against the current submission change.
+entire graph risk --repo . --base origin/main --head HEAD --format text
+entire graph risk --repo . --base origin/main --head HEAD --format json > risk-report.json
+
+# Run the repository test suite (or `mise run test`).
+go test -timeout 30m ./...
+```
+
+For a focused check of this feature, run `go test ./internal/cli`. The CI environment must include the repository's generated Tree-sitter grammar sources; without them Go can fail during package setup before risk tests execute.
+
+## Databricks use, data sources and limitations
+
+**Capabilities used:** Databricks Declarative Automation Bundles (formerly Asset Bundles), a Lakeflow Job, a Python notebook task, Spark DataFrames, Unity Catalog schema/table creation, and Delta Lake append writes.
+
+**Why it is essential:** Databricks is optional for the individual CLI decision, but essential for the team-scale analytics workflow: it turns multiple deterministic risk reports into a governed, queryable history for release/risk trends without changing or externalizing the repository analysis runtime.
+
+**Relevant paths:**
+
+- [`databricks/databricks.yml`](databricks/databricks.yml)
+- [`databricks/resources/risk_ingestion.job.yml`](databricks/resources/risk_ingestion.job.yml)
+- [`databricks/src/ingest_risk_reports.py`](databricks/src/ingest_risk_reports.py)
+- [`docs/databricks-risk-ingestion.md`](docs/databricks-risk-ingestion.md)
+
+**Data provenance:** The input is JSON explicitly generated by `entire graph risk --format json` for a named Git base/head revision or checkpoint. The job writes entity-level rows containing revision metadata, risk classifications, graph evidence, recommended-test paths, limitations, source-report path, and ingestion timestamp. No third-party or scraped data is used.
+
+**Reproduction:**
+
+```sh
+entire graph risk --repo . --base origin/main --head HEAD --format json > risk-report.json
+# Upload risk-report.json to a Unity Catalog Volume, for example:
+# /Volumes/main/entire_graph/risk_reports/risk-report.json
+cd databricks
+databricks bundle validate -t dev
+databricks bundle deploy -t dev
+databricks bundle run entire_graph_risk_ingestion -t dev \
+  --params risk_report_path=/Volumes/main/entire_graph/risk_reports/risk-report.json
+```
+
+**Workspace/app/endpoint/demo URL:** **not deployed yet.** Add the Databricks Job URL and one successful run URL here only after the reproduction steps complete. The Databricks CLI was not installed in the development checkout, so bundle validation and a workspace run were not performed locally.
+
+## Known limitations and next steps
+
+- Graph evidence is intentionally bounded and can be incomplete for ambiguous symbols, partial parses, or a requested head that is not the current checkout.
+- Risk categories are deterministic heuristics, not a claim of test coverage or production safety.
+- Databricks ingestion is append-only; downstream queries should deduplicate by revision/checkpoint and source-report path when needed.
+- Required Entire checkpoint links, an Entire mirror/project URL if mandated, and a successful Databricks job run URL remain to be added before final submission.
+
+## Demo readiness
+
+**Opening sentence:** “Entire Graph Risk Intelligence helps code reviewers see which semantic code changes are most likely to break dependent components, and what to test next.”
+
+Show this critical path, not slides alone:
+
+1. Run `entire graph risk --repo . --base origin/main --head HEAD --format text` and point out one changed entity, its caller/type-consumer evidence, risk level, and recommended tests.
+2. Show the corresponding JSON output and the focused test command/result.
+3. Explain that Entire Graph supplies the semantic diff and dependency evidence that a Git text diff cannot.
+4. Open a real Entire checkpoint and state what implementation decision it records. Do this only after the links above have been added.
+5. Explain the curveball: analysis stays no-egress/local; only a user-exported JSON report enters the Databricks workflow.
+6. If opting into Databricks, run the bundle and show the resulting Delta table query plus the successful job run URL.
+7. Close with the known limitations and the next production step: scheduled report ingestion, deduplication, and a release-risk dashboard.
+
+If a live Databricks workspace is unavailable, record a reliable screen capture of steps 1–3 and the pre-recorded successful Databricks job/table result. Do not present an unrun bundle as a live demo.

--- a/databricks/databricks.yml
+++ b/databricks/databricks.yml
@@ -1,0 +1,26 @@
+bundle:
+  name: entire-graph-risk
+
+include:
+  - resources/*.yml
+
+variables:
+  catalog:
+    description: Unity Catalog catalog that stores risk history.
+    default: main
+  schema:
+    description: Unity Catalog schema that stores risk history.
+    default: entire_graph
+  risk_report_path:
+    description: Path to a JSON report produced by `entire graph risk --format json`.
+    default: ""
+  target_table:
+    description: Delta table name for normalized entity-level risk records.
+    default: changeset_risk
+
+targets:
+  dev:
+    mode: development
+    default: true
+    workspace:
+      root_path: ~/.bundle/${bundle.name}/${bundle.target}

--- a/databricks/resources/risk_ingestion.job.yml
+++ b/databricks/resources/risk_ingestion.job.yml
@@ -1,0 +1,20 @@
+resources:
+  jobs:
+    entire_graph_risk_ingestion:
+      name: "[${bundle.target}] entire-graph-risk-ingestion"
+      description: Normalizes JSON output from `entire graph risk` into a Unity Catalog Delta table.
+      max_concurrent_runs: 1
+      tasks:
+        - task_key: ingest_risk_report
+          notebook_task:
+            notebook_path: ../src/ingest_risk_reports.py
+            base_parameters:
+              catalog: ${var.catalog}
+              schema: ${var.schema}
+              target_table: ${var.target_table}
+              risk_report_path: ${var.risk_report_path}
+          environment_key: default
+      environments:
+        - environment_key: default
+          spec:
+            client: "1"

--- a/databricks/src/ingest_risk_reports.py
+++ b/databricks/src/ingest_risk_reports.py
@@ -1,0 +1,82 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # Entire Graph risk-report ingestion
+# MAGIC
+# MAGIC This job consumes JSON produced by `entire graph risk --format json`,
+# MAGIC normalizes one row per changed entity, and appends the result to Delta.
+
+# COMMAND ----------
+
+from pyspark.sql import functions as F
+
+
+def widget(name: str) -> str:
+    dbutils.widgets.text(name, "")
+    return dbutils.widgets.get(name).strip()
+
+
+def identifier(value: str, label: str) -> str:
+    # Catalog, schema, and table names are used in SQL. Keep them simple and
+    # quoted so job parameters cannot change the statement's structure.
+    if not value or not value.replace("_", "a").replace("-", "a").isalnum():
+        raise ValueError(f"{label} must contain only letters, digits, '_' or '-'")
+    return f"`{value}`"
+
+
+catalog = widget("catalog")
+schema = widget("schema")
+target_table = widget("target_table")
+risk_report_path = widget("risk_report_path")
+
+if not risk_report_path:
+    raise ValueError("risk_report_path is required")
+
+qualified_table = ".".join(
+    [identifier(catalog, "catalog"), identifier(schema, "schema"), identifier(target_table, "target_table")]
+)
+spark.sql(f"CREATE SCHEMA IF NOT EXISTS {identifier(catalog, 'catalog')}.{identifier(schema, 'schema')}")
+
+report = spark.read.option("multiline", "true").json(risk_report_path)
+if report.rdd.isEmpty():
+    raise ValueError(f"risk report is empty: {risk_report_path}")
+
+records = (
+    report.select(
+        F.col("format_version").alias("report_format_version"),
+        F.col("base").alias("base_revision"),
+        F.col("head").alias("head_revision"),
+        F.col("checkpoint"),
+        F.col("overall_risk"),
+        F.col("entities_changed"),
+        F.col("entities_analyzed"),
+        F.col("entities_skipped"),
+        F.explode_outer("entries").alias("entry"),
+    )
+    .where(F.col("entry").isNotNull())
+    .select(
+        "report_format_version",
+        "base_revision",
+        "head_revision",
+        "checkpoint",
+        "overall_risk",
+        "entities_changed",
+        "entities_analyzed",
+        "entities_skipped",
+        F.col("entry.name").alias("entity_name"),
+        F.col("entry.kind").alias("entity_kind"),
+        F.col("entry.change_type").alias("change_type"),
+        F.col("entry.file_path").alias("file_path"),
+        F.col("entry.start_line").alias("start_line"),
+        F.col("entry.dependents_count").alias("dependents_count"),
+        F.col("entry.level").alias("entity_risk"),
+        F.to_json(F.col("entry.graph_evidence")).alias("graph_evidence_json"),
+        F.to_json(F.col("entry.affected_tests")).alias("affected_tests_json"),
+        F.col("entry.inference").alias("inference"),
+        F.to_json(F.col("entry.limitations")).alias("limitations_json"),
+        F.lit(risk_report_path).alias("source_report_path"),
+        F.current_timestamp().alias("ingested_at"),
+    )
+)
+
+records.write.format("delta").mode("append").option("mergeSchema", "true").saveAsTable(qualified_table)
+display(records.orderBy(F.col("entity_risk").desc(), F.col("dependents_count").desc()))

--- a/docs/databricks-risk-ingestion.md
+++ b/docs/databricks-risk-ingestion.md
@@ -1,0 +1,44 @@
+# Databricks risk intelligence
+
+This optional [Databricks Declarative Automation Bundle](https://docs.databricks.com/aws/en/dev-tools/bundles/) turns the existing `entire graph risk --format json` output into a governed, queryable Delta table. It is deliberately separate from the local Go CLI: running or not running Databricks does not change risk analysis results.
+
+## What it stores
+
+The job writes one row per changed entity to Unity Catalog. Each row includes the report's revision/checkpoint, changeset and entity risk, changed file and line, dependent count, graph-evidence JSON, recommended-test JSON, inference, limitations, and ingestion timestamp.
+
+## Deploy
+
+1. Authenticate the [Databricks CLI](https://docs.databricks.com/aws/en/dev-tools/cli/authentication.html) to a workspace that has Unity Catalog and permission to create a schema/table in the chosen catalog.
+2. Produce a report and place it in a Unity Catalog volume or other Spark-readable location:
+
+   ```sh
+   entire graph risk --repo . --base main --head HEAD --format json > risk-report.json
+   # Upload risk-report.json to, for example:
+   # /Volumes/main/entire_graph/risk_reports/risk-report.json
+   ```
+
+3. From `databricks/`, validate and deploy the bundle:
+
+   ```sh
+   databricks bundle validate -t dev
+   databricks bundle deploy -t dev
+   databricks bundle run entire_graph_risk_ingestion -t dev \
+     --params risk_report_path=/Volumes/main/entire_graph/risk_reports/risk-report.json
+   ```
+
+   If you use another catalog, schema, or table name, set them during deploy/run with the corresponding bundle variables.
+
+4. Query the result:
+
+   ```sql
+   SELECT overall_risk, entity_risk, change_type, entity_name, file_path,
+          dependents_count, graph_evidence_json, affected_tests_json, ingested_at
+   FROM main.entire_graph.changeset_risk
+   ORDER BY ingested_at DESC, entity_risk DESC, dependents_count DESC;
+   ```
+
+## Operational notes
+
+- The report must use the current `riskReport` JSON contract (format version 1).
+- The ingestion is append-only. Re-running the same report intentionally records another ingestion event; use revision/checkpoint and `source_report_path` for deduplication in downstream queries.
+- This repository contains a deployable Databricks integration, but it is not a claim that a job has already been deployed or run in a workspace. Record the workspace job URL/run result in the submission only after completing the deploy step.

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -357,6 +357,23 @@ var commandDocs = []commandDoc{
 		examples: []string{"entire graph checkpoint abc123 --json"},
 	},
 	{
+		name:    "risk",
+		group:   groupAnalyze,
+		summary: "Classify a changeset's graph-derived risk and recommend tests",
+		usage:   []string{"entire graph risk [--base <rev> --head <rev> | --checkpoint <id>] [--format text|json] [--max-entities n] [--repo path]"},
+		long:    "Composes semantic diff and per-entity impact analysis into a bounded changeset risk report. Graph evidence (callers, type consumers, and locations) is printed separately from the deterministic risk inference. Test recommendations come only from graph caller and co-change paths and must be verified by running them.",
+		flags: []flagDoc{
+			{name: "--base", arg: "rev", def: "HEAD~1", desc: "Base revision"},
+			{name: "--head", arg: "rev", def: "HEAD", desc: "Head revision"},
+			{name: "--checkpoint", arg: "id", desc: "Analyze the semantic diff associated with an Entire checkpoint"},
+			{name: "--format", arg: "text|json", def: "text", desc: "Output format"},
+			{name: "--max-entities", arg: "n", def: "5", desc: "Maximum changed entities to impact-analyze"},
+			{name: "--profile", arg: "full|fast|syntax-only", def: "full", desc: "Graph snapshot profile"},
+			{name: "--repo", arg: "path", desc: "Repository (default: current repo)"},
+		},
+		examples: []string{"entire graph risk --repo . --base HEAD~1 --head HEAD", "entire graph risk --checkpoint abc123 --format json"},
+	},
+	{
 		name:    "verify",
 		group:   groupAnalyze,
 		summary: "Run a test command and return an adjudicated verdict, not test output",

--- a/internal/cli/help_test.go
+++ b/internal/cli/help_test.go
@@ -14,7 +14,7 @@ import (
 var dispatchCommands = []string{
 	"diff", "commit", "checkpoint", "analyze", "doctor", "capabilities",
 	"snapshot", "snapshot-query", "symbols", "edges", "search", "index", "def",
-	"explain", "neighbors", "impact", "verify", "stats", "agent-guide",
+	"explain", "neighbors", "impact", "risk", "verify", "stats", "agent-guide",
 	"init-agents", "version", "help",
 }
 

--- a/internal/cli/risk.go
+++ b/internal/cli/risk.go
@@ -1,0 +1,479 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/entireio/entire-graph/internal/gitutil"
+	"github.com/entireio/entire-graph/internal/sem"
+	"github.com/entireio/entire-graph/internal/termsafe"
+)
+
+// defaultRiskMaxEntities bounds a changeset report. The command is intended to
+// make a review decision promptly, not to turn one large diff into unbounded
+// repeated graph traversals.
+const defaultRiskMaxEntities = 5
+
+type riskLevel string
+
+const (
+	riskHigh   riskLevel = "high"
+	riskMedium riskLevel = "medium"
+	riskLow    riskLevel = "low"
+)
+
+type riskFlags struct {
+	Repo        string
+	Base        string
+	Head        string
+	Checkpoint  string
+	Format      string
+	Profile     string
+	MaxEntities int
+}
+
+type riskEvidence struct {
+	DirectCallers     int                `json:"direct_callers"`
+	TransitiveCallers int                `json:"transitive_callers"`
+	TypeConsumers     int                `json:"type_consumers"`
+	Callees           int                `json:"callees"`
+	TopCallers        []neighborEndpoint `json:"top_callers"`
+}
+
+type riskEntry struct {
+	Name            string       `json:"name"`
+	Kind            string       `json:"kind"`
+	ChangeType      string       `json:"change_type"`
+	FilePath        string       `json:"file_path,omitempty"`
+	StartLine       int          `json:"start_line,omitempty"`
+	DependentsCount int          `json:"dependents_count"`
+	Level           riskLevel    `json:"level"`
+	Evidence        riskEvidence `json:"graph_evidence"`
+	Tests           []string     `json:"affected_tests"`
+	Inference       string       `json:"inference"`
+	Limitations     []string     `json:"limitations,omitempty"`
+}
+
+type riskReport struct {
+	FormatVersion    int                   `json:"format_version"`
+	Base             string                `json:"base,omitempty"`
+	Head             string                `json:"head,omitempty"`
+	Checkpoint       string                `json:"checkpoint,omitempty"`
+	OverallRisk      riskLevel             `json:"overall_risk"`
+	EntitiesChanged  int                   `json:"entities_changed"`
+	EntitiesAnalyzed int                   `json:"entities_analyzed"`
+	EntitiesSkipped  int                   `json:"entities_skipped,omitempty"`
+	Entries          []riskEntry           `json:"entries"`
+	RecommendedTests []string              `json:"recommended_tests"`
+	Warnings         []sem.ProviderWarning `json:"warnings,omitempty"`
+	Limitations      []string              `json:"limitations,omitempty"`
+}
+
+func parseRiskFlags(args []string) (riskFlags, error) {
+	flags := riskFlags{Base: "HEAD~1", Head: "HEAD", Format: "text", Profile: "full", MaxEntities: defaultRiskMaxEntities}
+	baseSet, headSet := false, false
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		value := func() (string, error) {
+			i++
+			if i >= len(args) {
+				return "", fmt.Errorf("%s requires a value", arg)
+			}
+			return args[i], nil
+		}
+		switch arg {
+		case "--repo":
+			item, err := value()
+			if err != nil {
+				return flags, err
+			}
+			flags.Repo = item
+		case "--base":
+			item, err := value()
+			if err != nil {
+				return flags, err
+			}
+			if err := validateRevision("--base", item); err != nil {
+				return flags, err
+			}
+			flags.Base, baseSet = item, true
+		case "--head":
+			item, err := value()
+			if err != nil {
+				return flags, err
+			}
+			if err := validateRevision("--head", item); err != nil {
+				return flags, err
+			}
+			flags.Head, headSet = item, true
+		case "--checkpoint":
+			item, err := value()
+			if err != nil {
+				return flags, err
+			}
+			if strings.TrimSpace(item) == "" {
+				return flags, errors.New("--checkpoint requires a value")
+			}
+			flags.Checkpoint = item
+		case "--format":
+			item, err := value()
+			if err != nil {
+				return flags, err
+			}
+			flags.Format = item
+		case "--profile":
+			item, err := value()
+			if err != nil {
+				return flags, err
+			}
+			flags.Profile = item
+		case "--max-entities":
+			item, err := value()
+			if err != nil {
+				return flags, err
+			}
+			count, parseErr := strconv.Atoi(item)
+			if parseErr != nil || count <= 0 {
+				return flags, fmt.Errorf("--max-entities requires a positive integer, got %q", item)
+			}
+			flags.MaxEntities = count
+		default:
+			return flags, fmt.Errorf("risk received unexpected argument %q", arg)
+		}
+	}
+	if flags.Checkpoint != "" && (baseSet || headSet) {
+		return flags, errors.New("risk --checkpoint cannot be combined with --base or --head")
+	}
+	if flags.Format != "text" && flags.Format != "json" {
+		return flags, fmt.Errorf("risk --format must be text or json, got %q", flags.Format)
+	}
+	return flags, nil
+}
+
+func runRisk(ctx context.Context, opts Options, args []string) error {
+	flags, err := parseRiskFlags(args)
+	if err != nil {
+		return err
+	}
+	repo, err := resolveRepo(ctx, opts.Env, flags.Repo)
+	if err != nil {
+		return err
+	}
+	profile, err := parseProfile(flags.Profile)
+	if err != nil {
+		return err
+	}
+
+	var diff sem.Result
+	if flags.Checkpoint != "" {
+		diff, err = sem.AnalyzeCheckpoint(ctx, repo, flags.Checkpoint)
+	} else {
+		// Match the normal diff command's default budget. The report preserves
+		// the semantic diff's explicit budget warning rather than silently
+		// treating a partial result as a complete changeset.
+		diff, err = sem.AnalyzeGitRangeWithOptions(ctx, repo, flags.Base, flags.Head, nil, sem.AnalyzeOptions{
+			MaxDuration: time.Duration(defaultMaxSeconds) * time.Second,
+		})
+	}
+	if err != nil {
+		return err
+	}
+	// A range describes committed trees, so build the same committed current-tree
+	// view used by normal head-mode graph queries. A non-HEAD range is still
+	// reported honestly; symbol resolution may be incomplete if its head is not
+	// the checkout's current committed tree.
+	snapshot, _, err := sem.LoadOrBuildProviderSnapshot(ctx, repo, opts.Version, sem.ProviderSnapshotOptions{
+		NoNetwork: true, Worktree: false, Profile: profile,
+	}, resolveCacheDir("", opts.Env.PluginDataDir), false)
+	if err != nil {
+		return err
+	}
+	readSource, closeSource := openSnapshotLineReaderOrDegrade(ctx, snapshot, false, opts.Stderr)
+	if closeSource != nil {
+		defer closeSource()
+	}
+	evidenceAvailable, evidenceLimitation := riskEvidenceMatchesHead(ctx, repo, flags.Head, snapshot)
+	report := buildRiskReport(diff, snapshot, flags, readSource, evidenceAvailable, evidenceLimitation)
+	if flags.Checkpoint != "" {
+		report.Checkpoint = flags.Checkpoint
+		report.Limitations = append(report.Limitations, "checkpoint impact evidence is resolved against the current committed checkout; verify it if the checkpoint commit is not checked out")
+	} else {
+		report.Base, report.Head = flags.Base, flags.Head
+	}
+	if profile != sem.ProfileFull {
+		report.Limitations = append(report.Limitations, "the selected graph profile may omit relationship families; use --profile full for the most complete risk evidence")
+	}
+	switch flags.Format {
+	case "json":
+		encoder := json.NewEncoder(termsafe.NewJSONWriter(opts.Stdout))
+		encoder.SetEscapeHTML(false)
+		return encoder.Encode(report)
+	case "text":
+		return writeRiskText(opts.Stdout, report)
+	default:
+		return fmt.Errorf("risk --format must be text or json, got %q", flags.Format)
+	}
+}
+
+// riskEvidenceMatchesHead prevents a range from being paired with graph data
+// from another committed tree. Provider snapshots can only describe the
+// current checkout, so a non-current --head must not borrow its callers or
+// type consumers as evidence.
+func riskEvidenceMatchesHead(ctx context.Context, repo, head string, snapshot sem.ProviderSnapshot) (bool, string) {
+	if snapshot.Header.Tree == "" {
+		return false, "graph evidence was omitted because the current committed snapshot has no tree provenance"
+	}
+	requestedTree, err := gitutil.RevParse(ctx, repo, head+"^{tree}")
+	if err != nil {
+		return false, "graph evidence was omitted because the requested --head tree could not be resolved against the current committed snapshot"
+	}
+	if requestedTree != snapshot.Header.Tree {
+		return false, "graph evidence was omitted because the requested --head is not the current committed checkout; check out that revision before analyzing its callers or type consumers"
+	}
+	return true, ""
+}
+
+type riskChangedEntity struct {
+	change sem.EntityChange
+	path   string
+}
+
+func buildRiskReport(diff sem.Result, snapshot sem.ProviderSnapshot, flags riskFlags, readSource lineReader, evidenceAvailable bool, evidenceLimitation string) riskReport {
+	report := riskReport{FormatVersion: 1, OverallRisk: riskLow, Entries: []riskEntry{}, RecommendedTests: []string{}, Warnings: append([]sem.ProviderWarning{}, diff.Warnings...)}
+	report.Warnings = append(report.Warnings, snapshot.Header.Warnings...)
+	if !evidenceAvailable && evidenceLimitation != "" {
+		report.Limitations = append(report.Limitations, evidenceLimitation)
+	}
+	var changes []riskChangedEntity
+	for _, file := range diff.Files {
+		for _, change := range file.Changes {
+			path := change.NewPath
+			if path == "" {
+				path = file.Path
+			}
+			if path == "" {
+				path = change.OldPath
+			}
+			changes = append(changes, riskChangedEntity{change: change, path: path})
+		}
+	}
+	report.EntitiesChanged = len(changes)
+	sort.SliceStable(changes, func(i, j int) bool {
+		if changes[i].change.DependentsCount != changes[j].change.DependentsCount {
+			return changes[i].change.DependentsCount > changes[j].change.DependentsCount
+		}
+		if changes[i].path != changes[j].path {
+			return changes[i].path < changes[j].path
+		}
+		return changes[i].change.Name < changes[j].change.Name
+	})
+	if len(changes) > flags.MaxEntities {
+		report.EntitiesSkipped = len(changes) - flags.MaxEntities
+		changes = changes[:flags.MaxEntities]
+		report.Limitations = append(report.Limitations, fmt.Sprintf("analysis is capped at %d entities; %d lower-priority entity changes were skipped", flags.MaxEntities, report.EntitiesSkipped))
+	}
+	tests := map[string]bool{}
+	for _, item := range changes {
+		entry := buildRiskEntry(snapshot, item, readSource, evidenceAvailable, evidenceLimitation)
+		for _, test := range entry.Tests {
+			tests[test] = true
+		}
+		report.Entries = append(report.Entries, entry)
+	}
+	report.EntitiesAnalyzed = len(report.Entries)
+	for test := range tests {
+		report.RecommendedTests = append(report.RecommendedTests, test)
+	}
+	sort.Strings(report.RecommendedTests)
+	report.OverallRisk = classifyChangesetRisk(report.Entries)
+	if len(snapshot.Header.PartialFailures) > 0 {
+		report.Limitations = append(report.Limitations, "the graph reported partial parse/index failures; inspect the evidence before relying on a complete blast radius")
+	}
+	if report.EntitiesChanged == 0 {
+		report.Limitations = append(report.Limitations, "no semantic entity changes were detected")
+	}
+	return report
+}
+
+func buildRiskEntry(snapshot sem.ProviderSnapshot, item riskChangedEntity, readSource lineReader, evidenceAvailable bool, evidenceLimitation string) riskEntry {
+	change := item.change
+	name := change.NewName
+	if name == "" {
+		name = change.Name
+	}
+	if name == "" {
+		name = change.OldName
+	}
+	line := change.AfterStartLine
+	if line == 0 {
+		line = change.BeforeStartLine
+	}
+	entry := riskEntry{Name: name, Kind: change.Kind, ChangeType: change.Type, FilePath: item.path, StartLine: line, DependentsCount: change.DependentsCount, Tests: []string{}}
+	if !evidenceAvailable {
+		entry.Limitations = append(entry.Limitations, evidenceLimitation)
+		entry.Level = classifyEntityRisk(change, riskEvidence{})
+		entry.Inference = riskInference(change, entry.Level, riskEvidence{})
+		return entry
+	}
+	impact := buildImpactResponseFromReader(snapshot, impactFlags{Symbol: name, File: item.path, Line: line, Kind: change.Kind, Depth: 2, Limit: defaultImpactSectionLimit}, readSource)
+	if impact.Focus == nil || impact.DisambiguationRequired {
+		if impact.DisambiguationRequired {
+			entry.Limitations = append(entry.Limitations, "graph symbol resolution is ambiguous; no blast radius was inferred")
+		} else {
+			entry.Limitations = append(entry.Limitations, "changed symbol is absent from the current graph snapshot (commonly an added, removed, or non-current-range entity)")
+		}
+		entry.Level = classifyEntityRisk(change, riskEvidence{})
+		entry.Inference = riskInference(change, entry.Level, riskEvidence{})
+		return entry
+	}
+	annotateImpactCallSites(&impact, readSource)
+	evidence := riskEvidence{DirectCallers: impact.Callers.Direct, TransitiveCallers: impact.Callers.Transitive, TypeConsumers: impact.TypeConsumers.Total, Callees: impact.Callees.Total, TopCallers: []neighborEndpoint{}}
+	for _, caller := range impact.Callers.Entries {
+		evidence.TopCallers = append(evidence.TopCallers, caller.Endpoint)
+	}
+	entry.Evidence = evidence
+	entry.Tests = collectAffectedTests(impact)
+	entry.Level = classifyEntityRisk(change, evidence)
+	entry.Inference = riskInference(change, entry.Level, evidence)
+	if impact.Degenerate {
+		entry.Limitations = append(entry.Limitations, impact.DegenerateReason)
+	}
+	if len(impact.PartialFailures) > 0 {
+		entry.Limitations = append(entry.Limitations, "graph evidence is incomplete because this snapshot has partial failures")
+	}
+	return entry
+}
+
+// classifyEntityRisk is deliberately deterministic and conservative. Graph
+// counts are evidence; the verdict below is the tool's inference from them.
+func classifyEntityRisk(change sem.EntityChange, evidence riskEvidence) riskLevel {
+	if evidence.DirectCallers >= 10 || evidence.TypeConsumers >= 10 || (change.Type == "signature_changed" && evidence.DirectCallers >= 5) || (change.Type == "removed" && change.DependentsCount >= 5) {
+		return riskHigh
+	}
+	if evidence.DirectCallers > 0 || evidence.TypeConsumers > 0 || change.DependentsCount > 0 || change.Type == "signature_changed" || change.Type == "removed" {
+		return riskMedium
+	}
+	return riskLow
+}
+
+func classifyChangesetRisk(entries []riskEntry) riskLevel {
+	level := riskLow
+	for _, entry := range entries {
+		if entry.Level == riskHigh {
+			return riskHigh
+		}
+		if entry.Level == riskMedium {
+			level = riskMedium
+		}
+	}
+	return level
+}
+
+func collectAffectedTests(impact impactResponse) []string {
+	seen := map[string]bool{}
+	collect := func(section impactSection) {
+		for _, item := range section.Entries {
+			if isConventionalTestPath(item.Endpoint.FilePath) {
+				seen[item.Endpoint.FilePath] = true
+			}
+		}
+	}
+	collect(impact.Callers)
+	collect(impact.CoChanges)
+	tests := make([]string, 0, len(seen))
+	for path := range seen {
+		tests = append(tests, path)
+	}
+	sort.Strings(tests)
+	return tests
+}
+
+func riskInference(change sem.EntityChange, level riskLevel, evidence riskEvidence) string {
+	if evidence.DirectCallers > 0 {
+		return fmt.Sprintf("%s change with %d direct graph caller%s and %d type consumer%s → %s risk.", change.Type, evidence.DirectCallers, plural(evidence.DirectCallers), evidence.TypeConsumers, plural(evidence.TypeConsumers), strings.ToUpper(string(level)))
+	}
+	if change.DependentsCount > 0 {
+		return fmt.Sprintf("%s change has %d semantic-diff dependent%s but no resolved current-snapshot callers → %s risk.", change.Type, change.DependentsCount, plural(change.DependentsCount), strings.ToUpper(string(level)))
+	}
+	return fmt.Sprintf("%s change has no resolved graph callers or dependents → %s risk.", change.Type, strings.ToUpper(string(level)))
+}
+
+func plural(count int) string {
+	if count == 1 {
+		return ""
+	}
+	return "s"
+}
+
+func writeRiskText(out io.Writer, report riskReport) error {
+	out = termsafe.NewWriter(out)
+	fmt.Fprintf(out, "CHANGESET RISK: %s %s  (%d entities changed, %d analyzed)\n", strings.ToUpper(string(report.OverallRisk)), riskIcon(report.OverallRisk), report.EntitiesChanged, report.EntitiesAnalyzed)
+	if report.Checkpoint != "" {
+		fmt.Fprintf(out, "Checkpoint: %s\n", report.Checkpoint)
+	} else {
+		fmt.Fprintf(out, "Base: %s  Head: %s\n", report.Base, report.Head)
+	}
+	if len(report.Entries) == 0 {
+		fmt.Fprintln(out, "No semantic entity changes detected.")
+	}
+	for _, entry := range report.Entries {
+		fmt.Fprintf(out, "\n%s %s  %s [%s]\n", riskIcon(entry.Level), strings.ToUpper(string(entry.Level)), entry.Name, entry.ChangeType)
+		if entry.FilePath != "" {
+			fmt.Fprintf(out, "  Evidence location: %s:%d (%s)\n", entry.FilePath, entry.StartLine, entry.Kind)
+		}
+		fmt.Fprintln(out, "  Graph evidence:")
+		fmt.Fprintf(out, "    %d direct callers, %d transitive callers, %d type consumers, %d callees\n", entry.Evidence.DirectCallers, entry.Evidence.TransitiveCallers, entry.Evidence.TypeConsumers, entry.Evidence.Callees)
+		for _, caller := range entry.Evidence.TopCallers {
+			fmt.Fprintf(out, "    - %s:%d  %s\n", caller.FilePath, caller.StartLine, caller.Name)
+		}
+		fmt.Fprintf(out, "  Our inference: %s\n", entry.Inference)
+		for _, limitation := range entry.Limitations {
+			fmt.Fprintf(out, "  Limitation: %s\n", limitation)
+		}
+	}
+	fmt.Fprintf(out, "\nRECOMMENDED TESTS (%d files, from graph caller/co-change relationships)\n", len(report.RecommendedTests))
+	for _, test := range report.RecommendedTests {
+		fmt.Fprintf(out, "  %s\n", test)
+	}
+	if len(report.RecommendedTests) > 0 {
+		fmt.Fprintln(out, "  Verify by running the relevant test files; recommendations are path-based, not coverage-based.")
+	}
+	if len(report.Warnings) > 0 {
+		fmt.Fprintln(out, "\nWARNINGS")
+		for _, warning := range report.Warnings {
+			fmt.Fprintf(out, "  %s", warning.Code)
+			if warning.FilePath != "" {
+				fmt.Fprintf(out, " %s", warning.FilePath)
+			}
+			if warning.EffectOnCompleteness != "" {
+				fmt.Fprintf(out, " (%s)", warning.EffectOnCompleteness)
+			}
+			if warning.Detail != "" {
+				fmt.Fprintf(out, ": %s", warning.Detail)
+			}
+			fmt.Fprintln(out)
+		}
+	}
+	for _, limitation := range report.Limitations {
+		fmt.Fprintf(out, "Limitation: %s\n", limitation)
+	}
+	return nil
+}
+
+func riskIcon(level riskLevel) string {
+	switch level {
+	case riskHigh:
+		return "🔴"
+	case riskMedium:
+		return "🟡"
+	default:
+		return "🟢"
+	}
+}

--- a/internal/cli/risk_test.go
+++ b/internal/cli/risk_test.go
@@ -1,0 +1,210 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/entireio/entire-graph/internal/sem"
+)
+
+func TestClassifyEntityRisk(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		change   sem.EntityChange
+		evidence riskEvidence
+		want     riskLevel
+	}{
+		{"broad callers", sem.EntityChange{Type: "body_changed"}, riskEvidence{DirectCallers: 10}, riskHigh},
+		{"signature moderate callers", sem.EntityChange{Type: "signature_changed"}, riskEvidence{DirectCallers: 5}, riskHigh},
+		{"signature no snapshot match", sem.EntityChange{Type: "signature_changed"}, riskEvidence{}, riskMedium},
+		{"ordinary caller", sem.EntityChange{Type: "body_changed"}, riskEvidence{DirectCallers: 1}, riskMedium},
+		{"isolated addition", sem.EntityChange{Type: "added"}, riskEvidence{}, riskLow},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := classifyEntityRisk(testCase.change, testCase.evidence); got != testCase.want {
+				t.Fatalf("classifyEntityRisk() = %s, want %s", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestCollectAffectedTestsUsesOnlyImpactRelationships(t *testing.T) {
+	t.Parallel()
+	impact := impactResponse{
+		Callers: impactSection{Entries: []impactEntry{
+			{Endpoint: neighborEndpoint{FilePath: "internal/service_test.go"}},
+			{Endpoint: neighborEndpoint{FilePath: "internal/service.go"}},
+		}},
+		CoChanges: impactSection{Entries: []impactEntry{
+			{Endpoint: neighborEndpoint{FilePath: "tests/test_api.py"}},
+			{Endpoint: neighborEndpoint{FilePath: "docs/example.md"}},
+		}},
+		TypeConsumers: impactSection{Entries: []impactEntry{{Endpoint: neighborEndpoint{FilePath: "spec/not_used_test.go"}}}},
+	}
+	got := collectAffectedTests(impact)
+	want := []string{"internal/service_test.go", "tests/test_api.py"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("affected tests = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseRiskFlags(t *testing.T) {
+	t.Parallel()
+	flags, err := parseRiskFlags([]string{"--base", "main", "--head", "HEAD", "--format", "json", "--max-entities", "3"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if flags.Base != "main" || flags.Head != "HEAD" || flags.Format != "json" || flags.MaxEntities != 3 {
+		t.Fatalf("flags = %#v", flags)
+	}
+	for _, args := range [][]string{
+		{"--checkpoint", "abc", "--base", "HEAD~1"},
+		{"--max-entities", "0"},
+		{"--format", "yaml"},
+	} {
+		if _, err := parseRiskFlags(args); err == nil {
+			t.Fatalf("parseRiskFlags(%q) unexpectedly succeeded", args)
+		}
+	}
+}
+
+func TestWriteRiskJSONShape(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	report := riskReport{FormatVersion: 1, OverallRisk: riskMedium, Entries: []riskEntry{}, RecommendedTests: []string{}}
+	encoder := json.NewEncoder(&out)
+	if err := encoder.Encode(report); err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded["overall_risk"] != "medium" || decoded["format_version"] != float64(1) {
+		t.Fatalf("JSON report = %#v", decoded)
+	}
+}
+
+func TestBuildRiskReportHandlesEmptyAndAmbiguousGraphResults(t *testing.T) {
+	t.Parallel()
+	empty := buildRiskReport(sem.Result{}, sem.ProviderSnapshot{}, riskFlags{MaxEntities: defaultRiskMaxEntities}, nil, true, "")
+	if empty.EntitiesChanged != 0 || len(empty.Entries) != 0 || len(empty.Limitations) == 0 {
+		t.Fatalf("empty report = %#v", empty)
+	}
+
+	diff := sem.Result{Files: []sem.FileChange{{Changes: []sem.EntityChange{{Name: "Handle", Kind: "function", Type: "body_changed"}}}}}
+	snapshot := sem.ProviderSnapshot{Symbols: []sem.SymbolRecord{
+		{ID: "one", Name: "Handle", QualifiedName: "one.Handle", Kind: "function", FilePath: "one.go", StartLine: 1},
+		{ID: "two", Name: "Handle", QualifiedName: "two.Handle", Kind: "function", FilePath: "two.go", StartLine: 1},
+	}}
+	report := buildRiskReport(diff, snapshot, riskFlags{MaxEntities: defaultRiskMaxEntities}, nil, true, "")
+	if len(report.Entries) != 1 || len(report.Entries[0].Limitations) == 0 || !strings.Contains(report.Entries[0].Limitations[0], "ambiguous") {
+		t.Fatalf("ambiguous report = %#v", report)
+	}
+}
+
+func TestBuildRiskReportOmitsMismatchedSnapshotEvidence(t *testing.T) {
+	t.Parallel()
+	diff := sem.Result{Files: []sem.FileChange{{Changes: []sem.EntityChange{{Name: "Target", Kind: "function", Type: "body_changed"}}}}}
+	snapshot := sem.ProviderSnapshot{Symbols: []sem.SymbolRecord{
+		{ID: "target", Name: "Target", Kind: "function", FilePath: "sample.go", StartLine: 1},
+		{ID: "caller", Name: "Caller", Kind: "function", FilePath: "sample.go", StartLine: 3},
+	}, Relations: []sem.RelationRecord{{Type: "CALLS", FromID: "caller", ToID: "target"}}}
+	report := buildRiskReport(diff, snapshot, riskFlags{MaxEntities: defaultRiskMaxEntities}, nil, false, "graph evidence was omitted because the requested --head is not the current committed checkout")
+	if len(report.Entries) != 1 || report.Entries[0].Evidence.DirectCallers != 0 {
+		t.Fatalf("mismatched snapshot leaked graph evidence: %#v", report)
+	}
+	if !strings.Contains(strings.Join(report.Entries[0].Limitations, "\n"), "omitted") {
+		t.Fatalf("entry does not explain omitted evidence: %#v", report.Entries[0])
+	}
+}
+
+func TestRiskEvidenceMatchesHead(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	write(t, repo, "sample.go", "package sample\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	write(t, repo, "sample.go", "package sample\n\nfunc Current() {}\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "current")
+
+	snapshot := sem.ProviderSnapshot{Header: sem.SnapshotHeader{Tree: rev(t, repo, "HEAD^{tree}")}}
+	if matched, limitation := riskEvidenceMatchesHead(t.Context(), repo, "HEAD", snapshot); !matched || limitation != "" {
+		t.Fatalf("current head should match snapshot: matched=%t limitation=%q", matched, limitation)
+	}
+	if matched, limitation := riskEvidenceMatchesHead(t.Context(), repo, "HEAD~1", snapshot); matched || !strings.Contains(limitation, "omitted") {
+		t.Fatalf("non-current head should omit evidence: matched=%t limitation=%q", matched, limitation)
+	}
+}
+
+func TestWriteRiskTextIncludesWarnings(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	report := riskReport{
+		OverallRisk:      riskLow,
+		Entries:          []riskEntry{},
+		RecommendedTests: []string{},
+		Warnings: []sem.ProviderWarning{{
+			Code:                 "W_ANALYSIS_BUDGET_EXCEEDED",
+			FilePath:             "large.go",
+			EffectOnCompleteness: "partial",
+			Detail:               "analysis stopped before this file",
+		}},
+	}
+	if err := writeRiskText(&out, report); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"WARNINGS", "W_ANALYSIS_BUDGET_EXCEEDED", "large.go", "partial", "analysis stopped before this file"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("text output missing %q:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestRiskEndToEndReportsGraphEvidenceAndTests(t *testing.T) {
+	repo := t.TempDir()
+	git(t, repo, "init")
+	git(t, repo, "config", "user.name", "Entire Graph Test")
+	git(t, repo, "config", "user.email", "graph@example.com")
+	write(t, repo, "sample.go", "package sample\n\nfunc Target(value string) string { return value }\n\nfunc Caller() string { return Target(\"ok\") }\n")
+	write(t, repo, "sample_test.go", "package sample\n\nimport \"testing\"\n\nfunc TestCaller(t *testing.T) { if Caller() == \"\" { t.Fatal(\"empty\") } }\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "initial")
+	write(t, repo, "sample.go", "package sample\n\nfunc Target(value string, prefix string) string { return prefix + value }\n\nfunc Caller() string { return Target(\"ok\", \"\") }\n")
+	git(t, repo, "add", ".")
+	git(t, repo, "commit", "-m", "signature change")
+
+	var stdout, stderr bytes.Buffer
+	err := Run(t.Context(), Options{Version: "test", Env: EntireEnv{RepoRoot: repo, PluginDataDir: t.TempDir()}, Stdout: &stdout, Stderr: &stderr},
+		[]string{"risk", "--base", "HEAD~1", "--head", "HEAD", "--format", "json"})
+	if err != nil {
+		t.Fatalf("risk: %v\nstderr: %s", err, stderr.String())
+	}
+	var report riskReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("risk JSON: %v\n%s", err, stdout.String())
+	}
+	if report.EntitiesChanged == 0 || report.EntitiesAnalyzed == 0 {
+		t.Fatalf("empty risk report: %#v", report)
+	}
+	var target *riskEntry
+	for index := range report.Entries {
+		if report.Entries[index].Name == "Target" {
+			target = &report.Entries[index]
+			break
+		}
+	}
+	if target == nil || target.Evidence.DirectCallers == 0 {
+		t.Fatalf("Target lacks graph caller evidence: %#v", report.Entries)
+	}
+	if !strings.Contains(strings.Join(report.RecommendedTests, "\n"), "sample_test.go") {
+		t.Fatalf("recommended tests = %#v, want sample_test.go", report.RecommendedTests)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -101,6 +101,8 @@ func Run(ctx context.Context, opts Options, args []string) error {
 		return runNeighbors(ctx, opts, args[1:])
 	case "impact":
 		return runImpact(ctx, opts, args[1:])
+	case "risk":
+		return runRisk(ctx, opts, args[1:])
 	case "verify":
 		return runVerify(ctx, opts, args[1:])
 	case "stats":


### PR DESCRIPTION
Track 2 — Project Description
Entire Graph Risk Intelligence turns a normal code change into an actionable engineering decision.
In a large open-source codebase, a Git diff tells developers what changed, but not necessarily what could break because of that change. Our solution extends Entire Graph with a new entire graph risk workflow that combines semantic change detection with the repository's dependency graph.
For a changeset, it identifies affected symbols, analyzes their callers and dependents, classifies the change as HIGH, MEDIUM, or LOW risk, and recommends relevant tests. The output clearly separates graph-derived evidence from inferred risk and test recommendations, making the result explainable rather than a black-box AI prediction.
The workflow is bounded and deterministic so it can remain practical on large repositories, while also reporting incomplete or ambiguous analysis instead of hiding uncertainty.