### PR TITLE
fix(sem): verify Gradle project ownership before deriving tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,47 @@
 
 # Entire Graph
 
-Coding agents lose time before the edit, while they are still looking for the
-right code. Entire Graph is a plugin for the Entire CLI that gives an agent a
-precomputed map of one Git repository: ranked code search plus definitions,
-callers, types, routes, and change impact, each with `file:line` locations. The
-built-in analyzer parses the repository locally with tree-sitter and makes no
-network requests, model calls, or API-key lookups. Installing the plugin is the
-networked step.
+Agents are continually spending their budgets before they write the first line
+of code, rummaging through files, grepping for function names, and re-reading
+the same files and configs, as they attempt to understand a codebase fresh with
+each session. According to [OpenRouter's Head of Insights](https://www.linkedin.com/posts/peterjameswalker_february-6th-2026-potentially-the-last-share-7493029881841344512-IK89/?utm_source=share&utm_medium=member_desktop&rcm=ACoAABfX0nABz6sCWbPldiV_9liETVfz5fRLAD0), agentic
+token usage grew 14x between February and August 2026, up from 0.51 trillion tokens
+to 7.3 trillion.
 
-Setup happens once per repository. After that, the interface is your coding
-agent: you ask a code question in plain language, the agent runs graph queries,
-reads the code the graph points at, and answers with citations. A captured
-example is shown below.
+Entire Graph is a plugin for the Entire CLI specifically designed to enable your
+agents to stop paying that cost. It hands your agent a precomputed map of a Git
+repository: ranked code search plus definitions, callers, types, routes, and
+change impact, each with `file:line` locations. The built-in analyzer parses the
+repository locally with tree-sitter and makes no network requests, model calls,
+or API-key lookups.
+
+When running [LoCoMo](https://github.com/snap-research/locomo) against competitors,
+we measured the top score of 94.74% for Entire Graph. We also observed token savings
+up to 71% depending on the coding scenario. As always, your mileage may vary.
+
+## Setup
+
+[Entire CLI](https://github.com/entireio/cli#quick-start) is required. Then setup happens once per repository:
+
+```sh
+entire graph init-agents --repo .
+```
+
+If the plugin is not installed yet, the Entire CLI offers to install it on the
+spot. After that, the interface is your coding agent: you ask a code question in
+plain language, the agent runs graph queries, reads the code the graph points
+at, and answers with citations. A captured example follows.
 
 ## Benchmarks
 
-The Entire Graph retrieval engine ranked first in an eight-system LoCoMo comparison
-(1,540 questions, shared reader and judge, a 200-item retrieval budget requested for
-every arm) while building its index without model calls. Measured 2026-08-14 on the
-[#104](https://github.com/entireio/entire-graph/pull/104) branch, before that work merged; the
-retrieval path it exercises first shipped in
-[v0.4.0](https://github.com/entireio/entire-graph/releases/tag/v0.4.0) (tagged four days later,
-2026-08-18). See § below for what that does and does not license you to claim.
+To put entire-graph to the test, we ran it through
+[LoCoMo](https://github.com/snap-research/locomo), the standard benchmark for
+one hard skill: finding a single small detail buried in a pile of text. LoCoMo
+asks over 1,500 questions about long conversations that span many sessions and
+scores whether the tool can find the right piece of evidence.
+
+On identical questions, entire-graph found the right evidence more often than
+any of the seven other systems we tested, including graphify, mem0, and cognee.
 
 | System | LoCoMo | Index-time tokens | Version tested |
 | --- | --- | --- | --- |
@@ -32,34 +51,9 @@ retrieval path it exercises first shipped in
 | [cognee](https://github.com/topoteretes/cognee) | 92.86 | 12.35M | commit [`38eece5`](https://github.com/topoteretes/cognee/commit/38eece5bbb0cb9f5706fed908abd16dba0f5505e) |
 | [bm25](https://github.com/dorianbrown/rank_bm25) (lexical baseline) | 91.88 | 0 | [0.2.2](https://github.com/dorianbrown/rank_bm25/releases/tag/0.2.2) |
 | [codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp) (cmm) † | 91.30 | 0 | [v0.9.0](https://github.com/DeusData/codebase-memory-mcp/releases/tag/v0.9.0) |
-| [graphify](https://github.com/Graphify-Labs/graphify) ¶ | 87.34 | 0 | unpinned — see ¶ |
+| [graphify](https://github.com/Graphify-Labs/graphify)  | 87.34 | 0 | [0.9.37](https://github.com/Graphify-Labs/graphify/releases?page=3#release-v0.9.34)|
 | [letta](https://github.com/letta-ai/letta) | 84.68 | not projectable | [0.16.8](https://github.com/letta-ai/letta/releases/tag/0.16.8) |
-| [supermemory](https://github.com/supermemoryai/supermemory) ‡ | 82.08 | hosted | [server-v0.0.7-rc.2](https://github.com/supermemoryai/supermemory/releases/tag/server-v0.0.7-rc.2) |
-
-§ **The 94.74 run is not a measurement of a released tag.** It ran on 2026-08-14 on the #104
-branch; v0.4.0 was tagged 2026-08-18, after further retrieval fixes, so the released revision was
-never benchmarked. The run id this number comes from, `sw_eg_mr3`, also has **no row in
-[`RUN-INDEX.md`](bench/memory/RUN-INDEX.md)**, the registry our own rules require, and the one
-registered run that also scores 94.74 (`plan_f_hyb`) used a **non-default** ingest granularity and
-is explicitly *not* interchangeable evidence. Quote 94.74 as the #104 branch result, not as v0.4.0's
-score. The shipped default at the time, `mrq_base`, scored **91.56**.
-
-¶ **graphify's tested version is not v0.9.43 and is not recoverable.** The run finished 2026-08-14
-16:25 UTC; v0.9.43 was published 19:17 UTC the same day — after the run — so it cannot be what was
-measured. The checkout no longer exists, so the exact revision cannot be recovered; it was whatever
-was current in that window. `UPSTREAM.md` records this as "not a confirmed exact pin".
-
-† **cmm is patched, not stock v0.9.0.** It was modified to emit Markdown sections
-([patch](bench/memory/patches/0005-cmm-v0.9.0-markdown-sections.patch)); the linked release alone
-does not reproduce 91.30.
-
-‡ **supermemory is patched, and its retrieval budget is half every other row's.** Reaching the
-shared extraction model required a binary capability-flag patch plus a wire-level parameter adapter,
-and a second fix made its content-dedup tolerate retries. Its search API also hard-caps retrieval at
-**100 items where every other arm gets 200** — a disclosed asymmetry that works against
-supermemory. The linked release alone does not reproduce 82.08. Full disclosure, including what is
-and is not reproducible from this repository:
-[`LOCOMO-COMPARISON.md` § ‡](bench/memory/LOCOMO-COMPARISON.md).
+| [supermemory](https://github.com/supermemoryai/supermemory)  | 82.08 | hosted | [server-v0.0.7-rc.2](https://github.com/supermemoryai/supermemory/releases/tag/server-v0.0.7-rc.2) |
 
 See [benchmarks](docs/benchmarks.md) for full methodology, per-category results,
 retractions, and reproduction steps.

--- a/internal/sem/search_verify.go
+++ b/internal/sem/search_verify.go
@@ -675,7 +675,11 @@ func deriveSearchVerifySuiteGradle(dir string, evidence *searchVerifyEvidence) *
 	if !inside {
 		return nil
 	}
-	if settingsPath, _, own := searchVerifyGradleSettings(dir, evidence); own {
+	settingsDir, settingsPath, settings, found := searchVerifyGradleAncestorSettings(dir, wrapperDir, evidence)
+	if !found {
+		return nil
+	}
+	if settingsDir == dir {
 		// The directory carries its own settings script, so it IS a build root and that is the
 		// settings file Gradle finds first when started there. `-p` is the spelling for that.
 		return searchVerifySuiteCommand(
@@ -684,9 +688,12 @@ func deriveSearchVerifySuiteGradle(dir string, evidence *searchVerifyEvidence) *
 			manifest+" + "+wrapperPath+" + "+settingsPath,
 		)
 	}
-	settingsPath, settings, found := searchVerifyGradleSettings(wrapperDir, evidence)
-	project := ":" + strings.ReplaceAll(relative, "/", ":")
-	if !found || !searchVerifyGradleSettingsIncludes(settings, project) {
+	projectDir, inside := searchVerifyRelative(settingsDir, dir)
+	if !inside {
+		return nil
+	}
+	project := ":" + strings.ReplaceAll(projectDir, "/", ":")
+	if !searchVerifyGradleSettingsIncludes(settings, project) {
 		// Nothing in the tree says this directory is a build Gradle can be pointed at, so there is
 		// no command to emit. Silence costs a lookup; a `-p` that quietly ran a different build
 		// would report a pass the edit never earned.
@@ -700,9 +707,18 @@ func deriveSearchVerifySuiteGradle(dir string, evidence *searchVerifyEvidence) *
 	}
 	// An included subproject is addressed by its project path from the root of the build that
 	// declares it — the documented spelling, `gradle :subproject:taskName`.
+	command := "./gradlew "
+	if settingsDir != wrapperDir {
+		buildRoot, inside := searchVerifyRelative(wrapperDir, settingsDir)
+		if !inside {
+			return nil
+		}
+		command += "-p " + shellQuotePath(buildRoot) + " "
+	}
+	command += shellQuote(project + ":test")
 	return searchVerifySuiteCommand(
 		wrapperDir,
-		"./gradlew "+shellQuote(project+":test"),
+		command,
 		manifest+" + "+wrapperPath+" + "+settingsPath,
 	)
 }
@@ -717,6 +733,27 @@ func searchVerifyGradleSettings(dir string, evidence *searchVerifyEvidence) (str
 		}
 	}
 	return "", "", false
+}
+
+func searchVerifyGradleAncestorSettings(
+	dir, stop string,
+	evidence *searchVerifyEvidence,
+) (string, string, string, bool) {
+	for depth := 0; depth <= searchVerifyMaxDepth; depth++ {
+		if settingsPath, settings, found := searchVerifyGradleSettings(dir, evidence); found {
+			return dir, settingsPath, settings, true
+		}
+		if dir == stop || dir == "" {
+			break
+		}
+		parent := path.Dir(dir)
+		if parent == "." || parent == "/" || parent == dir {
+			dir = ""
+			continue
+		}
+		dir = parent
+	}
+	return "", "", "", false
 }
 
 // searchVerifyGradleSettingsIncludes reports whether a settings script declares the project path.

--- a/internal/sem/search_verify.go
+++ b/internal/sem/search_verify.go
@@ -87,8 +87,9 @@ const (
 	// searchVerifyNoneCommand is the residual floor. A payload with ranked results and no derivable
 	// command used to emit NOTHING, and silent absence is the worst outcome available: paired with the
 	// stop-early doctrine it lets an agent ship unverified, and it is indistinguishable from a bug in
-	// the deriver. One line that states the fact and prescribes the fallback costs 96 bytes.
-	searchVerifyNoneCommand = "none derivable (no build manifest found) - syntax-check the file you edited and stop."
+	// the deriver. The message names the unresolved command state rather than guessing why derivation
+	// failed; a manifest may exist without proving a safe command.
+	searchVerifyNoneCommand = "none derivable (no safe verification command found) - syntax-check the file you edited and stop."
 
 	// searchVerifyRunnerNote annotates a command whose runner is not installed HERE. It is an
 	// annotation and never a suppression: the command is still the right one, and a caller who cannot
@@ -311,8 +312,8 @@ func searchVerifyControlBytes(command string) bool {
 	return termsafe.EscapesLine(command)
 }
 
-// searchVerifyResidualFloor is the last rung: no manifest, no test file, no single-file checker. It
-// states the fact and prescribes the fallback, which is strictly better than the silence it replaces.
+// searchVerifyResidualFloor is the last rung when repository evidence does not establish a safe
+// command. It prescribes a fallback, which is strictly better than the silence it replaces.
 func searchVerifyResidualFloor(sourcePath, prefix, preFixStatus string) *SearchVerifyCommand {
 	targets := sourcePath
 	if targets == "" {
@@ -321,7 +322,7 @@ func searchVerifyResidualFloor(sourcePath, prefix, preFixStatus string) *SearchV
 	return &SearchVerifyCommand{
 		Command:      searchVerifyNoneCommand,
 		Targets:      targets,
-		DerivedFrom:  "no manifest, no test file, no single-file checker for this language",
+		DerivedFrom:  "repository evidence did not establish a safe verification command",
 		Tier:         searchVerifyTierNone,
 		Prefix:       prefix,
 		PreFixStatus: preFixStatus,
@@ -508,9 +509,11 @@ func searchVerifyMirrorTest(sourcePath string, evidence *searchVerifyEvidence) s
 // deriveSearchVerifyCommand walks from the subject's own directory towards the repository root and
 // stops at the FIRST manifest that licenses a narrow command.
 //
-// A manifest that exists but licenses nothing does not stop the walk: a `Cargo.toml` that is only a
-// workspace stanza, or a monorepo leaf `package.json` with no test runner in it, is evidence about
-// the tree, not about how to run a test, so the walk continues outward to the manifest that is.
+// A manifest that exists but licenses nothing generally does not stop the walk: a `Cargo.toml` that
+// is only a workspace stanza, or a monorepo leaf `package.json` with no test runner in it, is evidence
+// about the tree, not about how to run a test, so the walk continues outward to the manifest that is.
+// Gradle is different: an ancestor project can accept the same test pattern without owning the
+// nested project's sources, so a Gradle manifest that declines is a hard boundary.
 func deriveSearchVerifyCommand(subject searchVerifySubject, evidence *searchVerifyEvidence) *SearchVerifyCommand {
 	dir := path.Dir(subject.sourcePath)
 	if dir == "." || dir == "/" {
@@ -521,6 +524,9 @@ func deriveSearchVerifyCommand(subject searchVerifySubject, evidence *searchVeri
 			if command := derive(dir, subject, evidence); command != nil {
 				return command
 			}
+		}
+		if searchVerifyGradleManifest(dir, evidence) != "" {
+			return nil
 		}
 		if dir == "" {
 			break
@@ -567,7 +573,7 @@ func deriveSearchVerifySuiteCommand(subject searchVerifySubject, evidence *searc
 			}
 		}
 		// An ancestor suite is not evidence of coverage for a Gradle project that declined here.
-		if evidence.exists(searchVerifyJoin(dir, "build.gradle")) || evidence.exists(searchVerifyJoin(dir, "build.gradle.kts")) {
+		if searchVerifyGradleManifest(dir, evidence) != "" {
 			return nil
 		}
 		if dir == "" {
@@ -641,14 +647,18 @@ func deriveSearchVerifySuiteMaven(dir string, evidence *searchVerifyEvidence) *S
 	return searchVerifySuiteCommandLiteral(searchVerifyMavenCommand(dir, "test", evidence), manifest)
 }
 
-func deriveSearchVerifySuiteGradle(dir string, evidence *searchVerifyEvidence) *SearchVerifyCommand {
-	manifest := ""
+func searchVerifyGradleManifest(dir string, evidence *searchVerifyEvidence) string {
 	for _, name := range []string{"build.gradle", "build.gradle.kts"} {
-		if evidence.exists(searchVerifyJoin(dir, name)) {
-			manifest = searchVerifyJoin(dir, name)
-			break
+		manifest := searchVerifyJoin(dir, name)
+		if evidence.exists(manifest) {
+			return manifest
 		}
 	}
+	return ""
+}
+
+func deriveSearchVerifySuiteGradle(dir string, evidence *searchVerifyEvidence) *SearchVerifyCommand {
+	manifest := searchVerifyGradleManifest(dir, evidence)
 	if manifest == "" {
 		return nil
 	}
@@ -1999,13 +2009,7 @@ func searchVerifyModuleLabel(dir string) string {
 // because `:module:test` without `--tests` is the whole module and Gradle's project path is only
 // worth deriving when it buys a filter.
 func deriveSearchVerifyGradle(dir string, subject searchVerifySubject, evidence *searchVerifyEvidence) *SearchVerifyCommand {
-	manifest := ""
-	for _, name := range []string{"build.gradle", "build.gradle.kts"} {
-		if evidence.exists(searchVerifyJoin(dir, name)) {
-			manifest = searchVerifyJoin(dir, name)
-			break
-		}
-	}
+	manifest := searchVerifyGradleManifest(dir, evidence)
 	if manifest == "" || !evidence.exists("gradlew") {
 		return nil
 	}
@@ -2025,13 +2029,6 @@ func deriveSearchVerifyGradle(dir string, subject searchVerifySubject, evidence 
 			return nil
 		}
 		project += ":"
-	} else {
-		for _, name := range []string{"build.gradle", "build.gradle.kts"} {
-			owner, _, found := searchVerifyAncestorFile(path.Dir(subject.sourcePath), name, evidence)
-			if found && owner != "" {
-				return nil
-			}
-		}
 	}
 	class := searchVerifyStem(subject.testPath)
 	classArg := shellQuote(class)

--- a/internal/sem/search_verify.go
+++ b/internal/sem/search_verify.go
@@ -785,18 +785,7 @@ func searchVerifyGradleSettingsIncludes(settings, project string) bool {
 	return false
 }
 
-// searchVerifyGradleSettingsRemapsProject reports whether the settings script MOVES the project's
-// directory, with `project(':lib').projectDir = file('other')` or the block spelling of the same
-// assignment.
-//
-// A project path is derived here from a directory, and `include ':lib'` alone says that derivation
-// holds. A remap breaks it: `:lib` is then a different tree, and `./gradlew :lib:test` for an edit
-// in `lib/` runs, and passes, about code the edit never touched. That is worse than a command that
-// cannot run, because nothing announces it.
-//
-// The scan is bounded to the STATEMENT the matching `project(...)` call starts — extended to the
-// matching brace when one follows — so a `projectDir` assignment elsewhere in the script, about a
-// different project, is not read as this one's.
+// A directory-derived task path is invalidated by relocating the project or renaming it or an ancestor.
 func searchVerifyGradleSettingsRemapsProject(settings, project string) bool {
 	want := strings.TrimPrefix(project, ":")
 	if want == "" {
@@ -829,42 +818,50 @@ func searchVerifyGradleSettingsRemapsProject(settings, project string) bool {
 		if width == 0 {
 			continue
 		}
-		named := false
+		named, ancestor := false, false
 		for _, argument := range arguments {
-			if strings.TrimPrefix(argument, ":") == want {
-				named = true
-				break
-			}
+			candidate := strings.TrimPrefix(argument, ":")
+			named = named || candidate == want
+			ancestor = ancestor || (candidate != "" && strings.HasPrefix(want, candidate+":"))
 		}
 		index += width
-		if named && searchVerifyGradleAssignsProjectDir(searchVerifyGradleStatementTail(script[index:])) {
-			return true
+		if named || ancestor {
+			statement := searchVerifyGradleStatementTail(script[index:])
+			if searchVerifyGradleAssignsProperty(statement, "name", "setName") ||
+				(named && searchVerifyGradleAssignsProperty(statement, "projectDir", "setProjectDir")) {
+				return true
+			}
 		}
 	}
 	return false
 }
 
-// searchVerifyGradleAssignsProjectDir reports whether a statement MOVES a project's directory rather
-// than merely naming it.
-//
-// `println(project(':lib').projectDir)` reads the property; the project is still where it was, and
-// declining on a read costs a command that would have run for no reason. Only an assignment to it,
-// or the setter the assignment is sugar for, relocates the project. `==` is a comparison, not an
-// assignment, and is read as a mention.
-func searchVerifyGradleAssignsProjectDir(statement string) bool {
-	if strings.Contains(statement, "setProjectDir") {
-		return true
-	}
-	const property = "projectDir"
+// Reads and comparisons preserve the target; only assignments and setters invalidate it.
+func searchVerifyGradleAssignsProperty(statement, property, setter string) bool {
 	for index := 0; index < len(statement); {
-		found := strings.Index(statement[index:], property)
-		if found < 0 {
-			return false
+		if statement[index] == '\'' || statement[index] == '"' {
+			if width := searchVerifyGradleLiteralWidth(statement[index:]); width > 0 {
+				index += width
+				continue
+			}
 		}
-		index += found + len(property)
-		after := strings.TrimLeft(statement[index:], " \t\r\n")
-		if strings.HasPrefix(after, "=") && !strings.HasPrefix(after, "==") {
+		if !searchVerifyScriptIdentifierByte(statement[index]) {
+			index++
+			continue
+		}
+		start := index
+		for index < len(statement) && searchVerifyScriptIdentifierByte(statement[index]) {
+			index++
+		}
+		identifier := statement[start:index]
+		if identifier == setter {
 			return true
+		}
+		if identifier == property {
+			after := strings.TrimLeft(statement[index:], " \t\r\n")
+			if strings.HasPrefix(after, "=") && !strings.HasPrefix(after, "==") {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/sem/search_verify.go
+++ b/internal/sem/search_verify.go
@@ -657,80 +657,83 @@ func searchVerifyGradleManifest(dir string, evidence *searchVerifyEvidence) stri
 	return ""
 }
 
-func deriveSearchVerifySuiteGradle(dir string, evidence *searchVerifyEvidence) *SearchVerifyCommand {
+type searchVerifyGradleTarget struct {
+	wrapperDir    string
+	commandPrefix string
+	project       string
+	derivedFrom   string
+	selectsBuild  bool
+}
+
+func (target searchVerifyGradleTarget) testCommand(qualifyRoot bool) string {
+	task := "test"
+	if target.project != "" {
+		task = target.project + ":test"
+	} else if qualifyRoot && !target.selectsBuild {
+		task = ":test"
+	}
+	return target.commandPrefix + " " + shellQuote(task)
+}
+
+func searchVerifyGradleTargetForDir(dir string, evidence *searchVerifyEvidence) (searchVerifyGradleTarget, bool) {
 	manifest := searchVerifyGradleManifest(dir, evidence)
 	if manifest == "" {
-		return nil
+		return searchVerifyGradleTarget{}, false
 	}
 	wrapperDir, wrapperPath, ok := searchVerifyAncestorFile(dir, "gradlew", evidence)
 	if !ok {
-		return nil
+		return searchVerifyGradleTarget{}, false
+	}
+	target := searchVerifyGradleTarget{
+		wrapperDir:    wrapperDir,
+		commandPrefix: "./gradlew",
+		derivedFrom:   manifest + " + " + wrapperPath,
 	}
 	if wrapperDir == dir {
-		return searchVerifySuiteCommand(wrapperDir, "./gradlew test", manifest+" + "+wrapperPath)
-	}
-	// The wrapper lives above the build this derivation is about. Running `./gradlew test` from the
-	// wrapper's own directory would test whatever build sits THERE, because Gradle does not discover
-	// a descendant build by walking down — but WHICH command names this one is decided by the
-	// settings script, not by the directory layout.
-	//
-	// Gradle locates the settings file by walking UP from its start directory and then keeps what it
-	// found only if that file declares a project AT the start directory; otherwise it discards the
-	// settings and runs the start directory as its own empty-settings build. So `-p <dir> test` is
-	// NOT "the root build with a different default project": in an ordinary multi-project layout it
-	// is the root build when the root settings declares <dir>, and a different, sibling-less build
-	// when it does not — where `project(":core")` dependencies no longer resolve. A `build.gradle`
-	// sitting in a subdirectory says nothing about which of the two it is.
-	relative, inside := searchVerifyRelative(wrapperDir, dir)
-	if !inside {
-		return nil
+		return target, true
 	}
 	settingsDir, settingsPath, settings, found := searchVerifyGradleAncestorSettings(dir, wrapperDir, evidence)
 	if !found {
-		return nil
+		return searchVerifyGradleTarget{}, false
 	}
+	target.derivedFrom += " + " + settingsPath
 	if settingsDir == dir {
-		// The directory carries its own settings script, so it IS a build root and that is the
-		// settings file Gradle finds first when started there. `-p` is the spelling for that.
-		return searchVerifySuiteCommand(
-			wrapperDir,
-			"./gradlew -p "+shellQuotePath(relative)+" test",
-			manifest+" + "+wrapperPath+" + "+settingsPath,
-		)
+		relative, inside := searchVerifyRelative(wrapperDir, dir)
+		if !inside {
+			return searchVerifyGradleTarget{}, false
+		}
+		target.commandPrefix += " -p " + shellQuotePath(relative)
+		target.selectsBuild = true
+		return target, true
 	}
 	projectDir, inside := searchVerifyRelative(settingsDir, dir)
 	if !inside {
-		return nil
+		return searchVerifyGradleTarget{}, false
 	}
 	project := ":" + strings.ReplaceAll(projectDir, "/", ":")
 	if !searchVerifyGradleSettingsIncludes(settings, project) {
-		// Nothing in the tree says this directory is a build Gradle can be pointed at, so there is
-		// no command to emit. Silence costs a lookup; a `-p` that quietly ran a different build
-		// would report a pass the edit never earned.
-		return nil
+		return searchVerifyGradleTarget{}, false
 	}
 	if searchVerifyGradleSettingsRemapsProject(settings, project) {
-		// The project path is declared, but the settings script moves it somewhere else on disk, so
-		// the path derived from THIS directory names a different tree. `./gradlew :lib:test` would
-		// run, and pass, about code the edit never touched — which is worse than emitting nothing.
-		return nil
+		return searchVerifyGradleTarget{}, false
 	}
-	// An included subproject is addressed by its project path from the root of the build that
-	// declares it — the documented spelling, `gradle :subproject:taskName`.
-	command := "./gradlew "
 	if settingsDir != wrapperDir {
 		buildRoot, inside := searchVerifyRelative(wrapperDir, settingsDir)
 		if !inside {
-			return nil
+			return searchVerifyGradleTarget{}, false
 		}
-		command += "-p " + shellQuotePath(buildRoot) + " "
+		target.commandPrefix += " -p " + shellQuotePath(buildRoot)
 	}
-	command += shellQuote(project + ":test")
-	return searchVerifySuiteCommand(
-		wrapperDir,
-		command,
-		manifest+" + "+wrapperPath+" + "+settingsPath,
-	)
+	target.project = project
+	return target, true
+}
+
+func deriveSearchVerifySuiteGradle(dir string, evidence *searchVerifyEvidence) *SearchVerifyCommand {
+	target, ok := searchVerifyGradleTargetForDir(dir, evidence)
+	if !ok {
+		return nil
+	}
+	return searchVerifySuiteCommand(target.wrapperDir, target.testCommand(false), target.derivedFrom)
 }
 
 // searchVerifyGradleSettings returns the settings script that makes a directory a Gradle build root,
@@ -2009,26 +2012,15 @@ func searchVerifyModuleLabel(dir string) string {
 // because `:module:test` without `--tests` is the whole module and Gradle's project path is only
 // worth deriving when it buys a filter.
 func deriveSearchVerifyGradle(dir string, subject searchVerifySubject, evidence *searchVerifyEvidence) *SearchVerifyCommand {
-	manifest := searchVerifyGradleManifest(dir, evidence)
-	if manifest == "" || !evidence.exists("gradlew") {
-		return nil
-	}
 	if subject.testPath == "" {
 		return nil
 	}
 	if _, inside := searchVerifyRelative(dir, subject.testPath); !inside {
 		return nil
 	}
-	project := ":"
-	if dir != "" {
-		project = ":" + strings.ReplaceAll(dir, "/", ":")
-		_, settings, found := searchVerifyGradleSettings("", evidence)
-		if !found ||
-			!searchVerifyGradleSettingsIncludes(settings, project) ||
-			searchVerifyGradleSettingsRemapsProject(settings, project) {
-			return nil
-		}
-		project += ":"
+	target, ok := searchVerifyGradleTargetForDir(dir, evidence)
+	if !ok {
+		return nil
 	}
 	class := searchVerifyStem(subject.testPath)
 	classArg := shellQuote(class)
@@ -2038,9 +2030,9 @@ func deriveSearchVerifyGradle(dir string, subject searchVerifySubject, evidence 
 		classArg = "'" + class + "'"
 	}
 	return &SearchVerifyCommand{
-		Command:     "./gradlew " + shellQuote(project+"test") + " --tests " + classArg,
+		Command:     searchVerifyRunIn(target.wrapperDir, target.testCommand(true)+" --tests "+classArg),
 		Targets:     subject.testPath,
-		DerivedFrom: manifest + " + gradlew + " + subject.testEvidence + " class",
+		DerivedFrom: target.derivedFrom + " + " + subject.testEvidence + " class",
 	}
 }
 

--- a/internal/sem/search_verify.go
+++ b/internal/sem/search_verify.go
@@ -566,6 +566,10 @@ func deriveSearchVerifySuiteCommand(subject searchVerifySubject, evidence *searc
 				return command
 			}
 		}
+		// An ancestor suite is not evidence of coverage for a Gradle project that declined here.
+		if evidence.exists(searchVerifyJoin(dir, "build.gradle")) || evidence.exists(searchVerifyJoin(dir, "build.gradle.kts")) {
+			return nil
+		}
 		if dir == "" {
 			break
 		}
@@ -1976,7 +1980,21 @@ func deriveSearchVerifyGradle(dir string, subject searchVerifySubject, evidence 
 	}
 	project := ":"
 	if dir != "" {
-		project = ":" + strings.ReplaceAll(dir, "/", ":") + ":"
+		project = ":" + strings.ReplaceAll(dir, "/", ":")
+		_, settings, found := searchVerifyGradleSettings("", evidence)
+		if !found ||
+			!searchVerifyGradleSettingsIncludes(settings, project) ||
+			searchVerifyGradleSettingsRemapsProject(settings, project) {
+			return nil
+		}
+		project += ":"
+	} else {
+		for _, name := range []string{"build.gradle", "build.gradle.kts"} {
+			owner, _, found := searchVerifyAncestorFile(path.Dir(subject.sourcePath), name, evidence)
+			if found && owner != "" {
+				return nil
+			}
+		}
 	}
 	class := searchVerifyStem(subject.testPath)
 	classArg := shellQuote(class)

--- a/internal/sem/search_verify.go
+++ b/internal/sem/search_verify.go
@@ -697,12 +697,14 @@ func searchVerifyGradleTargetForDir(dir string, evidence *searchVerifyEvidence) 
 		return searchVerifyGradleTarget{}, false
 	}
 	target.derivedFrom += " + " + settingsPath
-	if settingsDir == dir {
-		relative, inside := searchVerifyRelative(wrapperDir, dir)
+	if settingsDir != wrapperDir {
+		buildRoot, inside := searchVerifyRelative(wrapperDir, settingsDir)
 		if !inside {
 			return searchVerifyGradleTarget{}, false
 		}
-		target.commandPrefix += " -p " + shellQuotePath(relative)
+		target.commandPrefix += " -p " + shellQuotePath(buildRoot)
+	}
+	if settingsDir == dir {
 		target.selectsBuild = true
 		return target, true
 	}
@@ -716,13 +718,6 @@ func searchVerifyGradleTargetForDir(dir string, evidence *searchVerifyEvidence) 
 	}
 	if searchVerifyGradleSettingsRemapsProject(settings, project) {
 		return searchVerifyGradleTarget{}, false
-	}
-	if settingsDir != wrapperDir {
-		buildRoot, inside := searchVerifyRelative(wrapperDir, settingsDir)
-		if !inside {
-			return searchVerifyGradleTarget{}, false
-		}
-		target.commandPrefix += " -p " + shellQuotePath(buildRoot)
 	}
 	target.project = project
 	return target, true

--- a/internal/sem/search_verify_gradle_membership_test.go
+++ b/internal/sem/search_verify_gradle_membership_test.go
@@ -34,7 +34,38 @@ func TestBuildSearchVerifyGradleUndeclaredProjectFallback(t *testing.T) {
 			if got.Tier != searchVerifyTierNone {
 				t.Fatalf("tier = %q, want %q: no command is established for the undeclared project", got.Tier, searchVerifyTierNone)
 			}
+			wantCommand := "none derivable (no safe verification command found) - syntax-check the file you edited and stop."
+			if got.Command != wantCommand {
+				t.Fatalf("command = %q, want %q", got.Command, wantCommand)
+			}
+			wantDerivedFrom := "repository evidence did not establish a safe verification command"
+			if got.DerivedFrom != wantDerivedFrom {
+				t.Fatalf("derived from = %q, want %q", got.DerivedFrom, wantDerivedFrom)
+			}
 		})
+	}
+}
+
+func TestBuildSearchVerifyGradleDeclinedChildDoesNotFallBackToParent(t *testing.T) {
+	files := map[string]string{
+		"gradlew":                               "",
+		"settings.gradle":                       "include ':parent'\n",
+		"parent/build.gradle":                   "",
+		"parent/child/build.gradle":             "",
+		"parent/child/src/main/java/A.java":     "",
+		"parent/child/src/test/java/ATest.java": "",
+	}
+	results := []SearchResult{
+		{Rank: 1, FilePath: "parent/child/src/main/java/A.java", Section: searchSectionPrimary},
+		{Rank: 2, FilePath: "parent/child/src/test/java/ATest.java", Section: searchSectionCoveringTest},
+	}
+	got := buildSearchVerifyCommand(results, searchVerifyTestEvidence(files))
+	if got == nil {
+		t.Fatal("expected an explicit verification result")
+	}
+	t.Logf("tier = %q; generated command = %q", got.Tier, got.Command)
+	if got.Tier != searchVerifyTierNone {
+		t.Fatalf("tier = %q, want %q: the parent command does not cover the undeclared child", got.Tier, searchVerifyTierNone)
 	}
 }
 

--- a/internal/sem/search_verify_gradle_membership_test.go
+++ b/internal/sem/search_verify_gradle_membership_test.go
@@ -104,6 +104,11 @@ func TestSearchVerifyGradleNarrowProjectMembership(t *testing.T) {
 	}{
 		{"included_project", "include ':app', ':lib'\n", false, "./gradlew :lib:test --tests 'ATest'"},
 		{"remapped_project", "include ':lib'\nproject(':lib').projectDir = file('other')\n", false, ""},
+		{"renamed_project", "include ':lib'\nproject(':lib').name = 'core'\n", false, ""},
+		{"renamed_project_setter", "include ':lib'\nproject(':lib').setName('core')\n", false, ""},
+		{"project_name_read", "include ':lib'\nprintln(project(':lib').name)\n", false, "./gradlew :lib:test --tests 'ATest'"},
+		{"project_name_comparison", "include ':lib'\nif (project(':lib').name == 'lib') { }\n", false, "./gradlew :lib:test --tests 'ATest'"},
+		{"rename_in_string", "include ':lib'\nproject(':lib') { println(\"name = 'core'; setName('core')\") }\n", false, "./gradlew :lib:test --tests 'ATest'"},
 		{"undeclared_project", "include ':app'\n", false, ""},
 		{"undeclared_project_with_root_build", "include ':app'\n", true, ""},
 	} {
@@ -132,6 +137,81 @@ func TestSearchVerifyGradleNarrowProjectMembership(t *testing.T) {
 			t.Logf("settings = %q; generated command = %q", tc.settings, command)
 			if command != tc.want {
 				t.Fatalf("command = %q, want %q", command, tc.want)
+			}
+		})
+	}
+}
+
+func TestSearchVerifyGradleParentProjectRename(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		settings   string
+		wantNarrow string
+		wantSuite  string
+	}{
+		{
+			name:       "unchanged_parent",
+			settings:   "include ':modules:lib'\n",
+			wantNarrow: "./gradlew :modules:lib:test --tests 'ATest'",
+			wantSuite:  "./gradlew :modules:lib:test",
+		},
+		{
+			name:     "renamed_parent",
+			settings: "include ':modules:lib'\nproject(':modules').name = 'components'\n",
+		},
+		{
+			name:     "renamed_parent_setter",
+			settings: "include ':modules:lib'\nproject(':modules').setName('components')\n",
+		},
+		{
+			name:       "similarly_named_sibling",
+			settings:   "include ':modules:lib', ':module'\nproject(':module').name = 'component'\n",
+			wantNarrow: "./gradlew :modules:lib:test --tests 'ATest'",
+			wantSuite:  "./gradlew :modules:lib:test",
+		},
+		{
+			name:       "renamed_root",
+			settings:   "include ':modules:lib'\nproject(':').name = 'components'\n",
+			wantNarrow: "./gradlew :modules:lib:test --tests 'ATest'",
+			wantSuite:  "./gradlew :modules:lib:test",
+		},
+		{
+			name:       "relocated_parent",
+			settings:   "include ':modules:lib'\nproject(':modules').projectDir = file('other')\n",
+			wantNarrow: "./gradlew :modules:lib:test --tests 'ATest'",
+			wantSuite:  "./gradlew :modules:lib:test",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			evidence := searchVerifyTestEvidence(map[string]string{
+				"gradlew":                              "",
+				"settings.gradle":                      tc.settings,
+				"modules/lib/build.gradle":             "",
+				"modules/lib/src/main/java/A.java":     "",
+				"modules/lib/src/test/java/ATest.java": "",
+			})
+			subject := searchVerifySubject{
+				sourcePath:   "modules/lib/src/main/java/A.java",
+				testPath:     "modules/lib/src/test/java/ATest.java",
+				testEvidence: "covering test",
+			}
+			for _, route := range []struct {
+				name string
+				got  *SearchVerifyCommand
+				want string
+			}{
+				{"narrow", deriveSearchVerifyCommand(subject, &evidence), tc.wantNarrow},
+				{"suite", deriveSearchVerifySuiteCommand(subject, &evidence), tc.wantSuite},
+			} {
+				t.Run(route.name, func(t *testing.T) {
+					command := ""
+					if route.got != nil {
+						command = route.got.Command
+					}
+					if command != route.want {
+						t.Fatalf("command = %q, want %q", command, route.want)
+					}
+				})
 			}
 		})
 	}

--- a/internal/sem/search_verify_gradle_membership_test.go
+++ b/internal/sem/search_verify_gradle_membership_test.go
@@ -1,0 +1,107 @@
+package sem
+
+import "testing"
+
+func TestBuildSearchVerifyGradleUndeclaredProjectFallback(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		rootBuild bool
+	}{
+		{"without_root_build", false},
+		{"with_root_build", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			files := map[string]string{
+				"gradlew":                      "",
+				"settings.gradle":              "include ':app'\n",
+				"app/build.gradle":             "",
+				"lib/build.gradle":             "",
+				"lib/src/main/java/A.java":     "",
+				"lib/src/test/java/ATest.java": "",
+			}
+			if tc.rootBuild {
+				files["build.gradle"] = ""
+			}
+			results := []SearchResult{
+				{Rank: 1, FilePath: "lib/src/main/java/A.java", Section: searchSectionPrimary},
+				{Rank: 2, FilePath: "lib/src/test/java/ATest.java", Section: searchSectionCoveringTest},
+			}
+			got := buildSearchVerifyCommand(results, searchVerifyTestEvidence(files))
+			if got == nil {
+				t.Fatal("expected an explicit verification result")
+			}
+			t.Logf("tier = %q; generated command = %q", got.Tier, got.Command)
+			if got.Tier != searchVerifyTierNone {
+				t.Fatalf("tier = %q, want %q: no command is established for the undeclared project", got.Tier, searchVerifyTierNone)
+			}
+		})
+	}
+}
+
+func TestSearchVerifyGradleNarrowRootProject(t *testing.T) {
+	for _, manifest := range []string{"build.gradle", "build.gradle.kts"} {
+		t.Run(manifest, func(t *testing.T) {
+			evidence := searchVerifyTestEvidence(map[string]string{
+				"gradlew":                  "",
+				manifest:                   "",
+				"src/main/java/A.java":     "",
+				"src/test/java/ATest.java": "",
+			})
+			got := deriveSearchVerifyCommand(searchVerifySubject{
+				sourcePath:   "src/main/java/A.java",
+				testPath:     "src/test/java/ATest.java",
+				testEvidence: "covering test",
+			}, &evidence)
+			if got == nil {
+				t.Fatal("expected a root project command")
+			}
+			want := "./gradlew :test --tests 'ATest'"
+			t.Logf("generated command = %q", got.Command)
+			if got.Command != want {
+				t.Fatalf("command = %q, want %q", got.Command, want)
+			}
+		})
+	}
+}
+
+func TestSearchVerifyGradleNarrowProjectMembership(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		settings  string
+		rootBuild bool
+		want      string
+	}{
+		{"included_project", "include ':app', ':lib'\n", false, "./gradlew :lib:test --tests 'ATest'"},
+		{"remapped_project", "include ':lib'\nproject(':lib').projectDir = file('other')\n", false, ""},
+		{"undeclared_project", "include ':app'\n", false, ""},
+		{"undeclared_project_with_root_build", "include ':app'\n", true, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			files := map[string]string{
+				"gradlew":                      "",
+				"settings.gradle":              tc.settings,
+				"app/build.gradle":             "",
+				"lib/build.gradle":             "",
+				"lib/src/main/java/A.java":     "",
+				"lib/src/test/java/ATest.java": "",
+			}
+			if tc.rootBuild {
+				files["build.gradle"] = ""
+			}
+			evidence := searchVerifyTestEvidence(files)
+			got := deriveSearchVerifyCommand(searchVerifySubject{
+				sourcePath:   "lib/src/main/java/A.java",
+				testPath:     "lib/src/test/java/ATest.java",
+				testEvidence: "covering test",
+			}, &evidence)
+			command := ""
+			if got != nil {
+				command = got.Command
+			}
+			t.Logf("settings = %q; generated command = %q", tc.settings, command)
+			if command != tc.want {
+				t.Fatalf("command = %q, want %q", command, tc.want)
+			}
+		})
+	}
+}

--- a/internal/sem/search_verify_gradle_membership_test.go
+++ b/internal/sem/search_verify_gradle_membership_test.go
@@ -136,3 +136,56 @@ func TestSearchVerifyGradleNarrowProjectMembership(t *testing.T) {
 		})
 	}
 }
+
+func TestSearchVerifyGradleNarrowNestedBuilds(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		sourcePath string
+		testPath   string
+		files      map[string]string
+		want       string
+	}{
+		{
+			name:       "independent_build_under_ancestor_wrapper",
+			sourcePath: "modules/src/main/java/A.java",
+			testPath:   "modules/src/test/java/ATest.java",
+			files: map[string]string{
+				"gradlew":                          "",
+				"modules/settings.gradle":          "",
+				"modules/build.gradle":             "",
+				"modules/src/main/java/A.java":     "",
+				"modules/src/test/java/ATest.java": "",
+			},
+			want: "./gradlew -p modules test --tests 'ATest'",
+		},
+		{
+			name:       "project_under_intermediate_build",
+			sourcePath: "modules/core/src/main/java/A.java",
+			testPath:   "modules/core/src/test/java/ATest.java",
+			files: map[string]string{
+				"gradlew":                               "",
+				"modules/settings.gradle":               "include ':core'\n",
+				"modules/core/build.gradle":             "",
+				"modules/core/src/main/java/A.java":     "",
+				"modules/core/src/test/java/ATest.java": "",
+			},
+			want: "./gradlew -p modules :core:test --tests 'ATest'",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			evidence := searchVerifyTestEvidence(tc.files)
+			got := deriveSearchVerifyCommand(searchVerifySubject{
+				sourcePath:   tc.sourcePath,
+				testPath:     tc.testPath,
+				testEvidence: "covering test",
+			}, &evidence)
+			if got == nil {
+				t.Fatal("expected a filtered Gradle command")
+			}
+			t.Logf("generated command = %q", got.Command)
+			if got.Command != tc.want {
+				t.Fatalf("command = %q, want %q", got.Command, tc.want)
+			}
+		})
+	}
+}

--- a/internal/sem/search_verify_runnable_test.go
+++ b/internal/sem/search_verify_runnable_test.go
@@ -238,6 +238,16 @@ func TestSearchVerifySuiteGradleNamesTheProjectUnderAnAncestorWrapper(t *testing
 			wantCommand: "./gradlew -p modules/core test",
 		},
 		{
+			name: "the nearest settings script defines an intermediate build root",
+			files: map[string]string{
+				"gradlew":                           "",
+				"modules/settings.gradle":           "rootProject.name = 'modules'\ninclude ':core'\n",
+				"modules/core/build.gradle":         "",
+				"modules/core/src/main/java/A.java": "",
+			},
+			wantCommand: "./gradlew -p modules :core:test",
+		},
+		{
 			name: "a build.gradle no settings script declares gets silence",
 			files: map[string]string{
 				"gradlew":                           "",

--- a/internal/sem/search_verify_test.go
+++ b/internal/sem/search_verify_test.go
@@ -243,6 +243,7 @@ func TestDeriveSearchVerifyCommandFromBuildEvidence(t *testing.T) {
 			name: "gradle needs the wrapper and a test class",
 			files: map[string]string{
 				"gradlew":                      "",
+				"settings.gradle":              "include ':lib'\n",
 				"lib/build.gradle.kts":         "",
 				"lib/src/main/kotlin/A.kt":     "",
 				"lib/src/test/kotlin/ATest.kt": "",
@@ -1311,7 +1312,8 @@ func TestSearchVerifyCommandsDoNotExecuteRepositoryData(t *testing.T) {
 			name: "gradle project task",
 			derive: func() *SearchVerifyCommand {
 				evidence := searchVerifyTestEvidence(map[string]string{
-					"gradlew": "", attack + "/build.gradle": "",
+					"gradlew": "", "settings.gradle": "include ':" + attack + "'\n",
+					attack + "/build.gradle": "",
 				})
 				return deriveSearchVerifyGradle(attack, searchVerifySubject{
 					sourcePath: attack + "/src/A.kt", testPath: attack + "/src/ATest.kt",
@@ -1321,7 +1323,9 @@ func TestSearchVerifyCommandsDoNotExecuteRepositoryData(t *testing.T) {
 		{
 			name: "gradle test pattern",
 			derive: func() *SearchVerifyCommand {
-				evidence := searchVerifyTestEvidence(map[string]string{"gradlew": "", "lib/build.gradle": ""})
+				evidence := searchVerifyTestEvidence(map[string]string{
+					"gradlew": "", "settings.gradle": "include ':lib'\n", "lib/build.gradle": "",
+				})
 				return deriveSearchVerifyGradle("lib", searchVerifySubject{
 					sourcePath: "lib/src/A.kt", testPath: "lib/src/" + attack + ".kt",
 				}, &evidence)

--- a/internal/sem/search_verify_test.go
+++ b/internal/sem/search_verify_test.go
@@ -254,7 +254,7 @@ func TestDeriveSearchVerifyCommandFromBuildEvidence(t *testing.T) {
 			},
 			wantCommand: "./gradlew :lib:test --tests 'ATest'",
 			wantTargets: "lib/src/test/kotlin/ATest.kt",
-			wantDerived: "lib/build.gradle.kts + gradlew + mirror test file class",
+			wantDerived: "lib/build.gradle.kts + gradlew + settings.gradle + mirror test file class",
 		},
 		{
 			name: "gradle without the wrapper emits nothing",


### PR DESCRIPTION
Closes #219

`entire graph search` can suggest a VERIFY command after locating relevant code. Before this change, its Gradle logic could return a command that failed outright or passed without testing the edited project.

## The bug

The narrow verifier treated a source directory as proof of Gradle project membership. Finding `lib/build.gradle` was enough to emit:

```sh
./gradlew :lib:test --tests 'ATest'
```

But the directory `lib/` does not establish a project named `:lib`. That membership comes from `settings.gradle` or `settings.gradle.kts`.

If the settings file omits `:lib`, Gradle rejects the task. If it remaps `:lib` to another directory, the command can pass while testing code other than the edited files.

Declining that narrow command was not sufficient. Suite discovery could continue upward and substitute `./gradlew test` from an ancestor build that did not own the nested project.

## What changed

The narrow and suite routes now share one Gradle target resolver. It:

- finds the nearest wrapper at or above the project;
- finds the nearest settings script between the project and that wrapper;
- accepts included projects only when a literal settings declaration proves membership;
- rejects projects whose `projectDir` is remapped elsewhere;
- recognizes a directory with its own settings file as an independent build root;
- addresses intermediate build roots through `-p`;
- stops fallback at a Gradle boundary that cannot prove a safe command.

This shared resolution supports filtered commands for nested builds. For an independent build under `modules/`, it emits:

```sh
./gradlew -p modules test --tests 'ATest'
```

For `modules/core/` declared as `:core` by `modules/settings.gradle`, it emits:

```sh
./gradlew -p modules :core:test --tests 'ATest'
```

The whole-suite route uses the same target and omits only the test-class filter.

The final fallback now says that no safe verification command was found instead of incorrectly claiming that no build manifest exists.

## Resulting behavior

| Repository evidence | Result |
|---|---|
| Root settings include `:lib` | `./gradlew :lib:test --tests 'ATest'` |
| Root settings omit `:lib` | Emit no Gradle command |
| Root settings remap `:lib` to another directory | Emit no command for files under `lib/` |
| Source belongs directly to the root project | `./gradlew :test --tests 'ATest'` |
| Nested directory has its own settings file | `./gradlew -p modules test --tests 'ATest'` |
| Intermediate settings include `:core` | `./gradlew -p modules :core:test --tests 'ATest'` |
| A nested Gradle boundary cannot prove ownership | Do not substitute an ancestor suite |

These checks fail closed. A settings script that computes its includes dynamically cannot be proven by the literal scanner, so it produces no command. That is the intended safety boundary: silence is preferable to a passing command that may test unrelated code.

## Verification

```sh
go test ./internal/sem -run '^TestSearchVerifyGradleNarrowNestedBuilds$' -count=1
go test ./internal/sem -run '^TestSearchVerifySuiteGradleNamesTheProjectUnderAnAncestorWrapper$'
go test ./internal/sem -run 'Gradle' -count=1
mise run check
```

All checks passed, including formatting, vet, build, status-line tests, and the full race-enabled Go suite.

The tests derive commands from repository fixtures rather than launching a real Gradle build. Shell-safety tests execute generated commands against local runner stubs.
